### PR TITLE
Remove hardcoded version string from CLI

### DIFF
--- a/quartz/bootstrap-cli.ts
+++ b/quartz/bootstrap-cli.ts
@@ -6,8 +6,6 @@ import { hideBin } from "yargs/helpers"
 
 // @ts-expect-error Importing from a JS file, no types
 import { CommonArgv, BuildArgv, CreateArgv, SyncArgv } from "./cli/args.js"
-// @ts-expect-error Importing from a JS file, no types
-import { version } from "./cli/constants.js"
 import { handleBuild } from "./cli/handlers"
 
 // Define type for command handlers
@@ -18,7 +16,6 @@ type CommandHandler = (
 // Create and configure yargs
 await yargs(hideBin(process.argv))
   .scriptName("quartz")
-  .version(version)
   .usage("$0 <cmd> [args]")
   .command("build", "Build Quartz into a bundle of static HTML files", BuildArgv, (async (argv) => {
     await handleBuild(argv)

--- a/quartz/cli/constants.js
+++ b/quartz/cli/constants.js
@@ -11,5 +11,4 @@ export const cwd = process.cwd()
 export const cacheDir = path.join(cwd, ".quartz-cache")
 export const cacheFile = "./quartz/.quartz-cache/transpiled-build.mjs"
 export const fp = "./quartz/build.ts"
-export const version = "1.4"
 export const contentCacheFolder = path.join(cacheDir, "content-cache")

--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -20,7 +20,6 @@ import { WebSocketServer, type WebSocket } from "ws"
 
 import { generateScss, generateScssRecord } from "../styles/generate-variables"
 import {
-  version,
   fp,
   cacheFile, // @ts-expect-error Importing from a JS file, no types
 } from "./constants.js"
@@ -71,7 +70,7 @@ export async function checkPortAvailability(port: number): Promise<void> {
  * Handles `npx quartz build`
  */
 export async function handleBuild(argv: BuildArguments): Promise<void> {
-  console.log(chalk.bgGreen.black(`\n turntrout.com v${version} \n`))
+  console.log(chalk.bgGreen.black(`\n turntrout.com \n`))
 
   if (argv.serve) {
     await checkPortAvailability(argv.port)


### PR DESCRIPTION
## Summary
Removes the hardcoded version constant from the Quartz CLI, eliminating version display from the build command output.

## Changes
- Removed `version` constant export from `quartz/cli/constants.js`
- Removed version import and `.version()` configuration from `quartz/bootstrap-cli.ts`
- Removed version import from `quartz/cli/handlers.ts`
- Updated build output message to remove version display (changed from `turntrout.com v1.4` to `turntrout.com`)

## Notes
This change simplifies the CLI by removing the static version string. If version information is needed in the future, it should be sourced from `package.json` or a dynamic source rather than a hardcoded constant.

https://claude.ai/code/session_011EzaS6KwVWPaiBYCRxALS3