### PR TITLE
fix: mark scroll event listeners as passive

### DIFF
--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -158,7 +158,7 @@ async function mouseEnterHandler(this: HTMLLinkElement) {
   activePopoverRemover = popoverCleanup
 
   window.addEventListener("resize", updatePosition)
-  window.addEventListener("scroll", handleScroll)
+  window.addEventListener("scroll", handleScroll, { passive: true })
 
   // skipcq: JS-0098 - Force reflow to ensure CSS transition
   void popoverElement.offsetWidth

--- a/quartz/components/scripts/scrollHandler.ts
+++ b/quartz/components/scripts/scrollHandler.ts
@@ -4,34 +4,38 @@ export function setupScrollHandler() {
   const scrollThreshold = 50 // Minimum scroll distance before toggle
   const topThreshold = 50 // Show navbar when within 50px of top
 
-  window.addEventListener("scroll", () => {
-    if (!ticking) {
-      window.requestAnimationFrame(() => {
-        const navbar = document.getElementById("navbar")
-        if (!navbar) return
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          const navbar = document.getElementById("navbar")
+          if (!navbar) return
 
-        const currentScrollY = window.scrollY
-        const delta = currentScrollY - lastScrollY
+          const currentScrollY = window.scrollY
+          const delta = currentScrollY - lastScrollY
 
-        navbar.classList.toggle("shadow", window.scrollY > 5)
+          navbar.classList.toggle("shadow", window.scrollY > 5)
 
-        if (Math.abs(delta) > scrollThreshold) {
-          if (delta > 0) {
-            navbar.classList.add("hide-above-screen")
-          } else {
+          if (Math.abs(delta) > scrollThreshold) {
+            if (delta > 0) {
+              navbar.classList.add("hide-above-screen")
+            } else {
+              navbar.classList.remove("hide-above-screen")
+            }
+            lastScrollY = currentScrollY
+          }
+
+          // Show navbar if close to top of page
+          if (currentScrollY <= topThreshold) {
             navbar.classList.remove("hide-above-screen")
           }
-          lastScrollY = currentScrollY
-        }
 
-        // Show navbar if close to top of page
-        if (currentScrollY <= topThreshold) {
-          navbar.classList.remove("hide-above-screen")
-        }
-
-        ticking = false
-      })
-      ticking = true
-    }
-  })
+          ticking = false
+        })
+        ticking = true
+      }
+    },
+    { passive: true },
+  )
 }


### PR DESCRIPTION
## Summary
- Add `{ passive: true }` to two scroll event listeners that never call `preventDefault()`, eliminating browser console violations about scroll-blocking listeners

## Changes
- `quartz/components/scripts/scrollHandler.ts`: Add passive flag to navbar show/hide scroll listener
- `quartz/components/scripts/popover.inline.ts`: Add passive flag to popover dismiss scroll listener

## Testing
- `pnpm check` passes (type checking, prettier, stylelint)
- `pnpm test` passes (3412 tests, 100% coverage)
- Verified neither handler calls `preventDefault()`, so passive is safe

https://claude.ai/code/session_0194Pxj98s9xyhax9r5n9qK1