### PR TITLE
Fix quote style consistency in build handler output

### DIFF
--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -70,7 +70,7 @@ export async function checkPortAvailability(port: number): Promise<void> {
  * Handles `npx quartz build`
  */
 export async function handleBuild(argv: BuildArguments): Promise<void> {
-  console.log(chalk.bgGreen.black(`\n turntrout.com \n`))
+  console.log(chalk.bgGreen.black("\n turntrout.com \n"))
 
   if (argv.serve) {
     await checkPortAvailability(argv.port)


### PR DESCRIPTION
## Summary
Updated quote style in the build handler console output to maintain consistent code formatting standards.

## Changes
- Changed single quotes to double quotes in the `handleBuild` function's console.log statement for the banner output
- This aligns with the project's quote style conventions

## Details
This is a minor style fix that ensures consistent quote usage throughout the codebase. The functional behavior remains unchanged.

https://claude.ai/code/session_01VwwBaQ9RoebBGxJ3R7x4PH