### PR TITLE
Simplify critical SCSS generation tests with snapshot testing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -47,4 +47,4 @@ jobs:
         uses: ./.github/actions/setup-build-env
         with:
           install-python: "false"
-      - run: pnpm test -u
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ tsconfig.tsbuildinfo
 # Testing & Coverage
 .coverage*
 coverage
-*snapshots*
-*__snapshots__
 lost-pixel/*
 .lostpixel
 /test-results/

--- a/quartz/plugins/transformers/tests/__snapshots__/formatting_improvement_html.test.ts.snap
+++ b/quartz/plugins/transformers/tests/__snapshots__/formatting_improvement_html.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`assertSmartQuotesMatch should throw for mismatched closing quotes 1`] = `"Mismatched quotes in This has a random ending quote”"`;
+
+exports[`assertSmartQuotesMatch should throw for mismatched closing quotes 2`] = `"Mismatched quotes in “More” nested mismatches”"`;
+
+exports[`assertSmartQuotesMatch should throw for mismatched opening quotes 1`] = `"Mismatched quotes in “This is missing an end quote"`;
+
+exports[`assertSmartQuotesMatch should throw for mismatched opening quotes 2`] = `"Mismatched quotes in “Nested “quotes” that are incorrect"`;

--- a/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
+++ b/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Critical SCSS Generation generateCritical() should generate critical.scss with correct content 1`] = `
+":root {
+  font-family: var(--font-main);
+}
+
+:root[data-theme="light"] {
+  --midground-faint: #{$midground-faint-light};
+  --midground: #{$midground-light};
+}
+
+:root[data-theme="dark"] {
+  --midground-faint: #{$midground-faint-dark};
+  --midground: #{$midground-dark};
+}
+
+#navbar-left h2 {
+  color: var(--midground);
+}
+
+code,
+pre {
+  font-family: "FiraCode__subset", FiraCode, monospace;
+}
+
+article[data-use-dropcap="true"] {
+  --dropcap-vertical-offset: #{$dropcap-vertical-offset};
+  --dropcap-font-size: #{$dropcap-font-size};
+  --before-color: var(--midground-faint);
+  --font-main: "EBGaramond__subset", "EBGaramond";
+  --font-italic: "EBGaramondItalic__subset", "EBGaramondItalic";
+  --font-italic-situational: var(--font-italic);
+  --font-dropcap-foreground: "EBGaramondInitialsF2__subset", "EBGaramondInitialsF2";
+  --font-dropcap-background: "EBGaramondInitialsF1__subset", "EBGaramondInitialsF1";
+}
+
+article[data-use-dropcap="true"] > p:first-of-type {
+  position: relative;
+  min-height: #{$dropcap-min-height};
+}
+
+article[data-use-dropcap="true"] > p:first-of-type::before {
+  content: attr(data-first-letter);
+  text-transform: uppercase;
+  position: absolute;
+  top: var(--dropcap-vertical-offset);
+  left: 0;
+  font-size: var(--dropcap-font-size);
+  line-height: 1;
+  padding-right: 0.1em;
+  font-family: var(--font-dropcap-background);
+  color: var(--before-color);
+}
+
+article[data-use-dropcap="true"] > p:first-of-type::first-letter {
+  padding-top: var(--dropcap-vertical-offset);
+  text-transform: uppercase;
+  font-style: normal !important;
+  float: left;
+  color: var(--foreground);
+  font-size: var(--dropcap-font-size);
+  width: var(--dropcap-font-size);
+  line-height: 1;
+  padding-right: 0.1em;
+  font-family: var(--font-dropcap-foreground);
+  font-weight: 500 !important;
+}
+
+article[data-use-dropcap="true"] > p:first-of-type::first-line {
+  --font-italic-situational: var(--font-main) !important;
+}
+
+em {
+  font-family: var(--font-italic-situational);
+}
+
+:root[saved-theme="dark"],
+.dark-mode {
+  --background: #303446;
+  --foreground: #c6d0f5;
+  --red: #de585a;
+  --green: #a6d189;
+  --blue: #8caaee;
+}
+
+:root[saved-theme="light"],
+.light-mode {
+  --background: #eff1f5;
+  --foreground: #4c4f69;
+  --red: #be415c;
+  --green: #22820d;
+  --blue: #3e6ccb;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  margin-top: $top-spacing;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  height: fit-content;
+}
+
+@media all and (min-width: $min-desktop-width) {
+  #quartz-body {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: calc(0.5 * #{$max-sidebar-gap});
+    margin: 0 auto;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: $top-spacing;
+    overflow-y: auto;
+    max-height: calc(100vh - #{$top-spacing});
+  }
+
+  #left-sidebar {
+    flex-basis: $left-sidebar-width;
+    flex-shrink: 0.25;
+    margin-left: calc(0.25 * #{$max-sidebar-gap});
+    z-index: 1;
+    order: 1;
+  }
+
+  #right-sidebar {
+    padding-right: calc(0.5 * #{$max-sidebar-gap});
+    flex-basis: $right-sidebar-width;
+    flex-shrink: 1;
+    order: 3;
+  }
+
+  #center-content {
+    flex-grow: 1;
+    flex-shrink: 1;
+    max-width: $page-width;
+    overflow-x: hidden;
+    width: 100%;
+    order: 2;
+  }
+}
+
+@media all and (min-width: $wider-gap-breakpoint) {
+  #quartz-body {
+    gap: $max-sidebar-gap;
+  }
+
+  #left-sidebar {
+    margin-left: 0;
+  }
+
+  #right-sidebar {
+    margin-right: 0;
+  }
+}
+"
+`;

--- a/quartz/styles/tests/generate-critical.test.ts
+++ b/quartz/styles/tests/generate-critical.test.ts
@@ -14,7 +14,7 @@ describe("Critical SCSS Generation", () => {
   })
 
   describe("generateCritical()", () => {
-    it("should write critical.scss with correct structure and SCSS variables", () => {
+    it("should generate critical.scss with correct content", () => {
       const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
 
       generateCritical()
@@ -25,88 +25,7 @@ describe("Critical SCSS Generation", () => {
       expect(path.basename(filePath as string)).toBe("critical.scss")
 
       const content = fileContent as string
-
-      // Check for SCSS variable usage
-      expect(content).toContain("$midground-faint-light")
-      expect(content).toContain("$midground-light")
-      expect(content).toContain("$midground-faint-dark")
-      expect(content).toContain("$midground-dark")
-      expect(content).toContain("$top-spacing")
-      expect(content).toContain("$min-desktop-width")
-      expect(content).toContain("$max-sidebar-gap")
-      expect(content).toContain("$left-sidebar-width")
-      expect(content).toContain("$right-sidebar-width")
-      expect(content).toContain("$page-width")
-      expect(content).toContain("$wider-gap-breakpoint")
-
-      // Check for dropcap variable usage
-      expect(content).toContain("$dropcap-vertical-offset")
-      expect(content).toContain("$dropcap-font-size")
-      expect(content).toContain("$dropcap-min-height")
-
-      // Check for key CSS selectors
-      expect(content).toContain(":root {")
-      expect(content).toContain(':root[data-theme="light"]')
-      expect(content).toContain(':root[data-theme="dark"]')
-      expect(content).toContain("article[data-use-dropcap")
-      expect(content).toContain(".sidebar {")
-      expect(content).toContain("#quartz-body {")
-
-      // Verify no hardcoded dropcap values
-      expect(content).not.toContain("0.15rem")
-      expect(content).not.toContain("3.95rem")
-      expect(content).not.toContain("4.2rem")
-
-      // Verify both data-theme and saved-theme are used
-      expect(content).toContain('data-theme="light"')
-      expect(content).toContain('data-theme="dark"')
-      expect(content).toContain('saved-theme="light"')
-      expect(content).toContain('saved-theme="dark"')
-    })
-
-    it("should include responsive layout styles", () => {
-      const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
-
-      generateCritical()
-
-      const content = writeSpy.mock.calls[0][1] as string
-
-      // Check for media queries
-      expect(content).toContain("@media all and (min-width: $min-desktop-width)")
-      expect(content).toContain("@media all and (min-width: $wider-gap-breakpoint)")
-
-      // Check for sidebar layout styles
-      expect(content).toContain("#left-sidebar")
-      expect(content).toContain("#right-sidebar")
-      expect(content).toContain("#center-content")
-    })
-
-    it("should include dropcap styles", () => {
-      const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
-
-      generateCritical()
-
-      const content = writeSpy.mock.calls[0][1] as string
-
-      // Check for dropcap-related CSS
-      expect(content).toContain("--font-dropcap-foreground")
-      expect(content).toContain("--font-dropcap-background")
-      expect(content).toContain("::first-letter")
-      expect(content).toContain("::first-line")
-      expect(content).toContain("EBGaramondInitialsF2")
-      expect(content).toContain("EBGaramondInitialsF1")
-    })
-
-    it("should include font family declarations", () => {
-      const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
-
-      generateCritical()
-
-      const content = writeSpy.mock.calls[0][1] as string
-
-      expect(content).toContain("FiraCode__subset")
-      expect(content).toContain("EBGaramond__subset")
-      expect(content).toContain("EBGaramondItalic__subset")
+      expect(content).toMatchSnapshot()
     })
 
     it("should throw an error if file writing fails", () => {


### PR DESCRIPTION
## Summary
Refactored the critical SCSS generation test suite to use Jest snapshot testing instead of individual assertion checks. This simplifies test maintenance and makes it easier to review content changes.

## Key Changes
- Consolidated four separate test cases into a single test that uses `toMatchSnapshot()`
- Removed 60+ individual assertions checking for specific SCSS variables, CSS selectors, media queries, font declarations, and dropcap styles
- Simplified test description from "should write critical.scss with correct structure and SCSS variables" to "should generate critical.scss with correct content"
- Eliminated redundant test setup across multiple test cases by consolidating into one

## Implementation Details
The snapshot approach provides several benefits:
- Easier to review what content is actually generated by viewing the snapshot file
- Simpler to update when intentional changes are made to the critical SCSS output
- Reduces test brittleness from overly specific assertions
- Maintains the same coverage of the generated content while being more maintainable

https://claude.ai/code/session_01NU6Div1eXmqtMsuxJNrL1S