### PR TITLE
Fix clipboard button z-index stacking context

### DIFF
--- a/quartz/components/styles/clipboard.scss
+++ b/quartz/components/styles/clipboard.scss
@@ -16,6 +16,7 @@ pre {
 .clipboard-button {
   display: flex;
   position: absolute;
+  z-index: 1;
   margin: $base-margin;
   padding: 0;
   color: var(--midground);


### PR DESCRIPTION
## Summary
Added explicit z-index to the clipboard button component to ensure proper stacking order and prevent it from being obscured by other page elements.

## Changes
- Added `z-index: 1` to `.clipboard-button` class in clipboard.scss

## Details
The clipboard button is positioned absolutely and needs to appear above other content. By setting an explicit z-index value, we establish a proper stacking context and ensure the button remains visible and interactive regardless of the z-index values of surrounding elements.

https://claude.ai/code/session_01R3xKV7oSWSbPUMwN9w3Dof