### PR TITLE
refactor: simplify triggerAndWaitForSPANav by removing window global

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -569,17 +569,15 @@ export async function triggerAndWaitForSPANav(
   page: Page,
   trigger: () => Promise<void>,
 ): Promise<void> {
-  // Register the listener *before* the action so we never miss the event.
-  await page.evaluate(() => {
-    ;(window as unknown as Record<string, unknown>).__spaNavComplete = new Promise<void>(
-      (resolve) => {
-        document.addEventListener("nav", () => resolve(), { once: true })
-      },
-    )
-  })
+  // Start listening *before* the action so we never miss the event.
+  // page.evaluate returns a Promise that resolves when the browser-side Promise resolves.
+  const navPromise = page.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        document.addEventListener("nav", () => resolve(), { once: true }),
+      ),
+  )
 
   await trigger()
-
-  // Playwright awaits the browser-side Promise returned by evaluate.
-  await page.evaluate(() => (window as unknown as Record<string, unknown>).__spaNavComplete)
+  await navPromise
 }


### PR DESCRIPTION
## Summary
- Simplifies `triggerAndWaitForSPANav` by eliminating the `window.__spaNavComplete` global, replacing two `page.evaluate()` calls with one

## Changes
- Capture the Promise directly from a single `page.evaluate()` call instead of stashing it on `window`
- Remove the type-assertion dance (`window as unknown as Record<string, unknown>`)
- Net reduction: 2 fewer lines, 1 fewer evaluate round-trip

## Testing
- Type checking passes (`pnpm check`)
- This is a test utility — existing Playwright tests that use `triggerAndWaitForSPANav` validate correctness

https://claude.ai/code/session_01HqHTrFL1s4HWBmPEEujnci