### PR TITLE
fix(ci): replace BtbN ffmpeg download with pinned system package

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -17,18 +17,10 @@ inputs:
     description: "Whether to cache Puppeteer browsers"
     required: false
     default: "false"
-  cache-ffmpeg:
-    description: "Whether to cache ffmpeg"
-    required: false
-    default: "false"
   install-python:
     description: "Whether to install Python and Python dependencies"
     required: false
     default: "true"
-outputs:
-  ffmpeg-cache-hit:
-    description: "Whether ffmpeg was found in cache"
-    value: ${{ steps.cache-ffmpeg.outputs.cache-hit }}
 runs:
   using: "composite"
   steps:
@@ -83,14 +75,6 @@ runs:
         key: puppeteer-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           puppeteer-${{ runner.os }}-
-
-    - name: Restore ffmpeg cache
-      if: inputs.cache-ffmpeg == 'true'
-      id: cache-ffmpeg
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: /opt/ffmpeg
-        key: ffmpeg-${{ runner.os }}-master-latest
 
     - name: Install Node Dependencies
       if: inputs.install-node-deps == 'true'

--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -19,7 +19,6 @@ runs:
         install-sharp: "true"
         cache-playwright: "false"
         cache-puppeteer: "false"
-        cache-ffmpeg: "false"
         install-python: ${{ inputs.install-python }}
 
     - name: Install Build Dependencies
@@ -28,23 +27,10 @@ runs:
         sudo apt-get install -y libxml2-utils dos2unix
       shell: bash
 
-    - name: Download and install latest ffmpeg
+    - name: Install ffmpeg from system packages
       if: inputs.install-node-deps == 'true'
       run: |
-        set -e
-        FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
-        FFMPEG_DIR="/opt/ffmpeg"
-
-        # Create the target directory
-        sudo mkdir -p "$FFMPEG_DIR"
-
-        # Download and extract ffmpeg, stripping the top-level directory
-        timeout 300 bash -c 'curl -sL "$1" | sudo tar -xJ -C "$2" --strip-components=1' -- "$FFMPEG_URL" "$FFMPEG_DIR"
-
-        # Create symlinks to make ffmpeg and ffprobe available on the PATH
-        sudo ln -sf "$FFMPEG_DIR"/bin/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf "$FFMPEG_DIR"/bin/ffprobe /usr/local/bin/ffprobe
-
-        # Verify the installation
-        ffmpeg -version
+        # Pinned to ubuntu-24.04 runner's ffmpeg version (only ffprobe is needed at build time)
+        sudo apt-get install -y ffmpeg=7:6.1.1-3ubuntu5
+        ffprobe -version
       shell: bash

--- a/.github/actions/setup-visual-testing-env/action.yaml
+++ b/.github/actions/setup-visual-testing-env/action.yaml
@@ -9,13 +9,11 @@ runs:
   using: "composite"
   steps:
     - name: Setup base environment
-      id: setup-base
       uses: ./.github/actions/setup-base-env
       with:
         install-sharp: "false"
         cache-playwright: "true"
         cache-puppeteer: "true"
-        cache-ffmpeg: "true"
         install-python: "false"
 
     - name: Install Playwright browsers and system dependencies
@@ -23,26 +21,10 @@ runs:
       run: pnpm exec playwright install --with-deps chromium webkit firefox
       shell: bash
 
-    - name: Download and install ffmpeg
-      if: steps.setup-base.outputs.ffmpeg-cache-hit != 'true'
+    - name: Install ffmpeg from system packages
       run: |
-        set -e
-        FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
-        FFMPEG_DIR="/opt/ffmpeg"
-
-        # Create the target directory
-        sudo mkdir -p "$FFMPEG_DIR"
-
-        # Download and extract ffmpeg, stripping the top-level directory
-        timeout 300 bash -c 'curl -sL "$1" | sudo tar -xJ -C "$2" --strip-components=1' -- "$FFMPEG_URL" "$FFMPEG_DIR"
-      shell: bash
-
-    - name: Setup ffmpeg symlinks
-      run: |
-        # Create symlinks to make ffmpeg and ffprobe available on the PATH
-        sudo ln -sf /opt/ffmpeg/bin/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf /opt/ffmpeg/bin/ffprobe /usr/local/bin/ffprobe
-
-        # Verify the installation
-        ffmpeg -version
+        # Pinned to ubuntu-24.04 runner's ffmpeg version (only ffprobe is needed at build time)
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg=7:6.1.1-3ubuntu5
+        ffprobe -version
       shell: bash

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libimage-exiftool-perl inkscape rclone fish ffmpeg
+          sudo apt-get install -y libimage-exiftool-perl inkscape rclone fish ffmpeg=7:6.1.1-3ubuntu5
           pip install linkchecker
 
       - name: Install ImageMagick 7 via Homebrew


### PR DESCRIPTION
## Summary
- Replace flaky BtbN ffmpeg GitHub release downloads with ubuntu-24.04's system ffmpeg package, pinned to `7:6.1.1-3ubuntu5`
- Remove the associated `cache-ffmpeg` input/output and cache restore infrastructure from `setup-base-env`, since system packages don't need caching

## Changes
- `.github/actions/setup-build-env/action.yaml`: Replace BtbN download/extract/symlink script with `apt-get install -y ffmpeg=7:6.1.1-3ubuntu5`
- `.github/actions/setup-visual-testing-env/action.yaml`: Same replacement; remove cache-hit conditional and symlinks step
- `.github/actions/setup-base-env/action.yaml`: Remove `cache-ffmpeg` input, `ffmpeg-cache-hit` output, and ffmpeg cache restore step
- `.github/workflows/python-tests.yaml`: Pin ffmpeg version in apt-get install for consistency

## Testing
- CI-only change; will be validated by the workflows themselves running on this PR

https://claude.ai/code/session_012Hz2zULM4WtGmJ99cYJWk1