### PR TITLE
Fix Playwright installation and increase visual testing timeout

### DIFF
--- a/.github/actions/setup-visual-testing-env/action.yaml
+++ b/.github/actions/setup-visual-testing-env/action.yaml
@@ -16,9 +16,9 @@ runs:
         cache-puppeteer: "true"
         install-python: "false"
 
-    - name: Install Playwright browsers and system dependencies
+    - name: Install Playwright system dependencies
       if: inputs.install-playwright == 'true'
-      run: pnpm exec playwright install --with-deps chromium webkit firefox
+      run: pnpm exec playwright install-deps chromium webkit firefox
       shell: bash
 
     - name: Install ffmpeg from system packages

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -79,7 +79,7 @@ jobs:
     needs: build
     # Using Ubuntu 24.04 (pinned) for stability - ubuntu-latest can break when GitHub updates it
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
This PR fixes the Playwright browser installation command and increases the timeout for visual testing jobs to accommodate longer test runs.

## Key Changes
- **Fixed Playwright installation command**: Changed from `playwright install --with-deps` to `playwright install-deps` to correctly install system dependencies without attempting to install browsers (which are already cached via Puppeteer)
- **Updated step description**: Clarified the step name from "Install Playwright browsers and system dependencies" to "Install Playwright system dependencies" to accurately reflect what the command does
- **Increased visual testing timeout**: Extended the timeout for the visual testing job from 20 minutes to 35 minutes to prevent premature job cancellation during longer test runs

## Implementation Details
The Playwright installation fix addresses a command compatibility issue where `--with-deps` flag was being used incorrectly. The `install-deps` command is the proper way to install only system dependencies without attempting to install browser binaries.

https://claude.ai/code/session_01J9uPh8BU4XJQHF9L92s7bR