### PR TITLE
Refactor favicon validation to use computed inclusion set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ Per `.cursorrules` and `design.md`:
 - Un-nest conditionals where possible; combine related checks into single blocks
 - Create shared helpers when the same logic is needed in multiple places
 - In TypeScript/JavaScript, avoid `!` field assertions (flagged by linter) - use proper null checks instead
+- **Never add backward-compatibility re-exports** (e.g., `export { foo } from "./other-module"`). Update imports at the call site instead
 
 ### Error Handling
 

--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -25,7 +25,7 @@ import { type StaticResources } from "../../util/resources"
 const { minFaviconCount, defaultPath } = simpleConstants
 import { faviconCounter } from "../transformers/countFavicons"
 // skipcq: JS-C1003
-import * as linkfavicons from "../transformers/favicons"
+import * as favicons from "../transformers/favicons"
 import { type QuartzEmitterPlugin } from "../types"
 
 let populateModule: typeof import("./populateContainers")
@@ -55,7 +55,7 @@ describe("PopulateContainers", () => {
   let mockCtx: BuildCtx
   const mockOutputDir = "/mock/output"
   const mockStaticResources: StaticResources = { css: [], js: [] }
-  const urlCache = linkfavicons.urlCache
+  const urlCache = favicons.urlCache
 
   beforeAll(async () => {
     populateModule = await import("./populateContainers")
@@ -540,17 +540,17 @@ describe("PopulateContainers", () => {
       it.each([
         ["turntrout", specialFaviconPaths.turntrout],
         ["anchor", specialFaviconPaths.anchor],
-      ])("should generate %s favicon element inside word joiner", async (_name, faviconPath) => {
+      ])("should generate %s favicon element inside favicon-span", async (_name, faviconPath) => {
         const generator = populateModule.generateSpecialFaviconContent(faviconPath)
         const elements = await generator()
         expect(elements).toHaveLength(1)
 
-        const wjSpan = elements[0]
-        expect(wjSpan).toMatchObject({
+        const faviconSpan = elements[0]
+        expect(faviconSpan).toMatchObject({
           tagName: "span",
-          properties: { className: "word-joiner" },
+          properties: { className: "favicon-span" },
         })
-        expect(wjSpan.children[1]).toMatchObject({
+        expect(faviconSpan.children[1]).toMatchObject({
           tagName: "svg",
           properties: {
             class: expect.stringContaining("favicon"),

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -21,8 +21,7 @@ import {
   urlCache,
   shouldIncludeFavicon,
 } from "../transformers/favicons"
-import { createWordJoinerSpan } from "../transformers/utils"
-import { hasClass } from "../transformers/utils"
+import { createNowrapSpan, hasClass } from "../transformers/utils"
 import { type QuartzEmitterPlugin } from "../types"
 
 const {
@@ -212,9 +211,7 @@ export const generateSpecialFaviconContent = (
 ): ContentGenerator => {
   return async (): Promise<Element[]> => {
     const faviconElement = createFaviconElement(faviconPath, altText)
-    const wordJoiner = createWordJoinerSpan()
-    wordJoiner.children.push(faviconElement)
-    return [wordJoiner]
+    return [createNowrapSpan("", faviconElement)]
   }
 }
 

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -12,7 +12,7 @@ import path from "path"
 import { PassThrough } from "stream"
 
 // skipcq: JS-C1003
-import * as linkfavicons from "./favicons"
+import * as favicons from "./favicons"
 
 jest.mock("fs")
 import fs from "fs"
@@ -24,6 +24,7 @@ import {
   defaultPath,
 } from "../../components/constants"
 import { faviconUrlsFile } from "../../components/constants.server"
+import { normalizeFaviconListEntry } from "../../util/favicon-config"
 import { hasClass } from "./utils"
 
 const { minFaviconCount, faviconSubstringBlacklist } = simpleConstants
@@ -42,7 +43,7 @@ beforeEach(async () => {
   tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), "favicons-test-"))
   jest.resetAllMocks()
   jest.restoreAllMocks()
-  linkfavicons.urlCache.clear()
+  favicons.urlCache.clear()
 })
 
 afterEach(async () => {
@@ -60,7 +61,7 @@ const createExpectedFavicon = (
   imgPath: string,
   extraMarginLeft?: boolean,
 ): Record<string, unknown> => {
-  const faviconElement = linkfavicons.createFaviconElement(imgPath)
+  const faviconElement = favicons.createFaviconElement(imgPath)
   faviconElement.properties.class = `favicon${extraMarginLeft ? " close-text" : ""}`
   return faviconElement as unknown as Record<string, unknown>
 }
@@ -145,13 +146,13 @@ describe("Favicon Utilities", () => {
         cdnSvgStatus,
       ) => {
         mockFetchAndFs(avifStatus, localPngExists, googleStatus, localSvgExists, cdnSvgStatus)
-        expect(await linkfavicons.MaybeSaveFavicon(hostname)).toBe(expected)
+        expect(await favicons.MaybeSaveFavicon(hostname)).toBe(expected)
       },
     )
 
     it("should return defaultPath when all attempts fail", async () => {
       mockFetchAndFs(404, false, 404, false, 404)
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
       expect(result).toBe(defaultPath)
       expect(global.fetch).toHaveBeenCalledTimes(3) // SVG CDN, AVIF CDN, and Google attempts
     })
@@ -159,7 +160,7 @@ describe("Favicon Utilities", () => {
     it("should return defaultPath immediately if blacklisted by transformUrl", async () => {
       const blacklistedHostname = "incompleteideas.net"
       const fetchSpy = jest.spyOn(global, "fetch")
-      const result = await linkfavicons.MaybeSaveFavicon(blacklistedHostname)
+      const result = await favicons.MaybeSaveFavicon(blacklistedHostname)
       expect(result).toBe(defaultPath)
       // Should not attempt any fetches since it's blacklisted
       expect(fetchSpy).not.toHaveBeenCalled()
@@ -170,13 +171,13 @@ describe("Favicon Utilities", () => {
       ["Local PNG exists", 404, true, false, 404],
       ["Download PNG from Google", 404, false, false, 404],
     ])("%s", async (_, avifStatus, localPngExists, localSvgExists, cdnSvgStatus) => {
-      const expected = linkfavicons.getQuartzPath(hostname)
+      const expected = favicons.getQuartzPath(hostname)
       mockFetchAndFs(avifStatus, localPngExists, 200, localSvgExists, cdnSvgStatus)
-      expect(await linkfavicons.MaybeSaveFavicon(hostname)).toBe(expected)
+      expect(await favicons.MaybeSaveFavicon(hostname)).toBe(expected)
     })
 
     it("should not write local files to URL cache", async () => {
-      const localPath = linkfavicons.getQuartzPath(hostname)
+      const localPath = favicons.getQuartzPath(hostname)
 
       jest.spyOn(global, "fetch").mockRejectedValue(new Error("CDN not available"))
 
@@ -186,15 +187,15 @@ describe("Favicon Utilities", () => {
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
         .mockResolvedValueOnce({} as fs.Stats)
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
 
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
 
       expect(result).toBe(localPath)
-      expect(linkfavicons.urlCache.size).toBe(0)
+      expect(favicons.urlCache.size).toBe(0)
 
       // Check that the URL cache doesn't contain the local path
-      expect(linkfavicons.urlCache.has(localPath)).toBe(false)
+      expect(favicons.urlCache.has(localPath)).toBe(false)
     })
 
     it("should cache and skip previously failed downloads", async () => {
@@ -202,7 +203,7 @@ describe("Favicon Utilities", () => {
       mockFetchAndFs(404, false, 404, false, 404)
 
       // First attempt should try all download methods
-      const firstResult = await linkfavicons.MaybeSaveFavicon(hostname)
+      const firstResult = await favicons.MaybeSaveFavicon(hostname)
       expect(firstResult).toBe(defaultPath)
       expect(global.fetch).toHaveBeenCalledTimes(3) // SVG CDN, AVIF CDN, and Google attempts
 
@@ -211,7 +212,7 @@ describe("Favicon Utilities", () => {
       mockFetchAndFs(404, false, 404, false, 404)
 
       // Second attempt should still check for SVG on CDN before using cached failure
-      const secondResult = await linkfavicons.MaybeSaveFavicon(hostname)
+      const secondResult = await favicons.MaybeSaveFavicon(hostname)
       expect(secondResult).toBe(defaultPath)
       expect(global.fetch).toHaveBeenCalledTimes(1) // Should check for SVG on CDN
       expect(global.fetch).toHaveBeenCalledWith(
@@ -225,14 +226,14 @@ describe("Favicon Utilities", () => {
 
       const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
 
-      await linkfavicons.MaybeSaveFavicon(hostname)
+      await favicons.MaybeSaveFavicon(hostname)
 
-      linkfavicons.writeCacheToFile()
+      favicons.writeCacheToFile()
 
       // Verify the failure was written to cache file
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         faviconUrlsFile,
-        expect.stringContaining(`${linkfavicons.getQuartzPath(hostname)},${defaultPath}`),
+        expect.stringContaining(`${favicons.getQuartzPath(hostname)},${defaultPath}`),
         expect.any(Object),
       )
     })
@@ -258,41 +259,41 @@ describe("Favicon Utilities", () => {
 
       jest.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined)
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
 
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
-      const expected = linkfavicons.getQuartzPath(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
+      const expected = favicons.getQuartzPath(hostname)
       expect(result).toBe(expected)
     })
 
     it("should return local SVG when found", async () => {
       const hostname = "example.com"
-      const faviconPath = linkfavicons.getQuartzPath(hostname)
+      const faviconPath = favicons.getQuartzPath(hostname)
       const svgPath = faviconPath.replace(".png", ".svg")
       const localSvgPath = path.join("quartz", svgPath)
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
 
       // Mock fs.promises.stat: SVG found
       jest.spyOn(fs.promises, "stat").mockResolvedValueOnce({ size: 1000 } as fs.Stats)
 
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
 
       expect(result).toBe(svgPath)
-      expect(linkfavicons.urlCache.get(faviconPath)).toBe(svgPath)
+      expect(favicons.urlCache.get(faviconPath)).toBe(svgPath)
       expect(fs.promises.stat).toHaveBeenCalledWith(localSvgPath)
     })
 
     it("should load and respect cached failures on startup", async () => {
-      const faviconPath = linkfavicons.getQuartzPath(hostname)
+      const faviconPath = favicons.getQuartzPath(hostname)
 
-      linkfavicons.urlCache.clear()
-      linkfavicons.urlCache.set(faviconPath, defaultPath)
+      favicons.urlCache.clear()
+      favicons.urlCache.set(faviconPath, defaultPath)
 
       // Mock download attempts (which shouldn't be called)
       mockFetchAndFs(200, false, 200)
 
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
 
       // Should check for SVG on CDN before returning cached failure
       expect(result).toBe(defaultPath)
@@ -303,16 +304,16 @@ describe("Favicon Utilities", () => {
     })
 
     it("should return cached successful favicon URL", async () => {
-      const faviconPath = linkfavicons.getQuartzPath(hostname)
+      const faviconPath = favicons.getQuartzPath(hostname)
       const cachedUrl = "https://assets.turntrout.com/favicon.png"
 
-      linkfavicons.urlCache.clear()
-      linkfavicons.urlCache.set(faviconPath, cachedUrl)
+      favicons.urlCache.clear()
+      favicons.urlCache.set(faviconPath, cachedUrl)
 
       // Mock download attempts (which shouldn't be called)
       mockFetchAndFs(200, false, 200)
 
-      const result = await linkfavicons.MaybeSaveFavicon(hostname)
+      const result = await favicons.MaybeSaveFavicon(hostname)
 
       expect(result).toBe(cachedUrl)
       expect(global.fetch).toHaveBeenCalledTimes(1) // Should check for SVG on CDN
@@ -324,7 +325,7 @@ describe("Favicon Utilities", () => {
       const subdomainHost = "open.spotify.com"
 
       beforeEach(() => {
-        linkfavicons.urlCache.clear()
+        favicons.urlCache.clear()
       })
 
       it("should find SVG locally via unnormalized hostname", async () => {
@@ -342,7 +343,7 @@ describe("Favicon Utilities", () => {
             new Response("", { status: 404, headers: { "Content-Type": "image/svg+xml" } }),
           )
 
-        const result = await linkfavicons.MaybeSaveFavicon(subdomainHost)
+        const result = await favicons.MaybeSaveFavicon(subdomainHost)
         expect(result).toBe("/static/images/external-favicons/open_spotify_com.svg")
       })
 
@@ -365,7 +366,7 @@ describe("Favicon Utilities", () => {
             new Response("SVG", { status: 200, headers: { "Content-Type": "image/svg+xml" } }),
           )
 
-        const result = await linkfavicons.MaybeSaveFavicon(subdomainHost)
+        const result = await favicons.MaybeSaveFavicon(subdomainHost)
         expect(result).toBe(
           "https://assets.turntrout.com/static/images/external-favicons/open_spotify_com.svg",
         )
@@ -381,7 +382,7 @@ describe("Favicon Utilities", () => {
       ["https://turntrout.com", specialFaviconPaths.turntrout],
       ["subdomain.example.org", "/static/images/external-favicons/example_org.png"],
     ])("should return the correct favicon path for %s", (hostname, expectedPath) => {
-      expect(linkfavicons.getQuartzPath(hostname)).toBe(expectedPath)
+      expect(favicons.getQuartzPath(hostname)).toBe(expectedPath)
     })
   })
 
@@ -399,7 +400,7 @@ describe("Favicon Utilities", () => {
       [specialFaviconPaths.mail, specialFaviconPaths.mail],
       ["https://example.com/favicon.ico", "https://example.com/favicon.ico"],
     ])("should construct URL from path %s", (path, expectedUrl) => {
-      expect(linkfavicons.getFaviconUrl(path)).toBe(expectedUrl)
+      expect(favicons.getFaviconUrl(path)).toBe(expectedUrl)
     })
 
     it("should return cached SVG URL when cache contains full URL", () => {
@@ -407,9 +408,9 @@ describe("Favicon Utilities", () => {
       const cachedSvgUrl =
         "https://assets.turntrout.com/static/images/external-favicons/example_com.svg"
 
-      linkfavicons.urlCache.set(pngPath, cachedSvgUrl)
+      favicons.urlCache.set(pngPath, cachedSvgUrl)
 
-      const result = linkfavicons.getFaviconUrl(pngPath)
+      const result = favicons.getFaviconUrl(pngPath)
       expect(result).toBe(cachedSvgUrl)
     })
 
@@ -417,9 +418,9 @@ describe("Favicon Utilities", () => {
       const pngPath = "/static/images/external-favicons/example_com.png"
       const cachedSvgPath = "/static/images/external-favicons/example_com.svg"
 
-      linkfavicons.urlCache.set(pngPath, cachedSvgPath)
+      favicons.urlCache.set(pngPath, cachedSvgPath)
 
-      const result = linkfavicons.getFaviconUrl(pngPath)
+      const result = favicons.getFaviconUrl(pngPath)
       expect(result).toBe(`https://assets.turntrout.com${cachedSvgPath}`)
     })
 
@@ -428,18 +429,18 @@ describe("Favicon Utilities", () => {
       const cachedAvifUrl =
         "https://assets.turntrout.com/static/images/external-favicons/example_com.avif"
 
-      linkfavicons.urlCache.set(pngPath, cachedAvifUrl)
+      favicons.urlCache.set(pngPath, cachedAvifUrl)
 
-      const result = linkfavicons.getFaviconUrl(pngPath)
+      const result = favicons.getFaviconUrl(pngPath)
       expect(result).toBe(cachedAvifUrl)
     })
 
     it("should ignore cached defaultPath", () => {
       const pngPath = "/static/images/external-favicons/example_com.png"
 
-      linkfavicons.urlCache.set(pngPath, defaultPath)
+      favicons.urlCache.set(pngPath, defaultPath)
 
-      const result = linkfavicons.getFaviconUrl(pngPath)
+      const result = favicons.getFaviconUrl(pngPath)
       // Should fall through to AVIF since defaultPath is ignored
       expect(result).toBe(
         "https://assets.turntrout.com/static/images/external-favicons/example_com.avif",
@@ -451,19 +452,19 @@ describe("Favicon Utilities", () => {
       const svgPath = "/static/images/external-favicons/example_com.svg"
       const localSvgPath = path.join("quartz", svgPath)
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
       jest.spyOn(fs, "accessSync").mockImplementationOnce(() => {
         // File exists
       })
 
-      const result = linkfavicons.getFaviconUrl(pngPath)
+      const result = favicons.getFaviconUrl(pngPath)
       expect(result).toBe(`https://assets.turntrout.com${svgPath}`)
       expect(fs.accessSync).toHaveBeenCalledWith(localSvgPath, fs.constants.F_OK)
     })
 
     it("should handle non-PNG non-SVG paths", () => {
       const otherPath = "/static/images/external-favicons/example_com.jpg"
-      const result = linkfavicons.getFaviconUrl(otherPath)
+      const result = favicons.getFaviconUrl(otherPath)
       expect(result).toBe(`https://assets.turntrout.com${otherPath}`)
     })
   })
@@ -471,29 +472,29 @@ describe("Favicon Utilities", () => {
   describe("normalizePathForCounting", () => {
     it("should preserve full URLs", () => {
       const url = specialFaviconPaths.mail
-      expect(linkfavicons.normalizePathForCounting(url)).toBe(url)
+      expect(favicons.normalizePathForCounting(url)).toBe(url)
     })
 
     it("should preserve .svg paths", () => {
       const svgPath = "/static/images/external-favicons/mail.svg"
-      expect(linkfavicons.normalizePathForCounting(svgPath)).toBe(svgPath)
+      expect(favicons.normalizePathForCounting(svgPath)).toBe(svgPath)
     })
 
     it("should preserve .ico paths", () => {
       const icoPath = `/static/images/${localTroutFaviconBasename}`
-      expect(linkfavicons.normalizePathForCounting(icoPath)).toBe(icoPath)
+      expect(favicons.normalizePathForCounting(icoPath)).toBe(icoPath)
     })
 
     it("should remove .png extension", () => {
       const pngPath = "/static/images/external-favicons/example_com.png"
-      expect(linkfavicons.normalizePathForCounting(pngPath)).toBe(
+      expect(favicons.normalizePathForCounting(pngPath)).toBe(
         "/static/images/external-favicons/example_com",
       )
     })
 
     it("should remove .avif extension", () => {
       const avifPath = "/static/images/external-favicons/example_com.avif"
-      expect(linkfavicons.normalizePathForCounting(avifPath)).toBe(
+      expect(favicons.normalizePathForCounting(avifPath)).toBe(
         "/static/images/external-favicons/example_com",
       )
     })
@@ -510,7 +511,7 @@ describe("Favicon Utilities", () => {
       // Counts are stored without extensions (format-agnostic)
       faviconCounts.set("/static/images/external-favicons/example_com", count)
 
-      const result = linkfavicons.shouldIncludeFavicon(
+      const result = favicons.shouldIncludeFavicon(
         "/favicon.png",
         "/static/images/external-favicons/example_com.png",
         faviconCounts,
@@ -522,7 +523,7 @@ describe("Favicon Utilities", () => {
     it("should treat missing count as zero", () => {
       const faviconCounts = new Map<string, number>()
 
-      const result = linkfavicons.shouldIncludeFavicon(
+      const result = favicons.shouldIncludeFavicon(
         "/favicon.png",
         "/static/images/external-favicons/example_com.png",
         faviconCounts,
@@ -539,9 +540,9 @@ describe("Favicon Utilities", () => {
     ])("should include whitelisted favicon %s even if count is zero", (imgPath) => {
       const faviconCounts = new Map<string, number>()
       // Counts are stored without extensions (format-agnostic), but special paths are preserved
-      faviconCounts.set(linkfavicons.normalizePathForCounting(imgPath), 0)
+      faviconCounts.set(favicons.normalizePathForCounting(imgPath), 0)
 
-      const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+      const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
       expect(result).toBe(true)
     })
@@ -549,38 +550,38 @@ describe("Favicon Utilities", () => {
     describe("favicon blacklist", () => {
       it.each(
         faviconSubstringBlacklist.map((blacklistEntry: string) => [
-          `/static/images/external-favicons/${linkfavicons.normalizeFaviconListEntry(blacklistEntry)}.png`,
+          `/static/images/external-favicons/${normalizeFaviconListEntry(blacklistEntry)}.png`,
         ]),
       )("should exclude blacklisted favicon %s even if count exceeds threshold", (imgPath) => {
         const faviconCounts = new Map<string, number>()
         // Counts are stored without extensions (format-agnostic)
-        faviconCounts.set(linkfavicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
+        faviconCounts.set(favicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
 
-        const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+        const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
         expect(result).toBe(false)
       })
 
       it("should exclude favicons with blacklisted substring in middle of path", () => {
-        const blacklistEntry = linkfavicons.normalizeFaviconListEntry(faviconSubstringBlacklist[0])
+        const blacklistEntry = normalizeFaviconListEntry(faviconSubstringBlacklist[0])
         const imgPath = `/static/images/external-favicons/subdomain_${blacklistEntry}.png`
         const faviconCounts = new Map<string, number>()
         // Counts are stored without extensions (format-agnostic)
-        faviconCounts.set(linkfavicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
+        faviconCounts.set(favicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
 
-        const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+        const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
         expect(result).toBe(false)
       })
     })
   })
 
-  describe("linkfavicons.CreateFaviconElement", () => {
+  describe("favicons.CreateFaviconElement", () => {
     it.each([
       ["/path/to/favicon.png", "Test Description"],
       ["/another/favicon.jpg", "Another Description"],
     ])("should create a favicon img element with src=%s and alt=%s", (urlString, description) => {
-      const element = linkfavicons.createFaviconElement(urlString, description)
+      const element = favicons.createFaviconElement(urlString, description)
       expect(element).toEqual({
         type: "element",
         tagName: "img",
@@ -598,7 +599,7 @@ describe("Favicon Utilities", () => {
       ["https://assets.turntrout.com/static/images/external-favicons/github_com.svg", "github_com"],
       ["https://assets.turntrout.com/static/images/external-favicons/openai_com.svg", "openai_com"],
     ])("should create a favicon svg element for SVG with src=%s", (urlString, expectedDomain) => {
-      const element = linkfavicons.createFaviconElement(urlString, "")
+      const element = favicons.createFaviconElement(urlString, "")
       expect(element.type).toBe("element")
       expect(element.tagName).toBe("svg")
       expect(element.properties.class).toBe("favicon")
@@ -621,7 +622,7 @@ describe("Favicon Utilities", () => {
     ])(
       "should create accessible svg element when description provided for %s",
       (urlString, description) => {
-        const element = linkfavicons.createFaviconElement(urlString, description)
+        const element = favicons.createFaviconElement(urlString, description)
         expect(element.type).toBe("element")
         expect(element.tagName).toBe("svg")
         expect(element.properties.class).toBe("favicon")
@@ -637,13 +638,13 @@ describe("Favicon Utilities", () => {
     )
   })
 
-  describe("linkfavicons.insertFavicon", () => {
+  describe("favicons.insertFavicon", () => {
     it.each([
       [null, 0],
       ["/valid/path.png", 1],
     ])("should insert favicon correctly when imgPath is %s", (imgPath, expectedChildren) => {
       const node = h("div")
-      linkfavicons.insertFavicon(imgPath, node)
+      favicons.insertFavicon(imgPath, node)
       expect(node.children.length).toBe(expectedChildren)
     })
 
@@ -657,7 +658,7 @@ describe("Favicon Utilities", () => {
         "should splice last 4 chars into favicon-span for %s",
         (text, remainingText, splicedChars) => {
           const node = h("div", {}, [text])
-          linkfavicons.insertFavicon(imgPath, node)
+          favicons.insertFavicon(imgPath, node)
 
           // text is truncated, favicon-span (containing last chars + favicon) appended
           expect(node.children.length).toBe(2)
@@ -671,7 +672,7 @@ describe("Favicon Utilities", () => {
 
       it("should replace text node entirely when text is <= 4 chars", () => {
         const node = h("div", {}, ["1234"])
-        linkfavicons.insertFavicon(imgPath, node)
+        favicons.insertFavicon(imgPath, node)
 
         // text node removed, replaced with just the favicon-span
         expect(node.children.length).toBe(1)
@@ -685,7 +686,7 @@ describe("Favicon Utilities", () => {
         [h("div", {}, [h("div")]), "nodes without text content"],
         [h("div", {}, [""]), "empty text nodes"],
       ])("should handle %s correctly", (node) => {
-        linkfavicons.insertFavicon(imgPath, node)
+        favicons.insertFavicon(imgPath, node)
 
         // For non-text/empty nodes, favicon is appended directly (no span wrapping)
         const lastChild = node.children[node.children.length - 1] as Element
@@ -697,7 +698,7 @@ describe("Favicon Utilities", () => {
        becomes
        <a>Test <code>tag name <span class="favicon-span">test<img/></span></code></a>
       */
-      it.each(linkfavicons.tagsToZoomInto)(
+      it.each(favicons.tagsToZoomInto)(
         "should zoom into %s elements and splice text into favicon-span",
         (tagName) => {
           const innerText = "tag name test"
@@ -705,7 +706,7 @@ describe("Favicon Utilities", () => {
             { type: "text", value: "Test " },
             h(tagName as string, {}, [innerText]),
           ])
-          linkfavicons.insertFavicon(imgPath, node)
+          favicons.insertFavicon(imgPath, node)
 
           expect(node.children.length).toBe(2)
           expect(node.children[0]).toEqual({ type: "text", value: "Test " })
@@ -724,7 +725,7 @@ describe("Favicon Utilities", () => {
 
       it("should handle code element inside link", () => {
         const node = h("a", { href: "https://github.com/" }, [h("code", {}, [codeContent])])
-        linkfavicons.insertFavicon(imgPath, node)
+        favicons.insertFavicon(imgPath, node)
 
         expect(node.children.length).toBe(1)
         const codeChild = node.children[0] as Element
@@ -742,7 +743,7 @@ describe("Favicon Utilities", () => {
           { type: "text", value: "" }, // Empty text node at the end
         ])
 
-        linkfavicons.insertFavicon(imgPath, linkWithEmptyText)
+        favicons.insertFavicon(imgPath, linkWithEmptyText)
 
         // Zooms into code (skips empty text), splices text inside code
         expect(linkWithEmptyText.children.length).toBe(2) // code + empty text
@@ -755,12 +756,12 @@ describe("Favicon Utilities", () => {
         expect(span.children[1]).toMatchObject(createExpectedFavicon(imgPath))
       })
 
-      it.each(linkfavicons.charsToSpace)(
+      it.each(favicons.charsToSpace)(
         "should handle special character %s with close-text class",
         (char) => {
           const text = `Test${char}`
           const node = h("p", {}, [text])
-          linkfavicons.insertFavicon(imgPath, node)
+          favicons.insertFavicon(imgPath, node)
 
           // "Test!" is 5 chars, so last 4 chars are spliced: text becomes "T", span has "est!"
           expect(node.children.length).toBe(2) // truncated text + favicon-span
@@ -781,7 +782,7 @@ describe("Favicon Utilities", () => {
           ".",
         ])
 
-        linkfavicons.insertFavicon(specialFaviconPaths.mail, node)
+        favicons.insertFavicon(specialFaviconPaths.mail, node)
 
         // "." is 1 char (<= 4), so text node is removed and replaced with favicon-span
         expect(node.children.length).toBe(3) // text + a + favicon-span (containing "." + favicon)
@@ -808,19 +809,19 @@ describe("Favicon Utilities", () => {
       const parent = h("div", [node])
       const faviconCounts = new Map<string, number>()
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       // Should not add any favicon since it has same-page-link class
       expect(node.children.length).toBe(0)
     })
   })
 
-  describe("linkfavicons.ModifyNode", () => {
+  describe("favicons.ModifyNode", () => {
     const faviconCounts = new Map<string, number>()
 
     beforeEach(() => {
       // Clear and reset urlCache to prevent test pollution
-      linkfavicons.urlCache.clear()
-      linkfavicons.urlCache.set(specialFaviconPaths.turntrout, specialFaviconPaths.turntrout)
+      favicons.urlCache.clear()
+      favicons.urlCache.set(specialFaviconPaths.turntrout, specialFaviconPaths.turntrout)
 
       faviconCounts.clear()
       // Set up counts for common favicons
@@ -849,7 +850,7 @@ describe("Favicon Utilities", () => {
       const node = h("a", { href })
       const parent = h("div", [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       // Empty node: favicon appended directly (no span wrapping)
       const faviconElement = node.children[0] as Element
       expect(faviconElement.tagName).toBe("svg")
@@ -866,7 +867,7 @@ describe("Favicon Utilities", () => {
       const node = h("a", { href })
       const parent = h("div", [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       // Empty node: favicon appended directly (no span wrapping)
       const faviconElement = node.children[0] as Element
       expect(faviconElement.tagName).toBe("svg")
@@ -880,7 +881,7 @@ describe("Favicon Utilities", () => {
       const node = h("a", { href })
       const parent = h(parentTag, [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       expect(node.children.length).toBe(0)
     })
 
@@ -932,7 +933,7 @@ describe("Favicon Utilities", () => {
               : h("a", { href: "#section-1", className: initialClassName })
         const parent = h("p", [node])
 
-        await linkfavicons.ModifyNode(node, parent, faviconCounts)
+        await favicons.ModifyNode(node, parent, faviconCounts)
 
         assertFn(node)
       },
@@ -944,7 +945,7 @@ describe("Favicon Utilities", () => {
         const node = h("a", { href })
         const parent = h("div", [node])
 
-        await linkfavicons.ModifyNode(node, parent, faviconCounts)
+        await favicons.ModifyNode(node, parent, faviconCounts)
         expect(node.children.length).toBe(0)
       },
     )
@@ -967,7 +968,7 @@ describe("Favicon Utilities", () => {
       const parent = h("div", [node])
       const initialChildrenCount = node.children.length
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
 
       expect(node.children.length).toBe(initialChildrenCount)
     })
@@ -976,7 +977,7 @@ describe("Favicon Utilities", () => {
       const node = h("a", { href: "mailto:test@example.com" }, [h("span", {}, ["rss"])])
       const parent = h("div", [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
 
       // span is not in tagsToZoomInto and not text, so favicon appended directly
       const lastChild = node.children[node.children.length - 1] as Element
@@ -992,7 +993,7 @@ describe("Favicon Utilities", () => {
       const node = h(tagName, properties)
       const parent = h("div", [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       expect(node.children.length).toBe(0)
     })
 
@@ -1001,13 +1002,13 @@ describe("Favicon Utilities", () => {
       const href = `https://${hostname}/page`
 
       // Set up cache to return defaultPath for this hostname
-      linkfavicons.urlCache.clear()
-      linkfavicons.urlCache.set(linkfavicons.getQuartzPath(hostname), defaultPath)
+      favicons.urlCache.clear()
+      favicons.urlCache.set(favicons.getQuartzPath(hostname), defaultPath)
 
       const node = h("a", { href }, [])
       const parent = h("div", {}, [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       expect(node.children.length).toBe(0)
     })
 
@@ -1017,45 +1018,45 @@ describe("Favicon Utilities", () => {
       const node = h("a", { href: invalidHref }, [])
       const parent = h("div", {}, [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
       expect(node.children.length).toBe(0)
     })
 
     describe("favicon count threshold", () => {
       it(`should skip favicons that appear fewer than ${minFaviconCount} times`, async () => {
         const hostname = "example.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         const counts = new Map<string, number>()
         counts.set(faviconPath, minFaviconCount - 1)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBe(0)
       })
 
       it(`should add favicons that appear exactly ${minFaviconCount} times`, async () => {
         const hostname = "example.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         const counts = new Map<string, number>()
         // Counts are stored without extensions (format-agnostic)
-        counts.set(linkfavicons.normalizePathForCounting(faviconPath), minFaviconCount)
+        counts.set(favicons.normalizePathForCounting(faviconPath), minFaviconCount)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBeGreaterThan(0)
         // Empty node: favicon appended directly
         const faviconElement = node.children[0] as Element
@@ -1064,20 +1065,20 @@ describe("Favicon Utilities", () => {
 
       it(`should add favicons that appear more than ${minFaviconCount} times`, async () => {
         const hostname = "example.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         const counts = new Map<string, number>()
         // Counts are stored without extensions (format-agnostic)
-        counts.set(linkfavicons.normalizePathForCounting(faviconPath), minFaviconCount + 10)
+        counts.set(favicons.normalizePathForCounting(faviconPath), minFaviconCount + 10)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBeGreaterThan(0)
         // Empty node: favicon appended directly
         const faviconElement = node.children[0] as Element
@@ -1086,18 +1087,18 @@ describe("Favicon Utilities", () => {
 
       it("should skip favicons not in counts map (treat as 0)", async () => {
         const hostname = "example.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         const counts = new Map<string, number>()
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBe(0)
       })
 
@@ -1113,7 +1114,7 @@ describe("Favicon Utilities", () => {
           const node = h("a", { href }, [])
           const parent = h(parentTag, {}, [node])
 
-          await linkfavicons.ModifyNode(node, parent, counts)
+          await favicons.ModifyNode(node, parent, counts)
           expect(node.children.length).toBeGreaterThan(0)
           // Empty node: favicon appended directly (no span wrapping)
           const faviconElement = node.children[0] as Element
@@ -1130,13 +1131,13 @@ describe("Favicon Utilities", () => {
         const counts = new Map<string, number>()
         counts.set(faviconPath, minFaviconCount - 1)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBeGreaterThan(0)
         // Empty node: favicon appended directly
         const faviconEl = node.children[0] as Element
@@ -1146,25 +1147,25 @@ describe("Favicon Utilities", () => {
 
       it("should skip non-whitelisted favicons if count is below threshold", async () => {
         const hostname = "example.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         const counts = new Map<string, number>()
         counts.set(faviconPath, minFaviconCount - 1)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBe(0)
       })
 
       it("should whitelist favicons that end with whitelist suffix", async () => {
         const hostname = "apple.com"
-        const faviconPath = linkfavicons.getQuartzPath(hostname)
+        const faviconPath = favicons.getQuartzPath(hostname)
         const href = `https://${hostname}/page`
 
         // Verify the path ends with the whitelist suffix
@@ -1173,13 +1174,13 @@ describe("Favicon Utilities", () => {
         const counts = new Map<string, number>()
         counts.set(faviconPath, minFaviconCount - 1)
 
-        linkfavicons.urlCache.clear()
-        linkfavicons.urlCache.set(faviconPath, faviconPath)
+        favicons.urlCache.clear()
+        favicons.urlCache.set(faviconPath, faviconPath)
 
         const node = h("a", { href }, [])
         const parent = h("div", {}, [node])
 
-        await linkfavicons.ModifyNode(node, parent, counts)
+        await favicons.ModifyNode(node, parent, counts)
         expect(node.children.length).toBeGreaterThan(0)
         // Empty node: favicon appended directly
         const faviconElement = node.children[0] as Element
@@ -1189,7 +1190,7 @@ describe("Favicon Utilities", () => {
   })
 })
 
-describe("linkfavicons.downloadImage", () => {
+describe("favicons.downloadImage", () => {
   const runTest = async (
     mockResponse: Response | Error,
     expectedResult: boolean,
@@ -1208,9 +1209,9 @@ describe("linkfavicons.downloadImage", () => {
     }
 
     if (expectedResult) {
-      await expect(linkfavicons.downloadImage(url, imagePath)).resolves.not.toThrow()
+      await expect(favicons.downloadImage(url, imagePath)).resolves.not.toThrow()
     } else {
-      await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow()
+      await expect(favicons.downloadImage(url, imagePath)).rejects.toThrow()
     }
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
@@ -1263,7 +1264,7 @@ describe("linkfavicons.downloadImage", () => {
 
     jest.spyOn(global, "fetch").mockResolvedValueOnce(mockResponse)
 
-    await expect(linkfavicons.downloadImage(url, imagePath)).resolves.toBe(true)
+    await expect(favicons.downloadImage(url, imagePath)).resolves.toBe(true)
 
     // skipcq: JS-P1003
     const fileExists = await fsExtra.pathExists(imagePath)
@@ -1294,9 +1295,7 @@ describe("linkfavicons.downloadImage", () => {
       .spyOn(fs, "createWriteStream")
       .mockImplementation(() => fsExtra.createWriteStream(imagePath))
 
-    await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow(
-      "Downloaded file is empty",
-    )
+    await expect(favicons.downloadImage(url, imagePath)).rejects.toThrow("Downloaded file is empty")
 
     expect(fs.existsSync(imagePath)).toBe(false)
   })
@@ -1314,7 +1313,7 @@ describe("linkfavicons.downloadImage", () => {
 
     jest.spyOn(global, "fetch").mockResolvedValueOnce(mockResponse)
 
-    await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow("Empty image file")
+    await expect(favicons.downloadImage(url, imagePath)).rejects.toThrow("Empty image file")
   })
 
   it("should throw if write stream fails", async () => {
@@ -1332,16 +1331,14 @@ describe("linkfavicons.downloadImage", () => {
     // where file permission restrictions don't apply (e.g., running as root)
     jest.spyOn(fs.promises, "mkdir").mockRejectedValueOnce(new Error("EACCES: permission denied"))
 
-    await expect(linkfavicons.downloadImage(url, imagePath)).rejects.toThrow(
-      "Failed to write image",
-    )
+    await expect(favicons.downloadImage(url, imagePath)).rejects.toThrow("Failed to write image")
   })
 })
 
 describe("writeCacheToFile", () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    linkfavicons.urlCache.clear()
+    favicons.urlCache.clear()
     jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined)
   })
 
@@ -1356,10 +1353,10 @@ describe("writeCacheToFile", () => {
     ],
     [new Map(), "", "empty cache"],
   ])("should write $description to file", (cacheEntries, expectedContent) => {
-    linkfavicons.urlCache.clear()
-    cacheEntries.forEach((value, key) => linkfavicons.urlCache.set(key, value))
+    favicons.urlCache.clear()
+    cacheEntries.forEach((value, key) => favicons.urlCache.set(key, value))
 
-    linkfavicons.writeCacheToFile()
+    favicons.writeCacheToFile()
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(faviconUrlsFile, expectedContent, {
       flag: "w+",
@@ -1367,7 +1364,7 @@ describe("writeCacheToFile", () => {
   })
 })
 
-describe("linkfavicons.readFaviconUrls", () => {
+describe("favicons.readFaviconUrls", () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
@@ -1393,7 +1390,7 @@ describe("linkfavicons.readFaviconUrls", () => {
   ])("should handle $description", async (fileContent, expectedMap) => {
     jest.spyOn(fs.promises, "readFile").mockResolvedValue(fileContent)
 
-    const result = await linkfavicons.readFaviconUrls()
+    const result = await favicons.readFaviconUrls()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(expectedMap.size)
@@ -1407,7 +1404,7 @@ describe("linkfavicons.readFaviconUrls", () => {
     const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined)
     jest.spyOn(fs.promises, "readFile").mockRejectedValue(mockError)
 
-    const result = await linkfavicons.readFaviconUrls()
+    const result = await favicons.readFaviconUrls()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
@@ -1415,7 +1412,7 @@ describe("linkfavicons.readFaviconUrls", () => {
   })
 })
 
-describe("linkfavicons.readFaviconCounts", () => {
+describe("favicons.readFaviconCounts", () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
@@ -1423,7 +1420,7 @@ describe("linkfavicons.readFaviconCounts", () => {
   it("should return empty Map when file doesn't exist", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(false)
 
-    const result = linkfavicons.readFaviconCounts()
+    const result = favicons.readFaviconCounts()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
@@ -1469,7 +1466,7 @@ describe("linkfavicons.readFaviconCounts", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(true)
     jest.spyOn(fs, "readFileSync").mockReturnValue(fileContent)
 
-    const result = linkfavicons.readFaviconCounts()
+    const result = favicons.readFaviconCounts()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(expectedMap.size)
@@ -1482,7 +1479,7 @@ describe("linkfavicons.readFaviconCounts", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(true)
     jest.spyOn(fs, "readFileSync").mockReturnValue("invalid json {")
 
-    const result = linkfavicons.readFaviconCounts()
+    const result = favicons.readFaviconCounts()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
@@ -1494,7 +1491,7 @@ describe("linkfavicons.readFaviconCounts", () => {
       throw new Error("File read error")
     })
 
-    const result = linkfavicons.readFaviconCounts()
+    const result = favicons.readFaviconCounts()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
@@ -1513,7 +1510,7 @@ describe("linkfavicons.readFaviconCounts", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(true)
     jest.spyOn(fs, "readFileSync").mockReturnValue(jsonContent)
 
-    const result = linkfavicons.readFaviconCounts()
+    const result = favicons.readFaviconCounts()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(3)
@@ -1538,12 +1535,12 @@ describe("isHeading", () => {
     ["span", false],
   ])("should correctly identify if %s is a heading", (tagName, expected) => {
     const node = { tagName } as Element
-    expect(linkfavicons.isHeading(node)).toBe(expected)
+    expect(favicons.isHeading(node)).toBe(expected)
   })
 
   it("should handle undefined tagName", () => {
     const node = {} as Element
-    expect(linkfavicons.isHeading(node)).toBe(false)
+    expect(favicons.isHeading(node)).toBe(false)
   })
 })
 
@@ -1587,7 +1584,7 @@ describe("isAssetLink", () => {
     ["../video.mp4", true],
     ["audio.mp3", true],
   ])("should return %s for %s", (href, expected) => {
-    expect(linkfavicons.isAssetLink(href)).toBe(expected)
+    expect(favicons.isAssetLink(href)).toBe(expected)
   })
 })
 
@@ -1609,14 +1606,14 @@ describe("AddFavicons plugin", () => {
   })
 
   it("should return a plugin configuration with correct name", () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     expect(plugin.name).toBe("AddFavicons")
     expect(plugin.htmlPlugins).toBeDefined()
     expect(typeof plugin.htmlPlugins).toBe("function")
   })
 
   it("should return [] when offline mode is enabled", () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     const offlineCtx = {
       argv: {
         offline: true,
@@ -1627,7 +1624,7 @@ describe("AddFavicons plugin", () => {
   })
 
   it("should default offline to false when ctx.argv.offline is undefined", () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     const ctxWithoutOffline = {
       argv: {},
     } as unknown as import("../../util/ctx").BuildCtx
@@ -1636,7 +1633,7 @@ describe("AddFavicons plugin", () => {
   })
 
   it("should process HTML tree and add favicons to links", async () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     const htmlPlugins = plugin.htmlPlugins(mockCtx)
     const transformFunction = htmlPlugins[0]()
 
@@ -1670,7 +1667,7 @@ describe("AddFavicons plugin", () => {
   })
 
   it("should handle nodes with undefined parent", async () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     const htmlPlugins = plugin.htmlPlugins(mockCtx)
     const transformFunction = htmlPlugins[0]()
 
@@ -1683,7 +1680,7 @@ describe("AddFavicons plugin", () => {
   })
 
   it("should skip elements without href", async () => {
-    const plugin = linkfavicons.AddFavicons()
+    const plugin = favicons.AddFavicons()
     const htmlPlugins = plugin.htmlPlugins(mockCtx)
     const transformFunction = htmlPlugins[0]()
 
@@ -1707,7 +1704,7 @@ describe("AddFavicons plugin", () => {
 
 describe("transformUrl", () => {
   beforeEach(() => {
-    linkfavicons.urlCache.clear()
+    favicons.urlCache.clear()
   })
 
   it.each([
@@ -1719,23 +1716,23 @@ describe("transformUrl", () => {
       "/static/images/external-favicons/apple_com.png",
     ],
   ])("should return %s if whitelisted", (input, expected) => {
-    const result = linkfavicons.transformUrl(input)
+    const result = favicons.transformUrl(input)
     expect(result).toBe(expected)
   })
 
   it.each(
     faviconSubstringBlacklist.map((blacklistEntry: string) => [
-      `/static/images/external-favicons/${linkfavicons.normalizeFaviconListEntry(blacklistEntry)}.png`,
+      `/static/images/external-favicons/${normalizeFaviconListEntry(blacklistEntry)}.png`,
       defaultPath,
     ]),
   )("should return defaultPath if blacklisted: %s", (input, expected) => {
-    const result = linkfavicons.transformUrl(input)
+    const result = favicons.transformUrl(input)
     expect(result).toBe(expected)
   })
 
   it("should return path unchanged for non-whitelisted, non-blacklisted paths", () => {
     const input = "/static/images/external-favicons/example_com.png"
-    const result = linkfavicons.transformUrl(input)
+    const result = favicons.transformUrl(input)
     expect(result).toBe(input)
   })
 })
@@ -1748,7 +1745,7 @@ describe("normalizeHostname", () => {
     ["www.example.com", "example.com", "www subdomain"],
     ["cdn.assets.example.org", "example.org", "multiple subdomains"],
   ])("should remove subdomains: %s -> %s (%s)", (input, expected) => {
-    const result = linkfavicons.getQuartzPath(input)
+    const result = favicons.getQuartzPath(input)
     const expectedPath = `/static/images/external-favicons/${expected.replace(/\./g, "_")}.png`
     expect(result).toBe(expectedPath)
   })
@@ -1761,7 +1758,7 @@ describe("normalizeHostname", () => {
     ["example.co.jp", "example.co.jp", "co.jp TLD"],
     ["cdn.example.co.jp", "example.co.jp", "co.jp with subdomain"],
   ])("should handle multi-part TLDs: %s -> %s (%s)", (input, expected) => {
-    const result = linkfavicons.getQuartzPath(input)
+    const result = favicons.getQuartzPath(input)
     const expectedPath = `/static/images/external-favicons/${expected.replace(/\./g, "_")}.png`
     expect(result).toBe(expectedPath)
   })
@@ -1776,7 +1773,7 @@ describe("normalizeHostname", () => {
     ["www.nbc.com", "msnbc.com", "nbc.com with www"],
     ["news.nbc.com", "msnbc.com", "nbc.com with subdomain"],
   ])("should apply special domain mappings: %s -> %s (%s)", (input, expected) => {
-    const result = linkfavicons.getQuartzPath(input)
+    const result = favicons.getQuartzPath(input)
     const expectedPath = `/static/images/external-favicons/${expected.replace(/\./g, "_")}.png`
     expect(result).toBe(expectedPath)
   })
@@ -1787,7 +1784,7 @@ describe("normalizeHostname", () => {
     ["maps.google.com", "google.com", "maps.google.com"],
     ["www.google.com", "google.com", "www.google.com"],
   ])("should normalize google subdomains: %s -> %s (%s)", (input, expected) => {
-    const result = linkfavicons.getQuartzPath(input)
+    const result = favicons.getQuartzPath(input)
     const expectedPath = `/static/images/external-favicons/${expected.replace(/\./g, "_")}.png`
     expect(result).toBe(expectedPath)
   })
@@ -1797,7 +1794,7 @@ describe("normalizeHostname", () => {
     ["play.google.com", "play.google.com", "play"],
     ["docs.google.com", "docs.google.com", "docs"],
   ])("should preserve whitelisted google subdomains: %s -> %s (%s)", (input, expected) => {
-    const result = linkfavicons.getQuartzPath(input)
+    const result = favicons.getQuartzPath(input)
     const expectedPath = `/static/images/external-favicons/${expected.replace(/\./g, "_")}.png`
     expect(result).toBe(expectedPath)
   })
@@ -1806,19 +1803,19 @@ describe("normalizeHostname", () => {
     "should preserve stackexchange subdomains: %s.stackexchange.com",
     (subdomain) => {
       const hostname = `${subdomain}.stackexchange.com`
-      const result = linkfavicons.getQuartzPath(hostname)
+      const result = favicons.getQuartzPath(hostname)
       const expectedPath = `/static/images/external-favicons/${hostname.replace(/\./g, "_")}.png`
       expect(result).toBe(expectedPath)
     },
   )
 
   it("should handle localhost specially", () => {
-    const result = linkfavicons.getQuartzPath("localhost")
+    const result = favicons.getQuartzPath("localhost")
     expect(result).toBe(specialFaviconPaths.turntrout)
   })
 
   it("should handle turntrout.com specially", () => {
-    const result = linkfavicons.getQuartzPath("turntrout.com")
+    const result = favicons.getQuartzPath("turntrout.com")
     expect(result).toBe(specialFaviconPaths.turntrout)
   })
 })
@@ -1830,7 +1827,7 @@ describe("normalizeFaviconListEntry", () => {
     ["blog_example_com", "example_com", "strips subdomain"],
     ["developer_mozilla_org", "mozilla_org", "strips subdomain"],
   ])("should normalize %s to %s (%s)", (input, expected) => {
-    expect(linkfavicons.normalizeFaviconListEntry(input)).toBe(expected)
+    expect(normalizeFaviconListEntry(input)).toBe(expected)
   })
 })
 
@@ -1844,42 +1841,42 @@ describe("getQuartzPath hostname normalization", () => {
     ["subdomain.blog.openai.com", "/static/images/external-favicons/openai_com.png"],
     ["any.subdomain.google.com", "/static/images/external-favicons/google_com.png"],
   ])("should normalize hostname %s to canonical domain", (hostname, expected) => {
-    const result = linkfavicons.getQuartzPath(hostname)
+    const result = favicons.getQuartzPath(hostname)
     expect(result).toBe(expected)
   })
 
   it("should not normalize google.com itself", () => {
-    const result = linkfavicons.getQuartzPath("google.com")
+    const result = favicons.getQuartzPath("google.com")
     expect(result).toBe("/static/images/external-favicons/google_com.png")
   })
 
   it("should preserve whitelisted google.com subdomains", () => {
-    expect(linkfavicons.getQuartzPath("scholar.google.com")).toBe(
+    expect(favicons.getQuartzPath("scholar.google.com")).toBe(
       "/static/images/external-favicons/scholar_google_com.png",
     )
-    expect(linkfavicons.getQuartzPath("play.google.com")).toBe(
+    expect(favicons.getQuartzPath("play.google.com")).toBe(
       "/static/images/external-favicons/play_google_com.png",
     )
-    expect(linkfavicons.getQuartzPath("docs.google.com")).toBe(
+    expect(favicons.getQuartzPath("docs.google.com")).toBe(
       "/static/images/external-favicons/docs_google_com.png",
     )
   })
 
   it("should not normalize non-matching hostnames", () => {
-    const result = linkfavicons.getQuartzPath("example.com")
+    const result = favicons.getQuartzPath("example.com")
     expect(result).toBe("/static/images/external-favicons/example_com.png")
   })
 
   describe("integration with ModifyNode", () => {
     it("should use normalized path for favicon insertion", async () => {
       const hostname = "blog.openai.com"
-      const normalizedPath = linkfavicons.getQuartzPath(hostname)
-      const normalizedAvifUrl = linkfavicons.getFaviconUrl(normalizedPath)
+      const normalizedPath = favicons.getQuartzPath(hostname)
+      const normalizedAvifUrl = favicons.getFaviconUrl(normalizedPath)
       const href = `https://${hostname}/page`
 
       const faviconCounts = new Map<string, number>()
       // Counts are stored without extensions (format-agnostic)
-      faviconCounts.set(linkfavicons.normalizePathForCounting(normalizedPath), minFaviconCount + 1)
+      faviconCounts.set(favicons.normalizePathForCounting(normalizedPath), minFaviconCount + 1)
 
       // Mock fetch: normalized SVG (404), unnormalized SVG (404), AVIF (200)
       jest
@@ -1910,12 +1907,12 @@ describe("getQuartzPath hostname normalization", () => {
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
 
       const node = h("a", { href }, [])
       const parent = h("div", {}, [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
 
       expect(node.children.length).toBeGreaterThan(0)
       // Empty node: favicon appended directly
@@ -1925,12 +1922,12 @@ describe("getQuartzPath hostname normalization", () => {
 
     it("should use normalized path for count checking", async () => {
       const hostname = "blog.openai.com"
-      const normalizedPath = linkfavicons.getQuartzPath(hostname)
+      const normalizedPath = favicons.getQuartzPath(hostname)
       const href = `https://${hostname}/page`
 
       const faviconCounts = new Map<string, number>()
       // Counts are stored without extensions (format-agnostic)
-      faviconCounts.set(linkfavicons.normalizePathForCounting(normalizedPath), minFaviconCount + 1)
+      faviconCounts.set(favicons.normalizePathForCounting(normalizedPath), minFaviconCount + 1)
 
       jest.spyOn(global, "fetch").mockResolvedValueOnce(
         new Response("Mock AVIF content", {
@@ -1939,12 +1936,12 @@ describe("getQuartzPath hostname normalization", () => {
         }),
       )
 
-      linkfavicons.urlCache.clear()
+      favicons.urlCache.clear()
 
       const node = h("a", { href }, [])
       const parent = h("div", {}, [node])
 
-      await linkfavicons.ModifyNode(node, parent, faviconCounts)
+      await favicons.ModifyNode(node, parent, faviconCounts)
 
       expect(node.children.length).toBeGreaterThan(0)
     })
@@ -1962,7 +1959,7 @@ describe("normalizeUrl", () => {
     ["./nested/./path", "https://www.turntrout.com/nested/./path"],
     ["../parent/../sibling", "https://www.turntrout.com/parent/../sibling"],
   ])("should normalize %s to %s", (input, expected) => {
-    const result = linkfavicons.normalizeUrl(input)
+    const result = favicons.normalizeUrl(input)
     expect(result).toBe(expected)
   })
 
@@ -1971,7 +1968,7 @@ describe("normalizeUrl", () => {
     ["./", "https://www.turntrout.com/"],
     ["../../deep/path", "https://www.turntrout.com/../deep/path"],
   ])("should handle edge cases: %s", (input, expected) => {
-    const result = linkfavicons.normalizeUrl(input)
+    const result = favicons.normalizeUrl(input)
     expect(result).toBe(expected)
   })
 })
@@ -1981,7 +1978,7 @@ describe("maybeSpliceText edge cases", () => {
 
   it("should handle node with only whitespace text", () => {
     const node = h("a", {}, ["   "])
-    const result = linkfavicons.maybeSpliceText(node, linkfavicons.createFaviconElement(imgPath))
+    const result = favicons.maybeSpliceText(node, favicons.createFaviconElement(imgPath))
     // Whitespace-only text is treated as empty, favicon returned directly (no span wrapping)
     expect(result).toMatchObject(createExpectedFavicon(imgPath))
   })
@@ -1992,7 +1989,7 @@ describe("maybeSpliceText edge cases", () => {
     ["12", "two character text"],
   ])("should handle node with %s", (text) => {
     const node = h("a", {}, [text])
-    linkfavicons.insertFavicon(imgPath, node)
+    favicons.insertFavicon(imgPath, node)
     // text <= 4 chars: text node removed, replaced with favicon-span containing all text
     expect(node.children.length).toBe(1)
     const span = node.children[0] as Element
@@ -2008,7 +2005,7 @@ describe("maybeSpliceText edge cases", () => {
       h("em", {}, [{ type: "text", value: "text " }]),
       h("strong", {}, [innerText]),
     ])
-    linkfavicons.insertFavicon(imgPath, node)
+    favicons.insertFavicon(imgPath, node)
 
     const strongElement = node.children[2] as Element
     expect(strongElement.tagName).toBe("strong")
@@ -2023,7 +2020,7 @@ describe("maybeSpliceText edge cases", () => {
 
   it("should handle node with element child that has no text", () => {
     const node = h("a", {}, [h("div")])
-    const result = linkfavicons.maybeSpliceText(node, linkfavicons.createFaviconElement(imgPath))
+    const result = favicons.maybeSpliceText(node, favicons.createFaviconElement(imgPath))
     // div is not zoomable and not text, favicon returned directly (no span wrapping)
     expect(node.children.length).toBe(1) // only the div
     expect(result).toMatchObject(createExpectedFavicon(imgPath))
@@ -2031,7 +2028,7 @@ describe("maybeSpliceText edge cases", () => {
 
   it("should handle node with mixed children ending in element", () => {
     const node = h("a", {}, [{ type: "text", value: "Text " }, h("span", {}, ["More"])])
-    linkfavicons.insertFavicon(imgPath, node)
+    favicons.insertFavicon(imgPath, node)
     // span is not in tagsToZoomInto and not text, so favicon appended directly
     expect(node.children.length).toBe(3) // text + span + favicon
     const faviconEl = node.children[2] as Element
@@ -2041,7 +2038,7 @@ describe("maybeSpliceText edge cases", () => {
   it("should zoom into abbr inside link (RSS link structure)", () => {
     // Simulates the RSS link structure created in afterArticle.ts
     const node = h("a", {}, [h("abbr", { class: "small-caps" }, ["rss"])])
-    linkfavicons.insertFavicon(imgPath, node)
+    favicons.insertFavicon(imgPath, node)
 
     // Favicon should be appended inside the abbr (it's in tagsToZoomInto)
     expect(node.children.length).toBe(1)
@@ -2061,11 +2058,11 @@ describe("maybeSpliceText edge cases", () => {
   })
 
   it("should append to existing favicon-span instead of creating a new one", () => {
-    const existingFavicon = linkfavicons.createFaviconElement("/first/favicon.png")
+    const existingFavicon = favicons.createFaviconElement("/first/favicon.png")
     const existingSpan = h("span", { className: "favicon-span" }, ["text", existingFavicon])
     const node = h("a", {}, [existingSpan])
 
-    const result = linkfavicons.maybeSpliceText(node, linkfavicons.createFaviconElement(imgPath))
+    const result = favicons.maybeSpliceText(node, favicons.createFaviconElement(imgPath))
     // Should return null because the favicon was appended to the existing span
     expect(result).toBeNull()
     // Existing span should now have 3 children: text + first favicon + second favicon
@@ -2094,10 +2091,7 @@ describe("favicon must be inside favicon-span (prevents line-break orphaning)", 
     ["nested code element", h("a", {}, [h("code", {}, ["linkchecker"])])],
     ["text ending with punctuation", h("a", {}, ["Hello!"])],
   ])("wraps favicon inside favicon-span for %s", (_name, node) => {
-    const result = linkfavicons.maybeSpliceText(
-      node as Element,
-      linkfavicons.createFaviconElement(imgPath),
-    )
+    const result = favicons.maybeSpliceText(node as Element, favicons.createFaviconElement(imgPath))
     if (result) {
       ;(node as Element).children.push(result)
     }
@@ -2131,10 +2125,7 @@ describe("favicon must be inside favicon-span (prevents line-break orphaning)", 
     ["empty node", h("a", {}, [])],
     ["non-text last child (div)", h("a", {}, [h("div")])],
   ])("returns favicon directly for %s (no text to splice)", (_name, node) => {
-    const result = linkfavicons.maybeSpliceText(
-      node as Element,
-      linkfavicons.createFaviconElement(imgPath),
-    )
+    const result = favicons.maybeSpliceText(node as Element, favicons.createFaviconElement(imgPath))
     // For nodes without text, favicon is returned directly (no span wrapping)
     expect(result).toBeDefined()
     expect(result).toMatchObject(createExpectedFavicon(imgPath))
@@ -2143,14 +2134,14 @@ describe("favicon must be inside favicon-span (prevents line-break orphaning)", 
 
 describe("shouldIncludeFavicon edge cases", () => {
   it("should exclude blacklisted favicon even if whitelisted", () => {
-    const blacklistEntry = linkfavicons.normalizeFaviconListEntry(faviconSubstringBlacklist[0])
+    const blacklistEntry = normalizeFaviconListEntry(faviconSubstringBlacklist[0])
     const imgPath = `/static/images/external-favicons/${blacklistEntry}.png`
     const faviconCounts = new Map<string, number>()
     // Counts are stored without extensions (format-agnostic)
-    faviconCounts.set(linkfavicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
+    faviconCounts.set(favicons.normalizePathForCounting(imgPath), minFaviconCount + 10)
 
     // Even if it contains a whitelist entry, blacklist should take precedence
-    const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+    const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
     expect(result).toBe(false)
   })
@@ -2159,7 +2150,7 @@ describe("shouldIncludeFavicon edge cases", () => {
     const imgPath = specialFaviconPaths.mail
     const faviconCounts = new Map<string, number>()
 
-    const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+    const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
     expect(result).toBe(true)
   })
@@ -2168,9 +2159,9 @@ describe("shouldIncludeFavicon edge cases", () => {
     const imgPath = "/static/images/external-favicons/subdomain_apple_com.png"
     const faviconCounts = new Map<string, number>()
     // Counts are stored without extensions (format-agnostic)
-    faviconCounts.set(linkfavicons.normalizePathForCounting(imgPath), 0)
+    faviconCounts.set(favicons.normalizePathForCounting(imgPath), 0)
 
-    const result = linkfavicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
+    const result = favicons.shouldIncludeFavicon(imgPath, imgPath, faviconCounts)
 
     expect(result).toBe(true)
   })
@@ -2180,9 +2171,9 @@ describe("shouldIncludeFavicon edge cases", () => {
     const countKey = "/static/images/external-favicons/example_com.png"
     const faviconCounts = new Map<string, number>()
     // Counts are stored without extensions (format-agnostic)
-    faviconCounts.set(linkfavicons.normalizePathForCounting(countKey), minFaviconCount + 1)
+    faviconCounts.set(favicons.normalizePathForCounting(countKey), minFaviconCount + 1)
 
-    const result = linkfavicons.shouldIncludeFavicon(imgPath, countKey, faviconCounts)
+    const result = favicons.shouldIncludeFavicon(imgPath, countKey, faviconCounts)
 
     expect(result).toBe(true)
   })
@@ -2196,7 +2187,7 @@ describe("getQuartzPath edge cases", () => {
     ["example.co.uk", "/static/images/external-favicons/example_co_uk.png"],
     ["test.example.co.uk", "/static/images/external-favicons/example_co_uk.png"],
   ])("should handle %s correctly", (hostname, expectedPath) => {
-    expect(linkfavicons.getQuartzPath(hostname)).toBe(expectedPath)
+    expect(favicons.getQuartzPath(hostname)).toBe(expectedPath)
   })
 })
 
@@ -2218,7 +2209,7 @@ describe("ModifyNode with asset links", () => {
     const node = h("a", { href })
     const parent = h("div", [node])
 
-    await linkfavicons.ModifyNode(node, parent, faviconCounts)
+    await favicons.ModifyNode(node, parent, faviconCounts)
 
     expect(node.children.length).toBe(0)
   })

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -112,9 +112,6 @@ export async function downloadImage(url: string, imagePath: string): Promise<boo
   return true
 }
 
-// Re-export for backward compatibility with test imports
-export { normalizeFaviconListEntry } from "../../util/favicon-config"
-
 /**
  * Normalizes a favicon path for counting by removing format-specific extensions.
  * Counts are format-agnostic (domain-based), so we store paths without extensions.

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -210,20 +210,6 @@ export function createNowrapSpan(text: string, child: Element): Element {
 }
 
 /**
- * Creates a word-joiner span element containing a Unicode word joiner
- * character (U+2060). Used to wrap favicons so they don't orphan from
- * adjacent text when lines break.
- */
-export function createWordJoinerSpan(): Element {
-  return {
-    type: "element",
-    tagName: "span",
-    properties: { className: "word-joiner" },
-    children: [{ type: "text" as const, value: "\u2060" }],
-  } as Element
-}
-
-/**
  * Splices the last few characters from a text node and wraps them with
  * the given element in a nowrap span, preventing line-break orphaning.
  *

--- a/quartz/util/favicon-config.ts
+++ b/quartz/util/favicon-config.ts
@@ -2,7 +2,7 @@
  * Shared favicon configuration: hostname normalization and computed
  * whitelist/blacklist arrays.
  *
- * Imported by both the Quartz transformer (linkfavicons.ts) and the
+ * Imported by both the Quartz transformer (favicons.ts) and the
  * Python validation helper (scripts/compute_favicon_lists.ts) so that
  * the inclusion predicate is defined in one place.
  */

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1311,18 +1311,17 @@ def check_favicons_are_svgs(soup: BeautifulSoup) -> list[str]:
     return non_svg_favicons
 
 
-def _build_favicon_lists(
+def _build_included_favicon_domains(
     git_root: Path,
-) -> tuple[list[str], list[str]]:
+) -> frozenset[str]:
     """
-    Build favicon whitelist and blacklist by calling the shared TS module.
+    Compute the set of domain entries whose favicons should appear in the
+    built site, by calling the shared TS module which runs the same
+    ``shouldIncludeFavicon`` logic (whitelist + blacklist + count threshold)
+    as the Quartz transformer.
 
-    Runs ``scripts/compute_favicon_lists.ts`` (which imports from
-    ``quartz/util/favicon-config.ts``) so that the Python validation
-    uses the exact same inclusion predicate -- including PSL-normalised
-    blacklist entries -- as the Quartz transformer.
-
-    Returns a (whitelist, blacklist) tuple.
+    Returns a frozenset of underscore-separated domain strings
+    (e.g. ``{"apple_com", "openai_com", "scholar_google_com"}``).
     """
     result = subprocess.run(  # skipcq: BAN-B607
         ["npx", "tsx", str(git_root / "scripts" / "compute_favicon_lists.ts")],
@@ -1332,16 +1331,11 @@ def _build_favicon_lists(
         check=True,
     )
     data = json.loads(result.stdout)
-    return data["whitelist"], data["blacklist"]
+    return frozenset(data["includedDomains"])
 
 
 def _is_asset_href(href: str) -> bool:
-    """
-    Check if an href points to an asset file (image/video/audio/pdf).
-
-    Mirrors the TS ``isAssetLink()`` which uses the ``mime-types``
-    library; here we use Python's stdlib ``mimetypes`` module.
-    """
+    """Check if an href points to an asset file (image/video/audio/pdf)."""
     path = href.split("?")[0].split("#")[0]
     mime_type, _ = mimetypes.guess_type(path)
     if not mime_type:
@@ -1352,63 +1346,45 @@ def _is_asset_href(href: str) -> bool:
     )
 
 
-def check_whitelisted_links_have_favicons(
+def _domain_matches(normalised: str, domain: str) -> bool:
+    """Boundary-aware domain matching (avoids e.g. 'x_com' matching 'vox_com')."""
+    return normalised == domain or normalised.endswith(f"_{domain}")
+
+
+def check_external_links_have_favicons(
     soup: BeautifulSoup,
-    favicon_whitelist: list[str],
-    favicon_blacklist: list[str] | None = None,
+    included_domains: frozenset[str],
 ) -> list[str]:
     """
-    Check that external links to whitelisted domains have favicons.
+    Check that external links to included domains have favicons.
 
-    For each ``<a class="external">`` link inside ``<article>`` whose
-    domain matches a whitelist entry (and is NOT blacklisted), verifies
-    the link contains a ``.favicon`` descendant element.
+    Uses the same ``shouldIncludeFavicon`` predicate as the Quartz
+    transformer (whitelist + blacklist + count threshold), pre-computed
+    by ``scripts/compute_favicon_lists.ts``.
 
-    Args:
-        soup: Parsed HTML page.
-        favicon_whitelist: Underscore-separated domain entries (e.g.
-            ``["apple_com", "scholar_google_com"]``).  Matching is by
-            substring inclusion in the underscore-normalised hostname.
-        favicon_blacklist: Underscore-separated domain entries that should
-            never receive favicons.  Blacklist takes priority over
-            whitelist (mirroring the TS logic).
-
-    Returns:
-        List of human-readable issue strings for whitelisted links missing
-        favicons.
+    Only checks ``<a class="external">`` links inside ``<article>``;
+    component-generated links (nav, aside) never pass through the
+    favicon transformer.
     """
     issues: list[str] = []
-    blacklist = favicon_blacklist or []
 
-    # Only check links inside <article>; component-generated links (nav,
-    # aside) never pass through the favicon transformer.
     for link in soup.select("article a.external[href]"):
         href = str(link.get("href", ""))
-        if not href.startswith(("http://", "https://")):
+        if not href.startswith(("http://", "https://")) or _is_asset_href(href):
             continue
 
-        if _is_asset_href(href):
-            continue
-
-        parsed = urlparse(href)
-        hostname = parsed.hostname or ""
+        hostname = urlparse(href).hostname or ""
         if not hostname:
             continue
 
-        # Normalise: strip www., convert dots to underscores
         normalised = hostname.removeprefix("www.").replace(".", "_")
-
-        # Blacklist takes priority (mirrors TS shouldIncludeFavicon)
-        if any(entry in normalised for entry in blacklist):
-            continue
-        if not any(entry in normalised for entry in favicon_whitelist):
+        if not any(_domain_matches(normalised, d) for d in included_domains):
             continue
 
-        has_favicon = bool(link.select_one("svg.favicon, img.favicon"))
-        if not has_favicon:
+        if not link.select_one("svg.favicon, img.favicon"):
             _append_to_list(
                 issues,
-                f"Whitelisted link missing favicon: {hostname} ({href})",
+                f"Link missing favicon: {hostname} ({href})",
             )
 
     return issues
@@ -1686,8 +1662,7 @@ class CheckOptions:
 
     should_check_fonts: bool = False
     defined_css_variables: Set[str] | None = None
-    favicon_whitelist: list[str] | None = None
-    favicon_blacklist: list[str] | None = None
+    favicon_included_domains: frozenset[str] | None = None
 
 
 def check_file_for_issues(
@@ -1771,11 +1746,9 @@ def check_file_for_issues(
         "orphaned_subfigures": check_orphaned_subfigures(soup),
     }
 
-    if opts.favicon_whitelist is not None:
-        issues["whitelisted_missing_favicons"] = (
-            check_whitelisted_links_have_favicons(
-                soup, opts.favicon_whitelist, opts.favicon_blacklist
-            )
+    if opts.favicon_included_domains is not None:
+        issues["missing_favicons"] = check_external_links_have_favicons(
+            soup, opts.favicon_included_domains
         )
 
     if opts.should_check_fonts:
@@ -2355,14 +2328,11 @@ def _process_html_files(  # pylint: disable=too-many-locals
     files_to_skip: Set[str] = script_utils.collect_aliases(content_dir)
     citation_to_files: Dict[str, list[str]] = defaultdict(list)
 
-    favicon_whitelist, favicon_blacklist = _build_favicon_lists(
-        public_dir.parent
-    )
+    included_domains = _build_included_favicon_domains(public_dir.parent)
     check_opts = CheckOptions(
         should_check_fonts=check_fonts,
         defined_css_variables=defined_css_vars,
-        favicon_whitelist=favicon_whitelist,
-        favicon_blacklist=favicon_blacklist,
+        favicon_included_domains=included_domains,
     )
     for root, _, files in os.walk(public_dir):
         root_path = Path(root)

--- a/scripts/compute_favicon_lists.ts
+++ b/scripts/compute_favicon_lists.ts
@@ -1,19 +1,42 @@
 /**
- * CLI helper that outputs the computed favicon whitelist and blacklist as JSON.
+ * CLI helper that outputs the set of domain entries whose favicons should appear
+ * in the built site, as determined by `shouldIncludeFavicon` with real counts.
  *
  * Called by scripts/built_site_checks.py so that the Python validation
  * mirrors the exact same inclusion predicate used by the Quartz transformer.
  *
  * Usage: npx tsx scripts/compute_favicon_lists.ts
  */
+import { defaultPath } from "../quartz/components/constants"
 import {
-  faviconCountWhitelistComputed,
-  faviconSubstringBlacklistComputed,
-} from "../quartz/util/favicon-config"
+  readFaviconCounts,
+  shouldIncludeFavicon,
+  transformUrl,
+  getFaviconUrl,
+} from "../quartz/plugins/transformers/favicons"
 
-console.log(
-  JSON.stringify({
-    whitelist: faviconCountWhitelistComputed,
-    blacklist: faviconSubstringBlacklistComputed,
-  }),
-)
+const faviconCounts = readFaviconCounts()
+
+// Compute the set of underscore-separated domain names that pass shouldIncludeFavicon
+const includedDomains: string[] = []
+for (const [pathWithoutExt] of faviconCounts) {
+  // Build path with extension (special paths like URLs and .svg/.ico are preserved)
+  const pathWithExt =
+    pathWithoutExt.startsWith("http") || /\.(?:svg|ico)$/.test(pathWithoutExt)
+      ? pathWithoutExt
+      : `${pathWithoutExt}.png`
+
+  const transformedPath = transformUrl(pathWithExt)
+  if (transformedPath === defaultPath) continue
+
+  const url = getFaviconUrl(transformedPath)
+  if (!shouldIncludeFavicon(url, pathWithoutExt, faviconCounts)) continue
+
+  // Extract domain part: /static/images/external-favicons/example_com -> example_com
+  const match = pathWithoutExt.match(/external-favicons\/(?<domain>.+)$/)
+  if (match?.groups?.domain) {
+    includedDomains.push(match.groups.domain)
+  }
+}
+
+console.log(JSON.stringify({ includedDomains }))

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -34,29 +33,18 @@ def quartz_project_structure(tmp_path: Path):
     """
     Create a minimal Quartz directory layout under *tmp_path*.
 
-    The structure mirrors the directories expected by many scripts.
+    The structure mirrors the directories expected by many scripts:
+    ├── public/
+    ├── quartz/static/
+    └── website_content/
     """
     dirs = {
         "public": tmp_path / "public",
         "static": tmp_path / "quartz" / "static",
         "content": tmp_path / "website_content",
-        "config": tmp_path / "config",
     }
     for d in dirs.values():
         d.mkdir(parents=True, exist_ok=True)
-
-    # Minimal constants.json used by _build_favicon_lists
-    (dirs["config"] / "constants.json").write_text(
-        json.dumps(
-            {
-                "faviconCountWhitelist": [],
-                "googleSubdomainWhitelist": [],
-                "faviconSubstringBlacklist": [],
-            }
-        ),
-        encoding="utf-8",
-    )
-
     return dirs
 
 

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -52,8 +52,8 @@ def mock_environment(quartz_project_structure, monkeypatch):
     )
     monkeypatch.setattr(
         built_site_checks,
-        "_build_favicon_lists",
-        lambda _git_root: ([], []),
+        "_build_included_favicon_domains",
+        lambda _git_root: frozenset(),
     )
 
     return {
@@ -3543,8 +3543,7 @@ def test_main_handles_markdown_mapping(
             built_site_checks.CheckOptions(
                 should_check_fonts=False,
                 defined_css_variables={"--color-primary", "--color-secondary"},
-                favicon_whitelist=[],
-                favicon_blacklist=[],
+                favicon_included_domains=frozenset(),
             ),
         )
 
@@ -3605,8 +3604,7 @@ def test_main_command_line_args(
         built_site_checks.CheckOptions(
             should_check_fonts=True,
             defined_css_variables={"--color-primary", "--color-secondary"},
-            favicon_whitelist=[],
-            favicon_blacklist=[],
+            favicon_included_domains=frozenset(),
         ),
     )
 
@@ -5806,43 +5804,40 @@ def test_is_asset_href(href, expected):
 
 
 @pytest.mark.parametrize(
-    "html,whitelist,expected",
+    "html,domains,expected",
     [
         # No external links
-        ("<article><p>No links here</p></article>", ["apple_com"], []),
-        # External link to whitelisted domain WITH favicon (valid)
+        ("<article><p>No links here</p></article>", {"apple_com"}, []),
+        # Included domain WITH favicon (valid)
         (
             '<article><a class="external" href="https://apple.com/products">'
             'Apple<span class="favicon-span">'
             '<svg class="favicon" style="--mask-url: url(apple.svg);"></svg>'
             "</span></a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
-        # External link to whitelisted domain WITHOUT favicon (invalid)
+        # Included domain WITHOUT favicon (invalid)
         (
             '<article><a class="external" href="https://apple.com/products">'
             "Apple</a></article>",
-            ["apple_com"],
-            [
-                "Whitelisted link missing favicon: apple.com"
-                " (https://apple.com/products)"
-            ],
+            {"apple_com"},
+            ["Link missing favicon: apple.com" " (https://apple.com/products)"],
         ),
-        # External link to non-whitelisted domain without favicon (valid)
+        # Non-included domain without favicon (valid — not expected)
         (
             '<article><a class="external" href="https://example.com">'
             "Example</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
-        # Subdomain of whitelisted domain without favicon (invalid)
+        # Subdomain of included domain without favicon (invalid)
         (
             '<article><a class="external" href="https://blog.apple.com/news">'
             "Blog</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [
-                "Whitelisted link missing favicon: blog.apple.com"
+                "Link missing favicon: blog.apple.com"
                 " (https://blog.apple.com/news)"
             ],
         ),
@@ -5850,24 +5845,21 @@ def test_is_asset_href(href, expected):
         (
             '<article><a class="external" href="https://www.apple.com">'
             "Apple</a></article>",
-            ["apple_com"],
-            [
-                "Whitelisted link missing favicon: www.apple.com"
-                " (https://www.apple.com)"
-            ],
+            {"apple_com"},
+            ["Link missing favicon: www.apple.com" " (https://www.apple.com)"],
         ),
-        # Asset link to whitelisted domain (should be skipped)
+        # Asset link to included domain (should be skipped)
         (
             '<article><a class="external" href="https://apple.com/image.png">'
             "Img</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
-        # Internal link (no class="external") to whitelisted domain (skip)
+        # Internal link (no class="external") to included domain (skip)
         (
             '<article><a href="https://apple.com/products">'
             "Apple</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
         # Multiple links: one valid, one missing favicon
@@ -5877,20 +5869,17 @@ def test_is_asset_href(href, expected):
             'ok<svg class="favicon" style="--mask-url: url(a.svg);"></svg></a>'
             '<a class="external" href="https://discord.gg/abc">bad</a>'
             "</article>",
-            ["apple_com", "discord_gg"],
-            [
-                "Whitelisted link missing favicon: discord.gg"
-                " (https://discord.gg/abc)"
-            ],
+            {"apple_com", "discord_gg"},
+            ["Link missing favicon: discord.gg" " (https://discord.gg/abc)"],
         ),
-        # Google subdomain whitelist entry
+        # Google subdomain included entry
         (
             '<article><a class="external"'
             ' href="https://scholar.google.com/citations">'
             "Scholar</a></article>",
-            ["scholar_google_com"],
+            {"scholar_google_com"},
             [
-                "Whitelisted link missing favicon: scholar.google.com"
+                "Link missing favicon: scholar.google.com"
                 " (https://scholar.google.com/citations)"
             ],
         ),
@@ -5898,83 +5887,91 @@ def test_is_asset_href(href, expected):
         (
             '<article><a class="external" href="ftp://apple.com/file">'
             "FTP</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
         # Link with img.favicon (also valid)
         (
             '<article><a class="external" href="https://apple.com">'
             'Apple<img class="favicon" src="apple.png"></a></article>',
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
-        # Empty whitelist - nothing flagged
+        # Empty included domains set - nothing flagged
         (
             '<article><a class="external" href="https://apple.com">'
             "Apple</a></article>",
-            [],
+            set(),
             [],
         ),
         # Malformed URL with no hostname (should be skipped gracefully)
         (
             '<article><a class="external" href="https://">'
             "Bad URL</a></article>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
         # Link outside <article> (nav/aside) - should be skipped
         (
             '<nav><a class="external" href="https://apple.com">'
             "Apple</a></nav>",
-            ["apple_com"],
+            {"apple_com"},
             [],
         ),
     ],
 )
-def test_check_whitelisted_links_have_favicons(html, whitelist, expected):
+def test_check_external_links_have_favicons(html, domains, expected):
     soup = BeautifulSoup(html, "html.parser")
-    result = built_site_checks.check_whitelisted_links_have_favicons(
-        soup, whitelist
+    result = built_site_checks.check_external_links_have_favicons(
+        soup, frozenset(domains)
     )
     assert result == expected
 
 
-def test_blacklist_overrides_whitelist():
-    """Blacklisted domains should be skipped even if matching whitelist."""
-    # "x_com" whitelist entry is a substring of "vox_com", but vox_com is
-    # blacklisted, so it should NOT be flagged.
+def test_boundary_aware_domain_matching():
+    """Boundary-aware matching prevents 'x_com' from matching 'vox_com'."""
     html = (
         '<article><a class="external" href="https://www.vox.com/article">'
         "Vox</a></article>"
     )
     soup = BeautifulSoup(html, "html.parser")
-    result = built_site_checks.check_whitelisted_links_have_favicons(
-        soup, ["x_com"], ["vox_com"]
+    # "x_com" should NOT match "vox_com" due to boundary-aware matching
+    result = built_site_checks.check_external_links_have_favicons(
+        soup, frozenset({"x_com"})
     )
     assert result == []
 
 
+def test_domain_matches_helper():
+    """Unit tests for the _domain_matches helper."""
+    assert built_site_checks._domain_matches("apple_com", "apple_com")
+    assert built_site_checks._domain_matches("blog_apple_com", "apple_com")
+    assert not built_site_checks._domain_matches("vox_com", "x_com")
+    assert not built_site_checks._domain_matches("foxnews_com", "x_com")
+    assert built_site_checks._domain_matches(
+        "scholar_google_com", "scholar_google_com"
+    )
+
+
 @mock.patch("built_site_checks.subprocess.run")
-def test_build_favicon_lists(mock_run):
-    """Test _build_favicon_lists calls TS script and parses output."""
+def test_build_included_favicon_domains(mock_run):
+    """Test _build_included_favicon_domains calls TS script and parses
+    output."""
     mock_run.return_value = subprocess.CompletedProcess(
         args=[],
         returncode=0,
         stdout=json.dumps(
-            {
-                "whitelist": ["apple_com", "x_com", "scholar_google_com"],
-                "blacklist": ["csir_co_za", "medium_com"],
-            }
+            {"includedDomains": ["apple_com", "openai_com", "x_com"]}
         ),
     )
-    whitelist, blacklist = built_site_checks._build_favicon_lists(Path("/fake"))
-    assert whitelist == ["apple_com", "x_com", "scholar_google_com"]
-    assert blacklist == ["csir_co_za", "medium_com"]
+    result = built_site_checks._build_included_favicon_domains(Path("/fake"))
+    assert result == frozenset({"apple_com", "openai_com", "x_com"})
     mock_run.assert_called_once()
 
 
-def test_check_file_for_issues_with_favicon_whitelist(tmp_path):
-    """Test that check_file_for_issues passes favicon_whitelist through."""
+def test_check_file_for_issues_with_included_domains(tmp_path):
+    """Test that check_file_for_issues passes favicon_included_domains
+    through."""
     base_dir = tmp_path / "public"
     base_dir.mkdir()
     file_path = base_dir / "test.html"
@@ -5993,16 +5990,18 @@ def test_check_file_for_issues_with_favicon_whitelist(tmp_path):
             file_path,
             base_dir,
             None,
-            built_site_checks.CheckOptions(favicon_whitelist=["apple_com"]),
+            built_site_checks.CheckOptions(
+                favicon_included_domains=frozenset({"apple_com"})
+            ),
         )
 
-    assert "whitelisted_missing_favicons" in issues
-    assert any("apple.com" in s for s in issues["whitelisted_missing_favicons"])
+    assert "missing_favicons" in issues
+    assert any("apple.com" in s for s in issues["missing_favicons"])
 
 
-def test_check_file_for_issues_without_favicon_whitelist(tmp_path):
-    """Test that check_file_for_issues skips favicon check when whitelist is
-    None."""
+def test_check_file_for_issues_without_included_domains(tmp_path):
+    """Test that check_file_for_issues skips favicon check when
+    favicon_included_domains is None."""
     base_dir = tmp_path / "public"
     base_dir.mkdir()
     file_path = base_dir / "test.html"
@@ -6021,7 +6020,7 @@ def test_check_file_for_issues_without_favicon_whitelist(tmp_path):
             file_path, base_dir, None, built_site_checks.CheckOptions()
         )
 
-    assert "whitelisted_missing_favicons" not in issues
+    assert "missing_favicons" not in issues
 
 
 def test_maybe_collect_citation_keys_redirect(tmp_path):
@@ -6160,6 +6159,11 @@ def test_process_html_files_duplicate_citations(tmp_path: Path):
         patch.object(script_utils, "build_html_to_md_map", return_value={}),
         patch.object(script_utils, "collect_aliases", return_value=set()),
         patch.object(script_utils, "should_have_md", return_value=False),
+        patch.object(
+            built_site_checks,
+            "_build_included_favicon_domains",
+            return_value=frozenset(),
+        ),
     ):
         result = built_site_checks._process_html_files(
             public_dir, content_dir, check_fonts=False


### PR DESCRIPTION
## Summary
This PR refactors the favicon validation logic to use a single computed set of included domains rather than separate whitelist and blacklist arrays. The change simplifies the validation predicate and makes the Python checks mirror the exact same inclusion logic as the Quartz transformer.

## Key Changes

- **Renamed module import**: Changed `linkfavicons` to `favicons` throughout test files for clarity
- **Simplified favicon inclusion model**: Replaced separate `favicon_whitelist` and `favicon_blacklist` parameters with a single `favicon_included_domains` frozenset that represents the final computed set of domains whose favicons should appear in the built site
- **Updated `compute_favicon_lists.ts`**: Now calls `shouldIncludeFavicon` with real favicon counts to compute the exact set of included domains, rather than just exporting raw whitelist/blacklist arrays
- **Refactored `check_external_links_have_favicons()`**: 
  - Simplified the function signature to accept only `included_domains` parameter
  - Implemented boundary-aware domain matching via new `_domain_matches()` helper to prevent substring false positives (e.g., `x_com` matching `vox_com`)
  - Updated error messages from "Whitelisted link missing favicon" to "Link missing favicon"
- **Updated `CheckOptions` dataclass**: Replaced `favicon_whitelist` and `favicon_blacklist` fields with single `favicon_included_domains` field
- **Removed unused code**: Deleted `createWordJoinerSpan()` function from utils and updated imports in `populateContainers.ts`
- **Cleaned up test fixtures**: Removed unnecessary `config/constants.json` setup from conftest.py since the new approach computes domains dynamically

## Implementation Details

The new approach ensures Python validation uses the exact same `shouldIncludeFavicon` predicate as the Quartz transformer by having `compute_favicon_lists.ts` call the transformer's logic directly with real favicon counts. This eliminates the risk of validation and transformation logic diverging.

The boundary-aware domain matching prevents false positives where a short domain substring could match longer domains (e.g., `x_com` should not match `vox_com`).

https://claude.ai/code/session_01Dx4mz7Msw2cRQ3iNVvfsz6