### PR TITLE
feat: add alt text support for populated favicon SVG elements

### DIFF
--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -536,6 +536,27 @@ describe("PopulateContainers", () => {
           },
         })
       })
+
+      it("should generate accessible favicon element when alt text provided", async () => {
+        const altText = "A trout jumping to the left."
+        const generator = populateModule.generateSpecialFaviconContent(
+          specialFaviconPaths.turntrout,
+          altText,
+        )
+        const elements = await generator()
+        expect(elements).toHaveLength(1)
+
+        const faviconElement = elements[0].children[0] as Element
+        expect(faviconElement).toMatchObject({
+          tagName: "svg",
+          properties: {
+            role: "img",
+            "aria-label": altText,
+          },
+        })
+        // Should not have hidden properties when accessible
+        expect(faviconElement.properties["aria-hidden"]).toBeUndefined()
+      })
     })
 
     describe("populateElements", () => {

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -186,9 +186,12 @@ const checkCdnSvgs = async (pngPaths: string[]): Promise<void> => {
 }
 
 // skipcq: JS-D1001
-export const generateSpecialFaviconContent = (faviconPath: string): ContentGenerator => {
+export const generateSpecialFaviconContent = (
+  faviconPath: string,
+  altText = "",
+): ContentGenerator => {
   return async (): Promise<Element[]> => {
-    const faviconElement = createFaviconElement(faviconPath)
+    const faviconElement = createFaviconElement(faviconPath, altText)
     return [h("span", { className: "favicon-span" }, [faviconElement])]
   }
 }
@@ -331,8 +334,14 @@ const createPopulatorMap = (
     ["populate-favicon-container", generateFaviconContent()],
     ["populate-favicon-threshold", generateConstantContent(minFaviconCount)],
     ["populate-max-size-card", generateConstantContent(maxCardImageSizeKb)],
-    ["populate-turntrout-favicon", generateSpecialFaviconContent(specialFaviconPaths.turntrout)],
-    ["populate-anchor-favicon", generateSpecialFaviconContent(specialFaviconPaths.anchor)],
+    [
+      "populate-turntrout-favicon",
+      generateSpecialFaviconContent(specialFaviconPaths.turntrout, "A trout jumping to the left."),
+    ],
+    [
+      "populate-anchor-favicon",
+      generateSpecialFaviconContent(specialFaviconPaths.anchor, "A counterclockwise arrow."),
+    ],
     // Classes
     ["populate-commit-count", generateConstantContent(stats.commitCount.toLocaleString())],
     ["populate-js-test-count", generateConstantContent(stats.jsTestCount.toLocaleString())],

--- a/quartz/plugins/transformers/linkfavicons.test.ts
+++ b/quartz/plugins/transformers/linkfavicons.test.ts
@@ -561,6 +561,33 @@ describe("Favicon Utilities", () => {
       expect(element.properties["aria-hidden"]).toBe("true")
       expect(element.properties["aria-focusable"]).toBe("false")
     })
+
+    it.each([
+      [
+        "https://assets.turntrout.com/static/images/external-favicons/turntrout_com.svg",
+        "A trout jumping to the left.",
+      ],
+      [
+        "https://assets.turntrout.com/static/images/external-favicons/anchor.svg",
+        "A counterclockwise arrow.",
+      ],
+    ])(
+      "should create accessible svg element when description provided for %s",
+      (urlString, description) => {
+        const element = linkfavicons.createFaviconElement(urlString, description)
+        expect(element.type).toBe("element")
+        expect(element.tagName).toBe("svg")
+        expect(element.properties.class).toBe("favicon")
+        expect(element.properties.style).toBe(`--mask-url: url(${urlString});`)
+        expect(element.children).toEqual([])
+        // Accessible SVG properties
+        expect(element.properties.role).toBe("img")
+        expect(element.properties["aria-label"]).toBe(description)
+        // Should NOT have hidden properties
+        expect(element.properties["aria-hidden"]).toBeUndefined()
+        expect(element.properties["aria-focusable"]).toBeUndefined()
+      },
+    )
   })
 
   describe("linkfavicons.insertFavicon", () => {
@@ -1249,9 +1276,7 @@ describe("linkfavicons.downloadImage", () => {
 
     // Mock mkdir to throw an error - works in sandboxed environments
     // where file permission restrictions don't apply (e.g., running as root)
-    jest
-      .spyOn(fs.promises, "mkdir")
-      .mockRejectedValueOnce(new Error("EACCES: permission denied"))
+    jest.spyOn(fs.promises, "mkdir").mockRejectedValueOnce(new Error("EACCES: permission denied"))
 
     await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow(
       "Failed to write image",

--- a/quartz/plugins/transformers/linkfavicons.ts
+++ b/quartz/plugins/transformers/linkfavicons.ts
@@ -581,6 +581,8 @@ export interface FaviconNode extends Element {
     "data-domain"?: string
     "aria-hidden"?: "true" | "false"
     "aria-focusable"?: "true" | "false"
+    role?: "img"
+    "aria-label"?: string
   }
 }
 
@@ -598,6 +600,12 @@ export function createFaviconElement(urlString: string, description = ""): Favic
   if (urlString.endsWith(".svg")) {
     // istanbul ignore next
     const domain = urlString.match(/\/(?<domain>[^/]+)\.svg$/)?.groups?.domain || ""
+
+    // When description is provided, make SVG accessible; otherwise hide it
+    const accessibilityProps = description
+      ? ({ role: "img", "aria-label": description } as const)
+      : ({ "aria-hidden": "true", "aria-focusable": "false" } as const)
+
     return {
       type: "element",
       tagName: "svg",
@@ -606,8 +614,7 @@ export function createFaviconElement(urlString: string, description = ""): Favic
         class: "favicon",
         "data-domain": domain,
         style: `--mask-url: url(${urlString});`,
-        "aria-hidden": "true",
-        "aria-focusable": "false",
+        ...accessibilityProps,
       },
     }
   }


### PR DESCRIPTION
The generateSpecialFaviconContent function now accepts an optional altText parameter. When provided, SVG favicons use role="img" and aria-label instead of aria-hidden, making them accessible.

Alt text restored for design.md favicons:
- turntrout favicon: "A trout jumping to the left."
- anchor favicon: "A counterclockwise arrow."

https://claude.ai/code/session_01TRdBxrUwiaPvzezx2NRXNk