### PR TITLE
chore: update spellcheck wordlist and fix import formatting

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -3104,3 +3104,9 @@ Zack's
 pre-push
 preload
 transclusions
+DOMs
+Hallo
+README's
+regexes
+½
+1ˢᵗ

--- a/quartz/plugins/emitters/static.test.ts
+++ b/quartz/plugins/emitters/static.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "@jest/globals"
 
 import { type FilePath } from "../../util/path"
-
 import { isLocalFavicon, shouldCopyToRoot } from "./static"
 
 describe("isLocalFavicon", () => {


### PR DESCRIPTION
## Summary
Minor maintenance updates to improve code quality and spellcheck coverage.

## Changes
- **Spellcheck wordlist**: Added 6 new words/terms to the wordlist:
  - `DOMs` - plural of DOM (Document Object Model)
  - `Hallo` - proper noun/name
  - `README's` - possessive form of README
  - `regexes` - plural of regex
  - `½` - fraction symbol
  - `1ˢᵗ` - ordinal number with superscript formatting

- **Import formatting**: Removed unnecessary blank line in `quartz/plugins/emitters/static.test.ts` to improve code consistency and follow linting standards

## Notes
These changes maintain code quality standards and ensure the spellchecker doesn't flag commonly used terms as errors.

https://claude.ai/code/session_014CBB1ETQbH6iDEFEavHN3Q