### PR TITLE
refactor: import flattenTextNodes from punctilio/rehype

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,9 @@ The build follows a three-stage pipeline: **Transform → Filter → Emit**
 
 ### Text Processing
 
-- Smart quotes conversion (custom regex, 45 unit tests)
+- Typography transformations use `punctilio` library (quotes, dashes, symbols)
+- `flattenTextNodes` imported from `punctilio/rehype` for HTML AST traversal
 - Automatic smallcaps for 3+ consecutive capitals (excluding Roman numerals)
-- Hyphen → en-dash/em-dash conversion
 - Dropcaps using EB Garamond with CSS pseudo-elements
 
 ### Site Features

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -2,6 +2,7 @@ import type { Element, Text, Root, Parent, ElementContent } from "hast"
 
 import { h } from "hastscript"
 import { niceQuotes, hyphenReplace, symbolTransform } from "punctilio"
+import { flattenTextNodes } from "punctilio/rehype"
 import { type Transformer } from "unified"
 // skipcq: JS-0257
 import { visitParents } from "unist-util-visit-parents"
@@ -38,32 +39,6 @@ export const FRACTION_SKIP_TAGS = ["code", "pre", "a", "script", "style"] as con
  * CSS classes that indicate content should skip formatting.
  */
 export const SKIP_CLASSES = ["no-formatting", "elvish", "bad-handwriting"] as const
-
-/**
- * Flattens text nodes in an element tree into a single array
- * @param node - The element or element content to process
- * @param ignoreNode - Function to determine which nodes to skip
- * @returns Array of Text nodes
- */
-export function flattenTextNodes(
-  node: Element | ElementContent,
-  ignoreNode: (n: Element) => boolean,
-): Text[] {
-  if (ignoreNode(node as Element)) {
-    return []
-  }
-
-  if (node.type === "text") {
-    return [node as Text]
-  }
-
-  if (node.type === "element" && "children" in node) {
-    return node.children.flatMap((child) => flattenTextNodes(child, ignoreNode))
-  }
-
-  // For other node types (like comments), return an empty array
-  return []
-}
 
 /**
  * Extracts concatenated text content from an element

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -7,10 +7,11 @@ import { rehype } from "rehype"
 import { VFile } from "vfile"
 
 import { charsToMoveIntoLinkFromRight } from "../../../components/constants"
+import { flattenTextNodes } from "punctilio/rehype"
+
 import {
   massTransformText,
   getTextContent,
-  flattenTextNodes,
   improveFormatting,
   spacesAroundSlashes,
   transformElement,
@@ -1045,50 +1046,17 @@ describe("assertSmartQuotesMatch", () => {
   })
 })
 
-describe("flattenTextNodes and getTextContent", () => {
-  const ignoreNone = () => false
-  const ignoreCode = (n: Element) => n.tagName === "code"
-
+describe("getTextContent", () => {
   const testNodes = {
     empty: h("", []),
     simple: h("p", "Hello, world!"),
     nested: h("div", ["This is ", h("em", "emphasized"), " text."]),
-    withCode: h("div", ["This is ", h("code", "ignored"), " text."]),
-    emptyAndComment: h("div", [h("span"), { type: "comment", value: "This is a comment" }]),
-    deeplyNested: h("div", ["Level 1 ", h("span", ["Level 2 ", h("em", "Level 3")]), " End"]),
   }
 
-  describe("flattenTextNodes", () => {
-    it("should handle various node structures", () => {
-      expect(flattenTextNodes(testNodes.empty, ignoreNone)).toEqual([])
-      expect(flattenTextNodes(testNodes.simple, ignoreNone)).toEqual([
-        { type: "text", value: "Hello, world!" },
-      ])
-      expect(flattenTextNodes(testNodes.nested, ignoreNone)).toEqual([
-        { type: "text", value: "This is " },
-        { type: "text", value: "emphasized" },
-        { type: "text", value: " text." },
-      ])
-      expect(flattenTextNodes(testNodes.withCode, ignoreCode)).toEqual([
-        { type: "text", value: "This is " },
-        { type: "text", value: " text." },
-      ])
-      expect(flattenTextNodes(testNodes.emptyAndComment, ignoreNone)).toEqual([])
-      expect(flattenTextNodes(testNodes.deeplyNested, ignoreNone)).toEqual([
-        { type: "text", value: "Level 1 " },
-        { type: "text", value: "Level 2 " },
-        { type: "text", value: "Level 3" },
-        { type: "text", value: " End" },
-      ])
-    })
-  })
-
-  describe("getTextContent", () => {
-    it("should handle various node structures", () => {
-      expect(getTextContent(testNodes.empty)).toBe("")
-      expect(getTextContent(testNodes.simple)).toBe("Hello, world!")
-      expect(getTextContent(testNodes.nested)).toBe("This is emphasized text.")
-    })
+  it("should handle various node structures", () => {
+    expect(getTextContent(testNodes.empty)).toBe("")
+    expect(getTextContent(testNodes.simple)).toBe("Hello, world!")
+    expect(getTextContent(testNodes.nested)).toBe("This is emphasized text.")
   })
 })
 


### PR DESCRIPTION
## Summary
- Import `flattenTextNodes` from `punctilio/rehype` instead of local implementation
- Remove duplicate flattenTextNodes tests (now tested in punctilio)
- Update CLAUDE.md to document punctilio dependency

## Test plan
- [ ] CI passes
- [ ] Verify formatting transformations still work correctly on the site

https://claude.ai/code/session_01SGaGy9UWcj7BNsbYmZ19Ty