### PR TITLE
Change text-wrap from pretty to auto for headings

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -297,7 +297,7 @@ h5,
 h6,
 thead {
   position: relative; // For anchor links
-  text-wrap: pretty;
+  text-wrap: auto;
 
   article & > a[role="anchor"] {
     color: var(--midground-faint);

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -360,7 +360,6 @@ figure,
 }
 
 #article-title {
-  text-wrap: auto;
   margin: calc(4 * $base-margin) 0 0;
 
   @media all and (max-width: $max-mobile-width) {


### PR DESCRIPTION
## Summary
Updated the `text-wrap` CSS property for heading elements (h1-h6) and table headers from `pretty` to `auto` to adjust text wrapping behavior.

## Changes
- Modified `text-wrap` property in base.scss from `pretty` to `auto` for h1, h2, h3, h4, h5, h6, and thead elements
- This affects how text wrapping is handled for these elements, prioritizing performance and standard wrapping behavior over optimized line breaking

## Details
The change impacts the visual rendering of headings and table headers by using the browser's default text wrapping algorithm instead of the `pretty` value, which attempts to optimize line breaks for better readability at a potential performance cost.

https://claude.ai/code/session_01DBAooBAuT59igqHJxzKfFP