### PR TITLE
Skip Puppeteer download in sandboxed environments

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -194,6 +194,11 @@ uv_install_if_missing ots opentimestamps-client
 
 if [ -f "$PROJECT_DIR/package.json" ]; then
 	# Always run install (git hooks are configured in package.json postinstall)
+	# Skip Puppeteer's Chrome download — sandboxed environments can't reach
+	# storage.googleapis.com, and we use Playwright's browsers instead.
+	# Without this, subfont's nested `pnpm install` fails on puppeteer's
+	# postinstall, aborting the entire install and leaving node_modules incomplete.
+	export PUPPETEER_SKIP_DOWNLOAD=true
 	if command -v pnpm &>/dev/null; then
 		pnpm install --silent || warn "Failed to install Node dependencies"
 	elif command -v npm &>/dev/null; then


### PR DESCRIPTION
## Summary
Added environment variable configuration to skip Puppeteer's Chrome download during Node dependency installation in sandboxed environments where external network access is restricted.

## Changes
- Set `PUPPETEER_SKIP_DOWNLOAD=true` before running `pnpm install` or `npm install`
- Added explanatory comments documenting why this is necessary

## Details
Sandboxed environments cannot reach `storage.googleapis.com`, which is required for Puppeteer's postinstall script to download Chrome. This causes subfont's nested `pnpm install` to fail, aborting the entire installation and leaving `node_modules` incomplete.

Since the project uses Playwright's browsers instead of Puppeteer's, skipping this download is safe and allows the installation to complete successfully.

https://claude.ai/code/session_015zh856CniXruj4tcVBGQVA