### PR TITLE
Add skip ci flag to auto-commit in lint workflow

### DIFF
--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -58,7 +58,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add website_content/*.md README.md
-          git commit -m "chore: updated publication dates"
+          git commit -m "chore: updated publication dates [skip ci]"
           git push
           echo "pushed=true" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
Updated the git commit message in the lint-and-validate workflow to include the `[skip ci]` flag, preventing unnecessary CI runs when publication dates are automatically updated.

## Changes
- Added `[skip ci]` to the commit message when automatically updating publication dates in markdown files
- This prevents triggering additional CI pipeline runs for automated commits that only update metadata

## Details
The `[skip ci]` flag is a GitHub convention that tells CI systems to skip running workflows for that specific commit. This is useful for automated maintenance commits (like updating publication dates) that don't require validation and would otherwise trigger redundant workflow executions.

https://claude.ai/code/session_01NA2v5SNFygMBfkEvkhwcsB