### PR TITLE
Improve skip-to-content link accessibility and styling

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -430,9 +430,11 @@ export function renderPage(
 
   const body = (
     <body data-slug={slug}>
-      <a href="#center-content" className="skip-to-content internal same-page-link">
-        Skip to main content
-      </a>
+      <a
+        href="#center-content"
+        className="skip-to-content internal same-page-link"
+        aria-label="Skip to main content"
+      />
       <div id="quartz-root" className="page">
         <Body {...componentData}>
           {LeftComponent}

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -20,6 +20,11 @@ html {
   color: var(--foreground);
   text-decoration: underline;
 
+  // Use a pseudo-element so the text is not searchable via Ctrl+F
+  &::after {
+    content: "Skip to main content";
+  }
+
   &:focus {
     left: 50%;
     transform: translateX(-50%);


### PR DESCRIPTION
## Summary
This PR improves the accessibility and user experience of the "skip to main content" link by making it a self-closing anchor tag with an aria-label and moving the visible text to a CSS pseudo-element.

## Key Changes
- Changed the skip-to-content link from a text-containing anchor to a self-closing anchor tag with an `aria-label="Skip to main content"` for better semantic accessibility
- Moved the visible "Skip to main content" text to a CSS `::after` pseudo-element in the base styles
- Added a comment explaining that the pseudo-element approach prevents the text from being searchable via Ctrl+F, reducing noise in user searches

## Implementation Details
- The `aria-label` ensures screen readers and accessibility tools still announce the link's purpose
- Using a pseudo-element for the visible text is a progressive enhancement that keeps the link functional while preventing the skip text from appearing in text searches
- The styling remains consistent with the existing `.skip-to-content` class behavior (focus state with centering and transform)

https://claude.ai/code/session_01KCSQLqkC7t6rxPxPYbVaAM