### PR TITLE
Add dynamic metadata admonition generator for post info

### DIFF
--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -580,6 +580,29 @@ describe("PopulateContainers", () => {
       })
     })
 
+    describe("generateMetadataAdmonition", () => {
+      it("should generate a metadata admonition using renderPostStatistics", async () => {
+        const generator = populateModule.generateMetadataAdmonition()
+        const elements = await generator()
+
+        expect(elements).toHaveLength(1)
+        const blockquote = elements[0]
+        expect(blockquote.tagName).toBe("blockquote")
+        expect(blockquote.properties?.className).toEqual(
+          expect.arrayContaining(["admonition", "admonition-metadata"]),
+        )
+        expect(blockquote.properties?.dataAdmonition).toBe("info")
+      })
+
+      it("should strip the post-statistics ID to avoid duplicates", async () => {
+        const generator = populateModule.generateMetadataAdmonition()
+        const elements = await generator()
+
+        const blockquote = elements[0]
+        expect(blockquote.properties?.id).toBeUndefined()
+      })
+    })
+
     describe("populateElements", () => {
       it.each([
         [

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -5,9 +5,12 @@ import { type Element, type Root } from "hast"
 import { fromHtml } from "hast-util-from-html"
 import { toHtml } from "hast-util-to-html"
 import { h } from "hastscript"
+import { render } from "preact-render-to-string"
 import { visit } from "unist-util-visit"
 
 import { simpleConstants, specialFaviconPaths } from "../../components/constants"
+import { renderPostStatistics } from "../../components/ContentMeta"
+import { type QuartzComponentProps } from "../../components/types"
 import { createWinstonLogger } from "../../util/log"
 import { joinSegments, type FilePath } from "../../util/path"
 import { getFaviconCounts } from "../transformers/countFavicons"
@@ -208,6 +211,42 @@ export const generateSpecialFaviconContent = (
 }
 
 /**
+ * Generates a metadata admonition ("About this post" box) with dummy data,
+ * using the same component that renders real post metadata.
+ */
+export const generateMetadataAdmonition = (): ContentGenerator => {
+  return async (): Promise<Element[]> => {
+    const dummyProps = {
+      cfg: {},
+      fileData: {
+        text: "word ".repeat(1600), // ~8 minutes reading time
+        relativePath: "welcome-to-the-pond.md",
+        frontmatter: {
+          date_published: new Date("2024-10-30"),
+          date_updated: "2024-11-12",
+        },
+      },
+    } as unknown as QuartzComponentProps
+
+    const jsx = renderPostStatistics(dummyProps)
+    // istanbul ignore next
+    if (!jsx) return []
+
+    const html = render(jsx)
+    const root = fromHtml(html, { fragment: true })
+
+    // Strip the post-statistics ID to avoid duplicate IDs on the page
+    visit(root, "element", (node) => {
+      if (node.properties?.id === "post-statistics") {
+        delete node.properties.id
+      }
+    })
+
+    return root.children.filter((c): c is Element => c.type === "element")
+  }
+}
+
+/**
  * Generates favicon elements based on favicon counts from the build process.
  */
 export const generateFaviconContent = (): ContentGenerator => {
@@ -351,6 +390,7 @@ const createPopulatorMap = (
 ): Map<string, ContentGenerator> => {
   return new Map([
     // IDs
+    ["populate-metadata-admonition", generateMetadataAdmonition()],
     ["populate-favicon-container", generateFaviconContent()],
     ["populate-favicon-threshold", generateConstantContent(minFaviconCount)],
     ["populate-max-size-card", generateConstantContent(maxCardImageSizeKb)],

--- a/website_content/welcome-to-the-pond.md
+++ b/website_content/welcome-to-the-pond.md
@@ -126,7 +126,7 @@ Analogies can be useful; analogies can be deadly. For an analogy to be useful, i
 Each post states when it was published and when it was last updated. The updated link points to the file on [my GitHub repo](https://github.com/alexander-turner/TurnTrout.com) where the edit history can be inspected.
 
 <figure style="max-width: min(90%, 370px); margin-left: auto; margin-right: auto;">
-<blockquote class="admonition admonition-metadata" data-admonition="info" style="text-align:left; color: var(--midground); background-color: var(--background);"><div class="admonition-title"><div class="admonition-icon"></div><div class="admonition-title-inner">About this post</div></div><div class="admonition-content"><ul style="padding-left: 0px;"><p style="color:var(--midground);"><span class="reading-time">Read time: 8 minutes</span></p><p style="color:var(--midground);"><span class="publication-str">Published on <time datetime="2024-10-30 00:00:00">October 30<sup class="ordinal-suffix">th</sup>, 2024</time></span></p><p style="color:var(--midground);"><span class="last-updated-str"> <a href="https://github.com/alexander-turner/TurnTrout.com/blob/main/website_content/welcome-to-the-pond.md" class="external" style="color:var(--midground);" target="_blank" rel="noopener noreferrer">Updated</a> on <time datetime="2024-11-12 00:00:00">November 11<sup class="ordinal-suffix">th</sup>, 2024</time></span></p></ul></div></blockquote>
+<div id="populate-metadata-admonition"></div>
 <figcaption>An example post information bubble.</figcaption>
 </figure>
 


### PR DESCRIPTION
## Summary
This PR introduces a new `generateMetadataAdmonition()` function that dynamically generates an "About this post" metadata box using the existing `renderPostStatistics` component. This replaces the hardcoded HTML in the welcome page with a reusable, component-driven approach.

## Key Changes
- **New `generateMetadataAdmonition()` function** in `populateContainers.ts` that:
  - Renders the `renderPostStatistics` component with dummy data (8-minute read time, sample dates)
  - Converts the Preact JSX output to HTML and parses it into HAST elements
  - Strips the `post-statistics` ID to prevent duplicate IDs on the page
  - Returns an array of element nodes for injection into the page

- **Registered the generator** in the populator map with ID `populate-metadata-admonition` for template injection

- **Updated welcome page** to use the new dynamic placeholder (`<div id="populate-metadata-admonition"></div>`) instead of hardcoded HTML

- **Added comprehensive test coverage** with two test cases:
  - Verifies the generated blockquote has correct admonition classes and data attributes
  - Confirms the post-statistics ID is properly stripped

## Implementation Details
- Uses `preact-render-to-string` to convert JSX to HTML string
- Leverages `hast-util-from-html` to parse HTML into AST nodes
- Uses `unist-util-visit` to traverse and modify the AST (removing duplicate IDs)
- Maintains consistency with existing content generator patterns in the codebase

https://claude.ai/code/session_01T8H4QMTzUHbDxF6fcRyGtB