### PR TITLE
Remove redundant menu button screenshot assertion in navbar test

### DIFF
--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -181,8 +181,6 @@ test("Menu button makes menu visible (lostpixel)", async ({ page }, testInfo) =>
 
   // Test closed state
   await menuButton.click()
-  const newMenuButtonState = await menuButton.screenshot()
-  expect(newMenuButtonState).toEqual(originalMenuButtonState)
   await expect(navbarRightMenu).toBeHidden()
   await expect(navbarRightMenu).not.toHaveClass(/visible/)
 })


### PR DESCRIPTION
## Summary
Removed a redundant visual regression check from the navbar menu button test that was comparing screenshots of the button in its closed state.

## Changes
- Removed the screenshot comparison assertion that verified the menu button returns to its original visual state after being clicked closed
- Kept the existing assertions that verify the menu is hidden and loses the `visible` class

## Details
The removed screenshot comparison (`expect(newMenuButtonState).toEqual(originalMenuButtonState)`) was redundant given that:
1. The test already verifies functional behavior (menu visibility and CSS class state)
2. Visual regression testing is better handled by dedicated tools like LostPixel (as indicated by the test name)
3. The remaining assertions adequately validate that the menu closes properly

https://claude.ai/code/session_016PQbjEKUcXaCaeRbcz6fBq