### PR TITLE
Replace GitHub issue creation with email delivery for newsletters

### DIFF
--- a/.github/workflows/monthly-newsletter.yml
+++ b/.github/workflows/monthly-newsletter.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   generate-newsletter:
@@ -103,6 +102,11 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set"
+            exit 1
+          fi
+
           # Read gathered data
           COMMITS=$(cat /tmp/commits.txt | head -200)
           FEATURES=$(cat /tmp/features.txt 2>/dev/null || echo "None found")
@@ -149,7 +153,7 @@ jobs:
           ESCAPED_PROMPT=$(cat /tmp/full-prompt.md | jq -Rs .)
 
           # Call Claude API
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+          RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \
             -H "Content-Type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
@@ -163,25 +167,42 @@ jobs:
             }")
 
           # Extract the text content
-          NEWSLETTER=$(echo "$RESPONSE" | jq -r '.content[0].text // "Error generating newsletter"')
+          NEWSLETTER=$(echo "$RESPONSE" | jq -r '.content[0].text')
+          if [ -z "$NEWSLETTER" ] || [ "$NEWSLETTER" = "null" ]; then
+            echo "::error::Claude API returned no content. Response: $RESPONSE"
+            exit 1
+          fi
 
           # Save to file
           echo "$NEWSLETTER" > /tmp/newsletter-draft.md
 
           echo "Newsletter draft generated"
 
-      - name: Create GitHub Issue with draft
+      - name: Send newsletter draft via email
         env:
-          GH_TOKEN: ${{ github.token }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "::error::RESEND_API_KEY secret is not set"
+            exit 1
+          fi
+
           DRAFT=$(cat /tmp/newsletter-draft.md)
-          gh issue create \
-            --title "Newsletter Draft: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}" \
-            --body "**Commits:** ${{ steps.commits.outputs.commit_count }}
 
-          ---
+          # Build JSON payload with jq for proper escaping
+          jq -n \
+            --arg from "Newsletter Bot <newsletter@turntrout.com>" \
+            --arg to "alex@turntrout.com" \
+            --arg subject "Newsletter Draft: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}" \
+            --arg text "$DRAFT" \
+            '{from: $from, to: [$to], subject: $subject, text: $text}' > /tmp/email.json
 
-          $DRAFT"
+          RESPONSE=$(curl -sf -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/email.json)
+
+          echo "Email sent: $RESPONSE"
 
       - name: Update last run date
         run: |


### PR DESCRIPTION
## Summary
This PR refactors the monthly newsletter workflow to send draft newsletters via email instead of creating GitHub issues. It also adds improved error handling and validation for API calls.

## Key Changes
- **Removed GitHub issue creation**: Replaced the `gh issue create` step with email delivery via Resend API
- **Removed unnecessary permission**: Removed `issues: write` from workflow permissions since we no longer create issues
- **Enhanced error handling**:
  - Added validation checks for `ANTHROPIC_API_KEY` and `RESEND_API_KEY` secrets before use
  - Added validation of Claude API response to ensure content was actually returned
  - Changed curl flags from `-s` to `-sf` to fail on HTTP errors
  - Added explicit null/empty checks for API responses
- **Improved API robustness**: Used `jq` to properly escape JSON payload for email delivery, preventing potential issues with special characters in newsletter content

## Implementation Details
- Email is sent to `alex@turntrout.com` from `newsletter@turntrout.com` using the Resend email service
- The newsletter draft is passed as plain text in the email body
- All API calls now fail fast on errors with descriptive error messages
- Temporary files (`/tmp/email.json`) are used to safely pass JSON payloads to curl

https://claude.ai/code/session_01LN2v2v1oEQXRdUDvyiJoX7