### PR TITLE
fix: clear search results via DOM instead of broken input handler

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -419,14 +419,17 @@ export async function search(page: Page, term: string) {
   )
 
   // If results are already displayed from a previous search, clear them
-  // first. Otherwise all post-conditions (display-results class, visible
-  // result cards) are already satisfied, and the helper returns before the
-  // debounced new search fires — causing flaky failures on iPad Safari.
+  // directly via the DOM. We can't rely on the app's debounced input handler
+  // because it creates a "No results" .result-card element even for empty
+  // queries, so waiting for .result-card to detach would never succeed.
   const hasExistingResults = (await page.locator(".result-card").count()) > 0
   if (hasExistingResults) {
-    await searchBar.fill("")
-    await searchBar.dispatchEvent("input")
-    await expect(page.locator(".result-card").first()).not.toBeAttached({ timeout: 10_000 })
+    await page.evaluate(() => {
+      const results = document.getElementById("results-container")
+      if (results) results.innerHTML = ""
+      const layout = document.getElementById("search-layout")
+      layout?.classList.remove("display-results")
+    })
   }
 
   await searchBar.fill(term)


### PR DESCRIPTION
## Summary
- Fix 30+ Playwright test failures on Desktop Safari caused by the search helper's result-clearing logic
- The previous approach (fill("") + dispatchEvent) relied on the app's debounced `onType` handler, which always creates a "No Results" `.result-card` element for empty queries — making `not.toBeAttached()` impossible to satisfy

## Changes
- Replace `fill("") + dispatchEvent("input") + waitFor detach` with direct DOM manipulation via `page.evaluate()` to clear `#results-container` innerHTML and remove `display-results` class
- This is test infrastructure only — no production code changes

## Testing
- All failures were `expect(locator).not.toBeAttached()` on `.result-card` across 10+ Playwright shards on Desktop Safari
- The root cause is confirmed: `onType` with empty query calls `displayResults([], ...)` which renders `<a class="result-card no-match">No results</a>`
- The fix bypasses the debounced handler entirely, clearing DOM state directly before the new search term is filled

https://claude.ai/code/session_015tGjo2yqxsgRL7xLvGB8yV