### PR TITLE
fix: format page titles in search results and RSS feed

### DIFF
--- a/quartz/plugins/emitters/contentIndex.test.ts
+++ b/quartz/plugins/emitters/contentIndex.test.ts
@@ -1,6 +1,7 @@
 import { jest, describe, it, beforeAll, beforeEach, expect } from "@jest/globals"
 
 import { type QuartzConfig } from "../../cfg"
+import { uiStrings } from "../../components/constants"
 import { type BuildCtx } from "../../util/ctx"
 import { type FilePath, type FullSlug } from "../../util/path"
 import { type StaticResources } from "../../util/resources"
@@ -68,10 +69,12 @@ describe("ContentIndex", () => {
     write.mock.calls.find((c) => c[0].slug.includes(slugSubstring))
 
   // --- Title formatting (the fix under test) ---
-  it.each([
+  const titleTransformCases: [string, string, string][] = [
     ["straight quotes become smart quotes", '"hello world"', "\u201CHello World\u201D"],
     ["hyphens become em-dashes", "before -- after", "\u2014"],
-  ])("%s in content index JSON", async (_, input, expected) => {
+  ]
+
+  it.each(titleTransformCases)("%s in content index JSON", async (_, input, expected) => {
     const plugin = ContentIndex({ enableSiteMap: false, enableRSS: false })
     await plugin.emit(mockCtx, makeContent(input), mockResources)
 
@@ -80,10 +83,7 @@ describe("ContentIndex", () => {
     expect(index["test-post"].title).toContain(expected)
   })
 
-  it.each([
-    ["straight quotes become smart quotes", '"hello world"', "\u201CHello World\u201D"],
-    ["hyphens become em-dashes", "before -- after", "\u2014"],
-  ])("%s in RSS feed", async (_, input, expected) => {
+  it.each(titleTransformCases)("%s in RSS feed", async (_, input, expected) => {
     const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true })
     await plugin.emit(mockCtx, makeContent(input), mockResources)
 
@@ -143,20 +143,22 @@ describe("ContentIndex", () => {
     expect(rssCall![0].content).toContain("\u201C")
   })
 
-  it("uses richContent for RSS when rssFullHtml is enabled", async () => {
+  it("uses richContent in RSS description when rssFullHtml is enabled", async () => {
     const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true, rssFullHtml: true })
     await plugin.emit(mockCtx, makeContent("Post"), mockResources)
 
     const rssCall = getWriteCall("rss")
-    expect(rssCall).toBeDefined()
+    const xml = rssCall![0].content
+    // richContent is the HTML-escaped toHtml output; verify it lands in <description>
+    expect(xml).toMatch(/<description>.*<\/description>/)
   })
 
-  it("RSS shows unlimited items when rssLimit is undefined", async () => {
+  it("RSS uses all items when rssLimit is undefined", async () => {
     const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true, rssLimit: undefined })
     await plugin.emit(mockCtx, makeContent("Post"), mockResources)
 
     const rssCall = getWriteCall("rss")
-    expect(rssCall![0].content).toContain("Recent notes")
+    expect(rssCall![0].content).toContain(uiStrings.pages.rss.recentNotes)
   })
 
   // --- Dependency graph ---

--- a/quartz/plugins/emitters/contentIndex.test.ts
+++ b/quartz/plugins/emitters/contentIndex.test.ts
@@ -1,0 +1,245 @@
+import { jest, describe, it, beforeAll, beforeEach, expect } from "@jest/globals"
+
+import { type QuartzConfig } from "../../cfg"
+import { type BuildCtx } from "../../util/ctx"
+import { type FilePath, type FullSlug } from "../../util/path"
+import { type StaticResources } from "../../util/resources"
+import { defaultProcessedContent, type ProcessedContent } from "../vfile"
+
+jest.unstable_mockModule("./helpers", () => ({
+  write: jest.fn(async (opts: { slug: FullSlug }) => {
+    return await Promise.resolve(`${opts.slug}.xml`)
+  }),
+}))
+
+const mockCtx: BuildCtx = {
+  argv: {
+    directory: "/content",
+    output: "public",
+    verbose: false,
+    serve: false,
+    fastRebuild: false,
+    port: 3000,
+    wsPort: 3001,
+  },
+  cfg: {
+    configuration: { baseUrl: "example.com", pageTitle: "Test Site", defaultDateType: "published" },
+  } as unknown as QuartzConfig,
+  allSlugs: [],
+}
+
+const mockResources: StaticResources = { css: [], js: [] }
+
+describe("ContentIndex", () => {
+  let write: jest.MockedFunction<typeof import("./helpers").write>
+  let ContentIndex: typeof import("./contentIndex").ContentIndex
+
+  beforeAll(async () => {
+    const helpers = await import("./helpers")
+    write = helpers.write as jest.MockedFunction<typeof helpers.write>
+    const mod = await import("./contentIndex")
+    ContentIndex = mod.ContentIndex
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const makeContent = (
+    title: string,
+    overrides: {
+      slug?: FullSlug
+      text?: string
+      description?: string
+      publishedDate?: Date
+    } = {},
+  ): ProcessedContent[] => [
+    defaultProcessedContent({
+      slug: overrides.slug ?? ("test-post" as FullSlug),
+      filePath: "content/test.md" as FilePath,
+      frontmatter: { title, tags: [] },
+      text: overrides.text ?? "Some content here",
+      description: overrides.description,
+      dates: overrides.publishedDate ? { published: overrides.publishedDate } : undefined,
+    }),
+  ]
+
+  const getWriteCall = (slugSubstring: string) =>
+    write.mock.calls.find((c) => c[0].slug.includes(slugSubstring))
+
+  // --- Title formatting (the fix under test) ---
+  it.each([
+    ["straight quotes become smart quotes", '"hello world"', "\u201CHello World\u201D"],
+    ["hyphens become em-dashes", "before -- after", "\u2014"],
+  ])("%s in content index JSON", async (_, input, expected) => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: false })
+    await plugin.emit(mockCtx, makeContent(input), mockResources)
+
+    const jsonCall = getWriteCall("contentIndex")
+    const index = JSON.parse(jsonCall![0].content)
+    expect(index["test-post"].title).toContain(expected)
+  })
+
+  it.each([
+    ["straight quotes become smart quotes", '"hello world"', "\u201CHello World\u201D"],
+    ["hyphens become em-dashes", "before -- after", "\u2014"],
+  ])("%s in RSS feed", async (_, input, expected) => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true })
+    await plugin.emit(mockCtx, makeContent(input), mockResources)
+
+    const rssCall = getWriteCall("rss")
+    expect(rssCall![0].content).toContain(expected)
+  })
+
+  // --- Sitemap ---
+  it("generates sitemap with lastmod when date is present", async () => {
+    const plugin = ContentIndex({ enableSiteMap: true, enableRSS: false })
+    await plugin.emit(
+      mockCtx,
+      makeContent("My Post", { publishedDate: new Date("2025-01-15") }),
+      mockResources,
+    )
+
+    const sitemapCall = getWriteCall("sitemap")
+    expect(sitemapCall).toBeDefined()
+    const xml = sitemapCall![0].content
+    expect(xml).toContain("<loc>https://example.com/test-post</loc>")
+    expect(xml).toContain("<lastmod>")
+    expect(xml).toContain("</urlset>")
+  })
+
+  // --- RSS feed sorting ---
+  it("RSS feed sorts entries by date descending", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true })
+    const content = [
+      ...makeContent("First Post", {
+        slug: "aaa-first" as FullSlug,
+        publishedDate: new Date("2024-01-01"),
+      }),
+      ...makeContent("Second Post", {
+        slug: "zzz-second" as FullSlug,
+        publishedDate: new Date("2025-06-01"),
+      }),
+    ]
+    await plugin.emit(mockCtx, content, mockResources)
+
+    const rssCall = getWriteCall("rss")
+    const xml = rssCall![0].content
+    const secondIdx = xml.indexOf("zzz-second")
+    const firstIdx = xml.indexOf("aaa-first")
+    expect(secondIdx).toBeLessThan(firstIdx)
+  })
+
+  // --- RSS description transforms ---
+  it("applies text transforms to RSS descriptions", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true })
+    await plugin.emit(
+      mockCtx,
+      makeContent("Post", { description: '"quoted description"' }),
+      mockResources,
+    )
+
+    const rssCall = getWriteCall("rss")
+    expect(rssCall![0].content).toContain("\u201C")
+  })
+
+  it("uses richContent for RSS when rssFullHtml is enabled", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true, rssFullHtml: true })
+    await plugin.emit(mockCtx, makeContent("Post"), mockResources)
+
+    const rssCall = getWriteCall("rss")
+    expect(rssCall).toBeDefined()
+  })
+
+  it("RSS shows unlimited items when rssLimit is undefined", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: true, rssLimit: undefined })
+    await plugin.emit(mockCtx, makeContent("Post"), mockResources)
+
+    const rssCall = getWriteCall("rss")
+    expect(rssCall![0].content).toContain("Recent notes")
+  })
+
+  // --- Dependency graph ---
+  it.each([
+    ["includes sitemap/RSS edges when enabled", true, true],
+    ["omits sitemap/RSS edges when disabled", false, false],
+  ])("dependency graph %s", async (_, enableSiteMap, enableRSS) => {
+    const plugin = ContentIndex({ enableSiteMap, enableRSS })
+    const graph = await plugin.getDependencyGraph!(mockCtx, makeContent("Test"), mockResources)
+
+    expect(graph.hasNode("public/static/contentIndex.json" as FilePath)).toBe(true)
+    expect(graph.hasNode("public/sitemap.xml" as FilePath)).toBe(enableSiteMap)
+    expect(graph.hasNode("public/rss.xml" as FilePath)).toBe(enableRSS)
+  })
+
+  // --- Edge cases ---
+  it("skips files with empty text when includeEmptyFiles is false", async () => {
+    const plugin = ContentIndex({
+      enableSiteMap: false,
+      enableRSS: false,
+      includeEmptyFiles: false,
+    })
+    await plugin.emit(mockCtx, makeContent("Empty", { text: "" }), mockResources)
+
+    const jsonCall = getWriteCall("contentIndex")
+    const index = JSON.parse(jsonCall![0].content)
+    expect(index["test-post"]).toBeUndefined()
+  })
+
+  it("includes files with empty text when includeEmptyFiles is true", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: false, includeEmptyFiles: true })
+    await plugin.emit(mockCtx, makeContent("Empty", { text: "" }), mockResources)
+
+    const jsonCall = getWriteCall("contentIndex")
+    const index = JSON.parse(jsonCall![0].content)
+    expect(index["test-post"]).toBeDefined()
+  })
+
+  it("content index JSON strips description and date", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: false })
+    await plugin.emit(mockCtx, makeContent("Post", { description: "A description" }), mockResources)
+
+    const jsonCall = getWriteCall("contentIndex")
+    const index = JSON.parse(jsonCall![0].content)
+    expect(index["test-post"].description).toBeUndefined()
+    expect(index["test-post"].date).toBeUndefined()
+  })
+
+  it("handles missing baseUrl in sitemap and RSS", async () => {
+    const noBaseUrlCtx: BuildCtx = {
+      ...mockCtx,
+      cfg: {
+        configuration: { pageTitle: "Test", defaultDateType: "published" },
+      } as unknown as QuartzConfig,
+    }
+    const plugin = ContentIndex({ enableSiteMap: true, enableRSS: true })
+    await plugin.emit(noBaseUrlCtx, makeContent("Post"), mockResources)
+
+    const sitemapCall = getWriteCall("sitemap")
+    expect(sitemapCall![0].content).toContain("<loc>https://test-post</loc>")
+    const rssCall = getWriteCall("rss")
+    expect(rssCall![0].content).toContain("<link>https://</link>")
+  })
+
+  it("handles missing frontmatter and text", async () => {
+    const plugin = ContentIndex({ enableSiteMap: false, enableRSS: false, includeEmptyFiles: true })
+    const content: ProcessedContent[] = [
+      defaultProcessedContent({
+        slug: "bare" as FullSlug,
+        filePath: "content/bare.md" as FilePath,
+      }),
+    ]
+    await plugin.emit(mockCtx, content, mockResources)
+
+    const jsonCall = getWriteCall("contentIndex")
+    const index = JSON.parse(jsonCall![0].content)
+    expect(index["bare"].title).toBe("")
+    expect(index["bare"].tags).toEqual([])
+    expect(index["bare"].content).toBe("")
+  })
+
+  it("getQuartzComponents returns empty array", () => {
+    const plugin = ContentIndex({})
+    expect(plugin.getQuartzComponents(mockCtx)).toEqual([])
+  })
+})

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -3,6 +3,7 @@ import type { Root } from "hast"
 import { toHtml } from "hast-util-to-html"
 
 import { type GlobalConfiguration } from "../../cfg"
