### PR TITLE
ci: upgrade actions/cache and pnpm/action-setup to Node.js 24

### DIFF
--- a/.github/actions/deploy-to-cloudflare/action.yaml
+++ b/.github/actions/deploy-to-cloudflare/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
     - name: Install Wrangler
       run: pnpm install wrangler@3.99.0

--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -36,7 +36,7 @@ runs:
 
     - name: Install pnpm
       if: inputs.install-node-deps == 'true'
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
     - name: Get pnpm store directory
       if: inputs.install-node-deps == 'true'
@@ -46,7 +46,7 @@ runs:
 
     - name: Restore pnpm cache
       if: inputs.install-node-deps == 'true'
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -55,7 +55,7 @@ runs:
 
     - name: Restore asset dimensions cache
       id: asset-dimensions-cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: quartz/plugins/transformers/.asset_dimensions.json
         key: ${{ runner.os }}-asset-dimensions-${{ github.ref }}
@@ -64,7 +64,7 @@ runs:
 
     - name: Cache Playwright browsers
       if: inputs.cache-playwright == 'true'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -73,7 +73,7 @@ runs:
 
     - name: Cache Puppeteer browsers
       if: inputs.cache-puppeteer == 'true'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -82,7 +82,7 @@ runs:
 
     - name: Cache apt packages for Playwright system deps
       if: inputs.cache-apt-playwright == 'true'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: ~/apt-playwright-cache
         key: apt-playwright-${{ runner.os }}-24.04-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Upgrade `actions/cache` v4 → v5.0.4 and `pnpm/action-setup` v4 → v5.0.0 to resolve Node.js 20 deprecation warnings
- GitHub will force all actions to Node.js 24 starting June 2, 2026

## Changes
- `.github/actions/setup-base-env/action.yaml`: Updated `pnpm/action-setup` SHA (v4→v5) and all `actions/cache`/`actions/cache/restore` SHAs (v4→v5)
- `.github/actions/deploy-to-cloudflare/action.yaml`: Updated `pnpm/action-setup` SHA (v4→v5)
- `.github/workflows/security-vulnerability-scan.yaml`: Updated `pnpm/action-setup` tag (v4→v5)

## Testing
- CI will verify caches still work and pnpm installs correctly
- Deprecation warnings should no longer appear in workflow logs

https://claude.ai/code/session_01ReFAKQQsQmSAyzzQST73mH