### PR TITLE
fix: convert elvish-toggle to inline script for browser execution

### DIFF
--- a/quartz/components/Body.tsx
+++ b/quartz/components/Body.tsx
@@ -1,17 +1,18 @@
 // skipcq: JS-W1028
-import React from "react";
+import React from "react"
 
 // @ts-expect-error Not a module but a script
 // skipcq: JS-W1028
-import clipboardScript from "./scripts/clipboard.inline";
-// Side-effect import: registers nav event listener for Elvish toggle
-import "./scripts/elvish-toggle";
-import clipboardStyle from "./styles/clipboard.scss";
+import clipboardScript from "./scripts/clipboard.inline"
+// @ts-expect-error Not a module but a script
+// skipcq: JS-W1028
+import elvishToggleScript from "./scripts/elvish-toggle.inline"
+import clipboardStyle from "./styles/clipboard.scss"
 import {
   type QuartzComponent,
   type QuartzComponentConstructor,
   type QuartzComponentProps,
-} from "./types";
+} from "./types"
 
 const searchInterface = (
   <div className="search" role="region" aria-label="Displays search results.">
@@ -29,7 +30,7 @@ const searchInterface = (
       </div>
     </div>
   </div>
-);
+)
 
 const Body: QuartzComponent = ({ children }: QuartzComponentProps) => {
   // The quartz-body children are the three main sections of the page: left, center, and right bars
@@ -38,10 +39,10 @@ const Body: QuartzComponent = ({ children }: QuartzComponentProps) => {
       {searchInterface}
       <div id="quartz-body">{children}</div>
     </>
-  );
-};
+  )
+}
 
-Body.afterDOMLoaded = clipboardScript;
-Body.css = clipboardStyle;
+Body.afterDOMLoaded = clipboardScript + elvishToggleScript
+Body.css = clipboardStyle
 
-export default (() => Body) satisfies QuartzComponentConstructor;
+export default (() => Body) satisfies QuartzComponentConstructor

--- a/quartz/components/scripts/elvish-toggle.inline.ts
+++ b/quartz/components/scripts/elvish-toggle.inline.ts
@@ -1,0 +1,3 @@
+import { initializeElvishElements } from "./elvish-toggle"
+
+document.addEventListener("nav", initializeElvishElements)

--- a/quartz/components/scripts/elvish-toggle.test.ts
+++ b/quartz/components/scripts/elvish-toggle.test.ts
@@ -2,148 +2,139 @@
  * @jest-environment jsdom
  */
 
-import { describe, it, beforeEach, afterEach, expect } from "@jest/globals";
+import { describe, it, beforeEach, afterEach, expect } from "@jest/globals"
 
-import { type FullSlug } from "../../util/path";
 import {
   toggleElvish,
   handleElvishKeydown,
   handleElvishClick,
   createHelpText,
   initializeElvishElements,
-} from "./elvish-toggle";
-
-const triggerNav = () => {
-  document.dispatchEvent(
-    new CustomEvent("nav", { detail: { url: "" as FullSlug } }),
-  );
-};
+} from "./elvish-toggle"
 
 describe("elvish-toggle", () => {
   beforeEach(() => {
-    document.body.innerHTML = "";
-  });
+    document.body.innerHTML = ""
+  })
 
   afterEach(() => {
-    document.body.innerHTML = "";
-  });
+    document.body.innerHTML = ""
+  })
 
   describe("toggleElvish", () => {
     it("should toggle show-translation class", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
 
-      toggleElvish.call(el);
-      expect(el.classList.contains("show-translation")).toBe(true);
-      expect(el.getAttribute("aria-pressed")).toBe("true");
+      toggleElvish.call(el)
+      expect(el.classList.contains("show-translation")).toBe(true)
+      expect(el.getAttribute("aria-pressed")).toBe("true")
 
-      toggleElvish.call(el);
-      expect(el.classList.contains("show-translation")).toBe(false);
-      expect(el.getAttribute("aria-pressed")).toBe("false");
-    });
-  });
+      toggleElvish.call(el)
+      expect(el.classList.contains("show-translation")).toBe(false)
+      expect(el.getAttribute("aria-pressed")).toBe("false")
+    })
+  })
 
   describe("handleElvishKeydown", () => {
     it("should toggle on Enter key", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
 
       const event = new KeyboardEvent("keydown", {
         key: "Enter",
         bubbles: true,
         cancelable: true,
-      });
-      handleElvishKeydown.call(el, event);
+      })
+      handleElvishKeydown.call(el, event)
 
-      expect(el.classList.contains("show-translation")).toBe(true);
-      expect(event.defaultPrevented).toBe(true);
-    });
+      expect(el.classList.contains("show-translation")).toBe(true)
+      expect(event.defaultPrevented).toBe(true)
+    })
 
     it("should toggle on Space key", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
 
       const event = new KeyboardEvent("keydown", {
         key: " ",
         bubbles: true,
         cancelable: true,
-      });
-      handleElvishKeydown.call(el, event);
+      })
+      handleElvishKeydown.call(el, event)
 
