### PR TITLE
Add Python venv to PATH during session setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -166,7 +166,17 @@ fi
 echo "Installing Node dependencies..."
 pnpm install --silent || warn "Failed to install Node dependencies"
 
-command -v uv &>/dev/null && uv sync --quiet 2>/dev/null
+if command -v uv &>/dev/null; then
+  uv sync --quiet 2>/dev/null
+  # Add .venv/bin to PATH so Python tools (autoflake, isort, autopep8, etc.)
+  # installed by uv sync are available to lint-staged and other commands
+  if [ -d "$PROJECT_DIR/.venv/bin" ]; then
+    export PATH="$PROJECT_DIR/.venv/bin:$PATH"
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+    fi
+  fi
+fi
 
 if [ "$SETUP_WARNINGS" -gt 0 ]; then
   echo "Session setup complete with $SETUP_WARNINGS warning(s)" >&2


### PR DESCRIPTION
## Summary
This change ensures that Python tools installed by `uv sync` are available in the PATH during the session, making them accessible to lint-staged and other commands that need to run Python linters and formatters.

## Key Changes
- Refactored the `uv sync` command from a one-liner into a conditional block for better error handling and extensibility
- Added logic to detect and prepend the `.venv/bin` directory to the PATH after `uv sync` completes
- Persists the PATH modification to the Claude environment file (if available) so the Python tools remain available throughout the session

## Implementation Details
- The `.venv/bin` directory is only added to PATH if it exists, preventing errors on systems where `uv sync` may not create a virtual environment
- The PATH modification is exported to both the current shell session and optionally to `$CLAUDE_ENV_FILE` for persistence across session initialization steps
- This enables Python development tools (autoflake, isort, autopep8, etc.) to be properly discovered by pre-commit hooks and linting workflows

https://claude.ai/code/session_015bPHjrHiZdSEheZWqXk6xj