### PR TITLE
feat(a11y): add KaTeX upstream patch for scrollable-region-focusable fix

### DIFF
--- a/patches/katex-scrollable-region-focusable.patch
+++ b/patches/katex-scrollable-region-focusable.patch
@@ -54,10 +54,10 @@ index c359459..56dce32 100755
      <math xmlns="http://www.w3.org/1998/Math/MathML">
        <semantics>
 diff --git a/test/katex-spec.ts b/test/katex-spec.ts
-index f4443e8..2052fc2 100644
+index f4443e8..8e9970b 100644
 --- a/test/katex-spec.ts
 +++ b/test/katex-spec.ts
-@@ -4530,3 +4530,30 @@ describe("\\emph", () => {
+@@ -4530,3 +4530,36 @@ describe("\\emph", () => {
          expect`\textit{\emph{foo \emph{bar}}}`.toBuildLike`\textit{\textup{foo \textit{bar}}}`;
      });
  });
@@ -86,5 +86,11 @@ index f4443e8..2052fc2 100644
 +        const markup = katex.renderToString("x^2", {output: "html"});
 +        expect(markup).toContain('tabindex="0"');
 +        expect(markup).toContain('role="math"');
++    });
++
++    it("should not add tabindex or role in mathml-only output mode", function() {
++        const markup = katex.renderToString("x^2", {output: "mathml"});
++        expect(markup).not.toContain('tabindex');
++        expect(markup).not.toContain('role="math"');
 +    });
 +});


### PR DESCRIPTION
## Summary

- Adds a reference patch file documenting the proposed upstream KaTeX fix for the `scrollable-region-focusable` axe accessibility violation (WCAG 2.1 SC 2.1.1)
- The patch adds `tabindex="0"` and `role="math"` to `.katex` span elements in KaTeX's `src/buildTree.ts`, with 5 tests covering inline, display, html-only, and mathml-only output modes
- No existing issues or PRs address this in the KaTeX repo — the GitHub token lacks fork/issue-creation permissions, so the patch is stored here for manual upstream submission

## Changes

- `patches/katex-scrollable-region-focusable.patch`: Complete git patch against KaTeX v0.16.38 that:
  - Modifies `src/buildTree.ts` to add `tabindex="0"` and `role="math"` to root `.katex` spans in both `buildTree` and `buildHTMLTree` functions
  - Adds 5 new tests in `test/katex-spec.ts` covering all output modes
  - Updates 2 existing snapshots that include the `.katex` span markup

## Testing

- All 605 KaTeX tests pass (including 5 new accessibility tests)
- All 3374 TurnTrout.com tests pass with 100% coverage
- Type checking and linting pass

## Context

The site already has a workaround via `makeKatexDisplayAccessible()` in `quartz/plugins/transformers/latex.ts`. This patch is for upstream contribution to eliminate the need for per-consumer workarounds.

### References
- [axe: scrollable-region-focusable](https://dequeuniversity.com/rules/axe/4.10/scrollable-region-focusable)
- [WCAG 2.1 SC 2.1.1 (Keyboard)](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
- [ARIA math role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/math_role)

https://claude.ai/code/session_017kKGTV8vJ4KJuMoaSJBzfi