### PR TITLE
fix: use crypto.randomUUID() to prevent asset dimensions race condition

### DIFF
--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -1,6 +1,7 @@
 import type { Element, ElementContent, Root } from "hast"
 
 import { spawnSync, type SpawnSyncReturns } from "child_process"
+import crypto from "crypto"
 import gitRoot from "find-git-root"
 import fs from "fs/promises"
 import sizeOf from "image-size"
@@ -102,7 +103,7 @@ class AssetProcessor {
   public async maybeSaveAssetDimensions(): Promise<void> {
     if (this.assetDimensionsCache && this.needToSaveCache) {
       // Use unique temp file to avoid race conditions with parallel workers
-      const tempFilePath = `${paths.assetDimensions}.tmp.${process.pid}.${Date.now()}`
+      const tempFilePath = `${paths.assetDimensions}.tmp.${process.pid}.${crypto.randomUUID()}`
       const data = JSON.stringify(this.assetDimensionsCache, null, 2)
 
       await fs.writeFile(tempFilePath, data, "utf-8")

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -263,12 +263,16 @@ describe("Asset Dimensions Plugin", () => {
 
       // Temp file includes process.pid and timestamp for uniqueness
       expect(writeFileSpy).toHaveBeenCalledWith(
-        expect.stringMatching(new RegExp(`^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.\\d+$`)),
+        expect.stringMatching(
+          new RegExp(`^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.[0-9a-f-]+$`),
+        ),
         JSON.stringify(cacheData, null, 2),
         "utf-8",
       )
       expect(renameSpy).toHaveBeenCalledWith(
-        expect.stringMatching(new RegExp(`^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.\\d+$`)),
+        expect.stringMatching(
+          new RegExp(`^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.[0-9a-f-]+$`),
+        ),
         actualAssetDimensionsFilePath,
       )
       expect(assetProcessor["needToSaveCache"]).toBe(false)
@@ -1076,7 +1080,9 @@ describe("Asset Dimensions Plugin", () => {
       await assetProcessor.maybeSaveAssetDimensions()
       expect(writeFileSpy).toHaveBeenCalledTimes(2)
       // Temp file includes process.pid and timestamp for uniqueness
-      const tempFilePattern = new RegExp(`^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.\\d+$`)
+      const tempFilePattern = new RegExp(
+        `^${actualAssetDimensionsFilePath}\\.tmp\\.\\d+\\.[0-9a-f-]+$`,
+      )
       expect(writeFileSpy).toHaveBeenCalledWith(
         expect.stringMatching(tempFilePattern),
         expect.any(String),


### PR DESCRIPTION
## Summary
- Fixes intermittent CI build failure caused by a race condition in `maybeSaveAssetDimensions()` where concurrent file processors could generate identical temp file paths when `Date.now()` returned the same millisecond value
- Replaces `Date.now()` with `crypto.randomUUID()` for guaranteed uniqueness

## Changes
- `quartz/plugins/transformers/assetDimensions.ts`: Added `import crypto` and switched temp file naming from `Date.now()` to `crypto.randomUUID()`
- `quartz/plugins/transformers/tests/assetDimensions.test.ts`: Updated 3 regex patterns matching temp file names from `\d+` (timestamp) to `[0-9a-f-]+` (UUID)

## Testing
- All 74 assetDimensions tests pass with 100% coverage on `assetDimensions.ts`
- Type checking (`pnpm check`) passes clean

https://claude.ai/code/session_01LBDNRsSajKNEBg9fQwXY6N