### PR TITLE
Remove unnecessary max-width constraint on list items

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -41,10 +41,6 @@ li > blockquote:first-child {
     padding-right: 0;
   }
 
-  & li {
-    max-width: 100%;
-  }
-
   // Ordered lists in footnotes should start at 1, 2, 3, etc.
   & > li > ol {
     counter-reset: list;


### PR DESCRIPTION
## Summary
Removed an unnecessary CSS rule that was constraining list items to 100% max-width within footnotes.

## Changes
- Deleted the `& li { max-width: 100%; }` rule from the footnote styles in `custom.scss`

## Details
This rule was redundant as list items naturally respect their container's width without an explicit max-width constraint. Removing it simplifies the stylesheet and allows list items to flow more naturally within footnote contexts without artificial width limitations.

https://claude.ai/code/session_01D9ba6QUTtmsfLpzLVHHNKL