### PR TITLE
Add test cases for footnote reference formatting

### DIFF
--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1240,6 +1240,38 @@ describe("Skip Formatting", () => {
     const processedHtml = testHtmlFormattingImprovement(input)
     expect(processedHtml).toBe(expected)
   })
+
+  describe("Footnote references", () => {
+    // Footnote refs have data-footnote-ref attribute; their number text shouldn't be transformed
+    // Note: rehype serializes boolean attributes as `data-footnote-ref=""`
+    it.each([
+      [
+        "skip text inside footnote reference elements",
+        '<p>Some text<sup><a href="#fn-1" data-footnote-ref>15</a></sup> Am I right?</p>',
+        '<p>Some text<sup><a href="#fn-1" data-footnote-ref="">15</a></sup> Am I right?</p>',
+      ],
+      [
+        "not transform footnote ref number into time pattern",
+        // This is the specific bug case: "15" + " Am I" should NOT become "15 a.m. I"
+        '<p><sup><a data-footnote-ref>15</a></sup> Am I correct?</p>',
+        '<p><sup><a data-footnote-ref="">15</a></sup> Am I correct?</p>',
+      ],
+      [
+        "still transform text outside footnote refs normally",
+        '<p>Meet at 3 PM<sup><a href="#fn-1" data-footnote-ref>1</a></sup> for coffee.</p>',
+        '<p>Meet at 3 p.m.<sup><a href="#fn-1" data-footnote-ref="">1</a></sup> for coffee.</p>',
+      ],
+      [
+        "handle multiple footnote refs in same paragraph",
+        '<p>First<sup><a data-footnote-ref>1</a></sup> and second<sup><a data-footnote-ref>2</a></sup>.</p>',
+        // Note: punctuation gets moved into the second link due to rearrangeLinkPunctuation
+        '<p>First<sup><a data-footnote-ref="">1</a></sup> and second<sup><a data-footnote-ref="">2.</a></sup></p>',
+      ],
+    ])("should %s", (_description, input, expected) => {
+      const processedHtml = testHtmlFormattingImprovement(input)
+      expect(processedHtml).toBe(expected)
+    })
+  })
 })
 
 describe("Date Range", () => {


### PR DESCRIPTION
## Summary
Added comprehensive test cases for footnote reference handling in the HTML formatting improvement transformer to ensure footnote numbers are not inadvertently transformed into other patterns (e.g., time formats).

## Changes
- Added a new test suite "Footnote references" with 4 test cases covering:
  - Basic footnote reference preservation with `data-footnote-ref` attribute
  - Prevention of the specific bug where "15" followed by " Am I" was being transformed into "15 a.m. I"
  - Verification that text outside footnote references is still transformed normally
  - Handling of multiple footnote references in the same paragraph

## Details
These tests ensure that:
1. Footnote reference numbers (marked with `data-footnote-ref` attribute) are skipped during text transformation
2. The formatter correctly distinguishes between footnote numbers and regular text that should be transformed
3. Normal formatting rules still apply to non-footnote content in the same context
4. Edge cases with multiple footnotes are handled properly

The tests document the expected behavior where rehype serializes boolean attributes as `data-footnote-ref=""`.

https://claude.ai/code/session_01V63PWZ7C6judVisCHCkiR3