### PR TITLE
fix: set data-src on video/audio containers for print placeholders

### DIFF
--- a/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
+++ b/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
@@ -34,17 +34,17 @@ describe("WrapNakedElements Plugin Tests", () => {
       [
         "naked video element",
         '<video src="test.mp4"></video>',
-        '<span class="video-container"><video src="test.mp4"></video></span>',
+        '<span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span>',
       ],
       [
         "video element with attributes",
         '<video src="test.mp4" controls width="100%"></video>',
-        '<span class="video-container"><video src="test.mp4" controls width="100%"></video></span>',
+        '<span data-src="test.mp4" class="video-container"><video src="test.mp4" controls width="100%"></video></span>',
       ],
       [
         "video element with child source tags",
         '<video controls><source src="test.mp4" type="video/mp4"><source src="test.webm" type="video/webm"></video>',
-        '<span class="video-container"><video controls><source src="test.mp4" type="video/mp4"><source src="test.webm" type="video/webm"></video></span>',
+        '<span data-src="test.mp4" class="video-container"><video controls><source src="test.mp4" type="video/mp4"><source src="test.webm" type="video/webm"></video></span>',
       ],
     ])("should wrap %s in span.video-container", (_, input, expected) => {
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
@@ -75,9 +75,9 @@ describe("WrapNakedElements Plugin Tests", () => {
         '<p><video src="naked2.mp4" controls></video></p>' +
         '<div class="video-container"><video src="wrapped2.mp4" controls></video></div>'
       const expected =
-        '<span class="video-container"><video src="naked1.mp4"></video></span>' +
+        '<span data-src="naked1.mp4" class="video-container"><video src="naked1.mp4"></video></span>' +
         '<span class="video-container"><video src="wrapped1.mp4"></video></span>' +
-        '<p><span class="video-container"><video src="naked2.mp4" controls></video></span></p>' +
+        '<p><span data-src="naked2.mp4" class="video-container"><video src="naked2.mp4" controls></video></span></p>' +
         '<div class="video-container"><video src="wrapped2.mp4" controls></video></div>'
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
     })
@@ -88,25 +88,52 @@ describe("WrapNakedElements Plugin Tests", () => {
       [
         "video as child of paragraph",
         '<p><video src="test.mp4"></video></p>',
-        '<p><span class="video-container"><video src="test.mp4"></video></span></p>',
+        '<p><span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span></p>',
       ],
       [
         "video with text siblings",
         '<p>Some text <video src="test.mp4"></video> More text</p>',
-        '<p>Some text <span class="video-container"><video src="test.mp4"></video></span> More text</p>',
+        '<p>Some text <span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span> More text</p>',
       ],
       [
         "deeply nested video",
         '<div><section><article><p><video src="deep.mp4"></video></p></article></section></div>',
-        '<div><section><article><p><span class="video-container"><video src="deep.mp4"></video></span></p></article></section></div>',
+        '<div><section><article><p><span data-src="deep.mp4" class="video-container"><video src="deep.mp4"></video></span></p></article></section></div>',
       ],
     ])("should wrap %s", (_, input, expected) => {
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
     })
   })
 
