### PR TITLE
Replace webkit scrollbar styles with standard scrollbar properties

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -34,23 +34,13 @@ section {
   box-sizing: border-box;
 }
 
-/* Define the scrollbar style */
+/* Scrollbar styling using the standard property (avoids Chromium repaint
+   bug where ::-webkit-scrollbar pseudo-elements render as white rectangles
+   after a tab switch). scrollbar-color is supported in all modern browsers. */
 body,
 .right {
   scrollbar-color: var(--midground-fainter) var(--background);
-}
-
-.right::-webkit-scrollbar,
-body::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-/* Define the thumb style */
-.right::-webkit-scrollbar-thumb,
-body::-webkit-scrollbar-thumb {
-  background: var(--midground-fainter);
-  border-radius: 5px;
+  scrollbar-width: thin;
 }
 
 .text-highlight {


### PR DESCRIPTION
## Summary
Replaced Chromium-specific webkit scrollbar pseudo-elements with standard CSS scrollbar properties to avoid rendering bugs and improve cross-browser compatibility.

## Changes
- Removed `-webkit-scrollbar` and `-webkit-scrollbar-thumb` pseudo-element styles from `body` and `.right` selectors
- Added standard `scrollbar-color` property (already present, now as primary method)
- Added `scrollbar-width: thin` property for consistent scrollbar sizing across modern browsers
- Updated comment to explain the rationale: avoiding a Chromium repaint bug where webkit scrollbar elements render as white rectangles after tab switches

## Implementation Details
- The `scrollbar-color` property is now the single source of truth for scrollbar styling
- `scrollbar-width: thin` replaces the explicit `width: 10px; height: 10px` webkit rules
- This approach is supported in all modern browsers (Chrome 64+, Firefox 64+, Safari 15.4+, Edge 79+)
- Eliminates the visual glitch that occurs with webkit pseudo-elements during tab switching

https://claude.ai/code/session_01JRNv8VocwaZK34CZHzxEQD