### PR TITLE
fix: remove obsolete WebKit workarounds 

### DIFF
--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -49,12 +49,6 @@ test(".can-trigger-popover links show popover on hover (lostpixel)", async ({
   page,
   dummyLink,
 }, testInfo) => {
-  // DOM isolation (hiding all other elements) crashes Desktop Safari WebKit;
-  // visual coverage is provided by the Chrome and Firefox configurations.
-  test.skip(
-    page.context().browser()?.browserType().name() === "webkit",
-    "DOM isolation crashes Desktop Safari WebKit",
-  )
   await expect(dummyLink).toBeVisible()
 
   // Initial state - no popover

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -1,5 +1,3 @@
-import type { PageScreenshotOptions } from "@playwright/test"
-
 import { promises as fs } from "fs"
 import sharp from "sharp"
 
@@ -529,52 +527,6 @@ test.describe("takeRegressionScreenshot", () => {
     expect(dimensions.width).toBeLessThanOrEqual(clip.width + 1)
     expect(dimensions.height).toBeGreaterThanOrEqual(clip.height - 1)
     expect(dimensions.height).toBeLessThanOrEqual(clip.height + 1)
-  })
-
-  test.describe("takeRegressionScreenshot Default Viewport Clipping", () => {
-    test("clips viewport screenshot to clientWidth to avoid Safari gutter", async ({
-      page,
-    }, testInfo) => {
-      testInfo.skip(
-        !/webkit|safari/i.test(testInfo.project.name),
-        "Test is specific to WebKit/Safari gutter behavior",
-      )
-
-      const mockClientWidth = 1200
-      await page.evaluate((width) => {
-        Object.defineProperty(document.documentElement, "clientWidth", {
-          value: width,
-          configurable: true,
-        })
-      }, mockClientWidth)
-
-      // Ensure the test is nontrivial
-      const viewportSize = page.viewportSize()
-      expect(mockClientWidth).not.toBeCloseTo(viewportSize?.width ?? 0)
-
-      const originalScreenshot = page.screenshot
-      let capturedOptions: PageScreenshotOptions | undefined
-
-      page.screenshot = async (options?: PageScreenshotOptions): Promise<Buffer> => {
-        capturedOptions = options
-        // Return an empty buffer to satisfy the type, don't call original
-        return Buffer.from("")
-      }
-
-      try {
-        await takeRegressionScreenshot(page, testInfo, "gutter-test")
-
-        expect(capturedOptions).toBeDefined()
-        expect(capturedOptions?.clip).toBeDefined()
-        expect(capturedOptions?.clip?.width).toBeCloseTo(mockClientWidth)
-        expect(capturedOptions?.clip?.x).toBe(0)
-        expect(capturedOptions?.clip?.y).toBe(0)
-        const viewportHeight = page.viewportSize()?.height
-        expect(capturedOptions?.clip?.height).toBeCloseTo(viewportHeight ?? 0)
-      } finally {
-        page.screenshot = originalScreenshot
-      }
-    })
   })
 })
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -141,8 +141,6 @@ async function performDOMIsolation(
  * @returns A promise that resolves once the DOM restoration is complete.
  */
 async function restoreDOMFromIsolation(page: Page): Promise<void> {
-  // WebKit may crash during screenshots; if the page is already closed there's nothing to restore
-  if (page.isClosed()) return
   await page.evaluate(() => {
     const hiddenElements = window.__elementsToRestoreData
     if (hiddenElements) {
@@ -217,19 +215,6 @@ export async function takeRegressionScreenshot(
       await restoreDOM()
     }
   } else {
-    // If no explicit clip was provided, clip to clientWidth to avoid Safari/WebKit gutter
-    if (!options?.clip) {
-      const viewportSize = page.viewportSize()
-      if (!viewportSize) throw new Error("Could not get viewport size for clipping")
-      const clientWidth = await page.evaluate(() => document.documentElement.clientWidth)
-      screenshotOptions.clip = {
-        x: 0,
-        y: 0,
-        width: clientWidth,
-        height: viewportSize.height,
-      }
-    }
-
     screenshotBuffer = await page.screenshot(screenshotOptions)
   }
 


### PR DESCRIPTION
## Summary
- Removes WebKit-specific workarounds that are no longer needed after confirming the bugs don't reproduce on CI
- **Bug 2 (DOM isolation crash)**: Removes the `test.skip` for WebKit in `popover.spec.ts` and the `page.isClosed()` guard in `visual_utils.ts`
- **Bug 3 (clientWidth/viewport mismatch)**: Removes the `clientWidth` clipping workaround in `takeRegressionScreenshot` and its dedicated test

## Test plan
- [x] Verify all 30 Playwright shards pass on CI without the workarounds
- [x] Verify WebKit/Safari shards run the previously-skipped popover isolation test

https://claude.ai/code/session_01Y3wMBsMQLkuMMMsDB5FPDo