### PR TITLE
fix: handle nbsp in unrendered emphasis check for fill-in-blank patterns

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -785,7 +785,7 @@ def check_unrendered_emphasis(soup: BeautifulSoup) -> list[str]:
         # Get text excluding code and KaTeX elements
         stripped_text = script_utils.get_non_code_text(text_elt)
 
-        if stripped_text and (re.search(r"\*|\_(?!\_* +\%)", stripped_text)):
+        if stripped_text and (re.search(r"\*|\_(?!\_*[ \xa0]+\%)", stripped_text)):
             _append_to_list(
                 problematic_texts,
                 stripped_text,


### PR DESCRIPTION
The regex for excluding `___ %` patterns from unrendered emphasis checks used a regular space, but nbsp transformers now convert these to `___\xa0%`. Updated to match both regular space and nbsp.

https://claude.ai/code/session_01XdR71uC1DePh1D3ENcjNyh