### PR TITLE
Fix flaky favicon download permission test

### DIFF
--- a/quartz/plugins/transformers/linkfavicons.test.ts
+++ b/quartz/plugins/transformers/linkfavicons.test.ts
@@ -1238,7 +1238,7 @@ describe("linkfavicons.downloadImage", () => {
 
   it("should throw if write stream fails", async () => {
     const url = "https://example.com/image.png"
-    const imagePath = path.join(tempDir, "readonly-dir", "image.png")
+    const imagePath = path.join(tempDir, "image.png")
     const mockContent = "Mock image content"
     const mockResponse = new Response(mockContent, {
       status: 200,
@@ -1247,22 +1247,15 @@ describe("linkfavicons.downloadImage", () => {
 
     jest.spyOn(global, "fetch").mockResolvedValueOnce(mockResponse)
 
-    // Create a directory that doesn't allow writing
-    const readonlyDir = path.join(tempDir, "readonly-dir")
-    // skipcq: JS-P1003
-    await fsExtra.ensureDir(readonlyDir)
-    // skipcq: JS-P1003
-    await fsExtra.chmod(readonlyDir, 0o444) // Read-only permissions
+    // Mock mkdir to throw an error - works in sandboxed environments
+    // where file permission restrictions don't apply (e.g., running as root)
+    jest
+      .spyOn(fs.promises, "mkdir")
+      .mockRejectedValueOnce(new Error("EACCES: permission denied"))
 
-    try {
-      await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow(
-        "Failed to write image",
-      )
-    } finally {
-      // skipcq: JS-P1003
-      // Restore permissions so cleanup works
-      await fsExtra.chmod(readonlyDir, 0o755)
-    }
+    await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow(
+      "Failed to write image",
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
Refactored the "should throw if write stream fails" test in `linkfavicons.test.ts` to use mocking instead of file system permission manipulation, making it more reliable across different environments.

## Key Changes
- Replaced file system permission-based test approach with Jest mocking of `fs.promises.mkdir`
- Removed creation of read-only directories and associated permission restoration logic
- Simplified test by directly mocking the permission denied error (`EACCES`)
- Added clarifying comment explaining why mocking is necessary (sandboxed environments, root user scenarios)

## Implementation Details
The original test attempted to create a read-only directory to trigger write failures, which is unreliable in certain environments (e.g., when running as root or in sandboxed CI/CD systems where permission restrictions don't apply). The new approach mocks the `mkdir` operation to reject with a permission denied error, ensuring consistent test behavior regardless of the execution environment.

This change improves test reliability and maintainability while preserving the original test intent of verifying error handling when directory creation fails.

https://claude.ai/code/session_01Myzk3QcR7oCaBV3YLAL4iS