### PR TITLE
perf(test): optimize Playwright tests for faster execution

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
   timeout: 30000,
   workers: 1, // Parallelism causes flakiness
 
-  retries: process.env.CI ? 5 : 1,
+  retries: process.env.CI ? 3 : 1,
   testDir: "../../quartz/",
   testMatch: /.*\.spec\.ts/,
   snapshotPathTemplate: "../../lost-pixel/{arg}.png",
@@ -82,7 +82,7 @@ export default defineConfig({
     baseURL: "http://localhost:8080",
     trace: "on-first-retry",
     screenshot: {
-      mode: "on",
+      mode: "only-on-failure",
       fullPage: true,
     },
     // Stabilize device scale across runners to reduce text subpixel jitter.

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -16,7 +16,7 @@ async function goBackToTestPage(page: Page): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
+  await page.goto("http://localhost:8080/test-page", { waitUntil: "domcontentloaded" })
 })
 
 test.describe("Collapsible admonition state persistence", () => {

--- a/quartz/components/tests/darkmode.spec.ts
+++ b/quartz/components/tests/darkmode.spec.ts
@@ -12,7 +12,7 @@ const THEME_SCHEMES = ["light", "dark"] as const
 const ALL_THEMES = ["light", "dark", "auto"] as const
 const NAVIGATION_PREFIXES = ["./shard-theory", "./about", "./design#"]
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
+  await page.goto("http://localhost:8080/test-page", { waitUntil: "domcontentloaded" })
   await page.emulateMedia({ colorScheme: AUTO_THEME })
 })
 

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -111,7 +111,7 @@ async function setupVideoForTimestampTest(videoElements: VideoElements): Promise
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
+  await page.goto("http://localhost:8080/test-page", { waitUntil: "domcontentloaded" })
 
   await page.evaluate(() => window.scrollTo(0, 0))
 })

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -33,9 +33,7 @@ test.beforeEach(async ({ page }) => {
     test.skip()
   }
 
-  // I don't trust playwright's test isolation
-  await page.reload()
-  await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
+  await page.goto("http://localhost:8080/test-page", { waitUntil: "domcontentloaded" })
 })
 
 test(".can-trigger-popover links show popover on hover (lostpixel)", async ({
@@ -573,8 +571,7 @@ test.describe("Footnote popovers", () => {
 base.describe("Footnote popover on mobile", () => {
   base.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 })
-    await page.reload()
-    await page.goto("http://localhost:8080/test-page", { waitUntil: "load" })
+    await page.goto("http://localhost:8080/test-page", { waitUntil: "domcontentloaded" })
   })
 
   base("Tapping footnote opens pinned popover, close button dismisses it", async ({ page }) => {

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ page }) => {
   page.on("pageerror", (err) => console.error(err))
 
   // Navigate and wait for full initialization
-  await page.goto("http://localhost:8080/welcome", { waitUntil: "load" })
+  await page.goto("http://localhost:8080/welcome", { waitUntil: "domcontentloaded" })
 
   // Wait for search to be fully initialized
   await expect(page.locator("#search-container")).toBeAttached()


### PR DESCRIPTION
## Summary
- Reduce Playwright test overhead by eliminating unnecessary screenshots, redundant navigations, and excessive wait times across 5 spec files and the config

## Changes
- **Screenshot mode `"on"` → `"only-on-failure"`**: Previously every test captured a full-page screenshot even when passing. Visual regression screenshots are handled explicitly by `takeRegressionScreenshot()`, so the global setting was pure overhead
- **CI retries 5 → 3**: Reduces wasted time on persistently failing tests while still handling genuine flakiness
- **Remove redundant `page.reload()` in popover spec**: Both desktop and mobile `beforeEach` hooks did `page.reload()` immediately before `page.goto()` — the reload was wasted since `goto` navigates to a fresh URL
- **`waitUntil: "load"` → `"domcontentloaded"` in 5 spec files** (collapsible, darkmode, navbar, popover, search): CSS is render-blocking and ready at `domcontentloaded`, and all tests have explicit `expect` assertions that wait for element readiness. `spa.inline.spec.ts` already used this pattern successfully. `test-page.spec.ts` intentionally kept at `"load"` since it does visual regression testing

## Testing
- `pnpm check` passes (TypeScript type checking + Prettier + Stylelint)
- Self-critique sub-agent found no issues
- Full CI suite should validate the 1,602 Playwright tests still pass

https://claude.ai/code/session_014YVNVotSRwbe3LtZgRyAs8