### PR TITLE
Remove type checking from pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     ],
     "*.{js,jsx,ts,tsx}": [
       "pnpm eslint --fix --config config/javascript/eslint.config.js",
-      "prettier --write --config config/prettier/.prettierrc --ignore-path config/prettier/.prettierignore",
-      "bash -c 'pnpm exec tsc --noEmit'"
+      "prettier --write --config config/prettier/.prettierrc --ignore-path config/prettier/.prettierignore"
     ],
     ".hooks/prepare-commit-msg": [
       "prettier --write --config config/prettier/.prettierrc --ignore-path config/prettier/.prettierignore"
@@ -53,8 +52,7 @@
       "isort",
       "autopep8 --in-place",
       "black",
-      "ruff check --fix",
-      "bash -c 'uv run dmypy run -- --config-file config/python/mypy.ini scripts/'"
+      "ruff check --fix"
     ],
     "!(*.vale-styles)/**/*.md": [
       "markdownlint --config config/markdownlint/.markdownlint.jsonc --fix"


### PR DESCRIPTION
## Summary
- Remove `tsc --noEmit` and `dmypy` from lint-staged to speed up `git commit`
- Both are whole-project type checks that can't be scoped to staged files, adding several seconds to every commit regardless of change size
- Type checking is already covered by CI (`node.js.yml` runs `pnpm test`, `python-lint.yaml` runs `mypy`)

## Changes
- Remove `bash -c 'pnpm exec tsc --noEmit'` from `*.{js,jsx,ts,tsx}` lint-staged config
- Remove `bash -c 'uv run dmypy run -- --config-file config/python/mypy.ini scripts/'` from `*.py` lint-staged config

## Testing
- Committed with the updated lint-staged config — pre-commit hooks ran successfully
- Verified CI covers both checks: `node.js.yml` line 54 (`pnpm test`), `python-lint.yaml` lines 53-56 (`mypy`)

https://claude.ai/code/session_01XBcpoydDDwkPWNi3Daba15