### PR TITLE
fix(tests): resolve Playwright flakiness on Safari and Firefox

### DIFF
--- a/quartz/components/tests/darkmode.spec.ts
+++ b/quartz/components/tests/darkmode.spec.ts
@@ -17,6 +17,15 @@ const NAVIGATION_PREFIXES = ["./shard-theory", "./about", "./design#"]
 test.beforeEach(async ({ page }) => {
   await gotoPage(page, "http://localhost:8080/test-page")
   await page.emulateMedia({ colorScheme: AUTO_THEME })
+  // Wait for setupDarkMode() to finish (fires on initial "nav" event).
+  // Without this, WebKit/Safari can destroy the execution context before
+  // the first page.evaluate in the test body.
+  await page.waitForFunction(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => (window as any).__darkmodeReady === true,
+    null,
+    { timeout: 15_000 },
+  )
 })
 
 class DarkModeHelper {

--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -17,10 +17,13 @@ test.describe("Random dropcap color", () => {
     await page.addInitScript(mockRandom, [0.5])
     await gotoPage(page, DROPCAP_URL)
 
-    const color = await page.evaluate(() =>
-      document.documentElement.style.getPropertyValue("--random-dropcap-color"),
-    )
-    expect(color).toBe("")
+    // Retry: WebKit/Safari can destroy the execution context briefly after load
+    await expect(async () => {
+      const color = await page.evaluate(() =>
+        document.documentElement.style.getPropertyValue("--random-dropcap-color"),
+      )
+      expect(color).toBe("")
+    }).toPass({ timeout: 10_000 })
   })
 
   for (const [i, color] of DROPCAP_COLORS.entries()) {
@@ -29,10 +32,13 @@ test.describe("Random dropcap color", () => {
       await page.addInitScript(mockRandom, [0.01, colorFraction])
       await gotoPage(page, DROPCAP_URL)
 
-      const value = await page.evaluate(() =>
-        document.documentElement.style.getPropertyValue("--random-dropcap-color"),
-      )
-      expect(value).toBe(`var(--dropcap-background-${color})`)
+      // Retry: WebKit/Safari can destroy the execution context briefly after load
+      await expect(async () => {
+        const value = await page.evaluate(() =>
+          document.documentElement.style.getPropertyValue("--random-dropcap-color"),
+        )
+        expect(value).toBe(`var(--dropcap-background-${color})`)
+      }).toPass({ timeout: 10_000 })
     })
   }
 

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -572,6 +572,8 @@ test("Video timestamp is preserved during SPA navigation", async ({ page }) => {
 
 test("Video timestamp is preserved during refresh", async ({ page }) => {
   test.skip(!isDesktopViewport(page), "Desktop-only test")
+  // reloadPage + video timestamp restoration can exceed the default 30s in Firefox
+  test.setTimeout(60_000)
 
   const videoElements = getVideoElements(page)
   const timestampBeforeRefresh = await setupVideoForTimestampTest(videoElements)


### PR DESCRIPTION
## Summary

- **darkmode.spec.ts**: Wait for `__darkmodeReady` in `beforeEach` to prevent WebKit "Execution context destroyed" errors from racing with page initialization
- **dropcap.spec.ts**: Wrap `page.evaluate` + assertion in `toPass()` retry for the same WebKit context destruction issue after `gotoPage`
- **navbar.spec.ts**: Increase test timeout to 60s for "Video timestamp preserved during refresh" since `reloadPage` + video restore exceeds the default 30s on Firefox

## Test plan

- [ ] Lint and validate CI passes
- [ ] Playwright tests pass on Linux (add `ci:run-playwright` label)
- [ ] No new test failures introduced

https://claude.ai/code/session_01NprHsUtv3HfVLJy8oKug56