### PR TITLE
Lowercase 'Html' to 'html' in punctilio demo titles

### DIFF
--- a/quartz/components/scripts/punctilio-demo.inline.ts
+++ b/quartz/components/scripts/punctilio-demo.inline.ts
@@ -189,7 +189,7 @@ document.addEventListener("nav", () => {
     if (outputTitleInner) {
       const icon = outputTitleInner.querySelector(".admonition-icon")
       if (currentMode === "html") {
-        outputTitleInner.innerHTML = '<abbr class="small-caps">Html</abbr> source output'
+        outputTitleInner.innerHTML = '<abbr class="small-caps">html</abbr> source output'
       } else if (currentMode === "markdown") {
         outputTitleInner.textContent = "Markdown source output"
       } else {
@@ -200,7 +200,7 @@ document.addEventListener("nav", () => {
     if (inputTitleInner) {
       const icon = inputTitleInner.querySelector(".admonition-icon")
       if (currentMode === "html") {
-        inputTitleInner.innerHTML = 'Input your <abbr class="small-caps">Html</abbr> code'
+        inputTitleInner.innerHTML = 'Input your <abbr class="small-caps">html</abbr> code'
       } else {
         inputTitleInner.textContent = "Input"
       }

--- a/quartz/components/tests/punctilio-demo.spec.ts
+++ b/quartz/components/tests/punctilio-demo.spec.ts
@@ -292,13 +292,13 @@ test.describe("Admonition titles update per mode", () => {
     )
   })
 
-  test("output title says 'Html source output' in HTML mode", async ({ page }) => {
+  test("output title says 'html source output' in HTML mode", async ({ page }) => {
     await page.locator('.punctilio-mode-btn[data-mode="html"]').click()
     const outputAdmonition = page
       .locator(OUTPUT_CONTENT)
       .locator("xpath=ancestor::*[contains(@class,'admonition')]")
     await expect(outputAdmonition.locator(".admonition-title-inner")).toContainText(
-      "Html source output",
+      "html source output",
     )
     await expect(outputAdmonition.locator(".admonition-title-inner abbr.small-caps")).toBeAttached()
   })
@@ -310,7 +310,7 @@ test.describe("Admonition titles update per mode", () => {
     await expect(inputAdmonition.locator(".admonition-title-inner")).toHaveText(/^Input$/)
   })
 
-  test("input title changes to 'Input your Html code' in HTML mode", async ({ page }) => {
+  test("input title changes to 'Input your html code' in HTML mode", async ({ page }) => {
     await page.locator('.punctilio-mode-btn[data-mode="html"]').click()
     const inputAdmonition = page
       .locator("#punctilio-input")


### PR DESCRIPTION
## Summary
This PR updates the capitalization of "Html" to "html" in the punctilio demo component to maintain consistent lowercase styling for the HTML acronym in admonition titles.

## Changes
- Updated test expectations in `punctilio-demo.spec.ts` to expect lowercase "html" in admonition titles:
  - Output title test: "Html source output" → "html source output"
  - Input title test: "Input your Html code" → "Input your html code"
- Updated the corresponding implementation in `punctilio-demo.inline.ts` to render lowercase "html":
  - Output title HTML: `<abbr class="small-caps">Html</abbr>` → `<abbr class="small-caps">html</abbr>`
  - Input title HTML: `<abbr class="small-caps">Html</abbr>` → `<abbr class="small-caps">html</abbr>`

## Details
The changes apply the `small-caps` CSS class styling to lowercase "html" text, which renders it in small capital letters while maintaining the lowercase source. This provides a more semantically correct and visually consistent approach to displaying the HTML acronym.

https://claude.ai/code/session_01B5rjBpMCc581JMdsbPfwoi