### PR TITLE
fix(ci): prevent silent timeout failures in Playwright workflows

### DIFF
--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -81,6 +81,9 @@ jobs:
             --shard ${{ matrix.shard }} \
             --repeat-each ${{ needs.setup.outputs.repeat }} \
             | tee playwright-flake.log
+        env:
+          # 90 min job timeout → 85 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
@@ -177,6 +180,9 @@ jobs:
             --shard ${{ matrix.shard }} \
             --repeat-each ${{ needs.setup.outputs.repeat }} \
             | tee playwright-flake.log
+        env:
+          # 90 min job timeout → 85 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -102,6 +102,9 @@ jobs:
         run: |
           set -o pipefail
           pnpm exec playwright test --config config/playwright/playwright.config.ts --grep "^(?:(?!lostpixel).)*$" --shard ${{ matrix.shard }} | tee playwright-run.log
+        env:
+          # 20 min job timeout → 15 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "900000"
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
@@ -203,6 +206,9 @@ jobs:
         run: |
           set -o pipefail
           pnpm exec playwright test --config config/playwright/playwright.config.ts --grep "^(?:(?!lostpixel).)*$" --shard ${{ matrix.shard }} | tee playwright-run.log
+        env:
+          # 50 min job timeout → 45 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2700000"
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -103,6 +103,8 @@ jobs:
         env:
           CI: true
           NODE_OPTIONS: "--max-old-space-size=4096"
+          # 25 min job timeout → 20 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "1200000"
 
       - name: Create sanitized shard
         if: always()
@@ -111,7 +113,7 @@ jobs:
           MATRIX_SHARD: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
-        if: steps.playwright.outcome == 'failure'
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: visual-testing-log-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -129,7 +131,7 @@ jobs:
           retention-days: 1
 
       - name: Upload webServer build logs
-        if: steps.playwright.outcome == 'failure'
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: webserver-build-log-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -138,11 +140,12 @@ jobs:
           retention-days: 1
 
       - name: Upload Playwright traces
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        if: steps.playwright.outcome == 'failure'
         with:
           name: playwright-traces-linux-shard-${{ env.SANITIZED_SHARD }}
           path: test-results/
+          if-no-files-found: warn
           retention-days: 1
 
       - name: Upload Lost Pixel screenshots shard
@@ -154,7 +157,7 @@ jobs:
           retention-days: 1
 
       - name: Fail if playwright tests failed
-        if: steps.playwright.outcome == 'failure'
+        if: steps.playwright.outcome != 'success'
         run: exit 1
 
   # WebKit (Safari) visual tests on macOS for real Safari fidelity
@@ -212,6 +215,8 @@ jobs:
         env:
           CI: true
           NODE_OPTIONS: "--max-old-space-size=4096"
+          # 40 min job timeout → 35 min Playwright global timeout
+          PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2100000"
 
       - name: Create sanitized shard
         if: always()
@@ -220,7 +225,7 @@ jobs:
           MATRIX_SHARD: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
-        if: steps.playwright.outcome == 'failure'
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: visual-testing-log-macos-shard-${{ env.SANITIZED_SHARD }}
@@ -238,7 +243,7 @@ jobs:
           retention-days: 1
 
       - name: Upload webServer build logs
-        if: steps.playwright.outcome == 'failure'
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: webserver-build-log-macos-shard-${{ env.SANITIZED_SHARD }}
@@ -247,11 +252,12 @@ jobs:
           retention-days: 1
 
       - name: Upload Playwright traces
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        if: steps.playwright.outcome == 'failure'
         with:
           name: playwright-traces-macos-shard-${{ env.SANITIZED_SHARD }}
           path: test-results/
+          if-no-files-found: warn
           retention-days: 1
 
       - name: Upload Lost Pixel screenshots shard
@@ -263,7 +269,7 @@ jobs:
           retention-days: 1
 
       - name: Fail if playwright tests failed
-        if: steps.playwright.outcome == 'failure'
+        if: steps.playwright.outcome != 'success'
         run: exit 1
 
   # Unified status check — required by branch protection
@@ -293,7 +299,13 @@ jobs:
 
   summarize-failures:
     name: Summarize Failures
