### PR TITLE
fix: resolve flaky search tests on iPad Safari and a11y timeout

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -678,14 +678,15 @@ test("Search matches in preview do not have fade animation", async ({ page }) =>
   const previewMatch = preview.locator(".search-match").first()
   await expect(previewMatch).toBeAttached()
 
-  // WebKit/Safari may need a few frames for the CSS exclusion
-  // :not(#search-container .search-match) to settle.
+  // WebKit/Safari may need many frames for the CSS exclusion
+  // :not(#search-container .search-match) to settle — iPad Safari in CI
+  // can be especially slow.
   await expect(async () => {
     const animation = await previewMatch.evaluate((el) => {
       return window.getComputedStyle(el).animationName
     })
     expect(animation).toBe("none")
-  }).toPass({ timeout: 5_000 })
+  }).toPass({ timeout: 10_000 })
 })
 
 test("Search matches on navigated page have fade animation", async ({ page }) => {

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -418,6 +418,17 @@ export async function search(page: Page, term: string) {
     { timeout: 30_000 },
   )
 
+  // If results are already displayed from a previous search, clear them
+  // first. Otherwise all post-conditions (display-results class, visible
+  // result cards) are already satisfied, and the helper returns before the
+  // debounced new search fires — causing flaky failures on iPad Safari.
+  const hasExistingResults = (await page.locator(".result-card").count()) > 0
+  if (hasExistingResults) {
+    await searchBar.fill("")
+    await searchBar.dispatchEvent("input")
+    await expect(page.locator(".result-card").first()).not.toBeAttached({ timeout: 10_000 })
+  }
+
   await searchBar.fill(term)
   // Explicitly dispatch input event — Playwright's fill() should do this,
   // but Firefox on tablet viewports sometimes fails to trigger the handler.

--- a/quartz/static/scripts/katex-a11y-tabindex.js
+++ b/quartz/static/scripts/katex-a11y-tabindex.js
@@ -68,7 +68,11 @@ function init() {
   // Handle all existing .katex elements.
   document.querySelectorAll(".katex").forEach((el) => observeKatex(el, resizeObserver))
 
-  // Watch for new .katex elements added to the DOM.
+  // Watch for new .katex elements added to the DOM (e.g. SPA navigation).
+  // Only observe the article/content area to avoid processing unrelated DOM
+  // mutations (e.g. from accessibility testing tools that inject iframes).
+  const contentRoot =
+    document.querySelector("article") || document.querySelector("#quartz-body") || document.body
   new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       const nodes = Array.from(mutation.addedNodes)
@@ -82,7 +86,7 @@ function init() {
         }
       }
     }
-  }).observe(document.body, { childList: true, subtree: true })
+  }).observe(contentRoot, { childList: true, subtree: true })
 }
 
 if (document.readyState !== "loading") {


### PR DESCRIPTION
## Summary
- Fix two flaky Playwright search tests on iPad Pro Safari caused by the `search()` helper returning before debounced results updated
- Fix accessibility check timeout on math-heavy pages caused by MutationObserver processing axe-core's DOM mutations
- Increase CSS animation assertion timeout for WebKit settling in CI

## Changes
- **`visual_utils.ts`**: Clear existing search results before re-searching so post-conditions (display-results class, visible cards) aren't already satisfied from a prior query
- **`search.spec.ts`**: Increase `toPass` timeout from 5s to 10s for the animation name check on iPad Safari
- **`katex-a11y-tabindex.js`**: Scope MutationObserver to `article` / `#quartz-body` instead of `document.body` to avoid processing unrelated DOM mutations from a11y tools

## Testing
- All 3376 unit tests pass with 100% coverage
- Type checking and formatting pass
- Changes target specific CI flakes: Playwright shard 19/30 (iPad Pro Safari) and a11y check (155/156 pages passed, 1 timed out)

https://claude.ai/code/session_015tGjo2yqxsgRL7xLvGB8yV