### PR TITLE
Make Node.js installation optional in GitHub Actions workflows

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -1,6 +1,10 @@
 name: "Setup Base Environment"
 description: "Sets up Node.js, pnpm, Python with uv, and common caches"
 inputs:
+  install-node-deps:
+    description: "Whether to install Node.js and dependencies"
+    required: false
+    default: "true"
   install-sharp:
     description: "Whether to install sharp for Linux"
     required: false
@@ -29,19 +33,23 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
+      if: inputs.install-node-deps == 'true'
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: "22.12.0"
 
     - name: Install pnpm
+      if: inputs.install-node-deps == 'true'
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
     - name: Get pnpm store directory
+      if: inputs.install-node-deps == 'true'
       shell: bash
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
     - name: Restore pnpm cache
+      if: inputs.install-node-deps == 'true'
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.STORE_PATH }}
@@ -85,13 +93,14 @@ runs:
         key: ffmpeg-${{ runner.os }}-master-latest
 
     - name: Install Node Dependencies
+      if: inputs.install-node-deps == 'true'
       run: timeout 600 pnpm install --frozen-lockfile
       shell: bash
       env:
         NODE_OPTIONS: "--max-old-space-size=4096"
 
     - name: Install sharp
-      if: inputs.install-sharp == 'true'
+      if: inputs.install-sharp == 'true' && inputs.install-node-deps == 'true'
       run: pnpm install --os=linux --cpu=x64 sharp
       shell: bash
 

--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -1,6 +1,10 @@
 name: "Setup Build Environment"
 description: "Checks out code, sets up Node and Python, installs dependencies, and caches them."
 inputs:
+  install-node-deps:
+    description: "Whether to install Node.js and dependencies"
+    required: false
+    default: "true"
   install-python:
     description: "Whether to install Python and Python dependencies"
     required: false
@@ -11,6 +15,7 @@ runs:
     - name: Setup base environment
       uses: ./.github/actions/setup-base-env
       with:
+        install-node-deps: ${{ inputs.install-node-deps }}
         install-sharp: "true"
         cache-playwright: "false"
         cache-puppeteer: "false"
@@ -24,6 +29,7 @@ runs:
       shell: bash
 
     - name: Download and install latest ffmpeg
+      if: inputs.install-node-deps == 'true'
       run: |
         set -e
         FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
+        with:
+          install-node-deps: "false"
 
       - name: Run mypy
         run: |

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
+        with:
+          install-node-deps: "false"
 
       - name: Install test dependencies
         run: |
@@ -58,9 +60,6 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew install imagemagick
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-
-      - name: Add node_modules/.bin to PATH
-        run: echo "${{ github.workspace }}/node_modules/.bin" >> $GITHUB_PATH
 
       - name: Run pytest
         run: |

--- a/.github/workflows/update-article-dates.yml
+++ b/.github/workflows/update-article-dates.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Base Environment
         uses: ./.github/actions/setup-base-env
+        with:
+          install-node-deps: "false"
 
       - name: Update article dates
         run: uv run python scripts/update_date_on_publish.py --commit-range "${{ github.event.before }}..${{ github.event.after }}"


### PR DESCRIPTION
## Summary
This PR adds an optional `install-node-deps` input parameter to the GitHub Actions setup workflows, allowing workflows to skip Node.js and dependency installation when not needed. This optimization reduces workflow execution time for Python-only jobs.

## Key Changes
- Added `install-node-deps` input to `setup-base-env` action (defaults to `true` for backward compatibility)
- Added `install-node-deps` input to `setup-build-env` action and passed it through to `setup-base-env`
- Wrapped Node.js-related steps with conditional checks in `setup-base-env`:
  - Node.js setup
  - pnpm installation and cache operations
  - Node dependencies installation
  - sharp installation (also requires `install-node-deps` to be true)
- Updated Python-focused workflows to skip Node.js installation:
  - `python-tests.yaml`: Set `install-node-deps: "false"` and removed unnecessary `node_modules/.bin` PATH addition
  - `python-lint.yaml`: Set `install-node-deps: "false"` in `setup-base-env`
  - `update-article-dates.yml`: Set `install-node-deps: "false"` in `setup-base-env`

## Implementation Details
- The new input defaults to `"true"` to maintain backward compatibility with existing workflows
- Conditional steps use `if: inputs.install-node-deps == 'true'` to control execution
- The `install-sharp` step now requires both `install-sharp == 'true'` AND `install-node-deps == 'true'` since sharp depends on Node.js
- Python-only workflows now skip unnecessary Node.js setup, improving CI/CD performance

https://claude.ai/code/session_013qxBnJA3412eZFyfK1M1fi