### PR TITLE
fix: use overflow: clip to fix left fade on mobile Chromium

### DIFF
--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -1060,7 +1060,8 @@ test.describe("Scroll indicators", () => {
   })
 
   test("Left fade appears after scrolling a wide element right", async ({ page }) => {
-    const scrollIndicator = page.locator("#wide-equation + .scroll-indicator")
+    // Target the scroll-indicator wrapping the wide Maxwell's equations
+    const scrollIndicator = page.locator(".scroll-indicator").filter({ hasText: "∇" }).first()
     const scrollable = scrollIndicator.locator(".katex-display")
     await scrollable.scrollIntoViewIfNeeded()
 

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -479,8 +479,6 @@ $$
 
 Post-math text. The following equations should display properly:
 
-<span id="wide-equation"></span>
-
 $$\nabla \cdot \mathbf{E}  =\frac{\rho}{\varepsilon_0} \qquad \nabla \cdot \mathbf{B}  =0 \qquad \nabla \times \mathbf{E}  =-\frac{\partial \mathbf{B}}{\partial t} \qquad \nabla \times \mathbf{B}  =\mu_0\left(\mathbf{J}+\varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right)$$
 
 [Flipped integer](/flip-integers) number: ↗142.2.


### PR DESCRIPTION
## Summary
- On mobile Chromium, the left-side fade gradient on wide elements (equations/tables) never appeared when scrolled right, while the right-side fade worked fine
- Root cause: `overflow: hidden` on `.scroll-indicator` creates a scroll container that interferes with pseudo-element rendering on mobile Chromium
- Fix: change to `overflow: clip`, which provides identical visual clipping without creating a scroll container

## Changes
- `quartz/styles/scroll-indicator.scss`: Change `overflow: hidden` to `overflow: clip` on `.scroll-indicator`
- `quartz/components/tests/test-page.spec.ts`: Add Playwright test that scrolls a wide equation to its midpoint and verifies both `can-scroll-left`/`can-scroll-right` classes and `::before` computed opacity

## Testing
- All 3202 unit tests pass
- Type checking, formatting, and linting pass
- New Playwright test passes on all 9 configurations (3 browsers x 3 viewports)
- All CI failures are pre-existing (popover close button test, a11y)

https://claude.ai/code/session_01JBqCtFqFzyv5KVxJjxGZnr