### PR TITLE
perf(ci): optimize git fetch operations in workflows

### DIFF
--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -32,8 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Fetch enough history to access before/after commits from the push event
-          fetch-depth: 0
+          fetch-depth: 2  # Get current commit + parent for git diff
+
+      - name: Fetch before commit
+        run: git fetch --depth=2 origin ${{ github.event.before }}
 
       - name: Setup Base Environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -52,8 +52,7 @@ jobs:
     steps:
       - name: Checkout child repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # Default shallow fetch is sufficient - git operations are on template repo
 
       - name: Checkout template repository
         uses: actions/checkout@v4

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -208,8 +208,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
+        # Default shallow fetch is sufficient - this job only combines artifacts
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env


### PR DESCRIPTION
## Summary

Optimize CI performance by replacing unnecessary `fetch-depth: 0` (full git history) with minimal shallow fetches. This reduces network overhead and speeds up workflow execution while maintaining all functionality.

## Changes

1. **lint-and-validate.yaml**: Changed from `fetch-depth: 0` to `fetch-depth: 2` (gets current commit + parent + before commit)
   - Ensures `git diff` operations work correctly for date update script
   - Handles edge cases like initial pushes where parent commits are needed
   
2. **template-sync.yaml**: Removed unnecessary `fetch-depth: 0`
   - Git operations are performed on the template repo checkout, not the main checkout
   - Shallow fetch of main repo is sufficient for file comparisons
   
3. **visual-testing.yaml** (combine-and-upload job): Removed unnecessary `fetch-depth: 0`
   - Job only combines screenshot artifacts from previous jobs
   - No git operations performed

## Workflows Unchanged

The following workflows legitimately need `fetch-depth: 0` because they run `pnpm build`, which executes `git rev-list --all --count` for repository statistics:

- deploy.yaml (both build jobs)
- playwright-tests.yaml (build job)
- site-build-checks.yaml (build job)  
- visual-testing.yaml (build job)
- monthly-newsletter.yml (uses `git log` with date ranges)

## Testing

- Verified `git diff` works correctly with shallow fetches in test scenario
- Reviewed `update_date_on_publish.py` logic to ensure compatibility with shallow clones
- All three workflow changes are either no-ops (template-sync, visual-testing) or safe optimizations (lint-and-validate)

## Performance Impact

- **Before**: Fetching full history can download hundreds of commits (~10-50MB+ depending on repo size)
- **After**: Fetching 2 commits downloads <1MB of git objects
- **Expected speedup**: 5-15 seconds per workflow run

https://claude.ai/code/session_01JCtvbapGbHFJd2kHjw3o4j