### PR TITLE
fix: prevent collapsible ID instability across SPA navigation

### DIFF
--- a/quartz/static/scripts/detectInitialState.js
+++ b/quartz/static/scripts/detectInitialState.js
@@ -60,6 +60,7 @@
 
   /** Applies saved state immediately when element added to DOM (prevents layout shift). */
   function applyCollapsibleState(element) {
+    if (element.dataset.collapsibleId) return // Already processed
     const slug = document.body?.dataset?.slug
     if (!slug) return
     const title = element.querySelector(".admonition-title")?.textContent?.trim() || ""


### PR DESCRIPTION
## Summary
- Collapsible admonition IDs were non-deterministic on initial page load due to the MutationObserver processing the same elements multiple times, inflating hash counter indices (e.g. `-5` instead of `-0`)
- After SPA navigation, `setupAdmonition` reset counts and assigned `-0` indices, causing localStorage key mismatches and lost persisted state
- Added an early-return guard in `applyCollapsibleState` to skip already-processed elements, matching the existing pattern in `admonition.inline.js`

## Changes
- `quartz/static/scripts/detectInitialState.js`: Added `if (element.dataset.collapsibleId) return` guard at the top of `applyCollapsibleState` to prevent redundant ID generation from the MutationObserver

## Testing
- All 3180 unit tests pass with 100% coverage (`pnpm test`)
- Type checking and linting pass (`pnpm check`)
- Fixes the 2 Playwright tests failing across all 8 affected shards:
  - `state persists across SPA navigation` (collapsible.spec.ts:87)
  - `IDs remain stable after SPA navigation and back` (collapsible.spec.ts:125)

https://claude.ai/code/session_01XpwtJjJPZNrVbQpMmavspk