### PR TITLE
Increase deploy job timeout from 90 to 120 minutes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   prepare-deploy:
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary
Extended the timeout for the `prepare-deploy` job in the GitHub Actions deployment workflow to accommodate longer build and deployment processes.

## Changes
- Increased `timeout-minutes` for the `prepare-deploy` job from 90 to 120 minutes

## Details
This change provides an additional 30 minutes of execution time for the deployment preparation job, reducing the risk of timeout failures during resource-intensive operations such as building, testing, or deploying the application.

https://claude.ai/code/session_01BesbLX3BqWbixDWv9cNwY7