### PR TITLE
Disable Lighthouse layout shift checks on pull requests

### DIFF
--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -15,19 +15,9 @@ on:
       - "pnpm-lock.yaml"
       - ".github/actions/**"
       - ".github/lighthouse-*.json"
-  pull_request:
-    paths:
-      - "quartz/**"
-      - "website_content/**"
-      - "config/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
-      - ".github/lighthouse-*.json"
 
 jobs:
   build_and_deploy:
-    if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
     runs-on: ubuntu-24.04
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
This change disables the Lighthouse layout shift workflow from running on pull requests while keeping it enabled for push events to the main branch.

## Key Changes
- Removed the `pull_request` trigger configuration from the Lighthouse layout shift workflow
- Removed the conditional check that skipped runs for deepsource branches
- The workflow now only runs on push events to the main branch

## Rationale
By removing the pull request trigger, the Lighthouse layout shift checks will no longer run on every PR, reducing CI overhead and noise. The checks will still run on commits to the main branch to catch any layout shift regressions before they reach production.

https://claude.ai/code/session_01VGpPAHT5Chrx2NbnJNpVpa