### PR TITLE
Add jsx-a11y ESLint plugin for accessibility linting

### DIFF
--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -1,6 +1,7 @@
 import pluginJs from "@eslint/js"
 import eslintConfigPrettier from "eslint-config-prettier"
 import jestPlugin from "eslint-plugin-jest"
+import jsxA11y from "eslint-plugin-jsx-a11y"
 import perfectionist from "eslint-plugin-perfectionist"
 import playwright from "eslint-plugin-playwright"
 import pluginReact from "eslint-plugin-react"
@@ -33,6 +34,7 @@ export default [
   pluginJs.configs.recommended,
   ...tseslintConfigs.recommended,
   pluginReact.configs.flat.recommended,
+  jsxA11y.flatConfigs.recommended,
 
   // Playwright specific config for test files
   {

--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
     "eslint": "9.26.0",
     "eslint-config-prettier": "9.1.2",
     "eslint-plugin-jest": "28.11.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-perfectionist": "4.9.0",
     "eslint-plugin-playwright": "2.2.0",
     "eslint-plugin-react": "7.37.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       eslint-plugin-jest:
         specifier: 28.11.0
         version: 28.11.0(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))(typescript@5.7.3))(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))(typescript@5.7.3))(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))(jest@29.7.0(@types/node@22.13.8)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.7.3)))(typescript@5.7.3)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))
       eslint-plugin-perfectionist:
         specifier: 4.9.0
         version: 4.9.0(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))(typescript@5.7.3)
@@ -2904,6 +2907,9 @@ packages:
   assetgraph@7.12.0:
     resolution: {integrity: sha512-U6g7Y4QsYg45PwZB8t105acX9kGFR0I4QH1JZswhe36ijwg3kUK0zNRBSWOM4faeGN0prX04TL8OK16Dq7Iejg==}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -2943,6 +2949,10 @@ packages:
 
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -3969,6 +3979,9 @@ packages:
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -4428,6 +4441,12 @@ packages:
         optional: true
       jest:
         optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-perfectionist@4.9.0:
     resolution: {integrity: sha512-76lDfJnonOcXGW3bEXuqhEGId0LrOlvIE1yLHvK/eKMMPOc0b43KchAIR2Bdbqlg+LPXU5/Q+UzuzkO+cWHT6w==}
@@ -6008,6 +6027,13 @@ packages:
   langium@3.3.1:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
     engines: {node: '>=16.0.0'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -8659,6 +8685,10 @@ packages:
   string-width@8.1.0:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -12515,6 +12545,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  ast-types-flow@0.0.8: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
@@ -12548,6 +12580,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   b4a@1.7.3: {}
 
@@ -13850,6 +13884,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
+  damerau-levenshtein@1.0.8: {}
+
   dargs@8.1.0: {}
 
   dash-ast@1.0.0: {}
@@ -14394,6 +14430,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.26.0(hono@4.11.7)(jiti@2.6.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-perfectionist@4.9.0(eslint@9.26.0(hono@4.11.7)(jiti@2.6.1))(typescript@5.7.3):
     dependencies:
@@ -16484,6 +16539,12 @@ snapshots:
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   layout-base@1.0.2: {}
 
@@ -19949,6 +20010,12 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
 
   string.prototype.matchall@4.0.12:
     dependencies:

--- a/quartz/util/jsx.tsx
+++ b/quartz/util/jsx.tsx
@@ -26,7 +26,8 @@ export function htmlToJsx(fp: FilePath, tree: Node): JSX.Element | undefined {
       }
       tableCounter++
       return (
-        // skipcq: JS-0762 -- tabIndex on scrollable region is intentional for keyboard accessibility
+        /* eslint-disable jsx-a11y/no-noninteractive-tabindex -- tabIndex on scrollable region is intentional for keyboard accessibility */
+        // skipcq: JS-0762
         <div
           className="table-container"
           tabIndex={0}
@@ -35,6 +36,7 @@ export function htmlToJsx(fp: FilePath, tree: Node): JSX.Element | undefined {
         >
           <table {...tableProps} />
         </div>
+        /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
       )
     },
   }


### PR DESCRIPTION
## Summary
Integrated the `eslint-plugin-jsx-a11y` plugin to enforce accessibility best practices in JSX code, and updated an existing accessibility exception to use the new plugin's directive format.

## Key Changes
- Added `eslint-plugin-jsx-a11y` dependency to the project
- Configured the jsx-a11y recommended rules in the ESLint configuration
- Updated the table container accessibility exception in `htmlToJsx` to use `eslint-disable` directives instead of the previous `skipcq` comment, providing clearer intent and better IDE integration

## Implementation Details
- The table container's `tabIndex={0}` attribute is intentionally set for keyboard accessibility on a scrollable region, which would normally trigger the `jsx-a11y/no-noninteractive-tabindex` rule
- The ESLint disable/enable directives now properly scope the exception to just the affected element, making the code more maintainable and the accessibility decision more explicit

https://claude.ai/code/session_01Rg2GdMgM2wvt51RszDVJWL