### PR TITLE
Refactor emitters and transformers to reduce boilerplate

### DIFF
--- a/quartz/plugins/emitters/allPostsPage.ts
+++ b/quartz/plugins/emitters/allPostsPage.ts
@@ -1,77 +1,14 @@
-import { defaultListPageLayout, sharedPageComponents } from "../../../config/quartz/quartz.layout"
-import BodyConstructor from "../../components/Body"
-import HeaderConstructor from "../../components/Header"
 import AllPosts, { allDescription, allSlug, allTitle } from "../../components/pages/AllPosts"
-import { pageResources, renderPage } from "../../components/renderPage"
-import { type QuartzComponentProps } from "../../components/types"
-import DepGraph from "../../depgraph"
-import { type FilePath, pathToRoot } from "../../util/path"
-import { type StaticResources } from "../../util/resources"
-import { type QuartzEmitterPlugin } from "../types"
-import { type ProcessedContent, defaultProcessedContent } from "../vfile"
-import { write } from "./helpers"
+import { createListPageEmitter } from "./helpers"
 
-export const AllPostsPage: QuartzEmitterPlugin = () => {
-  const opts = {
-    ...defaultListPageLayout,
-    ...sharedPageComponents,
-    pageBody: AllPosts,
-  }
-
-  const { head: Head, header, beforeBody, pageBody, left, right, footer: Footer } = opts
-  const Header = HeaderConstructor()
-  const Body = BodyConstructor()
-
-  return {
-    name: "AllPostsPage",
-    getQuartzComponents() {
-      return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
-    },
-    // skipcq: JS-0116 have to return async for type signature
-    async getDependencyGraph() {
-      const graph = new DepGraph<FilePath>()
-      return graph
-    },
-    async emit(ctx, content: ProcessedContent[], resources: StaticResources): Promise<FilePath[]> {
-      const slug = allSlug
-      const externalResources = pageResources(pathToRoot(slug), resources)
-      const [tree, file] = defaultProcessedContent({
-        slug,
-        frontmatter: {
-          title: allTitle,
-          tags: ["website"],
-          aliases: ["recent-posts", "recent", "all"],
-        },
-        description: allDescription,
-        text: allDescription,
-      })
-
-      const componentData: QuartzComponentProps = {
-        ctx,
-        fileData: file.data,
-        externalResources,
-        cfg: ctx.cfg.configuration,
-        children: [],
-        tree,
-        allFiles: content.map((c) => c[1].data),
-      }
-
-      const renderedContent = renderPage(
-        ctx.cfg.configuration,
-        slug,
-        componentData,
-        opts,
-        externalResources,
-      )
-
-      const fp = await write({
-        ctx,
-        content: renderedContent,
-        slug,
-        ext: ".html",
-      })
-
-      return [fp]
-    },
-  }
-}
+export const AllPostsPage = createListPageEmitter({
+  name: "AllPostsPage",
+  pageBody: AllPosts,
+  slug: allSlug,
+  title: allTitle,
+  description: allDescription,
+  frontmatter: {
+    tags: ["website"],
+    aliases: ["recent-posts", "recent", "all"],
+  },
+})

