### PR TITLE
ci: reduce CI costs and Actions tab spam

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -51,7 +51,7 @@ jobs:
     if: needs.should-run.outputs.run == 'true'
     uses: ./.github/workflows/build-site.yaml
 
-  a11y:
+  a11y-test:
     needs: [should-run, a11y-build]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -121,7 +121,7 @@ jobs:
   a11y-status:
     name: a11y
     if: always()
-    needs: [should-run, a11y]
+    needs: [should-run, a11y-test]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -131,7 +131,7 @@ jobs:
             echo "Tests were skipped (no label)"
             exit 0
           fi
-          if [[ "${{ needs.a11y.result }}" != "success" ]]; then
-            echo "a11y tests did not succeed (${{ needs.a11y.result }})"
+          if [[ "${{ needs.a11y-test.result }}" != "success" ]]; then
+            echo "a11y tests did not succeed (${{ needs.a11y-test.result }})"
             exit 1
           fi

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    types: [labeled, synchronize, opened, reopened]
     paths:
       - "quartz/**"
       - "!quartz/**/*.spec.ts"
@@ -29,12 +30,29 @@ permissions:
   contents: read
 
 jobs:
+  should-run:
+    name: a11y-should-run
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          run-labels: "ci:full-tests,ci:run-a11y"
+
   a11y-build:
-    if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
     uses: ./.github/workflows/build-site.yaml
 
   a11y:
-    needs: a11y-build
+    needs: [should-run, a11y-build]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -98,3 +116,22 @@ jobs:
           done
 
           kill $SERVER_PID 2>/dev/null || true
+
+  # Unified status check — provides passing status when gated off on PRs
+  a11y-status:
+    name: a11y
+    if: always()
+    needs: [should-run, a11y]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
+            echo "Tests were skipped (no label)"
+            exit 0
+          fi
+          if [[ "${{ needs.a11y.result }}" != "success" ]]; then
+            echo "a11y tests did not succeed (${{ needs.a11y.result }})"
+            exit 1
+          fi

--- a/.github/workflows/auto-merge-deepsource.yml
+++ b/.github/workflows/auto-merge-deepsource.yml
@@ -1,5 +1,7 @@
 name: Auto-merge DeepSource Style PRs
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 permissions:
   actions: read

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,9 @@ name: Auto-merge Dependabot PRs
 # pull_request_target is required because Dependabot PRs run from a
 # fork-like context and need write permissions. This is safe as long as
 # no step checks out or executes PR code.
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened]
 
 permissions:
   contents: write

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -9,21 +9,7 @@ on:
   push:
     branches: ["main", "dev", "no-layout-shift"]
   pull_request:
-    paths:
-      - "quartz/**/*.scss"
-      - "quartz/**/*.tsx"
-      - "!quartz/**/*.test.tsx"
-      - "quartz/**/*.ts"
-      - "!quartz/**/*.spec.ts"
-      - "!quartz/**/*.test.ts"
-      - "!quartz/**/tests/**"
-      - "quartz/static/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
-      - ".github/lighthouse-*.json"
+    types: [labeled]
   merge_group:
 
 permissions:
@@ -39,10 +25,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      run: ${{ steps.check.outputs.run }}
+      run: ${{ steps.gate.outputs.run }}
     steps:
-      - id: check
-        run: echo "run=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          run-labels: "ci:full-tests,ci:run-lighthouse"
 
   build:
     needs: should-run

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "dev", "no-layout-shift"]
+    branches: ["main", "dev"]
   pull_request:
     types: [labeled]
   merge_group:

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -8,6 +8,14 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
+    paths:
+      - "quartz/**"
+      - "website_content/**"
+      - "config/**"
+      - "scripts/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/**"
   merge_group:
 
 permissions:

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -1,7 +1,7 @@
 name: Playwright Flake Check
 
 # Runs each Playwright test multiple times to detect flaky tests.
-# Triggered manually or by adding the ci:flake-check label to a PR.
+# Manual-only: use the "Run workflow" button in the Actions UI.
 
 concurrency:
   group: playwright-flake-check-${{ github.ref_name }}
