### PR TITLE
Add `actions: read` permission to all GitHub workflows

### DIFF
--- a/.github/workflows/auto-merge-deepsource.yml
+++ b/.github/workflows/auto-merge-deepsource.yml
@@ -2,6 +2,7 @@ name: Auto-merge DeepSource Style PRs
 on: pull_request
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 

--- a/.github/workflows/built-site-checks.yaml
+++ b/.github/workflows/built-site-checks.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,9 @@ name: Dependabot Auto-merge
 on: pull_request_target
 
 permissions:
-  pull-requests: write
+  actions: read
   contents: write
+  pull-requests: write
 
 jobs:
   dependabot:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,10 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
-  pages: write
   id-token: write
+  pages: write
 
 jobs:
   prepare-deploy:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,7 @@ jobs:
     name: Run eslint scanning
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -15,9 +15,10 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       contents: read
-      pages: write
       id-token: write
+      pages: write
     outputs:
       deploy_url: ${{ steps.deploy_cf_pages.outputs.DEPLOY_URL }}
     steps:

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -9,6 +9,7 @@ on:
     branches: ["main", "jest-coverage"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/pull-request-merge.yml
+++ b/.github/workflows/pull-request-merge.yml
@@ -7,6 +7,7 @@
 name: "Combine PRs"
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/source-file-checks.yaml
+++ b/.github/workflows/source-file-checks.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "dev"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -9,6 +9,7 @@ on:
     branches: ["main", "jest-coverage"]
 
 permissions:
+  actions: read
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
This PR adds the `actions: read` permission to all GitHub Actions workflows across the repository. This change improves security by following the principle of least privilege and ensures workflows have explicit permissions for the actions they perform.

## Changes Made
- Added `actions: read` permission to 16 workflow files
- Alphabetically sorted permissions in workflows where they were reordered:
  - `deploy.yaml`: Reordered to `actions: read`, `contents: read`, `id-token: write`, `pages: write`
  - `dependabot-auto-merge.yml`: Reordered to `actions: read`, `contents: write`, `pull-requests: write`
  - `lighthouse-layout-shift.yaml`: Reordered to `actions: read`, `contents: read`, `id-token: write`, `pages: write`

## Affected Workflows
- auto-merge-deepsource.yml
- built-site-checks.yaml
- dependabot-auto-merge.yml
- deploy.yaml
- eslint.yml
- lighthouse-layout-shift.yaml
- linkchecker.yaml
- node.js.yml
- playwright-tests.yaml
- pull-request-merge.yml
- python-lint.yaml
- python-tests.yaml
- source-file-checks.yaml
- spellcheck.yaml
- stylelint.yaml
- vale.yaml
- visual-testing.yaml

## Implementation Details
The `actions: read` permission allows workflows to read information about GitHub Actions, which is necessary for workflows that need to access action metadata or status information. This change maintains consistency across all workflows and aligns with GitHub's security best practices for explicit permission declarations.

https://claude.ai/code/session_01Abwr2g8BWNdVKAJhr6fCTf