### PR TITLE
Add automated workflow to cleanup stale branches

### DIFF
--- a/.github/workflows/cleanup-stale-branches.yml
+++ b/.github/workflows/cleanup-stale-branches.yml
@@ -1,0 +1,58 @@
+name: Cleanup stale branches
+on:
+  schedule:
+    - cron: "0 0 1 * *" # First of each month at midnight UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete stale branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Delete branches with no commits in the last 90 days
+          # Excludes: main, dev, plotly, and any branch with an open PR
+
+          REPO="${{ github.repository }}"
+          CUTOFF_DATE=$(date -d "90 days ago" --iso-8601)
+
+          echo "Deleting branches with no commits since $CUTOFF_DATE"
+          echo "Protected branches: main, dev, plotly"
+
+          # Get all branches except protected ones
+          gh api repos/$REPO/branches --paginate --jq '.[].name' | while read -r branch; do
+            # Skip protected branches
+            if [[ "$branch" == "main" || "$branch" == "dev" || "$branch" == "plotly" ]]; then
+              echo "Skipping protected branch: $branch"
+              continue
+            fi
+
+            # Get last commit date for branch
+            LAST_COMMIT=$(gh api "repos/$REPO/branches/$branch" --jq '.commit.commit.committer.date' 2>/dev/null || echo "")
+
+            if [[ -z "$LAST_COMMIT" ]]; then
+              echo "Could not get commit date for $branch, skipping"
+              continue
+            fi
+
+            # Compare dates
+            if [[ "$LAST_COMMIT" < "$CUTOFF_DATE" ]]; then
+              # Check if branch has an open PR
+              OPEN_PR=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq 'length')
+
+              if [[ "$OPEN_PR" -gt 0 ]]; then
+                echo "Skipping $branch (has open PR)"
+                continue
+              fi
+
+              echo "Deleting stale branch: $branch (last commit: $LAST_COMMIT)"
+              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" || echo "Failed to delete $branch"
+            fi
+          done
+
+          echo "Cleanup complete"


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically deletes stale branches on a monthly schedule to keep the repository clean and maintainable.

## Changes
- **New workflow file**: `.github/workflows/cleanup-stale-branches.yml`
  - Scheduled to run on the first day of each month at midnight UTC
  - Can also be triggered manually via `workflow_dispatch`
  - Deletes branches with no commits in the last 90 days

## Implementation Details
- **Protected branches**: The workflow preserves critical branches (`main`, `dev`, `plotly`) and will never delete them
- **Open PRs**: Branches with open pull requests are skipped to avoid breaking in-progress work
- **Safe deletion**: Uses GitHub CLI (`gh`) to query branch metadata and perform deletions
- **Error handling**: Gracefully handles cases where commit dates cannot be retrieved and logs all actions for transparency
- **Permissions**: Requires `contents: write` permission to delete branches

This automation helps reduce clutter from abandoned feature branches while maintaining safety through multiple safeguards.

https://claude.ai/code/session_0194ufEw8aE6sUe9pDkJzfg9