### PR TITLE
fix: handle Lost Pixel summary with no parseable diff counts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -262,16 +262,22 @@ jobs:
 
           echo "Lost Pixel result: $SUMMARY"
 
-          # Extract counts for changed, added, and deleted images
-          CHANGED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(changed|visual|difference|diff))' | head -1)
-          ADDED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(added|new|created))' | head -1)
-          DELETED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(deleted|removed))' | head -1)
+          # A summary like "The check is completed!" with no counts means zero differences
+          if echo "$SUMMARY" | grep -qiP '(completed|passed|no\s+(visual\s+)?differences)'; then
+            echo "Lost Pixel reports success with no visual differences."
+            CHANGED=0; ADDED=0; DELETED=0
+          else
+            # Extract counts for changed, added, and deleted images
+            CHANGED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(changed|visual|difference|diff))' | head -1)
+            ADDED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(added|new|created))' | head -1)
+            DELETED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(deleted|removed))' | head -1)
 
-          # If none of the patterns matched, fail — the LP summary format may have changed
-          if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then
-            echo "::error::Could not parse any counts from Lost Pixel summary. Format may have changed."
-            echo "Raw summary: $SUMMARY"
-            exit 1
+            # If none of the patterns matched, fail — the LP summary format may have changed
+            if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then
+              echo "::error::Could not parse any counts from Lost Pixel summary. Format may have changed."
+              echo "Raw summary: $SUMMARY"
+              exit 1
+            fi
           fi
 
           CHANGED=${CHANGED:-0}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -223,24 +223,35 @@ jobs:
           MAX_ATTEMPTS=40  # 40 × 30s = 20 min max wait
           ATTEMPT=0
           SUMMARY=""
+          LP_CONCLUSION=""
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
 
-            # Check runs (GitHub App check)
-            SUMMARY=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
+            # Check runs (GitHub App check) — grab conclusion + summary + text
+            LP_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
               --paginate \
-              --jq '[.check_runs[] | select(.name | test("lost.pixel"; "i"))] | .[0].output.summary // empty' \
+              --jq '[.check_runs[] | select(.name | test("lost.pixel"; "i"))] | .[0] // empty | {conclusion, summary: .output.summary, text: .output.text}' \
               2>/dev/null || true)
 
-            if [ -z "$SUMMARY" ]; then
+            if [ -n "$LP_JSON" ] && [ "$LP_JSON" != "null" ]; then
+              LP_CONCLUSION=$(echo "$LP_JSON" | jq -r '.conclusion // empty')
+              SUMMARY=$(echo "$LP_JSON" | jq -r '.summary // empty')
+              # If summary has no counts, check the text field too
+              LP_TEXT=$(echo "$LP_JSON" | jq -r '.text // empty')
+            fi
+
+            if [ -z "$LP_CONCLUSION" ]; then
               # Also check commit statuses (Lost Pixel may use status API)
               SUMMARY=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/statuses" \
                 --jq '[.[] | select(.context | test("lost.pixel"; "i"))] | .[0].description // empty' \
                 2>/dev/null || true)
+              if [ -n "$SUMMARY" ]; then
+                LP_CONCLUSION="from_status"
+              fi
             fi
 
-            if [ -n "$SUMMARY" ]; then
+            if [ -n "$LP_CONCLUSION" ] || [ -n "$SUMMARY" ]; then
               echo "Lost Pixel check found on attempt $ATTEMPT"
               break
             fi
@@ -255,27 +266,35 @@ jobs:
             sleep 30
           done
 
-          if [ -z "$SUMMARY" ]; then
+          if [ -z "$LP_CONCLUSION" ] && [ -z "$SUMMARY" ]; then
             echo "::error::Lost Pixel check never appeared after $MAX_ATTEMPTS attempts"
             exit 1
           fi
 
-          echo "Lost Pixel result: $SUMMARY"
+          echo "Lost Pixel conclusion: $LP_CONCLUSION"
+          echo "Lost Pixel summary: $SUMMARY"
+          [ -n "${LP_TEXT:-}" ] && echo "Lost Pixel text: $LP_TEXT"
 
-          # A summary like "The check is completed!" with no counts means zero differences
-          if echo "$SUMMARY" | grep -qiP '(completed|passed|no\s+(visual\s+)?differences)'; then
-            echo "Lost Pixel reports success with no visual differences."
-            CHANGED=0; ADDED=0; DELETED=0
-          else
-            # Extract counts for changed, added, and deleted images
-            CHANGED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(changed|visual|difference|diff))' | head -1)
-            ADDED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(added|new|created))' | head -1)
-            DELETED=$(echo "$SUMMARY" | grep -oP '\d+(?=\s*(deleted|removed))' | head -1)
+          # Use the richest available source for count extraction
+          PARSE_SOURCE="$SUMMARY"
+          if [ -n "${LP_TEXT:-}" ]; then
+            PARSE_SOURCE="$SUMMARY $LP_TEXT"
+          fi
 
-            # If none of the patterns matched, fail — the LP summary format may have changed
-            if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then
-              echo "::error::Could not parse any counts from Lost Pixel summary. Format may have changed."
+          # Extract counts for changed, added, and deleted images
+          CHANGED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(changed|visual|difference|diff))' | head -1)
+          ADDED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(added|new|created))' | head -1)
+          DELETED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(deleted|removed))' | head -1)
+
+          # If no counts parsed, use conclusion to decide
+          if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then
+            if [ "$LP_CONCLUSION" = "success" ]; then
+              echo "Lost Pixel concluded with success and no parseable counts — treating as 0 differences."
+              CHANGED=0; ADDED=0; DELETED=0
+            else
+              echo "::error::Could not parse any counts from Lost Pixel output (conclusion: $LP_CONCLUSION)."
               echo "Raw summary: $SUMMARY"
+              [ -n "${LP_TEXT:-}" ] && echo "Raw text: $LP_TEXT"
               exit 1
             fi
           fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -224,13 +224,13 @@ jobs:
           ATTEMPT=0
           SUMMARY=""
           LP_CONCLUSION=""
+          LP_TEXT=""
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
 
             # Check runs (GitHub App check) — grab conclusion + summary + text
             LP_JSON=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
-              --paginate \
               --jq '[.check_runs[] | select(.name | test("lost.pixel"; "i"))] | .[0] // empty | {conclusion, summary: .output.summary, text: .output.text}' \
               2>/dev/null || true)
 


### PR DESCRIPTION
## Summary
- Fix `verify-test-results` CI failure when Lost Pixel returns a summary like "The check is completed!" with no diff count information
- Now fetches the check run's `conclusion` and `output.text` fields in addition to `output.summary`, only treating unparseable output as 0 diffs when conclusion is explicitly `"success"`

## Changes
- Fetch full Lost Pixel check run JSON (conclusion + summary + text) instead of just summary
- Parse counts from both `output.summary` and `output.text` fields for robustness
- Fall back to `conclusion` field: only treat as 0 diffs if `conclusion === "success"`; fail with diagnostics otherwise
- Initialize `LP_TEXT` variable at top, drop `--paginate` to avoid per-page jq filter issues
- Added `from_status` sentinel for status API fallback path (intentionally conservative — no success-fallback)

## Testing
- CI workflow change — validated by inspection and shell syntax
- Will be tested on next deploy to main

https://claude.ai/code/session_01Vf3cYMZDAgu52d8gWFa2Pz