### PR TITLE
fix: skip center-dot lists in paragraph punctuation check

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -769,6 +769,7 @@ Bonde
 Bowden
 Braun's
 Bricken
+Bri'ish
 BuzzFeed
 Byrne
 Byrne's
@@ -2278,6 +2279,7 @@ Minification
 750PX
 8pt
 AST
+ASTs
 Annatar
 Callouts
 Cryptographic
@@ -2949,10 +2951,12 @@ heil
 homomorphic
 homomorphically
 hotspot
+html
 iCloud
 iCloud's
 iPhones
 keyring
+localisation
 lockdown
 lookups
 masse

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -148,6 +148,10 @@ def check_article_dropcap_first_letter(soup: BeautifulSoup) -> list[str]:
 VALID_PARAGRAPH_ENDING_CHARACTERS = ".!?:;)]}’”…—"
 TRIM_CHARACTERS_FROM_END_OF_PARAGRAPH = "↗✓∎"
 PRESENTATIONAL_TAGS = ("span", "br")
+CENTER_DOT = "\u00b7"
+# Minimum number of center dots for a paragraph to be considered a
+# separator-delimited list (e.g. "Smart quotes\u00B7Em dashes\u00B7Ellipses")
+_CENTER_DOT_LIST_THRESHOLD = 2
 
 
 def _should_skip_paragraph(p: Tag) -> bool:
@@ -209,6 +213,10 @@ def check_top_level_paragraphs_end_with_punctuation(
 
             text = _get_paragraph_text_for_punctuation_check(p)
             if not text:
+                continue
+
+            # Skip separator-delimited lists (e.g. "A·B·C·D")
+            if text.count(CENTER_DOT) >= _CENTER_DOT_LIST_THRESHOLD:
                 continue
 
             if text[-1] not in VALID_PARAGRAPH_ENDING_CHARACTERS:
@@ -1872,14 +1880,20 @@ _INLINE_FORMATTING_SELECTORS = (
 
 
 _DIGITS = "0123456789"
+_LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 _ABBR_FOLLOWING_CHARS = ALLOWED_ELT_FOLLOWING_CHARS + "s"
-_ARROW_FOLLOWING_CHARS = ALLOWED_ELT_FOLLOWING_CHARS + _DIGITS
+# Arrows can appear adjacent to letters in transformation examples
+# (e.g. "Text→text", "HTML→html")
+_ARROW_PRECEDING_CHARS = ALLOWED_ELT_PRECEDING_CHARS + _DIGITS + _LETTERS
+_ARROW_FOLLOWING_CHARS = ALLOWED_ELT_FOLLOWING_CHARS + _DIGITS + _LETTERS
 _ORDINAL_PRECEDING_CHARS = ALLOWED_ELT_PRECEDING_CHARS + _DIGITS
 
 # Per-selector overrides for allowed preceding/following characters
 _SELECTOR_PRECEDING_CHARS: dict[str, str] = {
     "span.ordinal-num": _ORDINAL_PRECEDING_CHARS,
     "sup.ordinal-suffix": _ORDINAL_PRECEDING_CHARS,
+    "span.monospace-arrow": _ARROW_PRECEDING_CHARS,
+    "span.right-arrow": _ARROW_PRECEDING_CHARS,
 }
 _SELECTOR_FOLLOWING_CHARS: dict[str, str] = {
     "abbr.small-caps": _ABBR_FOLLOWING_CHARS,
@@ -1916,6 +1930,11 @@ def check_inline_formatting_spacing(soup: BeautifulSoup) -> list[str]:
             selector, ALLOWED_ELT_FOLLOWING_CHARS
         )
         for element in _tags_only(soup.select(selector)):
+            # Skip elements inside no-formatting zones (e.g. punctilio
+            # README examples like "hello" → "hello")
+            if should_skip(element):
+                continue
+
             # Skip preceding-space check for abbrs starting with a digit,
             # since they're part of proper nouns (e.g. "3Blue1Brown")
             if selector == "abbr.small-caps" and _abbr_starts_with_digit(

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2635,6 +2635,11 @@ def test_check_link_spacing(html, expected):
             "<p>9<abbr>combinations</abbr> test</p>",
             [],
         ),
+        # Elements inside no-formatting spans should be skipped
+        (
+            '<p><span class="no-formatting">Text<span class="right-arrow">\u2192</span>text</span></p>',
+            [],
+        ),
     ],
 )
 def test_check_inline_formatting_spacing(html, expected):
@@ -5928,6 +5933,21 @@ def test_check_top_level_paragraphs_trim_chars(char: str):
         (
             '<article><p>Text with <span class="h2">Header 2</span></p></article>',
             ["Paragraph ends with invalid character '2' Text withHeader 2"],
+        ),
+        # Center-dot separated lists should be skipped
+        (
+            "<article><p>Smart quotes\u00b7Em dashes\u00b7Ellipses\u00b7Fractions</p></article>",
+            [],
+        ),
+        # Exactly 2 center dots (threshold) should also be skipped
+        (
+            "<article><p>A\u00b7B\u00b7C</p></article>",
+            [],
+        ),
+        # Single center dot is NOT enough to skip
+        (
+            "<article><p>One\u00b7two</p></article>",
+            ["Paragraph ends with invalid character 'o' One\u00b7two"],
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- Fix `paragraphs_without_ending_punctuation` false positive for center-dot-separated feature lists (e.g. from the punctilio README injected into open-source.html)
- Fix `rendered_text_spelling` false positives for punctilio README terms: "Bri'ish", "localisation", "ASTs", and "html"
- Fix `inline_formatting_spacing` false positives: skip elements inside `no-formatting` zones and allow letters adjacent to arrow spans (for transformation examples like "Text→text")

## Changes
- Add `CENTER_DOT` constant and `_CENTER_DOT_LIST_THRESHOLD` (2) to `scripts/built_site_checks.py`
- Skip paragraphs containing 2+ center dots in `check_top_level_paragraphs_end_with_punctuation()`
- Skip elements inside `no-formatting` spans in `check_inline_formatting_spacing()` using existing `should_skip()`
- Add letters to `_ARROW_PRECEDING_CHARS` and `_ARROW_FOLLOWING_CHARS` so "Text→text" patterns are allowed
- Add "Bri'ish", "localisation", "ASTs", and "html" to `config/spellcheck/.wordlist.txt`
- Add 4 test cases: 3 for center-dot threshold (above/at/below) + 1 for no-formatting skip

## Testing
- All 744 tests in `test_built_site_checks.py` pass
- New center-dot test cases cover above/at/below threshold boundary
- New no-formatting test verifies arrow spans inside no-formatting zones are skipped

https://claude.ai/code/session_01AW7QzJspm9DC9pCjPyPUYj