### PR TITLE
Add word-joiner span utility and improve DeepSource docs

### DIFF
--- a/.claude/skills/pr-creation.md
+++ b/.claude/skills/pr-creation.md
@@ -130,7 +130,7 @@ EOF
 
 ### Step 6: Check DeepSource Issues
 
-After pushing, check for DeepSource static analysis issues:
+After pushing, check for DeepSource static analysis issues using the forked CLI (installed by the SessionStart hook). **Never** try to fetch DeepSource URLs via `WebFetch` — the web UI requires authentication and returns no useful content.
 
 1. Get the commit SHA: `git rev-parse HEAD`
 2. Run: `deepsource issues list --commit <SHA>`

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -101,8 +101,9 @@ After creating the PR, and after any subsequent fix commits, update the PR descr
 
 1. Run `gh pr checks <pr-number> --watch` to monitor
 2. If any checks fail, investigate and fix the issues
-3. Push fixes and wait again
-4. Only proceed once all checks are green
+3. For DeepSource failures, use the forked `deepsource` CLI: `deepsource issues list --commit <SHA>`. **Never** try to fetch DeepSource URLs via `WebFetch` — the web UI requires authentication and returns no useful content.
+4. Push fixes and wait again
+5. Only proceed once all checks are green
 
 ### Step 7: Report Result
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ After pushing to main:
 - Tests run on ~40 parallel shards to complete in ~10 minutes
 - Visual regression testing with `lost-pixel`
 - Lighthouse checks for minimal layout shift
-- DeepSource static analysis
+- DeepSource static analysis (use the forked `deepsource` CLI to check issues — **never** try to fetch DeepSource URLs via `WebFetch`, the web UI requires authentication and returns no useful content)
 
 ### CI Cost Optimization
 

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -210,6 +210,20 @@ export function createNowrapSpan(text: string, child: Element): Element {
 }
 
 /**
+ * Creates a word-joiner span element containing a Unicode word joiner
+ * character (U+2060). Used to wrap favicons so they don't orphan from
+ * adjacent text when lines break.
+ */
+export function createWordJoinerSpan(): Element {
+  return {
+    type: "element",
+    tagName: "span",
+    properties: { className: "word-joiner" },
+    children: [{ type: "text" as const, value: "\u2060" }],
+  } as Element
+}
+
+/**
  * Splices the last few characters from a text node and wraps them with
  * the given element in a nowrap span, preventing line-break orphaning.
  *

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1290,7 +1290,7 @@ def _build_favicon_lists(
 
     Returns a (whitelist, blacklist) tuple.
     """
-    result = subprocess.run(
+    result = subprocess.run(  # skipcq: BAN-B607
         ["npx", "tsx", str(git_root / "scripts" / "compute_favicon_lists.ts")],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
This PR adds a new utility function for creating word-joiner span elements and improves documentation around DeepSource static analysis checks.

## Key Changes

- **New utility function**: Added `createWordJoinerSpan()` to `quartz/plugins/transformers/utils.ts` that creates a span element containing a Unicode word joiner character (U+2060). This is used to prevent favicons from orphaning from adjacent text when lines break.

- **Documentation improvements**: Updated PR creation and CI documentation to clarify the proper way to check DeepSource issues:
  - Documented that the forked `deepsource` CLI should be used to list issues via `deepsource issues list --commit <SHA>`
  - Added explicit warnings against attempting to fetch DeepSource URLs via `WebFetch`, as the web UI requires authentication and provides no useful content
  - Updated references in `.claude/skills/pr-creation/SKILL.md`, `.claude/skills/pr-creation.md`, and `CLAUDE.md`

- **Code quality**: Added `skipcq: BAN-B607` comment to subprocess call in `scripts/built_site_checks.py` to suppress security linting for the intentional use of `npx` command execution.

## Implementation Details

The `createWordJoinerSpan()` function follows the existing pattern of similar utility functions in the file, returning an Element object with proper typing and structure for use in the document transformation pipeline.

https://claude.ai/code/session_015b3ASocZecKev1mueaQ4MB