### PR TITLE
fix: indent description list content to stay within <dd> elements

### DIFF
--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -74,28 +74,28 @@ Subtitle: MATS (starting with smallcaps).
 
 Header 1
 : Test item 1
+
 Unordered list inside a description list
 : - Voice & video calls
-
-- GPS
-- Audible
-- Uber / Lyft
-- Authenticators / alarms / other boring utilities
-- Roam / note-taking
+  - GPS
+  - Audible
+  - Uber / Lyft
+  - Authenticators / alarms / other boring utilities
+  - Roam / note-taking
 
 Code block in a `<dl>`
 : To verify that a commit `ABC012` was indeed committed by a given date, run
 
-```shell
-git clone https://github.com/alexander-turner/.timestamps
-cd .timestamps
-ots --no-bitcoin verify "files/ABC012.txt.ots"
-```
+  ```shell
+  git clone https://github.com/alexander-turner/.timestamps
+  cd .timestamps
+  ots --no-bitcoin verify "files/ABC012.txt.ots"
+  ```
 
 Admonition in a description list
 : > [!quote] Test
-
-> To be or not to be.
+  >
+  > To be or not to be.
 
 # Admonition lists
 


### PR DESCRIPTION
## Summary
- Description list content in Test-page.md (code block, admonition, unordered list) was breaking out of `<dd>` elements due to missing indentation, causing duplicate rendering on the page
- Added 2-space indentation to continuation content so `remark-definition-list` keeps it inside the `<dd>`

## Changes
- Indented bullet list items (GPS, Audible, etc.) with 2 spaces to stay inside the "Unordered list" definition
- Indented fenced code block (both markers and content) with 2 spaces to stay inside the "Code block" definition
- Indented blockquote continuation with 2 spaces so "To be or not to be." stays inside the admonition within the "Admonition" definition
- Added blank line between "Test item 1" and "Unordered list" to separate distinct definition terms

## Testing
- Verified with `remark-definition-list` parser that all content now produces a single `<dl>` with proper `<dt>`/`<dd>` nesting
- All 3188 TypeScript tests pass with 100% coverage
- Type checking and linting pass cleanly

https://claude.ai/code/session_01PD75FawCikUTnDSkxohpcg