### PR TITLE
Fix scroll restoration to respect user interactions during drift correction

### DIFF
--- a/quartz/static/scripts/instantScrollRestoration.js
+++ b/quartz/static/scripts/instantScrollRestoration.js
@@ -208,6 +208,16 @@
 
       // Correct if we've drifted more than 2px from target
       if (Math.abs(currentScroll - targetPos) > 2) {
+        // If a user interaction event (wheel/touch/pointer/key) has been detected,
+        // this "drift" is actually user-initiated scroll. Scroll events fire
+        // asynchronously after rAF callbacks, so the scrollHandler may not have
+        // run yet—but the interaction flag is set synchronously and is reliable.
+        if (userInteracted) {
+          userHasScrolled = true
+          window.removeEventListener("scroll", scrollHandler, { passive: true })
+          console.log("[InstantScrollRestoration] Monitoring canceled due to user input")
+          return
+        }
         console.debug(
           `[InstantScrollRestoration] Drift detected on frame ${frameCount}, correcting: ${currentScroll} → ${targetPos}`,
         )


### PR DESCRIPTION
## Summary
Improved the instant scroll restoration logic to properly detect and respect user-initiated scrolling during the drift correction phase, preventing the script from fighting against intentional user scroll actions.

## Key Changes
- Added a check in the drift correction logic to detect if a user interaction event (wheel/touch/pointer/key) has occurred
- When user interaction is detected during drift correction, the scroll monitoring is immediately canceled instead of attempting to correct the "drift"
- This prevents the script from overriding user-initiated scroll actions that may appear as drift before the scroll event handler fires

## Implementation Details
- Leverages the existing `userInteracted` flag which is set synchronously when interaction events occur
- Takes advantage of the fact that scroll events fire asynchronously after requestAnimationFrame callbacks, so the interaction flag is a reliable indicator of user intent even before the scroll handler runs
- Adds appropriate logging to indicate when monitoring is canceled due to user input

https://claude.ai/code/session_018sJkGwJbtbjTQzpoLtLkxj