### PR TITLE
Fix figcaption overflow in subfigure layouts

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -315,6 +315,7 @@ figure:has(> .subfigure) {
 
   > figcaption {
     flex: 0 0 100%;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
Added `max-width: 100%` constraint to figcaption elements within subfigure containers to prevent content overflow and ensure proper text wrapping.

## Key Changes
- Added `max-width: 100%` CSS property to `figure:has(> .subfigure) > figcaption` selector in custom.scss

## Implementation Details
The figcaption already had `flex: 0 0 100%` which sets its flex basis to 100%, but without an explicit `max-width` constraint, the element could still overflow its container in certain browsers or layout scenarios. This addition ensures the caption respects the container width and wraps content appropriately.

https://claude.ai/code/session_01Foesep1gVEceubPVmGXfnC