### PR TITLE
fix(checks): normalize text transforms in metadata comparison

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import unicodedata
 import urllib.parse
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -1734,7 +1735,22 @@ def _untransform_text(label: str) -> str:
     simple_quotes_label = re.sub(quote_chars, '"', lower_label)
     unescaped_label = html.unescape(simple_quotes_label)
     normalized_spaces = unescaped_label.replace(NBSP, " ")
-    return normalized_spaces.strip()
+    # Normalize em-dashes, en-dashes, and ellipsis to ASCII equivalents
+    normalized_dashes = (
+        normalized_spaces.replace("\u2014", " - ")
+        .replace("\u2013", " - ")
+        .replace(ELLIPSIS, "...")
+    )
+    # Strip diacritics (e.g. naïve → naive, café → cafe) via Unicode decomposition
+    nfkd = unicodedata.normalize("NFKD", normalized_dashes)
+    stripped_diacritics = "".join(
+        c for c in nfkd if unicodedata.category(c) != "Mn"
+    )
+    # Normalize comma+quote ordering: "," and "," both → ",
+    normalized_quotes = stripped_diacritics.replace('",', ',"')
+    # Collapse multiple spaces from dash normalization
+    normalized_quotes = re.sub(r" +", " ", normalized_quotes)
+    return normalized_quotes.strip()
 
 
 def check_metadata_matches(soup: BeautifulSoup, md_path: Path) -> list[str]:

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5033,12 +5033,31 @@ def test_check_unrendered_emoticons(html, expected):
         # All quote types in one string
         (
             "Mix of \"quotes\", 'apostrophes', \"regular\", and 'more'",
-            'mix of "quotes", "apostrophes", "regular", and "more"',
+            'mix of "quotes," "apostrophes," "regular," and "more"',
         ),
         # Non-breaking spaces normalized to regular spaces
         (
             f"title with{built_site_checks.NBSP}non-breaking{built_site_checks.NBSP}spaces",
             "title with non-breaking spaces",
+        ),
+        # Em-dash normalization
+        ("computations\u2014do transformers", "computations - do transformers"),
+        # En-dash normalization
+        ("pages 10\u201320", "pages 10 - 20"),
+        # Diacritics stripped
+        ("na\u00efve predictions", "naive predictions"),
+        ("caf\u00e9 culture", "cafe culture"),
+        ("d\u00e9j\u00e0 vu", "deja vu"),
+        # Ellipsis normalization
+        ("wait for it\u2026", "wait for it..."),
+        # Comma-inside-quotes normalization
+        (
+            'Munkres\' "Topology", reflecting',
+            'munkres" "topology," reflecting',
+        ),
+        (
+            "\u201cTopology,\u201d reflecting",
+            '"topology," reflecting',
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- Fix `built_site_checks` CI failure by improving `_untransform_text()` normalization to handle all text transforms the build pipeline applies to descriptions
- This prevents future mismatches without requiring frontmatter descriptions to use pre-transformed typography

## Changes
- **`scripts/built_site_checks.py`**: Enhanced `_untransform_text()` with:
  - Em-dash/en-dash → hyphen normalization
  - Unicode diacritic stripping (naïve → naive, café → cafe, etc.) via NFKD decomposition
  - Comma+quote ordering normalization (`",` and `,"` → canonical form)
  - Ellipsis `…` → `...` normalization
  - Multi-space collapsing
- **`scripts/tests/test_built_site_checks.py`**: Added test cases for all new normalizations (dashes, diacritics, ellipsis, comma-inside-quotes)

## Testing
- All 822 tests in `test_built_site_checks.py` pass
- New test cases cover each normalization: em-dash, en-dash, diacritics (naïve, café, déjà vu), ellipsis, comma+quote ordering

https://claude.ai/code/session_01EZp23smrdQxmsWK7gv1N49