### PR TITLE
fix: improve build error context and use AbortController for popover cleanup

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -456,7 +456,12 @@ async function rebuildFromEntrypoint(
     console.log(chalk.green(`Done rebuilding in ${perf.timeSince()}`))
   } catch (err) {
     console.log(chalk.yellow("Rebuild failed. Waiting on a change to fix the error..."))
-    if (argv.verbose) {
+    if (err instanceof Error) {
+      console.log(chalk.red(err.message))
+      if (argv.verbose && err.stack) {
+        console.log(chalk.red(err.stack))
+      }
+    } else if (argv.verbose) {
       console.log(chalk.red(err))
     }
   }

--- a/quartz/components/scripts/popover_helpers.ts
+++ b/quartz/components/scripts/popover_helpers.ts
@@ -297,52 +297,55 @@ export function attachPopoverEventListeners(
     }
   }
 
-  popoverElement.addEventListener("click", clickPopover)
+  const controller = new AbortController()
+  const { signal } = controller
+
+  popoverElement.addEventListener("click", clickPopover, { signal })
 
   // Hover listeners only for non-footnote popovers. Footnote popovers are
   // click-only: opened by clicking the footnote ref, dismissed by clicking
   // outside, pressing Escape, or clicking the close button.
-  let mouseenterLink: (() => void) | undefined
-  let mouseleaveLink: (() => void) | undefined
-  let mouseenterPopover: (() => void) | undefined
-  let mouseleavePopover: (() => void) | undefined
-
   if (!isFootnote) {
-    mouseenterLink = () => {
-      isMouseOverLink = true
-      showPopover()
-    }
-    mouseleaveLink = () => {
-      isMouseOverLink = false
-      if (!popoverElement.dataset.pinned) {
-        removePopover()
-      }
-    }
-    mouseenterPopover = () => {
-      isMouseOverPopover = true
-    }
-    mouseleavePopover = () => {
-      isMouseOverPopover = false
-      if (!popoverElement.dataset.pinned) {
-        removePopover()
-      }
-    }
-
-    linkElement.addEventListener("mouseenter", mouseenterLink)
-    linkElement.addEventListener("mouseleave", mouseleaveLink)
-    popoverElement.addEventListener("mouseenter", mouseenterPopover)
-    popoverElement.addEventListener("mouseleave", mouseleavePopover)
+    linkElement.addEventListener(
+      "mouseenter",
+      () => {
+        isMouseOverLink = true
+        showPopover()
+      },
+      { signal },
+    )
+    linkElement.addEventListener(
+      "mouseleave",
+      () => {
+        isMouseOverLink = false
+        if (!popoverElement.dataset.pinned) {
+          removePopover()
+        }
+      },
+      { signal },
+    )
+    popoverElement.addEventListener(
+      "mouseenter",
+      () => {
+        isMouseOverPopover = true
+      },
+      { signal },
+    )
+    popoverElement.addEventListener(
+      "mouseleave",
+      () => {
+        isMouseOverPopover = false
+        if (!popoverElement.dataset.pinned) {
+          removePopover()
+        }
+      },
+      { signal },
+    )
   }
 
   // Returned cleanup function
   return () => {
-    if (mouseenterLink) linkElement.removeEventListener("mouseenter", mouseenterLink)
-    if (mouseleaveLink) linkElement.removeEventListener("mouseleave", mouseleaveLink)
-    if (mouseenterPopover) popoverElement.removeEventListener("mouseenter", mouseenterPopover)
-    if (mouseleavePopover) popoverElement.removeEventListener("mouseleave", mouseleavePopover)
-    popoverElement.removeEventListener("click", clickPopover)
-
-    // Also trigger removal logic if cleanup is called directly
+    controller.abort()
     popoverElement.remove()
     onRemove()
   }


### PR DESCRIPTION
## Summary
- Show error messages during rebuild failures without requiring `--verbose`, so developers can debug faster
- Refactor popover event listener management to use `AbortController` for cleaner cleanup, reducing memory leak risk during SPA navigation

## Changes
- **`quartz/build.ts`**: Always log `err.message` on rebuild failure; gate full stack trace behind `--verbose`; handle non-Error thrown values in verbose mode only
- **`quartz/components/scripts/popover_helpers.ts`**: Replace manual tracking of 5 event listener functions with a single `AbortController`. All `addEventListener` calls receive `{ signal }`, and cleanup calls `controller.abort()` instead of individual `removeEventListener` calls

## Testing
- `pnpm check` passes (type checking, prettier, stylelint)
- Build error change is dev-server-only logging — no unit test changes needed
- Popover refactor preserves identical external behavior, covered by existing Playwright popover tests

https://claude.ai/code/session_019nFfLWXCDQ1NgbNZ1oFxRk