+import { formatTitle } from "../../components/component_utils"
 import { locale, uiStrings } from "../../components/constants"
 import { getDate } from "../../components/Date"
 import DepGraph from "../../depgraph"
@@ -183,7 +184,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
 
         if (opts?.includeEmptyFiles || (file.data.text && file.data.text !== "")) {
           linkIndex.set(slug, {
-            title: file.data.frontmatter?.title ?? "",
+            title: formatTitle(file.data.frontmatter?.title ?? ""),
             links: file.data.links ?? [],
             tags: file.data.frontmatter?.tags ?? [],
             content: (file.data.text as string) ?? "",

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -19,6 +19,15 @@ import { applyTextTransforms } from "../transformers/formatting_improvement_html
 import { type QuartzEmitterPlugin } from "../types"
 import { write } from "./helpers"
 
+/** Build-time content entry with required date (always set by emit via getDate). */
+type BuildContentDetails = ContentDetails & {
+  date: Date
+  description?: string
+}
+
+type BuildContentIndex = Map<FullSlug, BuildContentDetails>
+
+/** Client-side content details (date/description stripped before writing to JSON). */
 export type ContentIndex = Map<FullSlug, ContentDetails>
 export type ContentDetails = {
   title: string
@@ -26,9 +35,7 @@ export type ContentDetails = {
   tags: readonly string[]
   content: string
   richContent?: string
-  date?: Date
   authors?: readonly string[]
-  description?: string
 }
 
 interface Options {
@@ -52,10 +59,10 @@ const defaultOptions: Options = {
 const createSiteMapURLEntry = (
   base: string,
   slug: SimpleSlug,
-  content: ContentDetails,
+  content: BuildContentDetails,
 ): string => `<url>
     <loc>https://${joinSegments(base, encodeURI(slug))}</loc>
-    ${content.date && `<lastmod>${content.date.toISOString()}</lastmod>`}
+    <lastmod>${content.date.toISOString()}</lastmod>
   </url>`
 
 /**
@@ -65,7 +72,7 @@ const createSiteMapURLEntry = (
  * @param idx The content index to generate the sitemap from.
  * @returns An XML string representing the sitemap.
  */
-function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
+function generateSiteMap(cfg: GlobalConfiguration, idx: BuildContentIndex): string {
   const base = cfg.baseUrl ?? ""
   const urls = Array.from(idx)
     .map(([slug, content]) => createSiteMapURLEntry(base, simplifySlug(slug), content))
@@ -89,13 +96,13 @@ const textTransformDescription = (description: string): string => {
 const createRSSURLEntry = (
   base: string,
   slug: SimpleSlug,
-  content: ContentDetails,
+  content: BuildContentDetails,
 ): string => `<item>
     <title>${escapeHTML(content.title)}</title>
     <link>https://${joinSegments(base, encodeURI(slug))}</link>
     <description>${content.richContent ?? textTransformDescription(content.description ?? "")}</description>
     <guid isPermaLink="true">https://${joinSegments(base, encodeURI(slug))}</guid>
-    <pubDate>${content.date?.toUTCString()}</pubDate>
+    <pubDate>${content.date.toUTCString()}</pubDate>
   </item>`
 
 /**
@@ -104,18 +111,13 @@ const createRSSURLEntry = (
  */
 function generateRSSFeed(
   cfg: GlobalConfiguration,
-  idx: ContentIndex,
+  idx: BuildContentIndex,
   maxItemsInFeed?: number,
 ): string {
   const base = cfg.baseUrl ?? ""
 
   const items = Array.from(idx)
-    .sort(([, f1], [, f2]) => {
-      // date is always set by emit() via getDate() ?? new Date()
-      const d1 = f1.date as Date
-      const d2 = f2.date as Date
-      return d2.getTime() - d1.getTime()
-    })
+    .sort(([, f1], [, f2]) => f2.date.getTime() - f1.date.getTime())
     .map(([slug, content]) => createRSSURLEntry(base, simplifySlug(slug), content))
     .slice(0, maxItemsInFeed ?? idx.size)
     .join("")
@@ -171,7 +173,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
     async emit(ctx, content) {
       const cfg = ctx.cfg.configuration
       const emitted: FilePath[] = []
-      const linkIndex: ContentIndex = new Map()
+      const linkIndex: BuildContentIndex = new Map()
 
       for (const [tree, file] of content) {
         const slug = file.data.slug as FullSlug
@@ -217,13 +219,11 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
       }
 
       const fp = joinSegments("static", "contentIndex") as FullSlug
+      // Strip date and description — only needed for RSS/sitemap, not the client-side JSON
       const simplifiedIndex = Object.fromEntries(
-        Array.from(linkIndex).map(([slug, content]) => {
-          // remove description and date from content index as nothing downstream
-          // actually uses them. we only keep description for the RSS feed
-          delete content.description
-          delete content.date
-          return [slug, content]
+        Array.from(linkIndex).map(([slug, entry]): [string, ContentDetails] => {
+          const { title, links, tags, content: text, richContent, authors } = entry
+          return [slug, { title, links, tags, content: text, richContent, authors }]
         }),
       )
 

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -4,7 +4,7 @@ import { toHtml } from "hast-util-to-html"
 
 import { type GlobalConfiguration } from "../../cfg"
 import { formatTitle } from "../../components/component_utils"
-import { locale, uiStrings } from "../../components/constants"
+import { uiStrings } from "../../components/constants"
 import { getDate } from "../../components/Date"
 import DepGraph from "../../depgraph"
 import { escapeHTML } from "../../util/escape"
@@ -111,15 +111,10 @@ function generateRSSFeed(
 
   const items = Array.from(idx)
     .sort(([, f1], [, f2]) => {
-      if (f1.date && f2.date) {
-        return f2.date.getTime() - f1.date.getTime()
-      } else if (f1.date && !f2.date) {
-        return -1
-      } else if (!f1.date && f2.date) {
-        return 1
-      }
-
-      return f1.title.localeCompare(f2.title, locale)
+      // date is always set by emit() via getDate() ?? new Date()
+      const d1 = f1.date as Date
+      const d2 = f2.date as Date
+      return d2.getTime() - d1.getTime()
     })
     .map(([slug, content]) => createRSSURLEntry(base, simplifySlug(slug), content))
     .slice(0, maxItemsInFeed ?? idx.size)


### PR DESCRIPTION
## Summary
- Page titles stored in `contentIndex.json` were raw frontmatter values, so search results and RSS feed titles were missing smart quotes, em-dashes, and title-casing that all other title displays already applied via `formatTitle`
- Applied `formatTitle()` at build time in the content index emitter so formatted titles flow through to search and RSS automatically

## Changes
- `contentIndex.ts`: Call `formatTitle()` on titles when populating the content index
- `contentIndex.ts`: Split `ContentDetails` into build-time (`BuildContentDetails` with required `date`) and client-side types, eliminating optional chaining, `as Date` casts, conditional guards, and mutating `delete` calls
- `contentIndex.ts`: Remove dead RSS sort branches (dates are always present) and unused `locale` import
- `contentIndex.test.ts`: Add 17 tests with 100% coverage — title formatting, RSS generation, sitemap output, dependency graph, and edge cases

## Testing
- 3499 tests pass, 100% branch/statement/function/line coverage
- `pnpm check` passes (types + formatting + stylelint)
- Pre-push checks all pass
- Verified the 4 title-formatting tests fail without the `formatTitle` fix

https://claude.ai/code/session_01L5RgvWmFJv2ogxJdGNkWyt