### PR TITLE
Allow self-contained media elements in populate- elements

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1162,6 +1162,28 @@ def _check_populate_commit_count(
     return issues
 
 
+_SELF_CONTAINED_ELEMENTS = frozenset(
+    {"svg", "img", "video", "audio", "iframe", "object", "embed", "canvas", "picture"}
+)
+
+
+def _has_content(element: Tag) -> bool:
+    """Check if an element has meaningful content.
+
+    An element is considered to have content if it has:
+    - Non-whitespace text content, OR
+    - Self-contained media/visual elements (svg, img, video, etc.)
+      that don't require text content to be meaningful
+
+    Note: Structural elements like ul, div, span without text or media
+    are still considered empty, as they need their own content.
+    """
+    if element.get_text(strip=True):
+        return True
+    # Recursively check for self-contained elements (svg, img, video, etc.)
+    return element.find(_SELF_CONTAINED_ELEMENTS) is not None
+
+
 def check_populate_elements_nonempty(soup: BeautifulSoup) -> list[str]:
     """Check for issues with elements whose IDs or classes start with
     `populate-`."""
@@ -1174,7 +1196,7 @@ def check_populate_elements_nonempty(soup: BeautifulSoup) -> list[str]:
         if (
             isinstance(element_id, str)
             and element_id.startswith("populate-")
-            and not element.get_text(strip=True)
+            and not _has_content(element)
         ):
             _append_to_list(
                 issues, f"<{element.name}> with id='{element_id}' is empty"
@@ -1183,8 +1205,8 @@ def check_populate_elements_nonempty(soup: BeautifulSoup) -> list[str]:
         element_classes = element.get("class")
         if isinstance(element_classes, list):
             for class_name in element_classes:
-                if class_name.startswith("populate-") and not element.get_text(
-                    strip=True
+                if class_name.startswith("populate-") and not _has_content(
+                    element
                 ):
                     _append_to_list(
                         issues,


### PR DESCRIPTION
## Summary
Updated the `check_populate_elements_nonempty` validation to recognize self-contained media elements (SVG, img, video, audio, iframe, object, embed, canvas, picture) as meaningful content, even when they lack text. This allows populate- elements to be valid when they contain only these visual/media elements.

## Changes
- **Added `_has_content()` helper function** that checks if an element has meaningful content by:
  - Detecting non-whitespace text content, OR
  - Finding self-contained media/visual elements that don't require text to be meaningful
  
- **Updated `check_populate_elements_nonempty()`** to use `_has_content()` instead of only checking for text content via `get_text(strip=True)`

- **Added comprehensive test coverage** including:
  - Test cases for populate- elements with SVG, img, video, audio, iframe, and picture children
  - Tests for nested structures with media elements
  - Tests for the `_has_content()` helper function with various HTML structures
  - Edge cases like whitespace-only content and deeply nested elements

## Implementation Details
The `_SELF_CONTAINED_ELEMENTS` frozenset defines elements that are inherently meaningful without requiring text content. The `_has_content()` function uses `element.find()` to recursively search for these elements, allowing them to be found at any depth within the element tree. This is particularly useful for favicon populate- elements that contain SVG children wrapped in structural span elements.

https://claude.ai/code/session_01TRdBxrUwiaPvzezx2NRXNk