### PR TITLE
Move select element styles to global base stylesheet

### DIFF
--- a/quartz/components/styles/punctilioDemo.scss
+++ b/quartz/components/styles/punctilioDemo.scss
@@ -132,20 +132,5 @@ $panel-min-height: 200px;
         flex: 1;
       }
     }
-
-    select {
-      padding: calc(0.25 * $base-margin) calc(0.75 * $base-margin) calc(0.25 * $base-margin)
-        calc(0.25 * $base-margin);
-      border: 1px solid var(--midground-faint);
-      border-radius: 5px;
-      background: inherit;
-      color: var(--foreground);
-      font-family: inherit;
-      font-size: inherit;
-
-      &:focus {
-        outline: 1px solid var(--midground);
-      }
-    }
   }
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -476,6 +476,21 @@ video {
   border-radius: $border-radius;
 }
 
+select {
+  padding: calc(0.25 * $base-margin) calc(0.75 * $base-margin) calc(0.25 * $base-margin)
+    calc(0.25 * $base-margin);
+  border: 1px solid var(--midground-faint);
+  border-radius: 5px;
+  background: inherit;
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: inherit;
+
+  &:focus {
+    outline: 1px solid var(--midground);
+  }
+}
+
 .spacer {
   flex: 1 1 auto;
 }


### PR DESCRIPTION
## Summary
Refactored select element styling by moving component-specific styles from the punctilioDemo stylesheet to the global base stylesheet, promoting style reusability across the application.

## Key Changes
- Removed select element styling rules from `quartz/components/styles/punctilioDemo.scss`
- Added the same select element styling rules to `quartz/styles/base.scss` as global styles
- Styling includes padding, border, border-radius, background, color, font properties, and focus state

## Implementation Details
The select element styles were previously scoped to the punctilioDemo component. By moving them to the base stylesheet, these styles now apply globally to all select elements throughout the application, eliminating the need for component-specific overrides and ensuring consistent styling across different contexts.

https://claude.ai/code/session_01DgFjKbp8Cyjo7XqAed2QTs