### PR TITLE
Fix docstring formatting in _has_content function

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1168,7 +1168,8 @@ _SELF_CONTAINED_ELEMENTS = frozenset(
 
 
 def _has_content(element: Tag) -> bool:
-    """Check if an element has meaningful content.
+    """
+    Check if an element has meaningful content.
 
     An element is considered to have content if it has:
     - Non-whitespace text content, OR


### PR DESCRIPTION
## Summary
Updated the docstring formatting in the `_has_content()` function to follow PEP 257 conventions for multi-line docstrings.

## Changes
- Moved the opening docstring text to a new line after the opening triple quotes
- This ensures the docstring follows the standard Python style guide where the summary line should be on its own line for multi-line docstrings

## Details
The docstring now properly adheres to PEP 257, which recommends that multi-line docstrings have the summary on the first line, followed by a blank line, then the rest of the documentation. This change improves code consistency and readability across the codebase.

https://claude.ai/code/session_01Apbd2e66Q9qc7pXCWu7cAG