### PR TITLE
fix: repair YAML syntax error in comment-on-failed-checks workflow

### DIFF
--- a/.github/workflows/comment-on-failed-checks.yaml
+++ b/.github/workflows/comment-on-failed-checks.yaml
@@ -97,13 +97,15 @@ jobs:
                 return `- **${name}** [failed](${latest.url}) on commit ${latest.sha} (attempt ${runs.length}/${maxAttempts})`;
               }).join('\n');
 
-              const body = `${trackerMarker}
-<!-- failures:${JSON.stringify(failures)} -->
-@claude The following workflows have failed:
-
-${failureLines}
-
-Please investigate and fix the issues.`;
+              const body = [
+                trackerMarker,
+                `<!-- failures:${JSON.stringify(failures)} -->`,
+                '@claude The following workflows have failed:',
+                '',
+                failureLines,
+                '',
+                'Please investigate and fix the issues.'
+              ].join('\n');
 
               if (trackerComment) {
                 await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary
- Fix YAML parsing error that caused the "Comment on Failed Checks" workflow to fail on every run ([failed run](https://github.com/alexander-turner/TurnTrout.com/actions/runs/21766148345))
- The multi-line JavaScript template literal had lines at zero indentation, which terminated the YAML block scalar prematurely

## Changes
- Replace multi-line template literal with `[].join('\n')` array pattern in `.github/workflows/comment-on-failed-checks.yaml` (lines 100-108)
- This matches the pattern already used in the upstream template repo (`alexander-turner/claude-automation-template`)

## Testing
- Validated YAML syntax with Python's `yaml.safe_load()` — parses successfully
- No template repo PR needed — the upstream already has the correct version

https://claude.ai/code/session_01PHEJSxnkFusrmGkyVYQWP1