### PR TITLE
Refactor test fixtures to use monkeypatch instead of mock.patch

### DIFF
--- a/scripts/tests/test_convert_markdown.py
+++ b/scripts/tests/test_convert_markdown.py
@@ -27,7 +27,7 @@ def mock_load_shared_constants(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def mock_git_root(quartz_project_structure):
+def mock_git_root(quartz_project_structure, monkeypatch):
     """Override conftest mock_git_root to add card_images directory."""
     git_root = quartz_project_structure["public"].parent
     (git_root / "quartz" / "static" / "images" / "card_images").mkdir(
@@ -36,8 +36,11 @@ def mock_git_root(quartz_project_structure):
     (git_root / "static" / "images" / "posts").mkdir(
         parents=True, exist_ok=True
     )
-    with mock.patch("scripts.utils.get_git_root", return_value=git_root):
-        yield git_root
+    monkeypatch.setattr(
+        "scripts.utils.get_git_root",
+        lambda *_args, **_kwargs: git_root,
+    )
+    return git_root
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Refactored pytest fixtures in test files to use `monkeypatch` for mocking instead of `mock.patch` context managers. This improves test fixture design by separating concerns and making fixtures more reusable.

## Key Changes
- **test_download_external_media.py**:
  - Modified `mock_git_root` fixture to accept `monkeypatch` parameter and use `monkeypatch.setattr()` instead of `mock.patch()` context manager
  - Changed fixture from using `yield` with context manager to direct `return` statement
  - Removed redundant `monkeypatch.setattr()` calls from `test_main_no_markdown_files`, `test_main_no_external_urls`, `test_main_downloads_and_updates`, and `test_main_handles_download_failures` tests since mocking is now handled in the fixture
  - Minor formatting: consolidated multi-line `write_text()` calls to single lines

- **test_convert_markdown.py**:
  - Modified `mock_git_root` fixture to accept `monkeypatch` parameter and use `monkeypatch.setattr()` instead of `mock.patch()` context manager
  - Changed fixture from using `yield` with context manager to direct `return` statement

## Implementation Details
- The `monkeypatch` fixture is now injected into `mock_git_root` fixtures, allowing them to set up mocks without relying on context managers
- Lambda functions with `*_args, **_kwargs` parameters are used to match the original `return_value` behavior
- This approach is more idiomatic for pytest fixtures and reduces nesting complexity

https://claude.ai/code/session_01GuRT4JvmvcdMXbvgiqZyDR