### PR TITLE
Add SVG to formatting skip tags

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -693,7 +693,7 @@ export function setFirstLetterAttribute(tree: Root): void {
 export function toSkip(node: Element): boolean {
   if (node.type === "element") {
     const elementNode = node as ElementMaybeWithParent
-    const skipTag = ["code", "script", "style", "pre"].includes(elementNode.tagName)
+    const skipTag = ["code", "script", "style", "pre", "svg"].includes(elementNode.tagName)
     const skipClass = ["no-formatting", "elvish", "bad-handwriting"].some((cls) =>
       hasClass(elementNode, cls),
     )
@@ -710,7 +710,7 @@ function fractionToSkip(node: Text, _idx: number, parent: Parent, ancestors: Par
     hasAncestor(
       parent as Element,
       (ancestor) =>
-        ["code", "pre", "a", "script", "style"].includes(ancestor.tagName) ||
+        ["code", "pre", "a", "script", "style", "svg"].includes(ancestor.tagName) ||
         hasClass(ancestor, "fraction"),
       ancestors,
     ) ||


### PR DESCRIPTION
## Summary
This change adds `svg` to the list of HTML tags that should be skipped during text formatting transformations. This prevents formatting rules from being applied to content within SVG elements.

## Changes
- Added `"svg"` to the skip tags list in `toSkip()` function (line 696)
- Added `"svg"` to the skip tags list in `fractionToSkip()` function (line 713)

## Details
SVG elements contain vector graphics markup that should not be subject to the same text formatting rules as regular HTML content. By adding SVG to both skip lists, we ensure that:
- Formatting transformations are not applied to SVG element content
- Fraction formatting logic does not process text within SVG ancestors

This aligns SVG handling with other non-text content tags like `code`, `pre`, `script`, and `style`.

https://claude.ai/code/session_018WurpcHJ9bYVVqyW33N5cQ