### PR TITLE
Add optional publication date validation to source file checks

### DIFF
--- a/.github/workflows/source-file-checks.yaml
+++ b/.github/workflows/source-file-checks.yaml
@@ -27,4 +27,4 @@ jobs:
         run: echo "${{ github.workspace }}/node_modules/.bin" >> $GITHUB_PATH
 
       - name: Run source file checks
-        run: uv run python scripts/source_file_checks.py
+        run: uv run python scripts/source_file_checks.py --check-publication-dates


### PR DESCRIPTION
## Summary
This PR adds an optional `--check-publication-dates` flag to the source file checks script that validates all posts have a `date_published` field. This flag is enabled in the CI workflow to enforce publication dates on all content.

## Key Changes
- Added `check_publication_date()` function to validate that `date_published` field exists and is non-empty
- Added command-line argument parsing with `--check-publication-dates` flag to `scripts/source_file_checks.py`
- Updated `check_file_data()` to accept `check_publication_dates` parameter and conditionally run the new validation
- Updated `main()` to accept and pass through the `check_publication_dates` flag
- Modified GitHub Actions workflow to run checks with `--check-publication-dates` flag
- Added comprehensive test coverage for the new validation function and flag behavior

## Implementation Details
- The publication date check is optional and only runs when the flag is explicitly passed, maintaining backward compatibility
- Empty strings and `None` values are both treated as missing dates
- Empty metadata dictionaries are skipped (handled by existing `check_required_fields()`)
- The flag uses `action="store_true"` for clean CLI interface
- Tests verify both the validation logic and the integration with the main function

https://claude.ai/code/session_011KbhPVdyGpnNRc3EVA5rqh