### PR TITLE
Restrict ffmpeg installation to Linux runners

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -153,7 +153,7 @@ runs:
       shell: bash
 
     - name: Install ffmpeg from system packages
-      if: inputs.install-ffmpeg == 'true'
+      if: inputs.install-ffmpeg == 'true' && runner.os == 'Linux'
       run: |
         # Skip if ffmpeg is already available (e.g. pre-installed in Docker image)
         if command -v ffprobe &>/dev/null; then


### PR DESCRIPTION
## Summary
Updated the ffmpeg installation step to only run on Linux runners, preventing unnecessary installation attempts on other operating systems.

## Changes
- Added `runner.os == 'Linux'` condition to the ffmpeg installation step in the setup-site GitHub Action
- This ensures the system package installation only executes on Linux-based runners where the apt-based installation method is applicable

## Details
The ffmpeg installation was previously attempted on all runners when `install-ffmpeg` was set to `true`. By restricting this to Linux runners only, we avoid potential failures or unnecessary operations on macOS and Windows runners that may have different package management systems or pre-installed ffmpeg availability.

https://claude.ai/code/session_01KDP49eQxBHakufhgDTj69Q