### PR TITLE
Optimize search test timeouts by moving Safari slow marker to beforeEach

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -17,7 +17,10 @@ import {
   moveMouseToSafePosition,
 } from "./visual_utils"
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  // Safari/WebKit is consistently slow for search operations in CI
+  test.slow(testInfo.project.name.includes("Safari"), "Safari/WebKit is slow for search in CI")
+
   // Log any console errors
   page.on("pageerror", (err) => console.error(err))
 
@@ -267,10 +270,10 @@ test("search matches in headers have correct color styling", async ({ page }) =>
 })
 
 test("Search results are case-insensitive", async ({ page }, testInfo) => {
-  // Two sequential searches can exceed default timeouts on Firefox and WebKit
+  // Two sequential searches can exceed default timeouts on Firefox
   test.slow(
-    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
-    "Firefox and WebKit are slow in CI",
+    testInfo.project.name.includes("Firefox"),
+    "Firefox is slow in CI",
   )
 
   await search(page, "TEST")
@@ -308,10 +311,10 @@ test("Search results work for a single character", async ({ page }, testInfo) =>
 })
 
 test("Preview element persists after closing and reopening search", async ({ page }, testInfo) => {
-  // Two full search + preview cycles can exceed default timeouts on Firefox and WebKit
+  // Two full search + preview cycles can exceed default timeouts on Firefox
   test.slow(
-    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
-    "Firefox and WebKit are slow in CI",
+    testInfo.project.name.includes("Firefox"),
+    "Firefox is slow in CI",
   )
   await search(page, "Steering")
   await waitForArticlePreview(page)
@@ -769,10 +772,10 @@ test("Result card matching stays synchronized with preview", async ({ page }) =>
 test("should not select a search result on initial render, even if the mouse is hovering over it", async ({
   page,
 }, testInfo) => {
-  // Two sequential searches can exceed default timeouts on Firefox and WebKit
+  // Two sequential searches can exceed default timeouts on Firefox
   test.slow(
-    testInfo.project.name.includes("Firefox") || testInfo.project.name.includes("Safari"),
-    "Firefox and WebKit are slow in CI",
+    testInfo.project.name.includes("Firefox"),
+    "Firefox is slow in CI",
   )
   await search(page, "alignment")
 


### PR DESCRIPTION
## Summary
Refactored search test timeout handling to more efficiently manage Safari/WebKit performance issues in CI by centralizing the slow marker in the `beforeEach` hook rather than repeating it across multiple individual tests.

## Key Changes
- Added `testInfo` parameter to `beforeEach` hook and applied `test.slow()` for Safari/WebKit globally, eliminating the need to repeat this check in individual tests
- Removed Safari/WebKit slow markers from four individual tests:
  - "Search results are case-insensitive"
  - "Preview element persists after closing and reopening search"
  - "should not select a search result on initial render, even if the mouse is hovering over it"
- Updated comments to reflect that only Firefox (not Safari/WebKit) requires individual test-level slow markers for specific multi-operation scenarios
- Simplified conditional logic by removing redundant Safari checks from individual tests

## Implementation Details
This change reduces code duplication and improves maintainability by recognizing that Safari/WebKit slowness is a consistent CI environment issue that affects all search operations, not just specific test cases. The global `beforeEach` marker provides a blanket timeout extension for all Safari tests, while Firefox-specific slow markers remain in tests that perform multiple sequential search operations that can still exceed timeouts even with the global extension.

https://claude.ai/code/session_01P9TxPvvEDPfHWwtqsYTfrX