### PR TITLE
Clean up unused imports and fix formatting issues

### DIFF
--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -14,7 +14,6 @@ import {
   simpleConstants,
   specialFaviconPaths,
   defaultPath,
-  specialDomainMappings,
   cdnBaseUrl,
 } from "../../components/constants"
 import { faviconUrlsFile, faviconCountsFile } from "../../components/constants.server"

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -113,7 +113,6 @@ svg.favicon {
       var(--attenuated-blue) 35deg 360deg
     );
   }
-
 }
 
 // Per-domain SVG colors

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -6058,37 +6058,7 @@ def test_maybe_collect_citation_keys_collects(tmp_path):
     assert citation_to_files["Turner2024Design"] == ["page.html"]
 
 
-def test_process_html_files_duplicate_citations(
-    mock_environment,
-    valid_css_file,
-    root_files,
-    monkeypatch,
-    disable_md_requirement,
-):
-    """Duplicate citation keys across files should be reported."""
-    public_dir = mock_environment["public_dir"]
-
-    # Create two HTML files with the same citation key
-    citation_html = "<html><body><code>@misc{DupeKey2024,</code></body></html>"
-    for name in ("page1.html", "page2.html"):
-        (public_dir / name).write_text(citation_html)
-
-    monkeypatch.setattr(script_utils, "build_html_to_md_map", lambda md_dir: {})
-
-    # Mock parse_html_file to read from the tmp public_dir
-    def _mock_parse(file_path):
-        with open(file_path, encoding="utf-8") as f:
-            return BeautifulSoup(f.read(), "html.parser")
-
-    monkeypatch.setattr(script_utils, "parse_html_file", _mock_parse)
-
-    result = built_site_checks._process_html_files(
-        public_dir,
-        mock_environment["content_dir"],
-        check_fonts=False,
-        defined_css_vars=set(),
-    )
-
+@pytest.mark.parametrize(
     "html,expected",
     [
         # Subfigures correctly inside <figure> (valid)

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -709,9 +709,7 @@ This is a plain code block without a language specified.
 <!-- spellchecker-disable -->
 Elvish
 : <span class="elvish"><span class="elvish-tengwar" lang="qya">    ⸱</span><span class="elvish-translation">Ah! like gold fall the leaves in the wind,</span></span>
-
 : <span class="elvish"><span class="elvish-tengwar" lang="qya"> :</span><span class="elvish-translation">in the song of her voice, holy and queenly.</span></span>
-
 : <span class="elvish"><span class="elvish-tengwar" lang="qya">  ⸱  ⸱ </span><span class="elvish-translation">Now lost, lost to those from the East is Valimar!</span></span>
 
 <!-- spellchecker-enable -->


### PR DESCRIPTION
## Summary
This PR removes unused imports and fixes minor formatting inconsistencies across the codebase.

## Key Changes
- **Removed unused import** in `quartz/plugins/transformers/favicons.ts`: Deleted the `specialDomainMappings` import from constants that was not being used
- **Fixed formatting** in `quartz/styles/favicon.scss`: Removed trailing blank line before closing brace
- **Fixed formatting** in `website_content/Test-page.md`: Removed unnecessary blank lines between definition list items in the Elvish section
- **Cleaned up test file** in `scripts/tests/test_built_site_checks.py`: Removed incomplete test function `test_process_html_files_duplicate_citations` that appeared to be in progress

## Notes
These are primarily code quality improvements with no functional changes to the application behavior.

https://claude.ai/code/session_01KTfa5GPjVSTu2Knv9Wu1yF