### PR TITLE
Refactor figure layouts and fix markdown formatting

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -316,6 +316,11 @@ sup {
 figure:has(> .subfigure) {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
+
+  > figcaption {
+    flex-basis: 100%;
+  }
 }
 
 figure {

--- a/website_content/My-research.md
+++ b/website_content/My-research.md
@@ -272,7 +272,6 @@ Subtitle: January 2023 through November 2024
 In 2023, I popularized _steering vectors_[^steering] as a cheap way to control model outputs at inference time. I first discovered the [cheese vector](/understanding-and-controlling-a-maze-solving-policy-network#subtract-the-cheese-vector-subtract-the-cheese-seeking) in a maze-solving RL environment:
 
 <figure>
-<div style="display:flex; justify-content: center; ">
 <div class="subfigure">
 <img src="https://assets.turntrout.com/static/images/posts/original_maze_field.avif" alt="The original probability vectors. The mouse seems 'torn' between the cheese and the right side of the maze."/>
 <figcaption>(a) Original probabilities</figcaption>
@@ -284,7 +283,6 @@ In 2023, I popularized _steering vectors_[^steering] as a cheap way to control m
 <div class="subfigure">
 <img src="https://assets.turntrout.com/static/images/posts/maze_field_diff.avif" alt="The change in the action probability vectors, shown in green. They point away from the cheese."/>
 <figcaption>(c) Steered minus original</figcaption>
-</div>
 </div>
 <figcaption><b>Left:</b> The net probability vectors induced by the unmodified forward passes.  <br/> <b>Middle:</b> After subtracting the cheese vector, we plot the new probability vectors induced by the modified forward passes. <br/><b>Right:</b> The agent now heads away from the cheese.</figcaption>
 </figure>

--- a/website_content/bruce-wayne-and-the-cost-of-inaction.md
+++ b/website_content/bruce-wayne-and-the-cost-of-inaction.md
@@ -275,7 +275,7 @@ His dad winked at his mom, and they both laughed at some joke which Bruce didn't
 
 They left the small opera room and entered the big outdoor room, which usually was beautiful and starry but was cloudy tonight. It was rather chilly for a summer night, if he thought about it. His dad looked around for their limo. Alfred had said he'd come pick them up. Maybe the opera had finished early. Bruce couldn't possibly believe that _that_ was true.
 
-His dad had spotted something else, however. Some<i>one</i> else, next to the building, another beggar. Bruce's gaze was steady. He wanted to make his dad proud of how he didn't look away.
+His dad had spotted something else, however. Some*one* else, next to the building, another beggar. Bruce's gaze was steady. He wanted to make his dad proud of how he didn't look away.
 
 The man was slumped against the opera house. It was too dark to really see him, but Bruce thought he had an empty jar next to him. That would be for any money people gave him.
 

--- a/website_content/date-me.md
+++ b/website_content/date-me.md
@@ -78,8 +78,6 @@ AI-fueled house parties
 
   <figure>
   <figcaption><b>The <em>gigachad</em> house party</b>: MidJourney v3 interpolating my image with gigachad's in order to create a "gigachad Alex" to go on the name tag.</figcaption>
-  <div style="display:flex; justify-content: center; ">
-
   <div class="subfigure">
   <img src="https://assets.turntrout.com/static/images/posts/alex-gigachad-side.avif" style="width: 218px; height: 30vh; object-fit: cover; object-position: 80%;" alt="Me smiling, bearing some resemblance to gigachad."/>
   <figcaption>(a) Alex</figcaption>
@@ -92,13 +90,10 @@ AI-fueled house parties
   <img src="https://assets.turntrout.com/Attachments/GCAlex.avif"style="width: 218px; height: 30vh; object-fit: cover; object-position: top;" alt="A picture of me with my features exaggerated to resemble gigachad's."/>
   <figcaption>(c) Gigachad Alex</figcaption>
   </div>
-  </div>
   </figure>
 
   <figure>
   <figcaption><b>The <em>house</em> house party</b>: Each of my friends has their own spirit and vibe! I made them houses which capture their <em>essences</em>.</figcaption>
-  <div style="display:flex; justify-content: center; ">
-
   <div class="subfigure">
   <img src="https://assets.turntrout.com/Attachments/rivendellHouse.avif" alt="An AI image of a house which is reminiscent of Rivendell."/>
   <figcaption>(a) Tolkienesque</figcaption>
@@ -110,7 +105,6 @@ AI-fueled house parties
   <div class="subfigure">
   <img src="https://assets.turntrout.com/Attachments/marioHouse.avif" alt="A Mario-esque house."/>
   <figcaption>(c) Mario</figcaption>
-  </div>
   </div>
 
   </figure>

--- a/website_content/physiology.md
+++ b/website_content/physiology.md
@@ -170,7 +170,7 @@ Subtitle: Check out [Cells at Work](https://en.wikipedia.org/wiki/Cells_at_Work!
 
 This anime is fun. Not as fun as [Doctor Stone](/doctor-stone), but fun. Its representations of cells are sometimes hard to forget.  
 
-For example. Neutrophils are a first-responder immune cell and a type of white blood cell. They catch invaders, envelop them, and then dissolve them - a process called [phagocytosis](https://en.wikipedia.org/wiki/Phagocytosis). <em>Cells at Work</em> portrays neutrophils as knife-wielding maniacs.
+For example. Neutrophils are a first-responder immune cell and a type of white blood cell. They catch invaders, envelop them, and then dissolve them - a process called [phagocytosis](https://en.wikipedia.org/wiki/Phagocytosis). _Cells at Work_ portrays neutrophils as knife-wielding maniacs.
 
 <figure style="display: flex;" >
 <span class="subfigure">

--- a/website_content/understanding-and-controlling-a-maze-solving-policy-network.md
+++ b/website_content/understanding-and-controlling-a-maze-solving-policy-network.md
@@ -265,7 +265,6 @@ Overall, the first three results line up with our hands-on experience with the n
 To understand the network, we tried various hand-designed model edits. These edits change the forward pass, without any retraining or optimization. To see the effect of a modification, we display the diff between the vector fields:
 
 <figure>
-<div style="display:flex; justify-content: center; ">
 <div class="subfigure">
 <img src="https://assets.turntrout.com/static/images/posts/original_maze_field.avif" alt="The original probability vectors. The mouse seems 'torn' between the cheese and the right side of the maze."/>
 <figcaption>(a) Original probabilities</figcaption>
@@ -277,7 +276,6 @@ To understand the network, we tried various hand-designed model edits. These edi
 <div class="subfigure">
 <img src="https://assets.turntrout.com/static/images/posts/maze_field_diff.avif" alt="The change in the action probability vectors, shown in green. They point away from the cheese."/>
 <figcaption>(c) Steered minus original</figcaption>
-</div>
 </div>
 <figcaption><b>Left:</b> The net probability vectors induced by the unmodified forward passes.  
 <br/><b>Middle:</b> For any steering modification we make to forward passes, we plot the new probability vectors induced by the modified forward passes.  <br/>


### PR DESCRIPTION
## Summary
This PR refactors figure layouts to use CSS-based styling instead of inline HTML, improves markdown consistency, and fixes formatting issues across multiple content files.

## Key Changes

- **CSS Enhancement**: Updated `custom.scss` to add `flex-wrap: wrap` and `flex-basis: 100%` for figcaptions in figures with subfigures, enabling proper responsive layout without inline styles
- **HTML Cleanup**: Removed inline `style="display:flex; justify-content: center;"` wrapper divs from multiple markdown files, relying on the new CSS rules instead
- **Markdown Formatting**: Standardized emphasis markup by replacing `<i>` and `<em>` HTML tags with markdown equivalents (`*` for italics and `_` for emphasis)
- **Files Updated**:
  - `My-research.md`: Removed wrapper divs from steering vectors figure
  - `date-me.md`: Removed wrapper divs from two AI-generated image figures
  - `understanding-and-controlling-a-maze-solving-policy-network.md`: Removed wrapper divs from maze field visualization
  - `bruce-wayne-and-the-cost-of-inaction.md`: Fixed italic formatting
  - `physiology.md`: Fixed emphasis formatting

## Implementation Details

The CSS changes ensure that figures containing subfigures automatically wrap and position figcaptions at full width, eliminating the need for inline styling. This improves maintainability and allows for consistent, responsive behavior across all figure layouts.

https://claude.ai/code/session_01EYfhtdYdNLEXUSpTnnKL6i