### PR TITLE
Remove mermaid diagram text styling overrides

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -796,21 +796,6 @@ img.emoji {
   }
 }
 
-// Ensure all mermaid diagram text has sufficient contrast
-svg[id^="mermaid-"] {
-  font-size: 14px !important;
-  fill: var(--midground-faint) !important; // Ensure arrowheads are visible
-
-  & span,
-  & p,
-  & .label,
-  & .nodeLabel,
-  & .edgeLabel {
-    color: var(--foreground) !important;
-    fill: var(--foreground) !important;
-  }
-}
-
 .flowchart-link {
   stroke: var(--midground-faint) !important;
 }


### PR DESCRIPTION
## Summary
Removed CSS styling rules that were forcefully overriding mermaid diagram text appearance and contrast settings.

## Changes
- Deleted the `[id^="mermaid-"]` CSS rule block that was applying `!important` overrides to mermaid diagram elements
- This rule was setting font-size, fill color, and text color properties on mermaid diagram containers and their child elements (spans, paragraphs, labels, node labels, and edge labels)

## Rationale
The removed styling was using `!important` declarations to force specific colors and sizing on mermaid diagrams, which likely conflicted with mermaid's own styling logic or prevented proper theme application. Removing these overrides allows mermaid diagrams to render with their default or theme-appropriate styling.

The `.flowchart-link` rule for stroke styling remains in place.

https://claude.ai/code/session_01J3rfv8dEwA3Q69HGV7TTaW