### PR TITLE
fix: increase WebKit timeouts for sequential search tests

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -308,8 +308,11 @@ test("Search results work for a single character", async ({ page }, testInfo) =>
 })
 
 test("Preview element persists after closing and reopening search", async ({ page }, testInfo) => {
-  // Two full search + preview cycles can exceed 30s on Firefox in CI
-  test.slow(testInfo.project.name.includes("Firefox"), "Firefox is slow in CI")
+  // Two full search + preview cycles can exceed default timeouts on Firefox and WebKit
+  test.slow(
+    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
+    "Firefox and WebKit are slow in CI",
+  )
   await search(page, "Steering")
   await waitForArticlePreview(page)
 

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -267,8 +267,11 @@ test("search matches in headers have correct color styling", async ({ page }) =>
 })
 
 test("Search results are case-insensitive", async ({ page }, testInfo) => {
-  // Two sequential searches can exceed 30s on Firefox tablet viewports
-  test.slow(testInfo.project.name.includes("Firefox"), "Firefox is slow in CI")
+  // Two sequential searches can exceed default timeouts on Firefox and WebKit
+  test.slow(
+    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
+    "Firefox and WebKit are slow in CI",
+  )
 
   await search(page, "TEST")
   await expect(page.locator(".result-card").first()).toBeVisible()
@@ -763,7 +766,10 @@ test("Result card matching stays synchronized with preview", async ({ page }) =>
 test("should not select a search result on initial render, even if the mouse is hovering over it", async ({
   page,
 }, testInfo) => {
-  testInfo.setTimeout(60_000)
+  // Two sequential searches with mouse coordination need extra time,
+  // especially on WebKit which has a 90s project timeout.
+  test.slow(testInfo.project.name.includes("Safari"), "WebKit is slow in CI")
+  testInfo.setTimeout(Math.max(60_000, testInfo.timeout))
   await search(page, "alignment")
 
   // Figure out where the second result is, and hover over it

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -766,10 +766,11 @@ test("Result card matching stays synchronized with preview", async ({ page }) =>
 test("should not select a search result on initial render, even if the mouse is hovering over it", async ({
   page,
 }, testInfo) => {
-  // Two sequential searches with mouse coordination need extra time,
-  // especially on WebKit which has a 90s project timeout.
-  test.slow(testInfo.project.name.includes("Safari"), "WebKit is slow in CI")
-  testInfo.setTimeout(Math.max(60_000, testInfo.timeout))
+  // Two sequential searches can exceed default timeouts on Firefox and WebKit
+  test.slow(
+    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
+    "Firefox and WebKit are slow in CI",
+  )
   await search(page, "alignment")
 
   // Figure out where the second result is, and hover over it


### PR DESCRIPTION
## Summary
- Two search tests on iPad Pro Safari (WebKit) were timing out on macOS CI
- "Search results are case-insensitive" had `test.slow()` only for Firefox, not WebKit
- "should not select a search result on initial render" had an explicit 60s timeout shorter than WebKit's 90s project default
- Both now use the same `test.slow()` pattern for Firefox and Safari

## Test plan
- [ ] Playwright tests pass on macOS WebKit (iPad Pro Safari)
- [ ] No regressions on other browsers/viewports

https://claude.ai/code/session_01SYiA1dVw9dYEz17R4P1iKH