### PR TITLE
Remove dev branch from pull request workflow triggers

### DIFF
--- a/.github/workflows/built-site-checks.yaml
+++ b/.github/workflows/built-site-checks.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["main", "dev"]
   schedule:
     - cron: "16 12 * * 4"
 

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches: ["main", "dev", "no-layout-shift"]
   pull_request:
-    branches: ["main", "dev", "no-layout-shift"]
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/source-file-checks.yaml
+++ b/.github/workflows/source-file-checks.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
This PR removes the `dev` branch from pull request triggers across all GitHub Actions workflows, simplifying the CI/CD pipeline to only run on pull requests regardless of target branch.

## Changes
- Removed `branches: ["main", "dev"]` (or similar) from `pull_request` triggers in 11 workflow files
- Affected workflows:
  - built-site-checks.yaml
  - eslint.yml
  - lighthouse-layout-shift.yaml
  - linkchecker.yaml
  - node.js.yml
  - python-lint.yaml
  - python-tests.yaml
  - source-file-checks.yaml
  - spellcheck.yaml
  - stylelint.yaml
  - vale.yaml

## Implementation Details
By removing the explicit `branches` filter from `pull_request` triggers, these workflows will now run on all pull requests regardless of which branch they target. This is the default GitHub Actions behavior and simplifies configuration maintenance.

The `push` triggers remain unchanged, continuing to run only on the `main` branch (and `dev`/`no-layout-shift` for lighthouse-layout-shift.yaml).

https://claude.ai/code/session_012ypHx4DMND4xL8Rd5j7oMs