### PR TITLE
Fix bibtex cache population in worker thread environments

### DIFF
--- a/.claude/skills/pr-creation.md
+++ b/.claude/skills/pr-creation.md
@@ -74,12 +74,16 @@ Review the critique and fix legitimate issues:
 Ensure quality checks pass before creating the PR.
 
 **TypeScript changes:**
+
 ```bash
 pnpm check        # Type checking
 pnpm test         # Tests with 100% coverage
 ```
 
+**Note**: Do NOT run `pnpm build` for validation - it takes 5+ minutes. Use `pnpm check` and `pnpm test` instead. The full build runs in CI after the PR is created.
+
 **Python changes:**
+
 ```bash
 conda activate website
 mypy <changed_files>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,12 @@ Personal blog/website (turntrout.com) built on Quartz, a static site generator. 
 
 ```bash
 pnpm dev          # Development server with hot reload
-pnpm build        # Production build
+pnpm build        # Production build (SLOW: ~5+ minutes, avoid unless necessary)
 pnpm start        # Build and serve locally on port 8080
 pnpm preview      # Build and serve
 ```
+
+**Note**: `pnpm build` is slow. For validation, prefer running `pnpm test` and `pnpm check` instead.
 
 ### Testing
 

--- a/quartz/plugins/vfile.ts
+++ b/quartz/plugins/vfile.ts
@@ -52,6 +52,8 @@ export interface Data {
   blocks?: BlockData
   dates?: { created?: Date; modified?: Date; published?: Date }
   children?: string[]
+  /** BibTeX citation content, stored during transform for cross-thread access */
+  bibtexContent?: string
   [key: string]: unknown
 }
 

--- a/quartz/processors/emit.ts
+++ b/quartz/processors/emit.ts
@@ -3,6 +3,7 @@ import type { BuildCtx } from "../util/ctx"
 
 import { injectCriticalCSSIntoHTMLFiles } from "../cli/handlers"
 import { getStaticResourcesFromPlugins } from "../plugins"
+import { rebuildBibtexCacheFromContent } from "../plugins/transformers/bibtex"
 import { createWinstonLogger } from "../util/log"
 import { PerfTimer } from "../util/perf"
 import { trace } from "../util/trace"
@@ -11,6 +12,9 @@ export async function emitContent(ctx: BuildCtx, content: ProcessedContent[]) {
   const { argv, cfg } = ctx
   const perf = new PerfTimer()
   const log = createWinstonLogger("emit")
+
+  // Rebuild bibtex cache from content that may have been parsed in worker threads
+  rebuildBibtexCacheFromContent(content)
 
   log.info("Emitting output files")
 


### PR DESCRIPTION
## Summary
Fixes an issue where the bibtex cache was not properly populated when content parsing happens in worker threads. The cache was being populated in worker processes but not accessible in the main thread during the emit phase.

## Changes
- **New function `rebuildBibtexCacheFromContent()`**: Rebuilds the bibtex cache from processed content before emitting, ensuring the cache is available in the main thread
- **Store bibtexContent in file.data**: Added `bibtexContent` field to the VFile data interface so citation content survives worker thread serialization
- **Call cache rebuild in emit phase**: Invokes `rebuildBibtexCacheFromContent()` at the start of `emitContent()` to repopulate the cache from the serialized data
- **Added test coverage**: Tests for the new `rebuildBibtexCacheFromContent()` function and `parseAuthors()` edge cases
- **Documentation updates**: Clarified in CLAUDE.md and pr-creation.md that `pnpm build` is slow (~5+ minutes) and should be avoided for validation in favor of `pnpm check` and `pnpm test`

## Implementation Details
The bibtex cache is a module-level Map that gets populated during the transform phase. When transforms run in worker threads, the cache is populated in those worker processes but the main thread's cache remains empty. By storing the bibtexContent in `file.data` during transformation, it gets serialized and can be reconstructed in the main thread before the emit phase needs it.

https://claude.ai/code/session_011KktpLUCpyQkFLqPu9hyJP