@@ -15,48 +15,32 @@ on:
         required: false
         default: "3"
         type: string
-  pull_request:
-    types: [labeled]
 
 permissions:
   actions: read
   contents: read
 
 jobs:
-  should-run:
-    name: flake-check-gate
+  setup:
+    name: flake-check-setup
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      run: ${{ steps.check.outputs.run }}
       repeat: ${{ steps.check.outputs.repeat }}
     steps:
       - id: check
         env:
-          EVENT_NAME: ${{ github.event_name }}
           REPEAT_EACH: ${{ github.event.inputs.repeat-each || '3' }}
-          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:flake-check') }}
-        run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "repeat=$REPEAT_EACH" >> "$GITHUB_OUTPUT"
-          elif [[ "$HAS_LABEL" == "true" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "repeat=3" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "repeat=3" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "repeat=$REPEAT_EACH" >> "$GITHUB_OUTPUT"
 
   build:
     name: flake-check-build
-    needs: should-run
-    if: needs.should-run.outputs.run == 'true'
+    needs: setup
     uses: ./.github/workflows/build-site.yaml
 
   # Chromium + Firefox flake check on Linux
   flake-check-linux:
-    needs: [should-run, build]
+    needs: [setup, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -86,7 +70,7 @@ jobs:
           key: site-build-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - name: Run Playwright tests (repeat-each=${{ needs.should-run.outputs.repeat }})
+      - name: Run Playwright tests (repeat-each=${{ needs.setup.outputs.repeat }})
         id: playwright
         continue-on-error: true
         run: |
@@ -95,7 +79,7 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!lostpixel).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${{ needs.should-run.outputs.repeat }} \
+            --repeat-each ${{ needs.setup.outputs.repeat }} \
             | tee playwright-flake.log
 
       - name: Sanitize shard name
@@ -146,7 +130,7 @@ jobs:
 
   # WebKit flake check on macOS
   flake-check-macos:
-    needs: [should-run, build]
+    needs: [setup, build]
     runs-on: macos-14
     timeout-minutes: 90
     strategy:
@@ -182,7 +166,7 @@ jobs:
           key: site-build-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - name: Run Playwright tests (repeat-each=${{ needs.should-run.outputs.repeat }})
+      - name: Run Playwright tests (repeat-each=${{ needs.setup.outputs.repeat }})
         id: playwright
         continue-on-error: true
         run: |
@@ -191,7 +175,7 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!lostpixel).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${{ needs.should-run.outputs.repeat }} \
+            --repeat-each ${{ needs.setup.outputs.repeat }} \
             | tee playwright-flake.log
 
       - name: Sanitize shard name
@@ -244,16 +228,12 @@ jobs:
   flake-check:
     name: flake-check
     if: always()
-    needs: [should-run, flake-check-linux, flake-check-macos]
+    needs: [flake-check-linux, flake-check-macos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
-            echo "Flake check was skipped (no label/dispatch)"
-            exit 0
-          fi
           if [[ "${{ needs.flake-check-linux.result }}" != "success" ]] || \
              [[ "${{ needs.flake-check-macos.result }}" != "success" ]]; then
             echo "Flake check did not succeed (linux=${{ needs.flake-check-linux.result }}, macos=${{ needs.flake-check-macos.result }})"

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -98,7 +98,7 @@ jobs:
           retention-days: 3
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: flake-check-winston-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -194,7 +194,7 @@ jobs:
           retention-days: 3
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: flake-check-winston-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -98,7 +98,7 @@ jobs:
           retention-days: 3
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: flake-check-winston-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -194,7 +194,7 @@ jobs:
           retention-days: 3
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: flake-check-winston-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -64,18 +64,14 @@ jobs:
       matrix:
         shard:
           [
-            "1/12",
-            "2/12",
-            "3/12",
-            "4/12",
-            "5/12",
-            "6/12",
-            "7/12",
-            "8/12",
-            "9/12",
-            "10/12",
-            "11/12",
-            "12/12",
+            "1/8",
+            "2/8",
+            "3/8",
+            "4/8",
+            "5/8",
+            "6/8",
+            "7/8",
+            "8/8",
           ]
     env:
       PLAYWRIGHT_BROWSERS: ${{ needs.should-run.outputs.browsers }}
@@ -123,7 +119,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -224,7 +220,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -119,7 +119,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -220,7 +220,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main", "dev"]
     paths:

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -23,6 +23,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/actions/**"
   pull_request:
+    types: [labeled, synchronize, opened, reopened]
     paths:
       - "quartz/**"
       - "!quartz/**/*.spec.ts"
@@ -45,15 +46,32 @@ permissions:
   contents: read
 
 jobs:
+  should-run:
+    name: site-checks-should-run
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          run-labels: "ci:full-tests,ci:run-site-checks"
+
   build:
     name: site-checks-build
-    if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
     uses: ./.github/workflows/build-site.yaml
     with:
       fetch-depth: 0
 
   built-site-checks:
-    needs: build
+    needs: [should-run, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     steps:
@@ -91,7 +109,7 @@ jobs:
         run: uv run python scripts/built_site_checks.py
 
   linkchecker:
-    needs: build
+    needs: [should-run, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 12
     steps:
@@ -140,5 +158,25 @@ jobs:
             echo "Link checks failed:"
             echo "Internal linkchecker: $INTERNAL_STATUS"
             echo "External linkchecker: $EXTERNAL_STATUS"
+            exit 1
+          fi
+
+  # Unified status check — provides passing status when gated off on PRs
+  site-build-checks:
+    name: site-build-checks
+    if: always()
+    needs: [should-run, built-site-checks, linkchecker]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
+            echo "Tests were skipped (no label)"
+            exit 0
+          fi
+          if [[ "${{ needs.built-site-checks.result }}" != "success" ]] || \
+             [[ "${{ needs.linkchecker.result }}" != "success" ]]; then
+            echo "Site build checks did not succeed (checks=${{ needs.built-site-checks.result }}, links=${{ needs.linkchecker.result }})"
             exit 1
           fi

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -113,6 +113,15 @@ jobs:
           fi
           echo "Current template version: $TEMPLATE_SHA"
 
+          # Early exit: nothing to sync if template hasn't changed
+          if [ "$PREV_SHA" = "$TEMPLATE_SHA" ]; then
+            echo "Template is already at $TEMPLATE_SHA_SHORT — nothing to sync"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_conflicts=false" >> $GITHUB_OUTPUT
+            echo "has_deletions=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Generate changelog between versions if we have a previous SHA
           if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
             CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA" 2>/dev/null || echo "Could not generate changelog (previous SHA may no longer exist)")

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -120,7 +120,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -229,7 +229,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: failure()
+        if: steps.playwright.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -120,7 +120,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -229,7 +229,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Winston logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: winston-logs-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,13 +203,14 @@ After pushing to main:
 
 ### CI Cost Optimization
 
-- **Expensive tests always run on main**: Pushes to main always trigger Playwright, visual, and Lighthouse tests. All three workflows also support `workflow_dispatch` for manual triggering from the Actions UI.
-- **Cheap checks always run on PRs**: Accessibility (pa11y) runs on every PR push (with path filters). No label required.
+- **Expensive tests always run on main**: Pushes to main always trigger Playwright, visual, Lighthouse, a11y, and site-build-checks. These workflows also support `workflow_dispatch` for manual triggering from the Actions UI.
 - **Per-commit CI labels on PRs**: On PRs, expensive tests only run when a CI label is _actively added_ (one-shot per commit, not persistent). Adding a label triggers tests for the current HEAD; the next push won't re-trigger unless the label is added again. Labels:
   - `ci:run-playwright` — Playwright integration tests only (Linux shards only on PRs)
   - `ci:run-visual` — Visual regression tests only (Linux shards only on PRs)
   - `ci:run-lighthouse` — Lighthouse performance/CLS/audit tests only
-  - `ci:full-tests` — All of the above (Playwright + visual + Lighthouse)
+  - `ci:run-a11y` — Accessibility (pa11y) tests only
+  - `ci:run-site-checks` — Site build checks and link validation only
+  - `ci:full-tests` — All of the above
 
   Path filters further limit PR triggers to relevant file changes. **When creating a PR that modifies Playwright tests or interaction behavior, add the appropriate label** (e.g., `gh pr edit <number> --add-label "ci:run-playwright"`). Labels are per-commit: re-add to run again on the next push.
 - **Flake check**: `workflow_dispatch` only (manual trigger via Actions UI). Not triggered by labels or PR events. Configurable `repeat-each` count (default 3).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,14 +204,15 @@ After pushing to main:
 ### CI Cost Optimization
 
 - **Expensive tests always run on main**: Pushes to main always trigger Playwright, visual, and Lighthouse tests. All three workflows also support `workflow_dispatch` for manual triggering from the Actions UI.
-- **Cheap checks always run on PRs**: Accessibility (pa11y) and Lighthouse run on every PR push (with path filters). No label required.
+- **Cheap checks always run on PRs**: Accessibility (pa11y) runs on every PR push (with path filters). No label required.
 - **Per-commit CI labels on PRs**: On PRs, expensive tests only run when a CI label is _actively added_ (one-shot per commit, not persistent). Adding a label triggers tests for the current HEAD; the next push won't re-trigger unless the label is added again. Labels:
   - `ci:run-playwright` — Playwright integration tests only (Linux shards only on PRs)
   - `ci:run-visual` — Visual regression tests only (Linux shards only on PRs)
-  - `ci:full-tests` — All of the above (Playwright + visual)
-  - `ci:flake-check` — Run Playwright tests with `--repeat-each 3` to detect flaky tests (also available via `workflow_dispatch` with configurable repeat count)
+  - `ci:run-lighthouse` — Lighthouse performance/CLS/audit tests only
+  - `ci:full-tests` — All of the above (Playwright + visual + Lighthouse)
 
   Path filters further limit PR triggers to relevant file changes. **When creating a PR that modifies Playwright tests or interaction behavior, add the appropriate label** (e.g., `gh pr edit <number> --add-label "ci:run-playwright"`). Labels are per-commit: re-add to run again on the next push.
+- **Flake check**: `workflow_dispatch` only (manual trigger via Actions UI). Not triggered by labels or PR events. Configurable `repeat-each` count (default 3).
 - **Shared builds**: Playwright, visual testing, and site-build-checks each build the site once and share the artifact across shards/jobs.
 - **Path filters**: PR workflows only trigger when relevant files change. Each workflow lists only the `config/` subdirectories it actually uses. Build/deploy workflows exclude test files from triggering.
 - **Skip CI**: Use `[skip ci]` in commit messages to skip all workflows for a commit.


### PR DESCRIPTION
## Summary

- **Flake check**: `workflow_dispatch` only — never auto-runs on PR label events
- **Lighthouse, a11y, site-build-checks**: label-gated on PRs (`ci:run-lighthouse`, `ci:run-a11y`, `ci:run-site-checks`, or `ci:full-tests`); always run on push to main
- **Playwright Linux shards**: 12 → 8 (saves ~8-12 min setup overhead per run)
- **Winston logs**: upload only on failure instead of always (6 fewer artifact uploads per passing run)
- **Lint-and-validate**: path-filtered on PRs (skips README/CLAUDE.md-only changes)
- **Auto-merge workflows**: only trigger on PR `opened` (not every `synchronize`)
- **Lighthouse**: removed defunct `no-layout-shift` branch trigger
- **Template sync**: early-exit when template SHA unchanged (skips daily no-ops)

All gated workflows use unified status check jobs so branch protection required checks still pass on PRs without labels. Pushes to main are unaffected — ci-gate returns `run=true` for all non-PR events.

## Test plan

- [ ] Verify pushes to main still trigger all workflows (Playwright, visual, Lighthouse, a11y, site-build-checks)
- [ ] Verify PRs without CI labels only run cheap gate jobs (should-run → run=false → unified status passes)
- [ ] Verify adding `ci:full-tests` label to a PR triggers all gated workflows
- [ ] Verify flake check only available via Actions UI "Run workflow" button
- [ ] Confirm branch protection required checks still pass on unlabeled PRs

https://claude.ai/code/session_01ERHV2WG9gK2ohmTPJRrbUz