### PR TITLE
Handle non-breaking spaces in slug generation

### DIFF
--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -297,7 +297,7 @@ const slugger = new GithubSlugger()
 
 // skipcq: JS-D1001
 export function preprocessSlug(headerText: string): string {
-  const charsToConvert = ["'", "’", "/", "&", "—", "‘"]
+  const charsToConvert = ["'", "'", "/", "&", "—", "'", "\u00A0"]
 
   let protoSlug = headerText
   for (const char of charsToConvert) {

--- a/quartz/plugins/transformers/tests/gfm.test.ts
+++ b/quartz/plugins/transformers/tests/gfm.test.ts
@@ -102,6 +102,11 @@ describe("slugify function", () => {
       "Rock & Roll — The Beginning",
       "rock-roll-the-beginning",
     ],
+    [
+      "should convert non-breaking spaces to hyphens",
+      "Floating\u00A0Image\u00A0Right",
+      "floating-image-right",
+    ],
   ])("%s", (_desc: string, input: string, expected: string) => {
     expect(slugify(input)).toBe(expected)
   })
@@ -291,6 +296,8 @@ describe("preprocessSlug function", () => {
     ["Text/&/Combo", "Text-Combo"],
     ["", ""],
     ["Normal Text", "Normal Text"],
+    ["Text\u00A0With\u00A0Nbsp", "Text-With-Nbsp"],
+    ["Floating\u00A0Image", "Floating-Image"],
   ])("should process '%s' to '%s'", (input: string, expected: string) => {
     expect(preprocessSlug(input)).toBe(expected)
   })

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1612,8 +1612,8 @@ def check_spacing(
     return []
 
 
-ALLOWED_ELT_PRECEDING_CHARS = "[({-—~×“=+‘ \n\t\r"
-ALLOWED_ELT_FOLLOWING_CHARS = "])}.,;!?:-—~×+”…=’ \n\t\r"
+ALLOWED_ELT_PRECEDING_CHARS = "[({-—~×“=+‘ \n\t\r "
+ALLOWED_ELT_FOLLOWING_CHARS = "])}.,;!?:-—~×+”…=’ \n\t\r "
 
 
 def _check_element_spacing(


### PR DESCRIPTION
## Summary
This PR adds support for converting non-breaking spaces (U+00A0) to hyphens during slug generation, ensuring consistent URL formatting across the site.

## Changes
- **GFM Transformer**: Added non-breaking space (`\u00A0`) to the character conversion list in `preprocessSlug()` function so it gets converted to hyphens like other special characters
- **GFM Tests**: Added test cases to verify non-breaking spaces are properly converted to hyphens in both the `slugify()` and `preprocessSlug()` functions
- **Site Checks**: Updated allowed character sets in `built_site_checks.py` to include non-breaking spaces in both preceding and following character patterns for element spacing validation

## Implementation Details
Non-breaking spaces can appear in content (especially in floating image captions or formatted text) and should be treated the same as regular spaces when generating URL slugs. This change ensures that headers or text containing non-breaking spaces produce valid, consistent slug URLs.

https://claude.ai/code/session_01XdR71uC1DePh1D3ENcjNyh