### PR TITLE
Increase prepare-deploy job timeout from 30 to 120 minutes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
   prepare-deploy:
     needs: deploy-build
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
Extended the timeout for the `prepare-deploy` job in the GitHub Actions deployment workflow to accommodate longer deployment preparation times.

## Changes
- Increased `prepare-deploy` job timeout from 30 minutes to 120 minutes

## Details
The prepare-deploy job was timing out at 30 minutes, which was insufficient for the deployment preparation process. This change extends the timeout to 120 minutes to allow the job adequate time to complete without premature cancellation.

https://claude.ai/code/session_01RbiXUJhLUCEdcKTVLp51eM