### PR TITLE
Fix BibTeX entry formatting to use proper field syntax

### DIFF
--- a/quartz/plugins/transformers/bibtex.ts
+++ b/quartz/plugins/transformers/bibtex.ts
@@ -72,10 +72,10 @@ export function generateBibtexEntry(
   const authorString = authors.join(" and ")
 
   return `@misc{${citationKey},
-  author = {${authorString}},
-  title = {${title}},
-  year = {${year}},
-  url = {${url}},
+  author = "${authorString}",
+  title = "${title}",
+  year = ${year},
+  url = "${url}"
 }`
 }
 

--- a/quartz/plugins/transformers/tests/bibtex.test.ts
+++ b/quartz/plugins/transformers/tests/bibtex.test.ts
@@ -39,12 +39,12 @@ describe("generateBibtexEntry", () => {
         authors: ["Alex Turner"],
         date_published: "2022-06-15",
       },
-      expectations: ["@misc{", "Alex Turner", "title = {Test", "year = {2022}"],
+      expectations: ["@misc{", "Alex Turner", 'title = "Test', "year = 2022"],
     },
     {
       name: "with permalink",
       frontmatter: { title: "Test", permalink: "custom-url", date_published: "2022-06-15" },
-      expectations: ["url = {https://turntrout.com/custom-url}"],
+      expectations: ['url = "https://turntrout.com/custom-url"'],
     },
     {
       name: "default author when undefined",
@@ -100,12 +100,17 @@ describe("generateBibtexEntry", () => {
       "turntrout.com",
       "test",
     )
-    expect(result).toContain("author = {Alex Turner and John Doe}")
+    expect(result).toContain('author = "Alex Turner and John Doe"')
   })
 
   it("uses permalink for citation key when available", () => {
     const result = generateBibtexEntry(
-      { title: "Test", permalink: "design", authors: ["Alex Turner"], date_published: "2022-06-15" },
+      {
+        title: "Test",
+        permalink: "design",
+        authors: ["Alex Turner"],
+        date_published: "2022-06-15",
+      },
       "turntrout.com",
       "the-design-of-this-website",
     )
@@ -142,7 +147,7 @@ describe("generateBibtexEntry", () => {
         "turntrout.com",
         "test-slug",
       )
-      expect(result).toContain(`year = {${new Date().getFullYear()}}`)
+      expect(result).toContain(`year = ${new Date().getFullYear()}`)
     } finally {
       process.env.CI = originalCI
     }


### PR DESCRIPTION
## Summary
Updated the BibTeX entry generation to use proper BibTeX field syntax with quoted string values instead of braced values, and numeric values without braces.

## Changes
- **Field value formatting**: Changed all string fields (`author`, `title`, `url`) to use double quotes instead of braces (e.g., `author = "value"` instead of `author = {value}`)
- **Numeric fields**: Changed `year` field to output as a bare number without braces (e.g., `year = 2022` instead of `year = {2022}`)
- **Test updates**: Updated all test expectations to match the new BibTeX formatting conventions
- **Code formatting**: Minor formatting improvement in one test case for better readability

## Implementation Details
This change aligns the generated BibTeX entries with standard BibTeX conventions where:
- String values are enclosed in double quotes
- Numeric values (like year) are unquoted
- This format is more compatible with BibTeX parsers and follows the official BibTeX specification more closely

https://claude.ai/code/session_0143TedhPSRV54vF4FAgAKGN