### PR TITLE
fix(ci): skip ffmpeg install when already available in Docker container

### DIFF
--- a/.github/actions/setup-visual-testing-env/action.yaml
+++ b/.github/actions/setup-visual-testing-env/action.yaml
@@ -23,6 +23,12 @@ runs:
 
     - name: Install ffmpeg from system packages
       run: |
+        # Skip if ffmpeg is already available (e.g. pre-installed in Docker image)
+        if command -v ffprobe &>/dev/null; then
+          echo "ffprobe already available, skipping install"
+          ffprobe -version
+          exit 0
+        fi
         # Pinned to ubuntu-24.04 runner's ffmpeg version (only ffprobe is needed at build time)
         sudo apt-get update
         sudo apt-get install -y ffmpeg=7:6.1.1-3ubuntu5


### PR DESCRIPTION
## Summary
- Playwright test shards run inside a Docker container that pre-bakes ffmpeg, but the `setup-visual-testing-env` action unconditionally runs `sudo apt-get install ffmpeg`, which fails with exit code 127 (`sudo: command not found`) inside the container.
- Adds an early-exit guard that checks if `ffprobe` is already available before attempting installation.

## Changes
- `.github/actions/setup-visual-testing-env/action.yaml`: Added `command -v ffprobe` check to skip ffmpeg installation when it's already present (e.g. in the Playwright Docker image). The fallthrough path continues to install via `sudo apt-get` for bare `ubuntu-24.04` runners (visual-testing workflow).

## Testing
- Validated YAML syntax
- The fix addresses the exact failure seen in [shard 23/30](https://github.com/alexander-turner/TurnTrout.com/actions/runs/22420962916/job/64918590378): `sudo: command not found` at the ffmpeg install step

https://claude.ai/code/session_015nuoyYSwvnj2Vh7KUTqYF5