### PR TITLE
fix: prevent deadlock in run_push_checks and remove redundant stashing

### DIFF
--- a/scripts/run_push_checks.py
+++ b/scripts/run_push_checks.py
@@ -262,14 +262,16 @@ def run_non_interactive_command(
             target=stream_reader,
             args=(process.stdout, stdout_lines, last_lines, progress, task_id),
         )
-        stdout_thread.start()
-        stdout_thread.join()
-
         stderr_thread = threading.Thread(
             target=stream_reader,
             args=(process.stderr, stderr_lines, last_lines, progress, task_id),
         )
+        # Start both threads before joining either to avoid deadlock:
+        # if the subprocess fills the stderr pipe buffer while we're
+        # blocked waiting for stdout to EOF, both sides block forever.
+        stdout_thread.start()
         stderr_thread.start()
+        stdout_thread.join()
         stderr_thread.join()
 
         return_code = process.wait()
@@ -424,7 +426,12 @@ def get_check_steps(git_root_path: Path) -> list[CheckStep]:
 
 
 def main() -> int:
-    """Run unique pre-push checks."""
+    """
+    Run unique pre-push checks.
+
+    Note: Stashing of uncommitted changes is handled by the calling
+    pre-push hook (.hooks/pre-push), not here.
+    """
     parser = argparse.ArgumentParser(
         description="Run pre-push checks with progress bars."
     )
@@ -435,29 +442,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    stash_created = False
-    git_path = shutil.which("git") or "git"
     try:
-        # Stash any uncommitted changes
-        stash_result = subprocess.run(
-            [
-                git_path,
-                "stash",
-                "push",
-                "-u",
-                "-m",
-                "run_push_checks auto-stash",
-            ],
-            cwd=_GIT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        # Check if stash was actually created (output won't contain "No local changes")
-        if "No local changes" not in stash_result.stdout:
-            stash_created = True
-            console.log("[cyan]Stashed uncommitted changes[/cyan]")
-
         steps = get_check_steps(_GIT_ROOT)
         all_step_names = [step.name for step in steps]
 
@@ -483,17 +468,6 @@ def main() -> int:
     except KeyboardInterrupt:
         console.log("\n[yellow]Process interrupted by user.[/yellow]")
         return 130  # Standard exit code for SIGINT
-    finally:
-        # Restore stashed changes if we created a stash
-        if stash_created:
-            subprocess.run(
-                [git_path, "stash", "pop"],
-                cwd=_GIT_ROOT,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            console.log("[cyan]Restored stashed changes[/cyan]")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -629,58 +629,6 @@ def test_main_preserves_state_on_interrupt(temp_state_dir):
         )
 
 
-def test_main_stashes_and_restores_changes(temp_state_dir):
-    """Test that main stashes uncommitted changes and restores them."""
-    with (
-        patch(
-            "argparse.ArgumentParser.parse_args",
-            return_value=MagicMock(resume=False),
-        ),
-        patch("scripts.run_push_checks.run_checks"),
-        patch(
-            "scripts.run_push_checks.get_check_steps",
-            return_value=[
-                run_push_checks.CheckStep(name="test", command=["test"])
-            ],
-        ),
-        patch("subprocess.run") as mock_subprocess,
-        patch("scripts.run_push_checks.console.log") as mock_log,
-        patch("shutil.which", return_value="git"),
-    ):
-        # Mock git stash to indicate changes were stashed
-        mock_subprocess.return_value = MagicMock(
-            stdout="Saved working directory and index state"
-        )
-
-        from scripts.run_push_checks import main
-
-        exit_code = main()
-
-        # Verify successful exit
-        assert exit_code == 0
-        # Verify git stash was called
-        assert mock_subprocess.call_count == 2  # stash push and stash pop
-        # Verify stash push was called
-        mock_subprocess.assert_any_call(
-            ["git", "stash", "push", "-u", "-m", "run_push_checks auto-stash"],
-            cwd=run_push_checks._GIT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        # Verify stash pop was called
-        mock_subprocess.assert_any_call(
-            ["git", "stash", "pop"],
-            cwd=run_push_checks._GIT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        # Verify logging
-        mock_log.assert_any_call("[cyan]Stashed uncommitted changes[/cyan]")
-        mock_log.assert_any_call("[cyan]Restored stashed changes[/cyan]")
-
-
 def test_run_interactive_command():
     """Test interactive command execution (like spellchecker)"""
     step = run_push_checks.CheckStep(


### PR DESCRIPTION
## Summary
- Fix potential deadlock in `run_non_interactive_command` by starting stdout/stderr reader threads concurrently instead of sequentially
- Remove redundant stash push/pop from `main()` since the pre-push hook already handles stashing

## Changes
- `scripts/run_push_checks.py`: Start both stdout and stderr reader threads before joining either one, preventing deadlock when a subprocess fills the stderr pipe buffer while blocked on stdout
- `scripts/run_push_checks.py`: Remove `git stash push`/`git stash pop` logic from `main()` — `.hooks/pre-push` already handles this via `stash_and_exit()` with a trap
- `scripts/tests/test_run_push_checks.py`: Remove the now-obsolete `test_main_stashes_and_restores_changes` test

## Testing
- All 42 `test_run_push_checks.py` tests pass

https://claude.ai/code/session_01GzPFWMgbLTHcYHH4w6T5TY