### PR TITLE
Fix print mode theme rendering in dark mode

### DIFF
--- a/quartz/components/tests/print.spec.ts
+++ b/quartz/components/tests/print.spec.ts
@@ -37,6 +37,9 @@ test("Print mode renders identically in light and dark themes", async ({ page },
 
   await page.emulateMedia({ media: "screen" })
   await setTheme(page, "dark")
+  // Fire beforeprint to trigger the JS that swaps data-theme to light,
+  // matching real browser behavior (emulateMedia alone doesn't fire it).
+  await page.evaluate(() => window.dispatchEvent(new Event("beforeprint")))
   await page.emulateMedia({ media: "print" })
   const darkScreenshot = await page.screenshot({
     animations: "disabled",

--- a/quartz/styles/print.scss
+++ b/quartz/styles/print.scss
@@ -1,9 +1,12 @@
 @use "./variables.scss" as *;
+@use "./palette" as *;
 
 @media print {
   // Light-mode is forced via beforeprint/afterprint JS in darkmode.ts,
   // so we only need to set print-specific overrides here.
   :root {
+    @include palette-vars($light-colors, $important: true);
+
     --background: #fff !important;
     --midground-faint: #{$midground-faint-light} !important;
     --midground: #{$midground-light} !important;


### PR DESCRIPTION
## Summary
This PR fixes print mode rendering when the site is in dark mode by ensuring all light theme CSS variables are properly applied during printing.

## Key Changes
- **print.scss**: Added explicit light theme color palette variables to the print media query with `!important` flag to ensure they override dark mode styles
- **print.spec.ts**: Updated the print mode test to dispatch a `beforeprint` event before taking screenshots, matching real browser behavior and ensuring the theme-switching JavaScript is triggered

## Implementation Details
The issue was that while the `beforeprint` event handler in darkmode.ts swaps the `data-theme` attribute to light mode, the CSS variables weren't being fully reset in the print stylesheet. By including `@include palette-vars($light-colors, $important: true)` in the print media query, we ensure all color variables are explicitly set to their light theme values with sufficient specificity to override any dark mode styles. The test fix ensures the beforeprint event is fired during testing to properly simulate browser behavior.

https://claude.ai/code/session_01SVA5EdTgNxJMdBBTFyJvFB