### PR TITLE
fix(ci): resolve darkmode test flake and a11y workflow timeout

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -25,7 +25,7 @@ jobs:
   a11y:
     if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/quartz/components/tests/darkmode.spec.ts
+++ b/quartz/components/tests/darkmode.spec.ts
@@ -130,6 +130,17 @@ test.describe("Theme persistence and UI states", () => {
       // may be treated as a soft refresh and skip re-running JS init scripts,
       // leaving data-theme unset.
       await gotoPage(page, "http://localhost:8080/about")
+
+      // Wait for setupDarkMode() to complete (sets localStorage + data-theme).
+      // Without this, Safari/WebKit may not have finished running the init
+      // script before verifyTheme checks the attribute.
+      await page.waitForFunction(
+        () =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (window as any).__darkmodeReady === true,
+        null,
+        { timeout: 15_000 },
+      )
       await helper.verifyTheme(theme)
       await helper.verifyStorage(theme)
       await helper.verifyThemeLabel(theme)


### PR DESCRIPTION
## Summary
- Fix Safari/WebKit dark mode test flake by waiting for `setupDarkMode()` to complete before asserting theme state after navigation
- Fix a11y workflow being cancelled by increasing job timeout from 20 to 30 minutes

## Changes
- **`quartz/components/tests/darkmode.spec.ts`**: Add `waitForFunction(__darkmodeReady)` after `gotoPage` in the "persists theme across reloads" test, matching the pattern already used by the navigation tests at lines 234-269
- **`.github/workflows/a11y.yml`**: Increase `timeout-minutes` from 20 to 30 — pa11y-ci scanning the full sitemap was exceeding 20 minutes, causing GitHub to cancel the job

## Testing
- `pnpm check` passes (type check + formatting + stylelint)
- Changes follow existing codebase patterns (same `__darkmodeReady` wait used in navigation tests)

https://claude.ai/code/session_01R5yQokVfZdWLV7E1CqyryT