### PR TITLE
ci: auto-create issue for Claude to fix failed deploys

### DIFF
--- a/.github/workflows/auto-fix-failed-deploy.yaml
+++ b/.github/workflows/auto-fix-failed-deploy.yaml
@@ -14,6 +14,8 @@ permissions:
   issues: write
   actions: read
 
+# If a deploy succeeds while we're creating a failure issue, cancel-in-progress
+# drops the issue creation — which is correct since CI is already passing.
 concurrency:
   group: auto-fix-deploy-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
@@ -67,8 +69,14 @@ jobs:
             });
 
             const failedJobs = jobs.filter(j => j.conclusion === 'failure');
+            if (failedJobs.length === 0) {
+              console.log('Run failed but no individual jobs show failure (infrastructure issue?), skipping');
+              return;
+            }
+
             const jobSummaries = [];
-            const maxLogBytes = 50_000;
+            // GitHub issue body limit is 65,536 chars; leave room for the template
+            const maxLogBytes = 45_000;
             let totalBytes = 0;
 
             for (const job of failedJobs) {
@@ -103,7 +111,7 @@ jobs:
               `@claude The **${run.name}** workflow failed on \`${branch}\` at commit ${sha}.`,
               '',
               `**Failed run:** ${run.html_url}`,
-              `**Failed jobs:** ${failedJobs.map(j => j.name).join(', ') || 'unknown'}`,
+              `**Failed jobs:** ${failedJobs.map(j => j.name).join(', ')}`,
               '',
               '## Failed job logs',
               '',


### PR DESCRIPTION
## Summary
- When "Deploy to Cloudflare" fails on `main` or `dev`, automatically creates a GitHub issue with failure logs and `@claude` mention, triggering the existing Claude workflow to investigate and open a fix PR

## Changes
- New workflow `.github/workflows/auto-fix-failed-deploy.yaml`:
  - Triggers on `workflow_run` completion of "Deploy to Cloudflare" on `main`/`dev`
  - Downloads failed job logs (last 80 lines per job, capped at 50KB total)
  - Creates a labeled issue (`auto-fix-deploy`) with `@claude` in the body
  - Circuit breaker: max 3 issues per branch per 24h to prevent infinite loops
  - Concurrency group prevents parallel issue creation for the same branch
  - Deduplicates: skips if an open issue already exists for the branch
  - Error handling with `core.setFailed` on issue creation failure

## Testing
- YAML-only change, no unit tests applicable
- Workflow uses the same `actions/github-script@v7` pattern as existing `comment-on-failed-checks.yaml`

https://claude.ai/code/session_0189o5DqmSakVq9mFUGXoK4d