### PR TITLE
fix: use GH_TOKEN for .timestamps clone in web sessions

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -140,8 +140,16 @@ fi
 #######################################
 
 if [ ! -d "$PROJECT_DIR/.timestamps/.git" ]; then
-	git clone --quiet https://github.com/alexander-turner/.timestamps "$PROJECT_DIR/.timestamps" ||
-		warn "Failed to clone .timestamps repo"
+	# In web sessions, direct GitHub URLs may not work through the local proxy.
+	# Use GH_TOKEN for authentication if available.
+	if [ -n "${GH_TOKEN:-}" ]; then
+		git clone --quiet "https://x-access-token:${GH_TOKEN}@github.com/alexander-turner/.timestamps.git" \
+			"$PROJECT_DIR/.timestamps" ||
+			warn "Failed to clone .timestamps repo"
+	else
+		git clone --quiet https://github.com/alexander-turner/.timestamps "$PROJECT_DIR/.timestamps" ||
+			warn "Failed to clone .timestamps repo"
+	fi
 fi
 
 # Configure .timestamps push access using GH_TOKEN (the local proxy only


### PR DESCRIPTION
## Summary
- In Claude Code web sessions, direct GitHub URLs don't work through the local proxy
- The `.timestamps` clone was silently failing because it used a plain `https://github.com` URL
- Now uses `GH_TOKEN` authentication when available, matching how push access is already configured

## Test plan
- [x] Verified fix manually: cloned `.timestamps` using `GH_TOKEN` in current session after clone failed during SessionStart
- [ ] Verify timestamps are created on subsequent commits in web sessions

https://claude.ai/code/session_015LsDYBg15eBz1SYkNdRwuV