### PR TITLE
Add validation for invalid CSS class name syntax in HTML

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -695,6 +695,33 @@ def check_images_have_dimensions(soup: BeautifulSoup) -> list[str]:
     return issues
 
 
+def check_invalid_class_names(soup: BeautifulSoup) -> list[str]:
+    """
+    Check for class names that contain commas or start with dots.
+
+    These indicate CSS selector syntax was incorrectly used as HTML class
+    attribute values (e.g. ``class="float-right,.bar"`` instead of
+    ``class="float-right bar"``).
+
+    Returns:
+        list of strings describing invalid class names
+    """
+    issues: list[str] = []
+
+    for element in _tags_only(soup.find_all(class_=True)):
+        classes = script_utils.get_classes(element)
+        for cls in classes:
+            if "," in cls or cls.startswith("."):
+                tag_preview = str(element)[:120]
+                _append_to_list(
+                    issues,
+                    f"Invalid class name '{cls}' on <{element.name}>:"
+                    f" {tag_preview}",
+                )
+
+    return issues
+
+
 def check_katex_elements_for_errors(soup: BeautifulSoup) -> list[str]:
     """Check for KaTeX elements with color #cc0000."""
     problematic_katex: list[str] = []
@@ -1549,6 +1576,7 @@ def check_file_for_issues(
             soup
         ),
         "invalid_tengwar_characters": check_tengwar_characters(soup),
+        "invalid_class_names": check_invalid_class_names(soup),
     }
 
     if should_check_fonts:

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -246,7 +246,7 @@ Hi! Am I being transcluded?
 > [!quote] Jacob Goldman-Wetzler
 > Subtitle: MATS 6.0, [Gradient Routing](/gradient-routing)
 >
-> ![[https://assets.turntrout.com/static/images/posts/team-shard-12222025-4.avif|A young man in a dress shirt smiles at the camera.]]{.float-right,.testimonial-maybe-negative-margin}
+> ![[https://assets.turntrout.com/static/images/posts/team-shard-12222025-4.avif|A young man in a dress shirt smiles at the camera.]]{.float-right .testimonial-maybe-negative-margin}
 >
 > Being a member of Team Shard helped me grow tremendously as a researcher. It gave me the necessary skills and confidence to work in AI Safety full-time.
 


### PR DESCRIPTION
## Summary
This PR adds a new validation check to detect invalid class names in HTML elements that use CSS selector syntax instead of proper HTML class attribute format.

## Changes
- **New validation function**: Added `check_invalid_class_names()` to `scripts/built_site_checks.py` that detects:
  - Class names containing commas (e.g., `class="float-right,.bar"`)
  - Class names starting with dots (e.g., `class=".highlighted"`)
  - These patterns indicate CSS selector syntax was incorrectly used as class attribute values
  
- **Integration**: Registered the new check in `check_file_for_issues()` to run as part of the standard site validation pipeline

- **Test coverage**: Added comprehensive parametrized tests in `test_built_site_checks.py` covering:
  - Valid space-separated classes
  - Valid single classes
  - Invalid comma-separated classes
  - Invalid dot-prefixed classes
  - Elements without class attributes

- **Content fix**: Corrected invalid class syntax in `website_content/Test-page.md` from `{.float-right,.testimonial-maybe-negative-margin}` to `{.float-right .testimonial-maybe-negative-margin}`

## Implementation Details
The check iterates through all HTML elements with class attributes, validates each class name for invalid patterns, and reports issues with a preview of the problematic element. This helps catch common mistakes where developers use CSS selector syntax instead of proper HTML class formatting.

https://claude.ai/code/session_01EjfVRPuXHGiWa7VaV5xjz2