### PR TITLE
Configure TableOfContents to require minimum of 3 entries

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -97,7 +97,7 @@ const config: QuartzConfig = {
       AfterArticle(),
       AddFavicons(),
       ColorVariables(),
-      TableOfContents(),
+      TableOfContents({ minEntries: 3 }),
       addAssetDimensionsFromSrc(),
     ],
     filters: [RemoveDrafts()],


### PR DESCRIPTION
## Summary
Updated the TableOfContents plugin configuration to only display when there are at least 3 headings in an article.

## Changes
- Modified `TableOfContents()` plugin instantiation to include `minEntries: 3` option in the Quartz config
- This prevents the table of contents from appearing on articles with fewer than 3 headings, improving the visual presentation of shorter articles

## Details
The `minEntries` parameter controls the minimum number of heading entries required before the table of contents component is rendered. This is a common UX pattern to avoid showing a table of contents for very short articles that don't benefit from one.

https://claude.ai/code/session_01UMFpNGeWY6rtivvJkwcVwk