### PR TITLE
Add redirect rule for effectivealtruism.org domain

### DIFF
--- a/config/constants.json
+++ b/config/constants.json
@@ -143,6 +143,10 @@
     {
       "pattern": "^xcancel\\.com$",
       "to": "x.com"
+    },
+    {
+      "pattern": "^.*effectivealtruism\\.org$",
+      "to": "forum.effectivealtruism.org"
     }
   ],
   "unicodeTypography": {


### PR DESCRIPTION
## Summary
Added a new domain redirect rule to route all effectivealtruism.org subdomains to the official forum subdomain.

## Changes
- Added a redirect pattern that matches any subdomain of `effectivealtruism.org` and redirects to `forum.effectivealtruism.org`
- This ensures users accessing the main domain or any subdomain are directed to the canonical forum location

## Implementation Details
- Uses a wildcard pattern (`^.*effectivealtruism\\.org$`) to match the domain and all its subdomains
- Follows the existing redirect rule format in the constants configuration file

https://claude.ai/code/session_01FBpK6qGuBVUS8YJqxsQcc9