--- a/quartz/plugins/emitters/allTagsPage.ts
+++ b/quartz/plugins/emitters/allTagsPage.ts
@@ -1,82 +1,19 @@
-import { defaultListPageLayout, sharedPageComponents } from "../../../config/quartz/quartz.layout"
-import BodyConstructor from "../../components/Body"
-import HeaderConstructor from "../../components/Header"
-import AllTagsContent from "../../components/pages/AllTagsContent"
-import {
+import AllTagsContent, {
   allTagsSlug,
   allTagsTitle,
   allTagsDescription,
 } from "../../components/pages/AllTagsContent"
-import { pageResources, renderPage } from "../../components/renderPage"
-import { type QuartzComponentProps } from "../../components/types"
-import DepGraph from "../../depgraph"
-import { type FilePath, pathToRoot } from "../../util/path"
-import { type StaticResources } from "../../util/resources"
-import { type QuartzEmitterPlugin } from "../types"
-import { type ProcessedContent, defaultProcessedContent } from "../vfile"
-import { write } from "./helpers"
+import { createListPageEmitter } from "./helpers"
 
-export const AllTagsPage: QuartzEmitterPlugin = () => {
-  const opts = {
-    ...defaultListPageLayout,
-    ...sharedPageComponents,
-    pageBody: AllTagsContent,
-  }
-
-  const { head: Head, header, beforeBody, pageBody, left, right, footer: Footer } = opts
-  const Header = HeaderConstructor()
-  const Body = BodyConstructor()
-
-  return {
-    name: "AllTagsPage",
-    getQuartzComponents() {
-      return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
-    },
-    // skipcq: JS-0116 have to return async for type signature
-    async getDependencyGraph() {
-      const graph = new DepGraph<FilePath>()
-      return graph
-    },
-    async emit(ctx, content: ProcessedContent[], resources: StaticResources): Promise<FilePath[]> {
-      const slug = allTagsSlug
-      const externalResources = pageResources(pathToRoot(slug), resources)
-      const [tree, file] = defaultProcessedContent({
-        slug,
-        frontmatter: {
-          title: allTagsTitle,
-          aliases: ["tags", "all-tags", "tags-index"],
-          hide_reading_time: true,
-        },
-        description: allTagsDescription,
-        text: "Information about the tags used in this site.",
-      })
-
-      const componentData: QuartzComponentProps = {
-        ctx,
-        fileData: file.data,
-        externalResources,
-        cfg: ctx.cfg.configuration,
-        children: [],
-        tree,
-        allFiles: content.map((c) => c[1].data),
-      }
-
-      const renderedContent = renderPage(
-        ctx.cfg.configuration,
-        slug,
-        componentData,
-        opts,
-        externalResources,
-      )
-
-      const fp = await write({
-        ctx,
-        content: renderedContent,
-        slug,
-        ext: ".html",
-      })
-
-      return [fp]
-    },
-  }
-}
+export const AllTagsPage = createListPageEmitter({
+  name: "AllTagsPage",
+  pageBody: AllTagsContent,
+  slug: allTagsSlug,
+  title: allTagsTitle,
+  description: allTagsDescription,
+  frontmatter: {
+    aliases: ["tags", "all-tags", "tags-index"],
+    hide_reading_time: true,
+  },
+  text: "Information about the tags used in this site.",
+})

--- a/quartz/plugins/emitters/helpers.ts
+++ b/quartz/plugins/emitters/helpers.ts
@@ -1,8 +1,17 @@
 import fs from "fs"
 import path from "path"
 
+import { defaultListPageLayout, sharedPageComponents } from "../../../config/quartz/quartz.layout"
+import BodyConstructor from "../../components/Body"
+import HeaderConstructor from "../../components/Header"
+import { pageResources, renderPage } from "../../components/renderPage"
+import { type QuartzComponent, type QuartzComponentProps } from "../../components/types"
+import DepGraph from "../../depgraph"
 import { type BuildCtx } from "../../util/ctx"
-import { type FilePath, type FullSlug, joinSegments } from "../../util/path"
+import { type FilePath, type FullSlug, joinSegments, pathToRoot } from "../../util/path"
+import { type StaticResources } from "../../util/resources"
+import { type QuartzEmitterPlugin } from "../types"
+import { type ProcessedContent, defaultProcessedContent } from "../vfile"
 
 type WriteOptions = {
   ctx: BuildCtx
@@ -17,4 +26,111 @@ export const write = async ({ ctx, slug, ext, content }: WriteOptions): Promise<
   await fs.promises.mkdir(dir, { recursive: true })
   await fs.promises.writeFile(pathToPage, content)
   return pathToPage
+}
+
+/**
+ * Configuration options for creating a list page emitter plugin.
+ */
+export interface ListPageEmitterConfig {
+  /** Name of the plugin (e.g., "AllPostsPage") */
+  name: string
+  /** The page body component to render */
+  pageBody: QuartzComponent
+  /** The slug for the page (e.g., "all-posts") */
+  slug: FullSlug
+  /** The page title */
+  title: string
+  /** The page description */
+  description: string
+  /** Additional frontmatter fields */
+  frontmatter?: Record<string, unknown>
+  /** Text content for the page (defaults to description) */
+  text?: string
+}
+
+/**
+ * Factory function to create list page emitter plugins (e.g., AllPostsPage, AllTagsPage).
+ * Reduces boilerplate for creating pages that list content with similar structure.
+ *
+ * @param config - Configuration object defining the page parameters
+ * @returns A QuartzEmitterPlugin that generates the list page
+ *
+ * @example
+ * export const AllPostsPage = createListPageEmitter({
+ *   name: "AllPostsPage",
+ *   pageBody: AllPosts,
+ *   slug: allSlug,
+ *   title: allTitle,
+ *   description: allDescription,
+ *   frontmatter: { tags: ["website"], aliases: ["recent-posts", "recent", "all"] },
+ * })
+ */
+export function createListPageEmitter(config: ListPageEmitterConfig): QuartzEmitterPlugin {
+  return () => {
+    const opts = {
+      ...defaultListPageLayout,
+      ...sharedPageComponents,
+      pageBody: config.pageBody,
+    }
+
+    const { head: Head, header, beforeBody, pageBody, left, right, footer: Footer } = opts
+    const Header = HeaderConstructor()
+    const Body = BodyConstructor()
+
+    return {
+      name: config.name,
+      getQuartzComponents() {
+        return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
+      },
+      // skipcq: JS-0116 have to return async for type signature
+      async getDependencyGraph() {
+        const graph = new DepGraph<FilePath>()
+        return graph
+      },
+      async emit(
+        ctx,
+        content: ProcessedContent[],
+        resources: StaticResources,
+      ): Promise<FilePath[]> {
+        const slug = config.slug
+        const externalResources = pageResources(pathToRoot(slug), resources)
+        const [tree, file] = defaultProcessedContent({
+          slug,
+          frontmatter: {
+            title: config.title,
+            ...config.frontmatter,
+          },
+          description: config.description,
+          text: config.text ?? config.description,
+        })
+
+        const componentData: QuartzComponentProps = {
+          ctx,
+          fileData: file.data,
+          externalResources,
+          cfg: ctx.cfg.configuration,
+          children: [],
+          tree,
+          allFiles: content.map((c) => c[1].data),
+        }
+
+        const renderedContent = renderPage(
+          ctx.cfg.configuration,
+          slug,
+          componentData,
+          opts,
+          externalResources,
+        )
+
+        const fp = await write({
+          ctx,
+          content: renderedContent,
+          slug,
+          ext: ".html",
+        })
+
+        return [fp]
+      },
+    }
+  }
 }

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -15,7 +15,7 @@ import {
   hatTipPlaceholder,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
-import { replaceRegex, fractionRegex, hasClass, hasAncestor, urlRegex } from "./utils"
+import { replaceRegex, fractionRegex, hasClass, hasAncestor, urlRegex, isCode } from "./utils"
 
 /**
  * Tags that should be skipped during text transformation.
@@ -157,10 +157,6 @@ export function applyTextTransforms(text: string): string {
   }
 
   return text
-}
-
-export function isCode(node: Element): boolean {
-  return node.tagName === "code"
 }
 
 export const l_pRegex = /(?<prefix>\s|^)L(?<number>\d+)\b(?!\.)/g

--- a/quartz/plugins/transformers/spoiler.ts
+++ b/quartz/plugins/transformers/spoiler.ts
@@ -1,10 +1,9 @@
-import type { Element, Parent, Root, Text } from "hast"
+import type { Element, Parent, Text } from "hast"
 
 // skipcq: JS-0257
 import { h } from "hastscript"
-import { visit } from "unist-util-visit"
 
-import type { QuartzTransformerPlugin } from "../types"
+import { createElementVisitorPlugin } from "./utils"
 
 const SPOILER_REGEX = /^!\s*(?<spoilerText>.*)/
 
@@ -127,13 +126,4 @@ export function processParagraph(paragraph: Element): Element | null {
  * interactive spoiler elements. Spoilers are marked with "! " at the start of
  * blockquote paragraphs.
  */
-export const rehypeCustomSpoiler: QuartzTransformerPlugin = () => ({
-  name: "customSpoiler",
-  htmlPlugins() {
-    return [
-      () => (tree: Root) => {
-        visit(tree, "element", modifyNode)
-      },
-    ]
-  },
-})
+export const rehypeCustomSpoiler = createElementVisitorPlugin("customSpoiler", modifyNode)

--- a/quartz/plugins/transformers/subtitles.ts
+++ b/quartz/plugins/transformers/subtitles.ts
@@ -1,8 +1,6 @@
-import type { Element, Parent, Root, Text } from "hast"
+import type { Element, Parent, Text } from "hast"
 
-import { visit } from "unist-util-visit"
-
-import type { QuartzTransformerPlugin } from "../types"
+import { createElementVisitorPlugin } from "./utils"
 
 export const SUBTITLE_REGEX = /^Subtitle:\s*(?<subtitleText>.*)/
 
@@ -78,13 +76,4 @@ export function modifyNode(
  * into styled subtitle elements with the "subtitle" class.
  */
 /* istanbul ignore next -- Quartz calls this plugin via integration (not unit tests) */
-export const rehypeCustomSubtitle: QuartzTransformerPlugin = () => ({
-  name: "customSubtitle",
-  htmlPlugins() {
-    return [
-      () => (tree: Root) => {
-        visit(tree, "element", modifyNode)
-      },
-    ]
-  },
-})
+export const rehypeCustomSubtitle = createElementVisitorPlugin("customSubtitle", modifyNode)

--- a/quartz/plugins/transformers/tablecaption.ts
+++ b/quartz/plugins/transformers/tablecaption.ts
@@ -1,18 +1,13 @@
-import type { Element, Root, Text, ElementContent } from "hast"
+import type { Element, ElementContent } from "hast"
 import type { Parent } from "unist"
 
 import { fromHtml } from "hast-util-from-html"
 import { h } from "hastscript"
-import { visit } from "unist-util-visit"
 
-import type { QuartzTransformerPlugin } from "../types"
+import { createElementVisitorPlugin, isTextNode, isElementNode } from "./utils"
 
-/**
- * Type guard to check if a node is a Text node
- */
-export function isTextNode(node: ElementContent): node is Text {
-  return node.type === "text"
-}
+// Re-export type guards for use by tests and other modules
+export { isTextNode, isElementNode }
 
 /**
  * Checks if a text node starts with the table caption prefix "^Table: "
@@ -37,13 +32,6 @@ export function createFigcaption(captionText: string): Element[] {
     fragment: true,
   })
   return captionHtml.children as Element[]
-}
-
-/**
- * Type guard to check if an element is an Element node
- */
-export function isElementNode(element: ElementContent): element is Element {
-  return element.type === "element"
 }
 
 // skipcq: JS-D1001
@@ -127,17 +115,4 @@ function processNode(node: Element, index: number | undefined, parent: Parent | 
  * </figure>
  * ```
  */
-export const TableCaption: QuartzTransformerPlugin = () => {
-  return {
-    name: "TableCaption",
-    htmlPlugins() {
-      return [
-        () => {
-          return (tree: Root) => {
-            visit(tree, "element", processNode)
-          }
-        },
-      ]
-    },
-  }
-}
+export const TableCaption = createElementVisitorPlugin("TableCaption", processNode)

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -6,8 +6,13 @@ import { visitParents } from "unist-util-visit-parents"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-import { isCode } from "./formatting_improvement_html"
-import { shouldCapitalizeNodeText, replaceRegex, gatherTextBeforeIndex, hasClass } from "./utils"
+import {
+  shouldCapitalizeNodeText,
+  replaceRegex,
+  gatherTextBeforeIndex,
+  hasClass,
+  isCode,
+} from "./utils"
 
 /** Validates if string matches Roman numeral pattern with optional trailing punctuation */
 export function isRomanNumeral(str: string): boolean {

--- a/quartz/plugins/transformers/tests/spoiler.test.ts
+++ b/quartz/plugins/transformers/tests/spoiler.test.ts
@@ -1,9 +1,6 @@
 import { expect, describe, it, test } from "@jest/globals"
 import { type Element, type Parent, type Root } from "hast"
 import { h } from "hastscript"
-import rehypeParse from "rehype-parse"
-import rehypeStringify from "rehype-stringify"
-import { unified } from "unified"
 import { visit } from "unist-util-visit"
 
 import { BuildCtx } from "../../../util/ctx"
@@ -14,32 +11,9 @@ import {
   processParagraph,
   rehypeCustomSpoiler,
 } from "../spoiler"
+import { removePositions, createRehypeProcessor } from "./test-utils"
 
-function removePositions(obj: unknown): unknown {
-  if (Array.isArray(obj)) {
-    return obj.map(removePositions)
-  } else if (typeof obj === "object" && obj !== null) {
-    const newObj: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(obj)) {
-      if (key !== "position") {
-        newObj[key] = removePositions(value)
-      }
-    }
-    return newObj
-  }
-  return obj
-}
-
-async function process(input: string) {
-  const result = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(() => (tree: Root) => {
-      visit(tree, "element", modifyNode)
-    })
-    .use(rehypeStringify)
-    .process(input)
-  return result.toString()
-}
+const process = createRehypeProcessor(modifyNode)
 
 describe("rehype-custom-spoiler", () => {
   it.each([

--- a/quartz/plugins/transformers/tests/subtitles.test.ts
+++ b/quartz/plugins/transformers/tests/subtitles.test.ts
@@ -15,48 +15,9 @@ import {
   processParagraph,
   rehypeCustomSubtitle,
 } from "../subtitles"
+import { removePositions, createRehypeProcessor } from "./test-utils"
 
-/**
- * Recursively removes 'position' properties from AST nodes for testing purposes.
- * This helps in comparing AST nodes without considering their position information.
- *
- * @param obj - The Element object to process, typically a HAST (HTML Abstract Syntax Tree) node
- * @returns A new object with all 'position' properties removed, preserving the rest of the structure
- *
- * @example
- * const node = {
- *   type: 'element',
- *   position: { start: { line: 1, column: 1 }, end: { line: 1, column: 10 } },
- *   children: []
- * }
- * const cleaned = removePositions(node) // Returns object without position property
- */
-function removePositions(obj: Element): unknown {
-  if (Array.isArray(obj)) {
-    return obj.map(removePositions)
-  } else if (typeof obj === "object") {
-    const newObj: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(obj)) {
-      if (key !== "position") {
-        newObj[key] = removePositions(value)
-      }
-    }
-    return newObj
-  } else {
-    return obj
-  }
-}
-
-async function process(input: string) {
-  const result = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(() => (tree: Root) => {
-      visit(tree, "element", modifyNode)
-    })
-    .use(rehypeStringify)
-    .process(input)
-  return result.toString()
-}
+const process = createRehypeProcessor(modifyNode)
 
 describe("rehype-custom-subtitle", () => {
   it.each([

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -1,7 +1,10 @@
-import type { Parent, RootContent, Text, Element, Root } from "hast"
+import type { Parent, RootContent, Text, Element, Root, ElementContent } from "hast"
 
 import { toString } from "hast-util-to-string"
 import { h } from "hastscript"
+import { visit } from "unist-util-visit"
+
+import type { QuartzTransformerPlugin } from "../types"
 
 export const urlRegex = new RegExp(
   /(?<protocol>https?:\/\/)(?<domain>(?:[\da-z.-]+\.)+)(?<path>[/?=\w.-]+(?:\([\w.\-,() ]*\))?)(?=\))/g,
@@ -214,4 +217,62 @@ export function hasClass(node: Element, className: string): boolean {
     return classProp.includes(className)
   }
   return false
+}
+
+/**
+ * Type guard to check if a node is a Text node.
+ * @param node - The node to check
+ * @returns True if the node is a Text node
+ */
+export function isTextNode(node: ElementContent): node is Text {
+  return node.type === "text"
+}
+
+/**
+ * Type guard to check if a node is an Element node.
+ * @param node - The node to check
+ * @returns True if the node is an Element node
+ */
+export function isElementNode(node: ElementContent): node is Element {
+  return node.type === "element"
+}
+
+/**
+ * Check if an element is a code element.
+ * @param node - The element to check
+ * @returns True if the element's tagName is "code"
+ */
+export function isCode(node: Element): boolean {
+  return node.tagName === "code"
+}
+
+/**
+ * Factory function to create a Quartz transformer plugin that visits all elements in the HTML AST.
+ * Reduces boilerplate for simple transformer plugins that just need to visit and modify elements.
+ *
+ * @param name - The name of the plugin (e.g., "customSpoiler")
+ * @param visitor - A function that processes each element node in the tree
+ * @returns A QuartzTransformerPlugin that applies the visitor to all elements
+ *
+ * @example
+ * export const MyPlugin = createElementVisitorPlugin("MyPlugin", (node, index, parent) => {
+ *   if (node.tagName === "p") {
+ *     // Modify paragraph elements
+ *   }
+ * })
+ */
+export function createElementVisitorPlugin(
+  name: string,
+  visitor: (node: Element, index: number | undefined, parent: Parent | undefined) => void,
+): QuartzTransformerPlugin {
+  return () => ({
+    name,
+    htmlPlugins() {
+      return [
+        () => (tree: Root) => {
+          visit(tree, "element", visitor)
+        },
+      ]
+    },
+  })
 }


### PR DESCRIPTION
## Summary
This PR significantly reduces code duplication across emitter and transformer plugins by introducing factory functions that encapsulate common patterns.

## Key Changes

### Emitters
- **New `createListPageEmitter` factory function** in `helpers.ts` that generates list page emitter plugins (AllPostsPage, AllTagsPage)
- Refactored `AllPostsPage` and `AllTagsPage` to use the factory, reducing each from ~77 lines to ~13 lines
- Moved common emitter logic (layout setup, component initialization, rendering pipeline) into the factory

### Transformers
- **New `createElementVisitorPlugin` factory function** in `utils.ts` for simple element visitor transformers
- Refactored `rehypeCustomSpoiler`, `rehypeCustomSubtitle`, and `TableCaption` to use the factory
- Consolidated utility functions (`isCode`, `isTextNode`, `isElementNode`) into `utils.ts` for better organization
- Moved test utilities (`removePositions`, `createRehypeProcessor`) to shared `test-utils.ts`

### Code Organization
- Extracted `isCode` from `formatting_improvement_html.ts` to `utils.ts` and updated imports in `tagSmallcaps.ts`
- Consolidated duplicate test helper functions across spoiler and subtitle tests
- Added comprehensive JSDoc documentation for new factory functions

## Benefits
- **Reduced duplication**: ~150 lines of boilerplate eliminated
- **Improved maintainability**: Changes to list page or element visitor logic only need to be made in one place
- **Better testability**: Shared test utilities make it easier to write consistent tests
- **Clearer intent**: Plugin definitions now focus on configuration rather than implementation details

https://claude.ai/code/session_016tSGf8YyqMwazg92QWunvH