### PR TITLE
Simplify a11y workflow to run only on main branch pushes

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -2,15 +2,7 @@ name: Accessibility
 
 on:
   push:
-    branches: ["main", "dev"]
-    paths:
-      - "quartz/**"
-      - "website_content/**"
-      - "config/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
-  pull_request:
+    branches: ["main"]
     paths:
       - "quartz/**"
       - "website_content/**"


### PR DESCRIPTION
## Summary
Simplified the accessibility workflow trigger configuration to reduce unnecessary workflow runs and focus on the main branch.

## Key Changes
- Removed `dev` branch from the push trigger, keeping only `main`
- Removed the entire `pull_request` trigger section
- Consolidated path filters to apply only to push events on the main branch

## Details
This change ensures the accessibility workflow runs only when code is pushed directly to the main branch, eliminating redundant checks on development branch pushes and pull requests. This reduces CI/CD overhead while maintaining accessibility checks on the primary branch.

https://claude.ai/code/session_014zGawkfFemF4ZSpMLQDN4C