### PR TITLE
Add Playwright configs constant and dynamic test calculation

### DIFF
--- a/config/constants.json
+++ b/config/constants.json
@@ -96,6 +96,7 @@
   "scrollTolerance": 30,
   "listTolerance": 5,
   "maxCardImageSizeKb": 300,
+  "playwrightConfigs": 9,
   "specialDomainMappings": [
     {
       "pattern": "^.*transformer-circuits\\.pub",

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -40,6 +40,7 @@ export const {
   tightScrollTolerance,
   scrollTolerance,
   listTolerance,
+  playwrightConfigs,
   specialDomainMappings: specialDomainMappingsConfig,
 } = simpleConstants
 

--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -74,7 +74,7 @@ describe("PopulateContainers", () => {
         return '<html><body><div id="populate-favicon-container"></div></body></html>'
       }
       if (pathStr.includes("design.html")) {
-        return '<html><body><div id="populate-favicon-threshold"></div><div id="populate-max-size-card"></div><span class="populate-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span></body></html>'
+        return '<html><body><div id="populate-favicon-threshold"></div><div id="populate-max-size-card"></div><span class="populate-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-playwright-configs"></span><span class="populate-playwright-total-tests"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span></body></html>'
       }
       // Default for other files
       return '<html><body><div id="populate-favicon-container"></div><div id="populate-favicon-threshold"></div><span class="populate-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span><span class="populate-turntrout-favicon"></span></body></html>'

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -26,7 +26,7 @@ import {
 import { hasClass } from "../transformers/utils"
 import { type QuartzEmitterPlugin } from "../types"
 
-const { minFaviconCount, defaultPath, maxCardImageSizeKb } = simpleConstants
+const { minFaviconCount, defaultPath, maxCardImageSizeKb, playwrightConfigs } = simpleConstants
 
 const logger = createWinstonLogger("populateContainers")
 
@@ -380,6 +380,11 @@ const createPopulatorMap = (
     [
       "populate-playwright-test-count",
       generateConstantContent(stats.playwrightTestCount.toLocaleString()),
+    ],
+    ["populate-playwright-configs", generateConstantContent(playwrightConfigs.toLocaleString())],
+    [
+      "populate-playwright-total-tests",
+      generateConstantContent((stats.playwrightTestCount * playwrightConfigs).toLocaleString()),
     ],
     ["populate-pytest-count", generateConstantContent(stats.pytestCount.toLocaleString())],
     ["populate-lines-of-code", generateConstantContent(stats.linesOfCode.toLocaleString())],

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1137,7 +1137,7 @@ ots --no-bitcoin verify "files/ABC012.txt.ots"
 When I `push` commits to [the `main` branch on GitHub](https://github.com/alexander-turner/TurnTrout.com), an Action generates the webpages. Before these pages are sent off to Cloudflare, they must pass yet another gauntlet of tests:
 
 Site functionality
-: I have [hundreds of Playwright tests to ensure stable, reliable site operation.](#simulating-site-interactions) I run these tests across three different viewport sizes (desktop, tablet, and mobile) and three browsers (Chrome, Firefox, and Safari) - 9 combinations in total. Therefore, I need to run 9 x 175 = 1,602 tests, each of which takes up to 90 seconds.
+: I have [hundreds of Playwright tests to ensure stable, reliable site operation.](#simulating-site-interactions) I run these tests across three different viewport sizes (desktop, tablet, and mobile) and three browsers (Chrome, Firefox, and Safari) — <span class="populate-playwright-configs"></span> combinations in total. Therefore, I need to run <span class="populate-playwright-configs"></span> × <span class="populate-playwright-test-count"></span> = <span class="populate-playwright-total-tests"></span> tests, each of which takes up to 90 seconds.
 
 : Sadly, Playwright test isolation isn't good, so parallel testing creates flaky, unreliable results. I need to know _for sure_ whether my site works. Therefore, I don't use parallelism. Instead, I run a GitHub Action with about 40 "shards" (i.e. different machines), with each machine running ≈ 1/40th of the tests. The Action completes in about 10 minutes.
 


### PR DESCRIPTION
## Summary
This PR introduces a new `playwrightConfigs` constant to track the number of Playwright test configurations and uses it to dynamically calculate and display the total number of tests across all configurations.

## Changes
- **Config**: Added `playwrightConfigs: 9` constant to `config/constants.json` to represent the number of browser/viewport combinations (3 browsers × 3 viewport sizes)
- **Constants export**: Exported the new `playwrightConfigs` constant from `quartz/components/constants.ts`
- **Populator logic**: Updated `populateContainers.ts` to:
  - Import the `playwrightConfigs` constant
  - Add two new population targets: `populate-playwright-configs` and `populate-playwright-total-tests`
  - Calculate total tests dynamically as `playwrightTestCount × playwrightConfigs`
- **Test fixtures**: Updated test HTML fixtures to include the new population targets
- **Documentation**: Updated `design.md` to use dynamic population spans instead of hardcoded values, making the test count information maintainable and automatically updated when constants change

## Implementation Details
The total test count is now calculated as a product of the number of individual Playwright tests and the number of configurations they run against, replacing the previously hardcoded value of 1,602 tests. This makes the documentation self-updating when either the test count or configuration count changes.

https://claude.ai/code/session_01MAKceoSrPLPVYBzUikY726