### PR TITLE
fix: relax Node engine requirement from >=24 to >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "engines": {
     "pnpm": ">=9.0.0",
-    "node": ">=24"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.23.0",
   "keywords": [


### PR DESCRIPTION
## Summary
- Relax the Node engine requirement in `package.json` from `>=24` to `>=22` so the project can build and test in environments without Node 24 (e.g. Claude Code web sessions)
- The only Node 24-specific API used (`RegExp.escape`) is polyfilled in `jest.setup.js` for tests, and natively available in all modern browsers for the client-side bundle

## Changes
- `package.json`: Changed `engines.node` from `">=24"` to `">=22"`

## Testing
- All 3,474 tests pass on Node 22.22.0
- Typecheck (`pnpm check`) passes cleanly
- CI workflows remain pinned to Node 24.11.0 and are unaffected

https://claude.ai/code/session_01CjZxqoQvJkbfd3vmkPEAk3