### PR TITLE
Enable CI/CD workflows to run on dev branch

### DIFF
--- a/.github/workflows/built-site-checks.yaml
+++ b/.github/workflows/built-site-checks.yaml
@@ -2,7 +2,7 @@ name: Built site checks
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "quartz/**"
       - "website_content/**"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,7 +11,7 @@ name: JavaScript linting
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "quartz/**"
       - "config/javascript/**"

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -2,7 +2,7 @@ name: Link checker
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "quartz/**"
       - "website_content/**"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "quartz/**"
       - "config/**"

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main", "jest-coverage"]
+    branches: ["main", "dev", "jest-coverage"]
     paths:
       - "quartz/**"
       - "website_content/**"

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -2,7 +2,7 @@ name: Python linting
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "scripts/**"
       - "config/python/**"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -2,7 +2,7 @@ name: Python tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "scripts/**"
       - "config/python/**"

--- a/.github/workflows/source-file-checks.yaml
+++ b/.github/workflows/source-file-checks.yaml
@@ -2,7 +2,7 @@ name: Source file checks
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "website_content/**"
       - "quartz/**"

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -2,7 +2,7 @@ name: Spellcheck
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "website_content/**"
       - "config/spellcheck/**"

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -2,7 +2,7 @@ name: Stylelint SCSS
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "quartz/**/*.scss"
       - "config/stylelint/**"

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -2,7 +2,7 @@ name: Vale prose linting
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "website_content/**"
       - "config/vale/**"

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main", "jest-coverage"]
+    branches: ["main", "dev", "jest-coverage"]
     paths:
       - "quartz/**"
       - "website_content/**"


### PR DESCRIPTION
## Summary
This PR extends all GitHub Actions workflows to run on the `dev` branch in addition to the `main` branch, enabling continuous integration and deployment checks for development work.

## Changes
- Updated 13 GitHub Actions workflow files to include `"dev"` in their branch triggers
- Affected workflows:
  - Built site checks
  - ESLint (JavaScript linting)
  - Link checker
  - Node.js tests
  - Playwright tests
  - Python linting
  - Python tests
  - Source file checks
  - Spellcheck
  - Stylelint (SCSS linting)
  - Vale (prose linting)
  - Visual testing

## Implementation Details
- All workflows now trigger on pushes to both `main` and `dev` branches
- Existing branch filters (e.g., `jest-coverage` in playwright-tests and visual-testing) are preserved
- Path-based filtering remains unchanged, ensuring workflows only run when relevant files are modified
- This enables developers to validate changes on the `dev` branch before merging to `main`

https://claude.ai/code/session_012QiwxHoHnpFNStC5UePm1n