### PR TITLE
Reduce number of oldest posts retained in page test

### DIFF
--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -144,7 +144,7 @@ test.describe("Unique content around the site", () => {
       await page.locator("body").waitFor({ state: "visible" })
 
       // Remove all but the oldest numOldest posts; stable as I add more
-      const numOldest = 9
+      const numOldest = 5
       await page.evaluate((numKeepOldest: number) => {
         const listElement = document.querySelectorAll("ul.section-ul")[0]
         if (!listElement) {


### PR DESCRIPTION
## Summary
Updated the test configuration to reduce the number of oldest posts retained during the unique content test from 9 to 5.

## Changes
- Modified `numOldest` constant in the page test from 9 to 5
  - This affects how many of the oldest posts are kept when testing unique content across the site
  - The comment indicates this value should remain stable as more posts are added

## Details
This change adjusts the test fixture to use a smaller sample size of historical posts, which may improve test performance or better reflect the actual content structure being tested.

https://claude.ai/code/session_01U7Aa58TtGoNtnSVjGg1aBP