### PR TITLE
fix: eliminate Playwright test flakiness and set retries to 0

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -66,7 +66,7 @@ function sanitizeConfigForBrowser(
 export default defineConfig({
   timeout: 30000,
   fullyParallel: true,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   testDir: "../../quartz/",
   testMatch: /.*\.spec\.ts/,
   snapshotPathTemplate: "../../lost-pixel/{arg}.png",
@@ -79,7 +79,7 @@ export default defineConfig({
   },
   use: {
     baseURL: "http://localhost:8080",
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     screenshot: {
       mode: "only-on-failure",
       fullPage: true,
@@ -106,6 +106,17 @@ export default defineConfig({
         ...sanitizeConfigForBrowser(device.config as Record<string, unknown>, browser.engine),
         browserName: browser.engine,
         deviceScaleFactor: 1,
+        // Chromium's headless SwiftShader renderer on CI runners without a GPU
+        // is prone to "Target crashed" / "Page crashed" errors.  These flags
+        // reduce memory pressure and disable the GPU-backed compositor that
+        // SwiftShader struggles with.
+        ...(browser.engine === "chromium"
+          ? {
+              launchOptions: {
+                args: ["--disable-gpu", "--disable-software-rasterizer", "--disable-dev-shm-usage"],
+              },
+            }
+          : {}),
       },
     })),
 })

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -96,6 +96,7 @@ test.describe("Collapsible admonition state persistence", () => {
 
     // Reload page and verify it stayed collapsed
     await reloadPage(page)
+    await waitForCollapsibleIds(page)
     const reloaded = page
       .locator(".admonition.is-collapsible")
       .filter({ hasText: "starts off open" })
@@ -115,6 +116,7 @@ test.describe("Collapsible admonition state persistence", () => {
 
     // Reload page and verify it stayed open
     await reloadPage(page)
+    await waitForCollapsibleIds(page)
     const reloaded = page
       .locator(".admonition.is-collapsible")
       .filter({ hasText: "starts off collapsed" })
@@ -227,6 +229,7 @@ test.describe("Collapsible admonition state persistence", () => {
 
     // Reload the page - localStorage should persist, and state should be applied before paint
     await reloadPage(page)
+    await waitForCollapsibleIds(page)
 
     // Verify the state was correctly applied (opposite of default)
     const actualState = await page

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -265,8 +265,13 @@ test("Popovers do not appear in search previews", async ({ page }) => {
   const previewContainer = page.locator("#preview-container")
   await expect(previewContainer).toBeVisible({ timeout: 10_000 })
 
+  // Wait for the preview article content to fully load before interacting
+  const previewArticle = previewContainer.locator("article.search-preview")
+  await expect(previewArticle).toBeAttached({ timeout: 10_000 })
+
   // Find an internal link in the preview and hover over it
   const searchDummyLink = previewContainer.locator("a#first-link-test-page")
+  await expect(searchDummyLink).toBeVisible({ timeout: 10_000 })
   await searchDummyLink.hover()
 
   // Verify no popover appears

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -43,11 +43,15 @@ function getPreviewLocator(page: Page): Locator {
   return page.locator("#preview-container")
 }
 
-/** Wait for the preview article content to be loaded */
+/** Wait for the preview article content to be loaded and non-empty.
+ *  Preview content is fetched asynchronously after the article element is
+ *  attached, so we also wait for it to have visible children to avoid
+ *  racing on content assertions like toContainText. */
 async function waitForPreviewArticle(page: Page): Promise<Locator> {
   const preview = getPreviewLocator(page)
   const article = preview.locator("article.search-preview")
   await expect(article).toBeAttached({ timeout: 10_000 })
+  await expect(article).not.toBeEmpty({ timeout: 10_000 })
   return preview
 }
 


### PR DESCRIPTION
## Summary
- Set Playwright retries to 0 (was 2 in CI) and fix the underlying race conditions that made retries necessary
- Add Chromium launch args to prevent SwiftShader crashes on GPU-less CI runners
- Switch trace mode to `retain-on-failure` so traces are actually captured now that retries are disabled

## Changes
- **`config/playwright/playwright.config.ts`**: Set `retries: 0`, change trace to `retain-on-failure`, add `--disable-gpu`, `--disable-software-rasterizer`, `--disable-dev-shm-usage` launch args for Chromium projects
- **`quartz/components/tests/collapsible.spec.ts`**: Add `waitForCollapsibleIds(page)` after `reloadPage()` in 3 persistence tests — fixes race where assertions ran before collapsible IDs were assigned on Safari
- **`quartz/components/tests/popover.spec.ts`**: Wait for preview article attachment and link visibility before hovering in "no popovers in search previews" test
- **`quartz/components/tests/search.spec.ts`**: Add `not.toBeEmpty()` check in `waitForPreviewArticle()` to ensure async content is loaded before `toContainText` assertions

## Testing
- `pnpm check` passes (TypeScript + formatting + stylelint)
- Changes are test infrastructure fixes — CI run will validate

https://claude.ai/code/session_01E7UW5BauYeEXF4cnDZHbLk