-      expect(el.classList.contains("show-translation")).toBe(true);
-      expect(event.defaultPrevented).toBe(true);
-    });
+      expect(el.classList.contains("show-translation")).toBe(true)
+      expect(event.defaultPrevented).toBe(true)
+    })
 
     it("should not toggle on other keys", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
 
       for (const key of ["Tab", "Escape", "a", "1"]) {
         const event = new KeyboardEvent("keydown", {
           key,
           bubbles: true,
           cancelable: true,
-        });
-        handleElvishKeydown.call(el, event);
-        expect(event.defaultPrevented).toBe(false);
+        })
+        handleElvishKeydown.call(el, event)
+        expect(event.defaultPrevented).toBe(false)
       }
 
-      expect(el.classList.contains("show-translation")).toBe(false);
-    });
-  });
+      expect(el.classList.contains("show-translation")).toBe(false)
+    })
+  })
 
   describe("handleElvishClick", () => {
     it("should toggle on click", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
 
-      const event = new MouseEvent("click", { bubbles: true });
-      Object.defineProperty(event, "target", { value: el });
-      handleElvishClick.call(el, event);
+      const event = new MouseEvent("click", { bubbles: true })
+      Object.defineProperty(event, "target", { value: el })
+      handleElvishClick.call(el, event)
 
-      expect(el.classList.contains("show-translation")).toBe(true);
-    });
+      expect(el.classList.contains("show-translation")).toBe(true)
+    })
 
     it("should not toggle when clicking a link", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
-      const link = document.createElement("a");
-      el.appendChild(link);
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
+      const link = document.createElement("a")
+      el.appendChild(link)
 
-      const event = new MouseEvent("click", { bubbles: true });
-      Object.defineProperty(event, "target", { value: link });
-      handleElvishClick.call(el, event);
+      const event = new MouseEvent("click", { bubbles: true })
+      Object.defineProperty(event, "target", { value: link })
+      handleElvishClick.call(el, event)
 
-      expect(el.classList.contains("show-translation")).toBe(false);
-    });
+      expect(el.classList.contains("show-translation")).toBe(false)
+    })
 
     it("should not toggle when clicking nested element inside link", () => {
-      const el = document.createElement("span");
-      el.setAttribute("aria-pressed", "false");
-      const link = document.createElement("a");
-      const strong = document.createElement("strong");
-      link.appendChild(strong);
-      el.appendChild(link);
+      const el = document.createElement("span")
+      el.setAttribute("aria-pressed", "false")
+      const link = document.createElement("a")
+      const strong = document.createElement("strong")
+      link.appendChild(strong)
+      el.appendChild(link)
 
-      const event = new MouseEvent("click", { bubbles: true });
-      Object.defineProperty(event, "target", { value: strong });
-      handleElvishClick.call(el, event);
+      const event = new MouseEvent("click", { bubbles: true })
+      Object.defineProperty(event, "target", { value: strong })
+      handleElvishClick.call(el, event)
 
-      expect(el.classList.contains("show-translation")).toBe(false);
-    });
-  });
+      expect(el.classList.contains("show-translation")).toBe(false)
+    })
+  })
 
   describe("createHelpText", () => {
     it("should create a visually-hidden span with correct content", () => {
-      const helpText = createHelpText();
+      const helpText = createHelpText()
 
-      expect(helpText.id).toBe("elvish-help");
-      expect(helpText.className).toBe("visually-hidden");
-      expect(helpText.textContent).toBe(
-        "Toggle between Elvish and English translation",
-      );
-    });
-  });
+      expect(helpText.id).toBe("elvish-help")
+      expect(helpText.className).toBe("visually-hidden")
+      expect(helpText.textContent).toBe("Toggle between Elvish and English translation")
+    })
+  })
 
   describe("initializeElvishElements", () => {
     it("should add accessibility attributes to elvish elements", () => {
@@ -152,81 +143,83 @@ describe("elvish-toggle", () => {
           <span class="elvish-tengwar">Tengwar</span>
           <span class="elvish-translation">English</span>
         </span>
-      `;
-      initializeElvishElements();
+      `
+      initializeElvishElements()
 
-      const el = document.querySelector(".elvish") as HTMLElement;
-      expect(el.getAttribute("tabindex")).toBe("0");
-      expect(el.getAttribute("role")).toBe("button");
-      expect(el.getAttribute("aria-pressed")).toBe("false");
-      expect(el.getAttribute("aria-describedby")).toBe("elvish-help");
-    });
+      const el = document.querySelector(".elvish") as HTMLElement
+      expect(el.getAttribute("tabindex")).toBe("0")
+      expect(el.getAttribute("role")).toBe("button")
+      expect(el.getAttribute("aria-pressed")).toBe("false")
+      expect(el.getAttribute("aria-describedby")).toBe("elvish-help")
+    })
 
     it("should create help text when elvish elements exist", () => {
-      document.body.innerHTML = '<span class="elvish"></span>';
-      initializeElvishElements();
+      document.body.innerHTML = '<span class="elvish"></span>'
+      initializeElvishElements()
 
-      const helpText = document.getElementById("elvish-help");
-      expect(helpText).not.toBeNull();
-    });
+      const helpText = document.getElementById("elvish-help")
+      expect(helpText).not.toBeNull()
+    })
 
     it("should not create help text when no elvish elements exist", () => {
-      document.body.innerHTML = '<span class="other"></span>';
-      initializeElvishElements();
+      document.body.innerHTML = '<span class="other"></span>'
+      initializeElvishElements()
 
-      const helpText = document.getElementById("elvish-help");
-      expect(helpText).toBeNull();
-    });
+      const helpText = document.getElementById("elvish-help")
+      expect(helpText).toBeNull()
+    })
 
     it("should not duplicate help text on multiple calls", () => {
-      document.body.innerHTML = '<span class="elvish"></span>';
-      initializeElvishElements();
-      initializeElvishElements();
-      initializeElvishElements();
+      document.body.innerHTML = '<span class="elvish"></span>'
+      initializeElvishElements()
+      initializeElvishElements()
+      initializeElvishElements()
 
-      const helpTexts = document.querySelectorAll("#elvish-help");
-      expect(helpTexts.length).toBe(1);
-    });
+      const helpTexts = document.querySelectorAll("#elvish-help")
+      expect(helpTexts.length).toBe(1)
+    })
 
     it("should not re-initialize already initialized elements", () => {
-      document.body.innerHTML = '<span class="elvish"></span>';
-      initializeElvishElements();
+      document.body.innerHTML = '<span class="elvish"></span>'
+      initializeElvishElements()
 
-      const el = document.querySelector(".elvish") as HTMLElement;
-      el.classList.add("show-translation");
-      el.setAttribute("aria-pressed", "true");
+      const el = document.querySelector(".elvish") as HTMLElement
+      el.classList.add("show-translation")
+      el.setAttribute("aria-pressed", "true")
 
-      initializeElvishElements(); // Should not reset
+      initializeElvishElements() // Should not reset
 
-      expect(el.classList.contains("show-translation")).toBe(true);
-      expect(el.getAttribute("aria-pressed")).toBe("true");
-    });
+      expect(el.classList.contains("show-translation")).toBe(true)
+      expect(el.getAttribute("aria-pressed")).toBe("true")
+    })
 
     it("should initialize all elvish elements independently", () => {
       document.body.innerHTML = `
         <span class="elvish" id="el1"></span>
         <span class="elvish" id="el2"></span>
         <span class="elvish" id="el3"></span>
-      `;
-      initializeElvishElements();
+      `
+      initializeElvishElements()
 
-      const elements = document.querySelectorAll(".elvish");
-      expect(elements.length).toBe(3);
+      const elements = document.querySelectorAll(".elvish")
+      expect(elements.length).toBe(3)
 
       for (const el of elements) {
-        expect(el.getAttribute("role")).toBe("button");
-        expect(el.getAttribute("aria-pressed")).toBe("false");
+        expect(el.getAttribute("role")).toBe("button")
+        expect(el.getAttribute("aria-pressed")).toBe("false")
       }
-    });
-  });
+    })
+  })
 
   describe("nav event integration", () => {
-    it("should initialize elements on nav event", () => {
-      document.body.innerHTML = '<span class="elvish"></span>';
-      triggerNav();
+    it("should initialize elements when called", () => {
+      document.body.innerHTML = '<span class="elvish"></span>'
+      // The inline script registers the nav event listener
+      // Here we just verify the function works when called
+      initializeElvishElements()
 
-      const el = document.querySelector(".elvish") as HTMLElement;
-      expect(el.getAttribute("role")).toBe("button");
-    });
-  });
-});
+      const el = document.querySelector(".elvish") as HTMLElement
+      expect(el.getAttribute("role")).toBe("button")
+    })
+  })
+})

--- a/quartz/components/scripts/elvish-toggle.ts
+++ b/quartz/components/scripts/elvish-toggle.ts
@@ -4,61 +4,56 @@
 
 /** Toggle the show-translation class and update aria-pressed */
 export function toggleElvish(this: HTMLElement): void {
-  this.classList.toggle("show-translation");
-  const isShowing = this.classList.contains("show-translation");
-  this.setAttribute("aria-pressed", isShowing ? "true" : "false");
+  this.classList.toggle("show-translation")
+  const isShowing = this.classList.contains("show-translation")
+  this.setAttribute("aria-pressed", isShowing ? "true" : "false")
 }
 
 /** Handle keydown - toggle on Enter or Space */
 export function handleElvishKeydown(this: HTMLElement, e: KeyboardEvent): void {
   if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    toggleElvish.call(this);
+    e.preventDefault()
+    toggleElvish.call(this)
   }
 }
 
 /** Handle click - toggle unless clicking a link inside */
 export function handleElvishClick(this: HTMLElement, e: MouseEvent): void {
-  if ((e.target as HTMLElement).closest("a")) return;
-  toggleElvish.call(this);
+  if ((e.target as HTMLElement).closest("a")) return
+  toggleElvish.call(this)
 }
 
 /** Create the screen reader help text element */
 export function createHelpText(): HTMLSpanElement {
-  const helpText = document.createElement("span");
-  helpText.id = "elvish-help";
-  helpText.className = "visually-hidden";
-  helpText.textContent = "Toggle between Elvish and English translation";
-  return helpText;
+  const helpText = document.createElement("span")
+  helpText.id = "elvish-help"
+  helpText.className = "visually-hidden"
+  helpText.textContent = "Toggle between Elvish and English translation"
+  return helpText
 }
 
 /** Initialize all elvish elements on the page */
 export function initializeElvishElements(): void {
-  const elvishElements = document.querySelectorAll(".elvish");
+  const elvishElements = document.querySelectorAll(".elvish")
 
   for (const el of elvishElements) {
-    const element = el as HTMLElement;
+    const element = el as HTMLElement
     // Prevent duplicate listeners on SPA navigation
-    if (element.dataset.elvishInitialized) continue;
-    element.dataset.elvishInitialized = "true";
+    if (element.dataset.elvishInitialized) continue
+    element.dataset.elvishInitialized = "true"
 
     // Add keyboard accessibility
-    element.setAttribute("tabindex", "0");
-    element.setAttribute("role", "button");
-    element.setAttribute("aria-pressed", "false");
-    element.setAttribute("aria-describedby", "elvish-help");
+    element.setAttribute("tabindex", "0")
+    element.setAttribute("role", "button")
+    element.setAttribute("aria-pressed", "false")
+    element.setAttribute("aria-describedby", "elvish-help")
 
-    element.addEventListener("click", handleElvishClick as EventListener);
-    element.addEventListener("keydown", handleElvishKeydown as EventListener);
+    element.addEventListener("click", handleElvishClick as EventListener)
+    element.addEventListener("keydown", handleElvishKeydown as EventListener)
   }
 
   // Add hidden help text for screen readers (only if elvish elements exist)
   if (elvishElements.length > 0 && !document.getElementById("elvish-help")) {
-    document.body.appendChild(createHelpText());
+    document.body.appendChild(createHelpText())
   }
-}
-
-// Register with SPA navigation (only in browser)
-if (typeof document !== "undefined") {
-  document.addEventListener("nav", initializeElvishElements);
 }


### PR DESCRIPTION
The elvish-toggle module was imported at build time but never ran in the browser. This converts it to an inline script that gets bundled and executed client-side, similar to the clipboard functionality.

- Create elvish-toggle.inline.ts as minimal wrapper
- Keep elvish-toggle.ts with exported functions for testing
- Add elvishToggleScript to Body.afterDOMLoaded

https://claude.ai/code/session_01FU8mTqoQwiwuhTH6ETdX3c