-    if: always() && (needs.visual-testing-linux.result == 'failure' || needs.visual-testing-macos.result == 'failure')
+    if: >-
+      always() && (
+        needs.visual-testing-linux.result == 'failure' ||
+        needs.visual-testing-linux.result == 'cancelled' ||
+        needs.visual-testing-macos.result == 'failure' ||
+        needs.visual-testing-macos.result == 'cancelled'
+      )
     needs: [visual-testing-linux, visual-testing-macos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
   // than its job timeout-minutes, giving Playwright time to report errors
   // and upload artifacts before GitHub Actions kills the runner.
   globalTimeout: process.env.PLAYWRIGHT_GLOBAL_TIMEOUT_MS
-    ? parseInt(process.env.PLAYWRIGHT_GLOBAL_TIMEOUT_MS)
+    ? Number(process.env.PLAYWRIGHT_GLOBAL_TIMEOUT_MS)
     : process.env.CI
       ? 45 * 60 * 1000
       : undefined,

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -76,9 +76,14 @@ export default defineConfig({
   timeout: 30000,
   // Cap total shard runtime in CI so tests fail with output instead of
   // silently hanging until the GitHub Actions job timeout kills them.
-  // Visual testing macOS: 40 min job → 35 min global.
-  // Playwright macOS: 50 min job → 45 min global.
-  globalTimeout: process.env.CI ? 45 * 60 * 1000 : undefined,
+  // Each workflow job sets PLAYWRIGHT_GLOBAL_TIMEOUT_MS to ~5 min less
+  // than its job timeout-minutes, giving Playwright time to report errors
+  // and upload artifacts before GitHub Actions kills the runner.
+  globalTimeout: process.env.PLAYWRIGHT_GLOBAL_TIMEOUT_MS
+    ? parseInt(process.env.PLAYWRIGHT_GLOBAL_TIMEOUT_MS)
+    : process.env.CI
+      ? 45 * 60 * 1000
+      : undefined,
   fullyParallel: true,
   // macOS-14 M1 runners have 3 cores but Playwright defaults to 1 worker for
   // WebKit, causing shards to hit their job timeout. Force 3 workers on macOS.


### PR DESCRIPTION
## Summary
- Playwright's `globalTimeout` was hardcoded to 45 min, but several jobs have shorter GitHub Actions `timeout-minutes` (as low as 20 min). When GHA killed the job first, Playwright produced zero diagnostic output — no error messages, no artifacts.
- `visual-testing.yaml` still used old artifact/failure patterns (`== 'failure'` instead of `if: always()` / `!= 'success'`) that were already fixed in `playwright-tests.yaml` by PR #1100. This meant cancelled/timed-out visual test runs produced no artifacts.

## Changes
- **`playwright.config.ts`**: `globalTimeout` now reads `PLAYWRIGHT_GLOBAL_TIMEOUT_MS` env var, falling back to 45 min default
- **All 3 workflow files** (`visual-testing.yaml`, `playwright-tests.yaml`, `playwright-flake-check.yaml`): Each job sets `PLAYWRIGHT_GLOBAL_TIMEOUT_MS` to ~5 min less than its `timeout-minutes`, giving Playwright time to report errors and upload artifacts before GitHub Actions kills the runner:
  - playwright-tests-linux: 20 min job → 15 min global
  - playwright-tests-macos: 50 min job → 45 min global
  - visual-testing-linux: 25 min job → 20 min global
  - visual-testing-macos: 40 min job → 35 min global
  - flake-check (both): 90 min job → 85 min global
- **`visual-testing.yaml`**: Aligned with PR #1100 improvements:
  - Artifact uploads (logs, webserver logs, traces) changed to `if: always()`
  - Failure detection changed from `== 'failure'` to `!= 'success'`
  - `summarize-failures` now includes `cancelled` state
  - Added `if-no-files-found: warn` to trace uploads

## Testing
- Type checking passes (`pnpm check`)
- Pre-push checks pass (linting, formatting)
- Changes are CI-only config — verifiable on next CI run

https://claude.ai/code/session_01AFdjmmxCQqHoWCCqk6TnnP