### PR TITLE
ci: always run Playwright/visual tests on main pushes

### DIFF
--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -5,16 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
-    paths:
-      - "quartz/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
   pull_request:
     branches: ["main", "dev"]
     types: [labeled, synchronize, opened, reopened]
@@ -26,16 +19,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/actions/**"
-  # Tests always run in the merge queue — this is the primary gate for dev
   merge_group:
-    paths:
-      - "quartz/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -5,18 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
-    paths:
-      - "quartz/**"
-      - "website_content/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "config/lostpixel/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
   pull_request:
     branches: ["main", "dev"]
     types: [labeled, synchronize, opened, reopened]
@@ -30,7 +21,6 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/actions/**"
-  # Tests always run in the merge queue — this is the primary gate for dev
   merge_group:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,10 +186,11 @@ After pushing to main:
 
 ### CI Cost Optimization
 
-- **Playwright/visual tests on PRs**: On PRs, these only run when the `ci:full-tests` label is added. They always run on push to main/dev and in the merge queue, enforcing that all tests pass before merge.
+- **Playwright/visual tests always run on main**: Pushes to main always trigger Playwright and visual tests (no path filters). Both workflows also support `workflow_dispatch` for manual triggering from the Actions UI.
+- **Playwright/visual tests on PRs**: On PRs, these only run when the `ci:full-tests` label is added. Path filters further limit PR triggers to relevant file changes.
 - **Shared builds**: Playwright, visual testing, and site-build-checks each build the site once and share the artifact across shards/jobs.
-- **Path filters**: Workflows only trigger when relevant files change. Each workflow lists only the `config/` subdirectories it actually uses. Build/deploy workflows exclude test files from triggering.
-- **Skip CI for docs-only changes**: Commits that only touch documentation files (README, CLAUDE.md, `.hooks/`, `.cursorrules`, `asset_staging/`) will not trigger CI workflows due to path filters. When creating PRs with only such changes, note that CI checks will be skipped.
+- **Path filters**: PR workflows only trigger when relevant files change. Each workflow lists only the `config/` subdirectories it actually uses. Build/deploy workflows exclude test files from triggering.
+- **Skip CI**: Use `[skip ci]` in commit messages to skip all workflows for a commit.
 - **Merge queue**: The repository uses GitHub merge queue. All required checks have `merge_group` triggers so they run in the merge queue context.
 
 ## Design Philosophy


### PR DESCRIPTION
## Summary
- Path filters on push-to-main meant Playwright and visual tests were silently skipped when only non-code files changed (e.g. `.github/workflows/`, `CLAUDE.md`), and `fail-on-no-checks: false` in the deploy workflow let these deploys through without any test gate
- Remove path filters from `push` (main) and `merge_group` triggers so tests always run in these contexts
- Add `workflow_dispatch` to both workflows for manual triggering from the Actions UI

## Changes
- `.github/workflows/playwright-tests.yaml`: Remove path filters from `push` and `merge_group` triggers, add `workflow_dispatch`
- `.github/workflows/visual-testing.yaml`: Remove path filters from `push` and `merge_group` triggers, add `workflow_dispatch`
- `CLAUDE.md`: Update CI Cost Optimization section to reflect new behavior

## Testing
- CI-only changes; the workflows themselves will validate correctness when this PR merges
- Path filters retained on `pull_request` triggers to preserve cost optimization for PRs

https://claude.ai/code/session_01SVHko5e2s1yjGEP4dTZyvt