### PR TITLE
ci: auto-merge Dependabot PRs for non-major updates

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,4 +1,7 @@
 name: Auto-merge Dependabot PRs
+# pull_request_target is required because Dependabot PRs run from a
+# fork-like context and need write permissions. This is safe as long as
+# no step checks out or executes PR code.
 on: pull_request_target
 
 permissions:
@@ -10,13 +13,21 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically approves and squash-merges Dependabot PRs
- Uses dependabot/fetch-metadata to skip major version bumps, which still require human review

## Changes
- New workflow: .github/workflows/auto-merge-dependabot.yml

## Testing
- Pattern follows existing auto-merge-deepsource.yml workflow

https://claude.ai/code/session_01MoubvXCnvkNsigGDrrFrBB