### PR TITLE
fix(test): fix deterministic Playwright failures on main

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -729,8 +729,6 @@ test("Result card matching stays synchronized with preview", async ({ page }) =>
 test("should not select a search result on initial render, even if the mouse is hovering over it", async ({
   page,
 }, testInfo) => {
-  // This test performs two full search operations with 10s timeouts each,
-  // plus a focus wait with 10s timeout, so the default 30s budget is tight.
   testInfo.setTimeout(60_000)
   await search(page, "alignment")
 
@@ -746,8 +744,13 @@ test("should not select a search result on initial render, even if the mouse is 
 
   await search(page, "test")
 
-  // The first result should gain focus once the mouseover lock expires
+  // The search input is debounced (400ms), so `search()` may return before
+  // the new results render. Wait for the first result card to reflect the
+  // "test" query before interacting with it.
   const firstResult = page.locator(".result-card").first()
+  await expect(firstResult).toHaveId("test-page", { timeout: 10_000 })
+
+  // The first result should gain focus once the mouseover lock expires
   await expect(firstResult).toHaveClass(/focus/, { timeout: 10_000 })
 
   await page.keyboard.press("Enter")


### PR DESCRIPTION
## Summary
- Fixes two Playwright test failures that broke main after PR #776, causing 12 of 30 shards to fail
- Both failures are race conditions in test timing, not production code issues

## Changes
- **spa.inline.spec.ts** (`layout stability monitoring cancels when user scrolls`): The `addInitScript` rAF was registered before page scripts, so it fired before the `programmaticScroll` flag was cleared by `scrollToProgrammatic`. The `scrollHandler` ignored the dispatched scroll event, so `userHasScrolled` was never set and the cancel message never appeared. Fixed by waiting two extra rAF frames before dispatching the wheel event, ensuring the flag has been reset.
- **search.spec.ts** (`should not select a search result on initial render`): The `search()` helper's visibility waits were already satisfied from the first search ("alignment"), so the second `search("test")` returned before the 400ms debounced results updated. The test then interacted with stale alignment results, pressed Enter, and navigated to the wrong page. Fixed by waiting for the first result card to have `id="test-page"` before proceeding.

## Testing
- `pnpm check` passes (TypeScript, Prettier, Stylelint)
- Changes are to Playwright spec files only; the spa test failed on all 9 browser/viewport combos and the search test failed on Chrome and Firefox

https://claude.ai/code/session_01WzFtkjCoJam8nzGmmyKVan