### PR TITLE
feat(ci): auto-create issues for failed deploys

### DIFF
--- a/.github/workflows/auto-fix-failed-deploy.yaml
+++ b/.github/workflows/auto-fix-failed-deploy.yaml
@@ -97,7 +97,7 @@ jobs:
                   .map(line => line.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z /, ''))
                   .join('\n');
 
-                const tail = cleaned.substring(0, maxLogBytes - totalBytes);
+                const tail = cleaned.slice(-(maxLogBytes - totalBytes));
                 totalBytes += tail.length;
                 jobSummaries.push(`### ${job.name}\n\n\`\`\`\n${tail}\n\`\`\``);
               } catch (e) {


### PR DESCRIPTION
## Summary
- Add a workflow that automatically creates GitHub issues when "Deploy to Cloudflare" fails, tagging `@claude` to investigate and fix
- Auto-closes issues when CI passes again on the same branch

## Changes
- New `.github/workflows/auto-fix-failed-deploy.yaml` with two jobs:
  - `create-fix-issue`: creates an issue with failed job logs, circuit breaker (max 3/day per branch), deduplication (one open issue per branch)
  - `close-fixed-issue`: closes open auto-fix issues when the deploy succeeds
- Logs are cleaned (timestamps stripped) and truncated from the tail end to stay under GitHub's 65K issue body limit
- Concurrency group with `cancel-in-progress` prevents stale issue creation when a quick success follows a failure

## Testing
- Workflow only triggers on `workflow_run` completion events from "Deploy to Cloudflare" — will be tested by the next real deploy failure on main/dev
- Circuit breaker and dedup logic reviewed via critique sub-agent

https://claude.ai/code/session_0189o5DqmSakVq9mFUGXoK4d