### PR TITLE
Remove unused test and expect imports from search spec

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Locator } from "@playwright/test"
+import { type Page, type Locator } from "@playwright/test"
 
 import { tabletBreakpoint } from "../../styles/variables"
 import { simpleConstants } from "../constants"


### PR DESCRIPTION
## Summary
Cleaned up unused imports in the search test file by removing `test` and `expect` from the Playwright test imports.

## Key Changes
- Removed `test` import from `@playwright/test` - not used in this test file
- Removed `expect` import from `@playwright/test` - not used in this test file
- Kept `Page` and `Locator` type imports which are actively used

## Details
This is a minor cleanup to reduce unnecessary imports and improve code clarity. The test file does not appear to use the `test` function or `expect` assertions directly, so these imports were removed to keep the dependency list minimal.

https://claude.ai/code/session_018kZ3n6KtDGqryfQviC1JHJ