### PR TITLE
Remove Safari autoplay script removal from build workflow

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -21,11 +21,6 @@ on:
         required: false
         type: number
         default: 1
-      remove-safari-autoplay:
-        description: "Remove Safari autoplay script before build (for visual testing)"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   actions: read
@@ -41,14 +36,14 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
           filter: ${{ inputs.fetch-depth == 0 && 'blob:none' || '' }}
 
-      # Cache keyed on commit SHA + autoplay variant. First workflow to build
+      # Cache keyed on commit SHA. First workflow to build
       # populates the cache; subsequent workflows get a hit and skip the build.
       - name: Restore build cache
         id: cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: public/
-          key: site-build-${{ github.sha }}-autoplay-${{ inputs.remove-safari-autoplay }}
+          key: site-build-${{ github.sha }}
 
       - name: Setup Build Environment
         if: steps.cache.outputs.cache-hit != 'true'
@@ -60,10 +55,6 @@ jobs:
           install-system-deps: "true"
           cache-playwright: "true"
           cache-puppeteer: "true"
-
-      - name: Remove Safari autoplay script
-        if: inputs.remove-safari-autoplay && steps.cache.outputs.cache-hit != 'true'
-        run: rm -f ./quartz/static/scripts/safari-autoplay.js
 
       - name: Build site
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -72,7 +72,6 @@ jobs:
     uses: ./.github/workflows/build-site.yaml
     with:
       artifact-name: visual-testing-public-dir
-      remove-safari-autoplay: true
 
   # Chromium + Firefox on main; Chromium-only on PRs/merge queue
   visual-testing-linux:

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -515,6 +515,13 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
   }
 
   await Promise.all([pauseMedia("video", "start"), pauseMedia("audio", "end")])
+
+  // Remove the autoplay attribute so the Safari autoplay script
+  // (safari-autoplay.js) won't restart videos on user-interaction events.
+  const videoScope = scope ?? page
+  for (const video of await videoScope.locator("video[autoplay]").all()) {
+    await video.evaluate((el) => el.removeAttribute("autoplay"))
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR removes the conditional removal of the Safari autoplay script from the build workflow and instead handles autoplay attribute removal directly in the visual testing utilities.

## Key Changes
- Removed the `remove-safari-autoplay` input parameter from the `build-site.yaml` workflow
- Simplified the build cache key to only use the commit SHA (previously included the autoplay variant)
- Removed the build step that conditionally deleted `safari-autoplay.js`
- Moved autoplay handling to the visual testing utilities by adding logic to `pauseMediaElements()` that removes the `autoplay` attribute from video elements, preventing the Safari autoplay script from restarting videos on user-interaction events
- Updated `visual-testing.yaml` to remove the `remove-safari-autoplay: true` parameter when calling the build workflow

## Implementation Details
The autoplay attribute removal is now handled at the test level in `quartz/components/tests/visual_utils.ts`. After pausing media elements, the code iterates through all `video[autoplay]` elements and removes their autoplay attributes using DOM evaluation. This approach is more targeted and avoids the need for build-time script removal, simplifying the workflow while maintaining the same visual testing behavior.

https://claude.ai/code/session_01BMGALy6zETCFVbzrJoSsqA