### PR TITLE
ci: add concurrency groups to cancel stale CI runs

### DIFF
--- a/.github/workflows/built-site-checks.yaml
+++ b/.github/workflows/built-site-checks.yaml
@@ -1,5 +1,9 @@
 name: Built site checks
 
+concurrency:
+  group: built-site-checks-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,6 +9,10 @@
 
 name: JavaScript linting
 
+concurrency:
+  group: eslint-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -1,5 +1,9 @@
 name: Link checker
 
+concurrency:
+  group: linkchecker-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,10 @@
 
 name: Node tests
 
+concurrency:
+  group: node-tests-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -1,5 +1,9 @@
 name: Python linting
 
+concurrency:
+  group: python-lint-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,5 +1,9 @@
 name: Python tests
 
+concurrency:
+  group: python-tests-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/source-file-checks.yaml
+++ b/.github/workflows/source-file-checks.yaml
@@ -1,5 +1,9 @@
 name: Source file checks
 
+concurrency:
+  group: source-file-checks-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,5 +1,9 @@
 name: Spellcheck
 
+concurrency:
+  group: spellcheck-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -1,5 +1,9 @@
 name: Stylelint SCSS
 
+concurrency:
+  group: stylelint-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -1,5 +1,9 @@
 name: Vale prose linting
 
+concurrency:
+  group: vale-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main", "dev"]


### PR DESCRIPTION
## Summary
- Adds concurrency groups to the 10 CI workflows that were missing them, so only the newest run per branch proceeds and stale in-progress runs are cancelled
- Matches the pattern already used by playwright-tests, visual-testing, and deploy workflows

## Changes
- Added `concurrency: { group: <workflow>-${{ github.event_name }}-${{ github.ref_name }}, cancel-in-progress: true }` to:
  - built-site-checks, eslint, linkchecker, node.js tests, python-lint, python-tests, source-file-checks, spellcheck, stylelint, vale

## Testing
- CI-only config change; no application code affected
- Pattern matches existing concurrency groups in playwright-tests.yaml and visual-testing.yaml

https://claude.ai/code/session_012QiwxHoHnpFNStC5UePm1n