### PR TITLE
Move Chromium shm flag to browser-specific config

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -88,10 +88,6 @@ export default defineConfig({
     // Stabilize device scale across runners to reduce text subpixel jitter.
     // Individual projects can override, but default to 1x CSS pixels.
     deviceScaleFactor: 1,
-    // Prevent Chromium crashes on CI runners with limited /dev/shm
-    launchOptions: {
-      args: process.env.CI ? ["--disable-dev-shm-usage"] : [],
-    },
   },
   projects: deviceList.flatMap((device) =>
     browsers.map((browser) => ({
@@ -99,6 +95,11 @@ export default defineConfig({
       use: {
         ...sanitizeConfigForBrowser(device.config as Record<string, unknown>, browser.engine),
         browserName: browser.engine,
+        // Prevent Chromium crashes on CI runners with limited /dev/shm
+        // (this flag is Chromium-only; WebKit rejects it)
+        ...(process.env.CI && browser.engine === "chromium"
+          ? { launchOptions: { args: ["--disable-dev-shm-usage"] } }
+          : {}),
       },
     })),
   ),


### PR DESCRIPTION
## Summary
Moved the `--disable-dev-shm-usage` launch argument from the global base configuration to a browser-specific configuration that only applies to Chromium on CI runners.

## Key Changes
- Removed `launchOptions` from the global `use` configuration object
- Added conditional `launchOptions` to individual browser project configurations
- The flag now only applies when both conditions are met:
  - Running in a CI environment (`process.env.CI`)
  - Using the Chromium browser engine (`browser.engine === "chromium"`)

## Implementation Details
- The flag is now applied at the project level rather than globally, allowing browser-specific handling
- Added clarifying comments explaining that this flag is Chromium-only and that WebKit rejects it
- Uses object spread syntax to conditionally include `launchOptions` only when needed, avoiding unnecessary configuration for non-Chromium browsers
- This prevents potential issues with WebKit and other browsers that don't support this Chromium-specific flag

https://claude.ai/code/session_01UCbqjYxrmZzPFr1HZyLQk3