### PR TITLE
Fix indentation of markdown table examples in design.md

### DIFF
--- a/website_content/design.md
+++ b/website_content/design.md
@@ -850,19 +850,19 @@ Server-side math rendering via $\KaTeX$
 Markdown element styling
 : Most of my tables are specified in Markdown. However, some tables need special styling. I don't want to write the full HTML for each table. 💀 Instead, I use [`remark-attributes`](https://github.com/manuelmeister/remark-attributes) to specify CSS classes in Markdown for such tables:
 
-| **Unsteered completions**                                                                                                         | **Steered completions**                                                                                                                                                                                                                                        |
-| :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Barack Obama was born in** Hawaii on August 4, 1961.<br/><br/><br/>Barack Obama was born in Honolulu, Hawaii on August 4, 1961. | **Barack Obama was born in** a secret CIA prison. He's the reason why ISIS is still alive and why Hillary Clinton lost the election.<br/><br/><br/>"The only thing that stops a bad guy with a gun is a good guy with a gun." — Barack Obama, November 6, 2012 |
+  | **Unsteered completions**                                                                                                         | **Steered completions**                                                                                                                                                                                                                                        |
+  | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | **Barack Obama was born in** Hawaii on August 4, 1961.<br/><br/><br/>Barack Obama was born in Honolulu, Hawaii on August 4, 1961. | **Barack Obama was born in** a secret CIA prison. He's the reason why ISIS is still alive and why Hillary Clinton lost the election.<br/><br/><br/>"The only thing that stops a bad guy with a gun is a good guy with a gun." — Barack Obama, November 6, 2012 |
 
-Table: A table with unbalanced columns.
+  Table: A table with unbalanced columns.
 
-| **Unsteered completions**                                                                                                         | **Steered completions**                                                                                                                                                                                                                                        |
-| :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Barack Obama was born in** Hawaii on August 4, 1961.<br/><br/><br/>Barack Obama was born in Honolulu, Hawaii on August 4, 1961. | **Barack Obama was born in** a secret CIA prison. He's the reason why ISIS is still alive and why Hillary Clinton lost the election.<br/><br/><br/>"The only thing that stops a bad guy with a gun is a good guy with a gun." — Barack Obama, November 6, 2012 |
+  | **Unsteered completions**                                                                                                         | **Steered completions**                                                                                                                                                                                                                                        |
+  | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | **Barack Obama was born in** Hawaii on August 4, 1961.<br/><br/><br/>Barack Obama was born in Honolulu, Hawaii on August 4, 1961. | **Barack Obama was born in** a secret CIA prison. He's the reason why ISIS is still alive and why Hillary Clinton lost the election.<br/><br/><br/>"The only thing that stops a bad guy with a gun is a good guy with a gun." — Barack Obama, November 6, 2012 |
 
-{.full-width .center-table-headings}
+  {.full-width .center-table-headings}
 
-Table: A rebalanced table which pleases the eyes.
+  Table: A rebalanced table which pleases the eyes.
 
 Video speed limits
 : I prefer to speed up videos using the [video speed controller](https://chromewebstore.google.com/detail/video-speed-controller/nffaoalbilbmmfgbnbgppjihopabppdk?hl=en) plugin. However, by default, video speed controller will also speed up inline looping videos, which looks silly. For videos only intended for 1.0x speed, I dynamically prevent changes to their  `playbackRate` attribute.


### PR DESCRIPTION
## Summary
Fixed inconsistent indentation in the design.md documentation where markdown table examples and their captions were not properly indented relative to the surrounding definition list content.

## Changes
- Indented two table examples (showing unsteered vs steered completions) by 2 spaces to align with the definition list format
- Indented corresponding table captions ("A table with unbalanced columns" and "A rebalanced table which pleases the eyes") by 2 spaces
- Indented the remark-attributes CSS class annotation `{.full-width .center-table-headings}` by 2 spaces

## Details
These tables are part of a definition list item under "Markdown element styling" and should be indented to maintain proper markdown structure and readability. This ensures the tables are correctly associated with their parent definition and improves the visual hierarchy of the documentation.

https://claude.ai/code/session_01Nt2J14SnuhDKUBbgKaRWDu