### PR TITLE
Make dropcap probability configurable and display it dynamically

### DIFF
--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -96,7 +96,7 @@ describe("PopulateContainers", () => {
         return '<html><body><div id="populate-favicon-container"></div></body></html>'
       }
       if (pathStr.includes("design.html")) {
-        return '<html><body><div id="populate-favicon-threshold"></div><div id="populate-max-size-card"></div><span class="populate-commit-count"></span><span class="populate-human-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-playwright-configs"></span><span class="populate-playwright-total-tests"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span></body></html>'
+        return '<html><body><div id="populate-favicon-threshold"></div><div id="populate-max-size-card"></div><div id="populate-dropcap-probability"></div><span class="populate-commit-count"></span><span class="populate-human-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-playwright-configs"></span><span class="populate-playwright-total-tests"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span></body></html>'
       }
       // Default for other files
       return '<html><body><div id="populate-favicon-container"></div><div id="populate-favicon-threshold"></div><span class="populate-commit-count"></span><span class="populate-human-commit-count"></span><span class="populate-js-test-count"></span><span class="populate-playwright-test-count"></span><span class="populate-pytest-count"></span><span class="populate-lines-of-code"></span><span class="populate-turntrout-favicon"></span></body></html>'

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -24,7 +24,13 @@ import {
 import { createNowrapSpan, hasClass } from "../transformers/utils"
 import { type QuartzEmitterPlugin } from "../types"
 
-const { minFaviconCount, defaultPath, maxCardImageSizeKb, playwrightConfigs } = simpleConstants
+const {
+  minFaviconCount,
+  defaultPath,
+  maxCardImageSizeKb,
+  playwrightConfigs,
+  colorDropcapProbability,
+} = simpleConstants
 
 const logger = createWinstonLogger("populateContainers")
 
@@ -393,6 +399,10 @@ const createPopulatorMap = (
     ["populate-favicon-container", generateFaviconContent()],
     ["populate-favicon-threshold", generateConstantContent(minFaviconCount)],
     ["populate-max-size-card", generateConstantContent(maxCardImageSizeKb)],
+    [
+      "populate-dropcap-probability",
+      generateConstantContent(`${Math.round(colorDropcapProbability * 100)}%`),
+    ],
     [
       "populate-turntrout-favicon",
       generateSpecialFaviconContent(specialFaviconPaths.turntrout, "A trout jumping to the left."),

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -463,7 +463,7 @@ However, text [blocks](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
 
 ### Rare dropcap coloring
 
-Every time you navigate to a new page, there's a 10% chance to get a random dropcap color. :)
+Every time you navigate to a new page, there's a <span id="populate-dropcap-probability"></span> chance to get a random dropcap color. :)
 
 <div id="the-pond-dropcaps" class="centered" style="font-size:min(4rem, 15vw); line-height: 1;">
 <span class="dropcap" data-first-letter="T" style="--before-color: var(--dropcap-background-red);">T</span>


### PR DESCRIPTION
## Summary
This PR makes the dropcap color probability configurable by extracting it from a hardcoded value into a dynamic constant that can be displayed on the design documentation page.

## Key Changes
- Added `colorDropcapProbability` to the destructured constants from `simpleConstants` in `populateContainers.ts`
- Created a new populator entry `populate-dropcap-probability` that displays the probability as a percentage (rounded to nearest whole number)
- Updated the design documentation to use the dynamic populator instead of the hardcoded "10%" text
- Updated test mocks to include the new `populate-dropcap-probability` div element in the design.html fixture

## Implementation Details
- The probability value is converted to a percentage string using `Math.round(colorDropcapProbability * 100)` to ensure clean display
- The populator uses the existing `generateConstantContent()` helper to inject the value into the DOM
- This allows the displayed probability to stay in sync with the actual configuration value without manual updates

https://claude.ai/code/session_01S89DhsWFV3kchvAy1C4hjk