### PR TITLE
Simplify Node dependencies installation in session setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -122,16 +122,8 @@ fi
 # Project dependencies
 #######################################
 
-if [ ! -d "$PROJECT_DIR/node_modules" ]; then
-  echo "Installing Node dependencies..."
-  pnpm install --silent || die "Failed to install Node dependencies"
-fi
-
-# Ensure markdownlint-cli is installed (required for pre-commit hooks)
-if [ ! -x "$PROJECT_DIR/node_modules/.bin/markdownlint" ]; then
-  echo "Installing markdownlint-cli..."
-  pnpm install --silent || die "Failed to install markdownlint-cli"
-fi
+echo "Installing Node dependencies..."
+pnpm install --silent || die "Failed to install Node dependencies"
 
 command -v uv &>/dev/null && uv sync --quiet 2>/dev/null
 


### PR DESCRIPTION
## Summary
Simplified the Node dependencies installation logic in the session setup hook by removing conditional checks and redundant installation attempts.

## Changes
- Removed the conditional check for `node_modules` directory existence before running `pnpm install`
- Removed the separate conditional check and installation step for `markdownlint-cli`
- Consolidated to a single `pnpm install` command that handles all dependencies in one pass

## Rationale
This change streamlines the setup process by:
- Eliminating unnecessary directory/file existence checks
- Relying on `pnpm install` to intelligently handle dependency installation (it will skip already-installed packages)
- Reducing code complexity and maintenance burden
- Ensuring all dependencies, including markdownlint-cli, are installed in a single operation

The behavior remains functionally equivalent while being more maintainable and efficient.

https://claude.ai/code/session_017KKt6oKNDE9wucbrHQMDJv