### PR TITLE
fix: keep dotted underline and prevent layout shift on elvish toggle

### DIFF
--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -623,6 +623,65 @@ for (const theme of ["light", "dark"]) {
   })
 }
 
+test.describe("Elvish toggle", () => {
+  test("clicking elvish text toggles between Tengwar and English", async ({ page }) => {
+    const elvishText = page.locator(".elvish").first()
+    await elvishText.scrollIntoViewIfNeeded()
+
+    // Initially should show Tengwar (elvish-tengwar visible, elvish-translation hidden)
+    const tengwar = elvishText.locator(".elvish-tengwar")
+    const translation = elvishText.locator(".elvish-translation")
+
+    await expect(tengwar).toBeVisible()
+    await expect(translation).toBeHidden()
+
+    // Click to toggle to English
+    await elvishText.click()
+
+    await expect(tengwar).toBeHidden()
+    await expect(translation).toBeVisible()
+
+    // Click again to toggle back to Tengwar
+    await elvishText.click()
+
+    await expect(tengwar).toBeVisible()
+    await expect(translation).toBeHidden()
+  })
+
+  test("toggling elvish text does not cause layout shift", async ({ page }) => {
+    const elvishText = page.locator(".elvish").first()
+    await elvishText.scrollIntoViewIfNeeded()
+
+    // Get the bounding box before toggle
+    const boxBefore = await elvishText.boundingBox()
+    expect(boxBefore).not.toBeNull()
+
+    // Click to toggle to English
+    await elvishText.click()
+
+    // Get the bounding box after toggle
+    const boxAfter = await elvishText.boundingBox()
+    expect(boxAfter).not.toBeNull()
+
+    // Height should remain the same (within 1px tolerance for rounding)
+    expect(boxAfter!.height).toBeCloseTo(boxBefore!.height, 0)
+  })
+
+  test("elvish text maintains dotted underline when showing translation", async ({ page }) => {
+    const elvishText = page.locator(".elvish").first()
+    await elvishText.scrollIntoViewIfNeeded()
+
+    // Click to toggle to English
+    await elvishText.click()
+
+    // Check that text-decoration-style is still dotted
+    const textDecorationStyle = await elvishText.evaluate(
+      (el) => window.getComputedStyle(el).textDecorationStyle,
+    )
+    expect(textDecorationStyle).toBe("dotted")
+  })
+})
+
 test.describe("Video Speed Controller visibility", () => {
   test("hides VSC controller for no-vsc videos after img", async ({ page }) => {
     await page.evaluate(() => {

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -63,12 +63,7 @@ $heading-sizes: (
 // FONT SETUP
 $fonts-dir: "/static/styles/fonts";
 
-@mixin font-face(
-  $font-family,
-  $file-name,
-  $ext: ".woff2",
-  $font-features: none
-) {
+@mixin font-face($font-family, $file-name, $ext: ".woff2", $font-features: none) {
   @font-face {
     font-family: $font-family;
     font-optical-sizing: auto;
@@ -83,16 +78,14 @@ $fonts-dir: "/static/styles/fonts";
 
 @font-face {
   font-family: "EBGaramondInitialsF1";
-  src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF1.woff2")
-    format("woff2");
+  src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF1.woff2") format("woff2");
   font-display: block;
   -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Used in ::before, so subfont doesn't find automatically
 }
 
 @font-face {
   font-family: "EBGaramondInitialsF2";
-  src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF2.woff2")
-    format("woff2");
+  src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF2.woff2") format("woff2");
   font-display: block;
   -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 }
@@ -106,24 +99,12 @@ $fonts-dir: "/static/styles/fonts";
   font-display: swap;
 }
 
-@include font-face(
-  "EBGaramondOriginal",
-  "EBGaramond/EBGaramond08-Regular-original",
-  ".woff2"
-);
+@include font-face("EBGaramondOriginal", "EBGaramond/EBGaramond08-Regular-original", ".woff2");
 @include font-face("EBGaramond12", "EBGaramond/EBGaramond12-Regular", ".woff2");
-@include font-face(
-  "EBGaramond12Italic",
-  "EBGaramond/EBGaramond12-Regular",
-  ".woff2"
-);
+@include font-face("EBGaramond12Italic", "EBGaramond/EBGaramond12-Regular", ".woff2");
 
 // Less commonly used
-@include font-face(
-  "DejaVuSerifCondensed-Bold",
-  "DejaVuSerifCondensed-Bold-subset",
-  ".woff2"
-);
+@include font-face("DejaVuSerifCondensed-Bold", "DejaVuSerifCondensed-Bold-subset", ".woff2");
 @include font-face("BadHandwriting", "badhandwriting-webfont", ".woff2");
 @include font-face("Scary", "DarkmodeRegular", ".woff2");
 @include font-face("Elvish", "tengwar_artano/TengwarArtano", ".woff2");
@@ -182,11 +163,7 @@ em {
 
   // Hover state - show hint that clicking will reveal translation
   &:hover {
-    text-decoration-color: color-mix(
-      in srgb,
-      var(--foreground) 70%,
-      transparent
-    );
+    text-decoration-color: color-mix(in srgb, var(--foreground) 70%, transparent);
   }
 
   // Focus state for keyboard users
@@ -199,8 +176,7 @@ em {
   // When toggled to show translation
   &.show-translation {
     font-family: var(--font-main);
-    line-height: inherit; // Reset to normal line-height for English text
-    text-decoration: none;
+    // Keep same line-height to prevent layout shift when toggling
 
     // Hide the Tengwar text and show translation
     .elvish-tengwar {


### PR DESCRIPTION
- Remove text-decoration: none from .show-translation so dotted underline persists when showing English translation
- Remove line-height: inherit to maintain consistent 2.2 line-height and prevent layout shift when toggling

Add Playwright tests:
- Test clicking toggles between Tengwar and English
- Test no layout shift (height remains same after toggle)
- Test dotted underline persists when showing translation

https://claude.ai/code/session_01FU8mTqoQwiwuhTH6ETdX3c