### PR TITLE
Remove test file exclusions from lint workflow

### DIFF
--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -99,10 +99,6 @@ jobs:
             source-checks:
               - 'website_content/**'
               - 'quartz/**'
-              - '!quartz/**/*.spec.ts'
-              - '!quartz/**/*.test.ts'
-              - '!quartz/**/*.test.tsx'
-              - '!quartz/**/tests/**'
               - 'scripts/source_file_checks.py'
               - 'config/quartz/**'
               - 'config/constants.json'


### PR DESCRIPTION
## Summary
Removed exclusion patterns for test files from the lint-and-validate workflow's source-checks job. This change allows test files to be included in the source code checks rather than being explicitly excluded.

## Changes
- Removed exclusion patterns for `*.spec.ts`, `*.test.ts`, `*.test.tsx` files
- Removed exclusion pattern for `tests/**` directories
- These patterns were previously preventing test files in the `quartz/` directory from triggering source checks

## Rationale
This change ensures that test files are now subject to the same source code validation checks as the rest of the codebase, improving consistency in code quality standards across all files including tests.

https://claude.ai/code/session_01Fa6c9abCZtuqqFMNnn1JQU