### PR TITLE
Replace link clicks with direct SPA navigation in tests

### DIFF
--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -538,9 +538,8 @@ test.describe("SPA Navigation DOM Cleanup", () => {
     await expect(page.locator(`#${pondVideoId}`)).toBeVisible()
     await expect(page.locator("#rogue-sibling")).toBeVisible()
 
-    // Click is ok because it doesn't scroll to it first
-    const localLink = page.locator("a").first()
-    await localLink.click()
+    await page.evaluate(() => window.spaNavigate(new URL("/design", window.location.origin)))
+    await page.waitForURL("**/design")
 
     await expect(page.locator("#rogue-sibling")).toBeHidden()
     await expect(page.locator(`#${pondVideoId}`)).toBeVisible()

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -3,6 +3,11 @@ import { test, expect, type Page } from "@playwright/test"
 // Helper to get collapsible admonitions
 const getCollapsibles = (page: Page) => page.locator(".admonition.is-collapsible")
 
+async function spaNavigateToAbout(page: Page): Promise<void> {
+  await page.evaluate(() => window.spaNavigate(new URL("/about", window.location.origin)))
+  await page.waitForURL("**/about")
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
 })
@@ -81,9 +86,8 @@ test.describe("Collapsible admonition state persistence", () => {
     await first.locator(".admonition-title").click()
     const toggledState = !initiallyCollapsed
 
-    // Navigate away using SPA navigation (click an internal link)
-    await page.locator('a[href$="/about"]').first().click()
-    await page.waitForURL("**/about")
+    // Navigate away using SPA navigation
+    await spaNavigateToAbout(page)
 
     // Navigate back
     await page.goBack()
@@ -119,8 +123,7 @@ test.describe("Collapsible admonition state persistence", () => {
     )
 
     // Navigate away and back
-    await page.locator('a[href$="/about"]').first().click()
-    await page.waitForURL("**/about")
+    await spaNavigateToAbout(page)
     await page.goBack()
     await page.waitForURL("**/test-page")
 

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -447,11 +447,8 @@ test("Video autoplay works correctly after SPA navigation", async ({ page }) => 
     return videoElement && !videoElement.paused && videoElement.readyState >= 3
   }, pondVideoId)
 
-  const initialUrl = page.url()
-  // TODO might not be local
-  const localLink = page.locator("a").first()
-  await localLink.click()
-  await page.waitForURL((url) => url.pathname !== initialUrl)
+  await page.evaluate(() => window.spaNavigate(new URL("/design", window.location.origin)))
+  await page.waitForURL("**/design")
 
   // Setting should persist and video should still be playing
   await expect(isPaused(video)).resolves.toBe(false)


### PR DESCRIPTION
## Summary
Refactored test navigation to use direct `window.spaNavigate()` calls instead of clicking anchor elements, making tests more reliable and explicit about navigation behavior.

## Key Changes
- **spa.inline.spec.ts**: Replaced anchor link click with direct `spaNavigate()` call to `/design` route
- **collapsible.spec.ts**: 
  - Extracted common SPA navigation pattern into `spaNavigateToAbout()` helper function
  - Updated two test cases to use the new helper instead of finding and clicking links
- **navbar.spec.ts**: Replaced generic first anchor click with explicit `spaNavigate()` call to `/design` route

## Implementation Details
- Direct `window.spaNavigate()` calls are more deterministic than relying on DOM selectors to find clickable links
- Eliminates potential issues with link selection (e.g., "might not be local" comment in navbar.spec.ts)
- Helper function in collapsible.spec.ts reduces code duplication and improves maintainability
- All navigation calls are followed by `page.waitForURL()` to ensure navigation completes before assertions

https://claude.ai/code/session_01XzShCob2YrScp2wxiGLDMq