### PR TITLE
Add null check for collapsible title element

### DIFF
--- a/quartz/static/scripts/collapsible-listeners.js
+++ b/quartz/static/scripts/collapsible-listeners.js
@@ -13,6 +13,8 @@ document.addEventListener("nav", function () {
 
   for (const collapsible of collapsibles) {
     const title = collapsible.querySelector(".collapsible-title")
-    title.addEventListener("click", collapseHandler.bind(collapsible))
+    if (title) {
+      title.addEventListener("click", collapseHandler.bind(collapsible))
+    }
   }
 })


### PR DESCRIPTION
## Summary
Added a defensive null check when attaching click event listeners to collapsible title elements to prevent runtime errors when the expected DOM element is missing.

## Changes
- Wrapped the event listener attachment in a conditional check to verify that the `.collapsible-title` element exists before attempting to add the click handler
- This prevents potential `TypeError` exceptions that could occur if a collapsible element lacks the expected title child element

## Implementation Details
The change is minimal and follows a defensive programming approach. By checking `if (title)` before calling `addEventListener()`, the code gracefully handles cases where the DOM structure may be incomplete or malformed, allowing the script to continue processing other collapsible elements without crashing.

https://claude.ai/code/session_0179BmoPbuJPdvXTnZFtcQLA