### PR TITLE
ci: consolidate site builds into reusable workflow and extract browser install

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -23,7 +23,6 @@ permissions:
 
 jobs:
   a11y-build:
-    if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
     uses: ./.github/workflows/build-site.yaml
     with:
       artifact-name: a11y-public-dir

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -85,8 +85,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Build Environment
-        uses: ./.github/actions/setup-build-env
+      - name: Setup base environment
+        uses: ./.github/actions/setup-base-env
+        with:
+          install-python: "false"
 
       - name: Download built site
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7


### PR DESCRIPTION
## Summary
- Reduce CI duplication by extracting the site build step into a reusable `build-site.yaml` workflow, called by 7 downstream workflows
- Move Playwright/Puppeteer browser installation out of `postinstall` into a dedicated `install-browsers` script so CI jobs that don't run tests (deploy, lint, node tests) skip browser setup

## Changes
- **New `build-site.yaml`**: Reusable `workflow_call` workflow with parameterized artifact name, retention days, fetch depth, and optional safari-autoplay removal
- **Refactored 7 workflows** to call `build-site.yaml` instead of duplicating build steps: `playwright-tests`, `visual-testing`, `site-build-checks`, `lighthouse-layout-shift`, `deploy`, `playwright-flake-check`, `a11y`
- **`package.json`**: `postinstall` now only runs `patch-package`; new `install-browsers` script for explicit browser installation
- **Lighthouse deploy job**: Uses `setup-base-env` instead of `setup-build-env` since it only needs Node/pnpm for subfont and wrangler
- **Deploy `verify-tests` check-regexp**: Updated to match new reusable workflow job names (e.g., `playwright-build / build`)
- **Removed dead `if` guard** on `a11y-build` (workflow only triggers on push, not PRs)

## Testing
- All workflow YAML files validated with Python yaml.safe_load
- Job dependency chains verified programmatically (all `needs` references resolve)
- Confirmed `pnpm build` only appears in `build-site.yaml` (no duplicates in downstream workflows)
- Confirmed `puppeteer browsers install` removed from all CI workflows, replaced with `pnpm run install-browsers` in Playwright/visual test workflows only
- Note: Developers must run `pnpm run install-browsers` after `pnpm install` for local Playwright/Puppeteer usage

https://claude.ai/code/session_0196sVNGmh3p7z1tNsdeUK3H