### PR TITLE
Fix anchor link reference in design documentation

### DIFF
--- a/website_content/design.md
+++ b/website_content/design.md
@@ -192,7 +192,7 @@ EB Garamond Regular 8pt takes 260KB as an `otf` file but compresses to 80KB unde
 
 I use [`subfont`](https://github.com/Munter/subfont) to subset each font across my entire website, taking the font footprint from 609KB to 113KB - a reduction of over 5x! Eventually, the ultimate solution will be [progressive font enrichment](https://www.w3.org/TR/PFE-evaluation/), which will load just those glyphs needed for a webpage, and then cache those glyphs so that they aren't reloaded during future calls. Sadly, progressive font enrichment is not yet available.
 
-For fonts that only appear on a few pages — like the [old italic comparison fonts](#font-selection) — I manually subset to just the characters used in those comparisons. This shrank the old italic fonts from 187KB to 36KB and the old regular font from 82KB to 3KB.
+For fonts that only appear on a few pages — like the [old italic comparison fonts](#upright-punctuation-in-italic-text) — I manually subset to just the characters used in those comparisons. This shrank the old italic fonts from 187KB to 36KB and the old regular font from 82KB to 3KB.
 
 ### Images
 


### PR DESCRIPTION
## Summary
Updated an incorrect anchor link reference in the design documentation to point to the correct section heading.

## Changes
- Fixed the anchor link in the font subsetting section from `#font-selection` to `#upright-punctuation-in-italic-text` to correctly reference the section discussing old italic comparison fonts

## Details
The documentation previously linked to a section anchor that either doesn't exist or has been renamed. This change ensures the internal link properly references the relevant section about italic comparison fonts and their manual subsetting process.

https://claude.ai/code/session_01A2H9RPSfk6QKXgmnZxnRnG