### PR TITLE
Mark Firefox search navigation test as slow in CI

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -134,7 +134,10 @@ test("Search results appear and can be navigated (lostpixel)", async ({ page }, 
   })
 })
 
-test("ArrowDown navigation does not get stuck below the second result", async ({ page }) => {
+test("ArrowDown navigation does not get stuck below the second result", async ({
+  page,
+}, testInfo) => {
+  test.slow(testInfo.project.name.includes("Firefox"), "Firefox is slow in CI")
   await search(page, "Steering")
   await page.waitForLoadState("domcontentloaded")
 


### PR DESCRIPTION
## Summary
Updated the search navigation test to account for Firefox's slower performance in CI environments by marking it with `test.slow()`.

## Changes
- Modified the "ArrowDown navigation does not get stuck below the second result" test to accept `testInfo` parameter
- Added `test.slow()` call to mark the test as slow specifically when running on Firefox, providing additional timeout tolerance for CI execution

## Details
This change helps prevent flaky test failures on Firefox in CI by giving the test more time to complete, while keeping normal timeout behavior for other browsers.

https://claude.ai/code/session_01J2oQf8uF91xfV8BFeVhUkz