### PR TITLE
Remove trailing comma from pa11y ignore configuration

### DIFF
--- a/config/pa11y/.pa11yci
+++ b/config/pa11y/.pa11yci
@@ -18,7 +18,7 @@
       "#trout-ornament-container"
     ],
     "ignore": [
-      "frame-tested",
+      "frame-tested"
     ],
     "concurrency": 1
   }


### PR DESCRIPTION
## Summary
Fixed a trailing comma in the pa11y configuration file that violates JSON formatting standards.

## Changes
- Removed trailing comma from the `ignore` array in `.pa11yci` configuration file
- This ensures the JSON is properly formatted and valid

## Details
The `ignore` array in the pa11y configuration had a trailing comma after the last element, which is invalid JSON syntax. This change removes that trailing comma to maintain proper JSON formatting and prevent potential parsing issues.

https://claude.ai/code/session_01PcveMTbfVWshfVcDQzDRiu