### PR TITLE
fix: prevent double-navigation race and unblock search handler registration

### DIFF
--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -702,7 +702,7 @@ let cleanupListeners: (() => void) | undefined
  * @param e - Navigation event
  */
 /* istanbul ignore next */
-async function onNav(e: CustomEventMap["nav"]) {
+function onNav(e: CustomEventMap["nav"]) {
   // Reset ready flag so tests wait for re-registration after SPA navigation.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).__searchHandlersReady = false
@@ -726,8 +726,11 @@ async function onNav(e: CustomEventMap["nav"]) {
     throw new Error("getContentIndex not initialized - check script injection order")
   }
 
-  data = await getContentIndex()
-  if (!data) return
+  // Start fetching content index in the background (cached for later use
+  // by initializeSearch). Don't block handler registration on the fetch —
+  // data is only needed when the user actually performs a search.
+  getContentIndex()
+
   results = document.createElement("div")
   const container = document.getElementById("search-container")
   const searchIcon = document.getElementById("search-icon")
@@ -1292,7 +1295,11 @@ async function initializeSearch(): Promise<void> {
       // Create the index
       index = createSearchIndex()
 
-      // Fetch and fill the index with data
+      // Ensure content index is available (fetch started by onNav, cached).
+      // getContentIndex is injected by renderPage.tsx and may not exist in unit tests.
+      if (!data && typeof getContentIndex === "function") {
+        data = await getContentIndex()
+      }
       if (data) {
         await fillDocument(data)
       }

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -624,7 +624,13 @@ function createRouter() {
     document.addEventListener("click", async (event) => {
       // Use getOpts to check for valid local links ignoring modifiers/targets
       const opts = getOpts(event)
-      if (!opts || !opts.url || (event as MouseEvent).ctrlKey || (event as MouseEvent).metaKey) {
+      if (
+        !opts ||
+        !opts.url ||
+        event.defaultPrevented ||
+        (event as MouseEvent).ctrlKey ||
+        (event as MouseEvent).metaKey
+      ) {
         return // Let browser handle normal links, external links, or modified clicks
       }
 

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -267,9 +267,6 @@ test("search matches in headers have correct color styling", async ({ page }) =>
 })
 
 test("Search results are case-insensitive", async ({ page }) => {
-  // Two sequential searches with index loading + debounce can exceed 30s in CI
-  test.slow()
-
   await search(page, "TEST")
   await expect(page.locator(".result-card").first()).toBeVisible()
   const uppercaseResults = await page
@@ -302,9 +299,6 @@ test("Search results work for a single character", async ({ page }) => {
 })
 
 test("Preview element persists after closing and reopening search", async ({ page }) => {
-  // Close/reopen/re-search cycle can exceed 30s on slow CI browsers
-  test.slow()
-
   await search(page, "Steering")
   const previewContainer = getPreviewLocator(page)
   const previewArticle = previewContainer.locator("article.search-preview")
@@ -450,10 +444,9 @@ test("Search matching title text stays at top even with body matches", async ({ 
   await expect(testPageResult).toBeVisible()
   await triggerAndWaitForSPANav(page, () => testPageResult.click())
 
-  // The title should contain a highlighted match — search highlighting runs
-  // asynchronously after SPA navigation and can be slow on Safari in CI.
+  // The title should contain a highlighted match
   const titleMatch = page.locator("#article-title .search-match")
-  await expect(titleMatch.first()).toBeAttached({ timeout: 15_000 })
+  await expect(titleMatch.first()).toBeAttached()
 
   // Page should stay at the top because the title contains a match
   const scrollY = await page.evaluate(() => window.scrollY)


### PR DESCRIPTION
## Summary
- Fixed two root causes of flaky search tests detected by flake-check on old main
- SPA router had a double-navigation race condition when clicking search result cards
- Search handler registration was unnecessarily blocked on content index fetch

## Changes
- `spa.inline.ts`: Check `event.defaultPrevented` in the SPA router's document-level click handler to prevent double-navigation when search result card click handlers have already called `preventDefault()` and started their own navigation with the `#:~:text=` hash
- `search.ts`: Make `onNav()` non-blocking by starting `getContentIndex()` fetch without awaiting it — handler registration and `__searchHandlersReady` flag are set immediately, data is lazily awaited in `initializeSearch()` when the user actually searches
- `search.ts`: Removed `async` from `onNav()` since it no longer awaits
- `search.spec.ts`: Reverted `test.slow()` and timeout band-aids since root causes are fixed

## Testing
- All 3377 unit tests pass with 100% coverage
- Type check and lint pass
- Flake-check run on old main confirmed all three tests as flaky (shards 5/10 and 7/10 failed)

https://claude.ai/code/session_011gecy5xUDYusEJttxNjBpy