-  describe("No Video Elements", () => {
-    it("should do nothing if there are no video elements", () => {
+  describe("Audio Wrapping", () => {
+    it.each([
+      [
+        "naked audio with src",
+        '<audio src="test.mp3" controls></audio>',
+        '<span data-src="test.mp3" class="audio-container"><audio src="test.mp3" controls></audio></span>',
+      ],
+      [
+        "naked audio with source child",
+        '<audio controls><source src="test.ogg" type="audio/ogg"></audio>',
+        '<span data-src="test.ogg" class="audio-container"><audio controls><source src="test.ogg" type="audio/ogg"></audio></span>',
+      ],
+      [
+        "audio in div wrapper",
+        '<div class="centered"><audio src="test.mp3" controls></audio></div>',
+        '<div class="centered"><span data-src="test.mp3" class="audio-container"><audio src="test.mp3" controls></audio></span></div>',
+      ],
+    ])("should wrap %s in span.audio-container", (_, input, expected) => {
+      expect(testWrapNakedElementsHTML(input)).toBe(expected)
+    })
+
+    it("should not wrap audio already in audio-container", () => {
+      const input = '<span class="audio-container"><audio src="test.mp3" controls></audio></span>'
+      expect(testWrapNakedElementsHTML(input)).toBe(input)
+    })
+  })
+
+  describe("No Video/Audio Elements", () => {
+    it("should do nothing if there are no video or audio elements", () => {
       const input = '<p>Some text without videos.</p><div><img src="image.png"></div>'
       expect(testWrapNakedElementsHTML(input)).toBe(input)
     })
@@ -165,10 +192,7 @@ describe("WrapNakedElements Plugin Tests", () => {
 
   describe("Edge Cases", () => {
     it.each([
-      [
-        "non-video elements",
-        '<img src="test.jpg"><audio src="test.mp3"></audio><div>content</div>',
-      ],
+      ["non-video/audio elements", '<img src="test.jpg"><div>content</div>'],
       ["empty HTML", ""],
     ])("should handle %s without throwing", (_, input) => {
       expect(() => testWrapNakedElementsHTML(input)).not.toThrow()
@@ -185,7 +209,7 @@ describe("WrapNakedElements Plugin Tests", () => {
       const input =
         '<div class="not-video-container-but-similar"><video src="test.mp4"></video></div>'
       const expected =
-        '<div class="not-video-container-but-similar"><span class="video-container"><video src="test.mp4"></video></span></div>'
+        '<div class="not-video-container-but-similar"><span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span></div>'
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
     })
   })
@@ -218,7 +242,7 @@ describe("WrapNakedElements Plugin Tests", () => {
       [
         "wraps when video needs wrapping",
         '<div><video src="test.mp4"></video></div>',
-        '<div><span class="video-container"><video src="test.mp4"></video></span></div>',
+        '<div><span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span></div>',
       ],
       [
         "skips when already wrapped",
@@ -228,7 +252,7 @@ describe("WrapNakedElements Plugin Tests", () => {
       [
         "wraps in paragraph context",
         '<p><video src="test.mp4"></video></p>',
-        '<p><span class="video-container"><video src="test.mp4"></video></span></p>',
+        '<p><span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span></p>',
       ],
     ])("should handle wrapping logic: %s", (_, input, expected) => {
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
@@ -258,7 +282,7 @@ describe("WrapNakedElements Plugin Tests", () => {
     it("should maintain normal processing functionality", () => {
       const normalResult = testWrapNakedElementsHTML('<div><video src="test.mp4"></video></div>')
       expect(normalResult).toBe(
-        '<div><span class="video-container"><video src="test.mp4"></video></span></div>',
+        '<div><span data-src="test.mp4" class="video-container"><video src="test.mp4"></video></span></div>',
       )
     })
 
@@ -294,7 +318,7 @@ describe("WrapNakedElements Plugin Tests", () => {
       const complexInput =
         '<main><section><article><div class="content"><div class="media-section"><video src="deep-nested.mp4" controls><source src="video.webm" type="video/webm"><source src="video.mp4" type="video/mp4"><p>Your browser doesn\'t support HTML5 video.</p></video></div></div></article></section></main>'
       const expectedOutput =
-        '<main><section><article><div class="content"><div class="media-section"><span class="video-container"><video src="deep-nested.mp4" controls><source src="video.webm" type="video/webm"><source src="video.mp4" type="video/mp4"><p>Your browser doesn\'t support HTML5 video.</p></video></span></div></div></article></section></main>'
+        '<main><section><article><div class="content"><div class="media-section"><span data-src="deep-nested.mp4" class="video-container"><video src="deep-nested.mp4" controls><source src="video.webm" type="video/webm"><source src="video.mp4" type="video/mp4"><p>Your browser doesn\'t support HTML5 video.</p></video></span></div></div></article></section></main>'
       expect(testWrapNakedElementsHTML(complexInput)).toBe(expectedOutput)
     })
   })
@@ -304,17 +328,17 @@ describe("WrapNakedElements Plugin Tests", () => {
       [
         "video with no properties",
         "<video></video>",
-        '<span class="video-container"><video></video></span>',
+        '<span data-src="" class="video-container"><video></video></span>',
       ],
       [
         "video with text content",
         '<div><p>Text before<video src="test.mp4">Your browser does not support video.</video>Text after</p></div>',
-        '<div><p>Text before<span class="video-container"><video src="test.mp4">Your browser does not support video.</video></span>Text after</p></div>',
+        '<div><p>Text before<span data-src="test.mp4" class="video-container"><video src="test.mp4">Your browser does not support video.</video></span>Text after</p></div>',
       ],
       [
         "video at root level",
         '<video src="root.mp4"></video>',
-        '<span class="video-container"><video src="root.mp4"></video></span>',
+        '<span data-src="root.mp4" class="video-container"><video src="root.mp4"></video></span>',
       ],
     ])("should handle %s", (_, input, expected) => {
       expect(testWrapNakedElementsHTML(input)).toBe(expected)
@@ -332,8 +356,8 @@ describe("WrapNakedElements Plugin Tests", () => {
 
       const expected = `
         <article>
-          <span class="video-container"><video src="naked1.mp4"></video></span>
-          <p><span class="video-container"><video src="naked2.mp4"></video></span></p>
+          <span data-src="naked1.mp4" class="video-container"><video src="naked1.mp4"></video></span>
+          <p><span data-src="naked2.mp4" class="video-container"><video src="naked2.mp4"></video></span></p>
           <span class="video-container"><video src="wrapped1.mp4"></video></span>
           <div class="video-container"><video src="wrapped2.mp4"></video></div>
         </article>
@@ -368,7 +392,7 @@ describe("WrapNakedElements Plugin Tests", () => {
         name: "wrap video-container when video has float-right",
         input: '<video class="float-right" width="316" height="178">Content</video>',
         shouldWrap: true,
-        preservedContent: '<span class="video-container"><video class="float-right"',
+        preservedContent: '<span data-src="" class="video-container"><video class="float-right"',
       },
       {
         name: "not wrap without float-right class",

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -2,7 +2,7 @@
 // If a video element is not already wrapped in a .video-container, the vsc controller will be the first child of <article>.
 // This plugin wraps all video elements in a .video-container to prevent that.
 
-import type { Element, Parent, Root } from "hast"
+import type { Element, Parent, Properties, Root } from "hast"
 import type { Plugin } from "unified"
 
 import { h } from "hastscript"
@@ -20,6 +20,7 @@ import { hasClass } from "./utils"
  * @param skipPredicate A predicate function to determine if wrapping should be skipped.
  * @param wrapperTagName The tag name of the wrapper element (e.g., "span", "figure").
  * @param wrapperClassName The class name to apply to the wrapper element (empty string for no class).
+ * @param wrapperProperties Additional properties to set on the wrapper element.
  */
 function wrapElement(
   node: Element,
@@ -27,6 +28,7 @@ function wrapElement(
   skipPredicate: (node: Element, ancestors: Parent[], wrapperClassName: string) => boolean,
   wrapperTagName: string,
   wrapperClassName: string,
+  wrapperProperties: Properties = {},
 ): void {
   /* istanbul ignore next */
   if (ancestors.length === 0) {
@@ -41,15 +43,31 @@ function wrapElement(
   const existsInParentChildren = index !== -1
   /* istanbul ignore else */
   if (existsInParentChildren) {
-    const wrapper: Element = wrapperClassName
-      ? h(wrapperTagName, { className: [wrapperClassName] }, [node])
-      : h(wrapperTagName, [node])
+    const props: Properties = { ...wrapperProperties }
+    if (wrapperClassName) {
+      props.className = [wrapperClassName]
+    }
+    const wrapper: Element = h(wrapperTagName, props, [node])
 
     ancestors[ancestors.length - 1].children.splice(index, 1, wrapper)
   } else {
     /* istanbul ignore next */
     throw new Error("Element is not actually a child of its claimed parent.")
   }
+}
+
+/**
+ * Extracts the source URL from a media element (video/audio).
+ * Checks the element's `src` attribute first, then falls back to the first `<source>` child's `src`.
+ */
+function getMediaSrc(node: Element): string {
+  const src = node.properties?.src as string | undefined
+  if (src) return src
+
+  const sourceChild = node.children.find(
+    (child) => child.type === "element" && child.tagName === "source",
+  ) as Element | undefined
+  return (sourceChild?.properties?.src as string) ?? ""
 }
 
 /**
@@ -72,9 +90,40 @@ function skipNodeForVideo(
 
 /**
  * Wraps a video node in a <span class="video-container"> if it is not already in one.
+ * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
  */
 function wrapVideo(videoNode: Element, ancestors: Parent[]): void {
-  wrapElement(videoNode, ancestors, skipNodeForVideo, "span", "video-container")
+  if (videoNode.tagName !== "video") return
+  const dataSrc = getMediaSrc(videoNode)
+  wrapElement(videoNode, ancestors, skipNodeForVideo, "span", "video-container", {
+    "data-src": dataSrc,
+  })
+}
+
+/**
+ * Determines if an audio node should be skipped based on its tag name and parent class.
+ */
+function skipNodeForAudio(
+  audioNode: Element,
+  ancestors: Parent[],
+  wrapperClassName: string,
+): boolean {
+  const notAudio = audioNode.tagName !== "audio"
+  const directParent = ancestors[ancestors.length - 1]
+  const inAudioContainer = hasClass(directParent as Element, wrapperClassName)
+  return notAudio || inAudioContainer
+}
+
+/**
+ * Wraps an audio node in a <span class="audio-container"> if it is not already in one.
+ * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
+ */
+function wrapAudio(audioNode: Element, ancestors: Parent[]): void {
+  if (audioNode.tagName !== "audio") return
+  const dataSrc = getMediaSrc(audioNode)
+  wrapElement(audioNode, ancestors, skipNodeForAudio, "span", "audio-container", {
+    "data-src": dataSrc,
+  })
 }
 
 /**
@@ -170,8 +219,9 @@ function wrapFloatRight(element: Element, ancestors: Parent[]): void {
  */
 const rehypeWrapNakedElements: Plugin<[], Root> = () => {
   return (tree: Root) => {
-    // First wrap naked videos in video-container
+    // Wrap naked videos and audio in containers with data-src for print
     visitParents(tree, "element", wrapVideo)
+    visitParents(tree, "element", wrapAudio)
     // Then wrap .float-right elements (or their parents) in figure
     visitParents(tree, "element", wrapFloatRight)
   }


### PR DESCRIPTION
## Summary
- Raw HTML `<video>` and `<audio>` elements weren't getting `data-src` on their container wrappers, so the print stylesheet's `[Video: url]` / `[Audio: url]` placeholders showed empty URLs
- Also wraps naked `<audio>` elements in `audio-container` spans, matching existing video behavior

## Changes
- Add `wrapperProperties` parameter to `wrapElement()` for passing additional attributes to wrapper elements
- Add `getMediaSrc()` helper to extract source URL from video/audio elements (checks `src` attribute, then falls back to first `<source>` child)
- `wrapVideo` now sets `data-src` on the `.video-container` wrapper
- New `wrapAudio` + `skipNodeForAudio` functions mirror the video wrapping pattern for `<audio>` elements
- Updated all test expectations to include `data-src`; added audio wrapping test suite

## Testing
- All 3416 tests pass with 100% coverage
- Tested video elements with `src` attribute, `<source>` children, and no source
- Tested audio elements with `src` attribute, `<source>` children, already-wrapped, and nested in divs

https://claude.ai/code/session_0152FdqeokLHn5Va8s6ofXvD