### PR TITLE
Skip color contrast audit in Lighthouse accessibility config

### DIFF
--- a/.github/lighthouse-a11y-config.json
+++ b/.github/lighthouse-a11y-config.json
@@ -4,7 +4,7 @@
       "numberOfRuns": 1,
       "settings": {
         "onlyCategories": ["accessibility"],
-        "skipAudits": [],
+        "skipAudits": ["color-contrast"],
         "throttling": {
           "cpuSlowdownMultiplier": 1,
           "rttMs": 40,


### PR DESCRIPTION
## Summary
Updated the Lighthouse accessibility configuration to skip the color contrast audit during accessibility testing.

## Changes
- Modified `.github/lighthouse-a11y-config.json` to add `"color-contrast"` to the `skipAudits` array
- This prevents the color contrast audit from running during Lighthouse accessibility checks

## Details
The color contrast audit is now excluded from the accessibility audit suite. This may be useful if color contrast validation is handled through alternative tooling or if there are known contrast issues that need to be addressed separately from the automated Lighthouse checks.

https://claude.ai/code/session_01CUvF2Fnv3B65VMA83afgVt