### PR TITLE
Manage Python tools via uv instead of pip

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -58,8 +58,7 @@ fi
 #######################################
 
 echo "Installing tools..."
-pip_install_if_missing docformatter
-pip_install_if_missing pyupgrade
+# docformatter and pyupgrade are managed by uv.lock, not pip
 pip_install_if_missing ots opentimestamps-client
 webi_install_if_missing shfmt
 webi_install_if_missing gh

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -13,9 +13,9 @@ fi
 STAGED_PY_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' | while read -r f; do echo "$GIT_ROOT/$f"; done)
 
 if [ -n "$STAGED_PY_FILES" ]; then
-  # Format only staged Python files
-  echo "$STAGED_PY_FILES" | xargs -r docformatter --in-place --config "$GIT_ROOT"/config/python/pyproject.toml 2>/dev/null || true
-  echo "$STAGED_PY_FILES" | xargs -r pyupgrade 2>/dev/null || true
+  # Format only staged Python files (use uv run for Python tools managed by uv.lock)
+  echo "$STAGED_PY_FILES" | xargs -r uv run docformatter --in-place --config "$GIT_ROOT"/config/python/pyproject.toml 2>/dev/null || true
+  echo "$STAGED_PY_FILES" | xargs -r uv run pyupgrade 2>/dev/null || true
 
   # Re-stage formatted files
   echo "$STAGED_PY_FILES" | xargs -r git add


### PR DESCRIPTION
## Summary
Migrate Python tool management from pip to uv by updating the session setup and pre-commit hook scripts. This ensures `docformatter` and `pyupgrade` are invoked through `uv run`, leveraging the dependencies defined in `uv.lock`.

## Changes
- **Session setup**: Removed direct pip installation of `docformatter` and `pyupgrade` with a comment indicating they're now managed by `uv.lock`
- **Pre-commit hook**: Updated tool invocations to use `uv run docformatter` and `uv run pyupgrade` instead of calling them directly
- **Documentation**: Added clarifying comment in pre-commit hook explaining that Python tools are managed via `uv.lock`

## Details
This change consolidates Python dependency management under uv, which provides better reproducibility and consistency across environments. The tools are now executed through `uv run`, which ensures they use the exact versions specified in `uv.lock` rather than relying on system-wide pip installations.

https://claude.ai/code/session_01WcnXfyRoA2PasGBy7bDGiC