### PR TITLE
fix(deps): resolve dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,7 +328,11 @@
       "immutable": "5.1.5",
       "underscore": "1.13.8",
       "serialize-javascript": "7.0.3",
-      "minimatch": "10.2.3",
+      "serve-handler>minimatch": "3.1.4",
+      "postcss-url>minimatch": "3.1.4",
+      "filelist>minimatch": "5.1.8",
+      "markdownlint-cli>minimatch": "10.2.3",
+      "glob>minimatch": "10.2.3",
       "@tootallnate/once": "3.0.1",
       "express-rate-limit": "8.2.2",
       "serve>ajv": "8.18.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,11 @@ overrides:
   immutable: 5.1.5
   underscore: 1.13.8
   serialize-javascript: 7.0.3
-  minimatch: 10.2.3
+  serve-handler>minimatch: 3.1.4
+  postcss-url>minimatch: 3.1.4
+  filelist>minimatch: 5.1.8
+  markdownlint-cli>minimatch: 10.2.3
+  glob>minimatch: 10.2.3
   '@tootallnate/once': 3.0.1
   express-rate-limit: 8.2.2
   serve>ajv: 8.18.0
@@ -3082,6 +3086,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
@@ -3169,6 +3176,12 @@ packages:
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.3:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
@@ -3575,6 +3588,9 @@ packages:
   compression@1.7.4:
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@1.5.2:
     resolution: {integrity: sha512-H6xsIBfQ94aESBG8jGHXQ7i5AEpy5ZeVaLDOisDICiTCKpqEfr34/KmTrspKQNoLKNu9gTkovlpQcUi630AKiQ==}
@@ -6815,6 +6831,20 @@ packages:
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.8:
+    resolution: {integrity: sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -11159,7 +11189,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.3
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11182,7 +11212,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 10.2.3
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12298,7 +12328,7 @@ snapshots:
       debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
-      minimatch: 10.2.3
+      minimatch: 9.0.9
       semver: 7.7.4
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -12312,7 +12342,7 @@ snapshots:
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/visitor-keys': 8.48.0
       debug: 4.4.3
-      minimatch: 10.2.3
+      minimatch: 9.0.9
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.1.0(typescript@5.7.3)
@@ -12759,6 +12789,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@2.0.0: {}
 
   balanced-match@4.0.4: {}
@@ -12849,6 +12881,15 @@ snapshots:
       type-fest: 2.19.0
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.3:
     dependencies:
@@ -13354,6 +13395,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   concat-stream@1.5.2:
     dependencies:
@@ -14480,7 +14523,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 10.2.3
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -14523,7 +14566,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 10.2.3
+      minimatch: 3.1.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -14588,7 +14631,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 10.2.3
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
       zod: 3.25.76
@@ -14829,7 +14872,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 10.2.3
+      minimatch: 5.1.8
 
   filesize@10.1.6: {}
 
@@ -17704,6 +17747,22 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.3
 
+  minimatch@3.1.4:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@5.1.8:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimist-options@4.1.0:
     dependencies:
       arrify: 1.0.1
@@ -18569,7 +18628,7 @@ snapshots:
     dependencies:
       make-dir: 3.1.0
       mime: 2.5.2
-      minimatch: 10.2.3
+      minimatch: 3.1.4
       postcss: 8.5.6
       xxhashjs: 0.2.2
 
@@ -19646,7 +19705,7 @@ snapshots:
       bytes: 3.0.0
       content-disposition: 0.5.2
       mime-types: 2.1.18
-      minimatch: 10.2.3
+      minimatch: 3.1.4
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
@@ -20445,7 +20504,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 10.2.3
+      minimatch: 3.1.5
 
   text-decoder@1.2.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Resolve 31 of 34 dependabot security vulnerabilities by adding pnpm overrides for transitive dependencies
- The 3 remaining vulnerabilities (jsonpath via pa11y, elliptic via 0x) have no available patches and are dev-only tools

## Changes
- Bump `hono` override 4.12.2→4.12.4 (arbitrary file access, cookie injection, SSE injection)
- Add `@hono/node-server`→1.19.10 override (auth bypass for static paths)
- Add `express-rate-limit`→8.2.2 override (IPv4-mapped IPv6 rate limit bypass)
- Add `dompurify`→3.3.2 override (XSS vulnerability)
- Add `svgo`→3.3.3 override (Billion Laughs DoS)
- Add `immutable`→5.1.5 override (prototype pollution)
- Add `underscore`→1.13.8 override (unlimited recursion DoS)
- Add `serialize-javascript`→7.0.3 override (RCE via RegExp.flags)
- Add scoped `minimatch` overrides for serve-handler (3.1.4), postcss-url (3.1.4), filelist (5.1.8), markdownlint-cli (10.2.3), glob (10.2.3) — uses scoped overrides to avoid breaking test-exclude/Jest which needs v3 API
- Add `@tootallnate/once`→3.0.1 override (incorrect control flow)
- Add `serve>ajv`→8.18.0 scoped override (ReDoS)

## Testing
- `pnpm check` passes (type checking, prettier, stylelint)
- `pnpm test` passes (63 test suites, 3374 tests, 100% coverage)
- `pnpm audit` reduced from 34 to 3 vulnerabilities (all unfixable: no patches available)
- Pre-push checks all pass

https://claude.ai/code/session_013Fx64zghHqzcdaNprj9eGT