### PR TITLE
fix(ci): disable Playwright navigator.platform override to fix WebKit crashes

### DIFF
--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -142,6 +142,10 @@ jobs:
         shard: ["1/7", "2/7", "3/7", "4/7", "5/7", "6/7", "7/7"]
     env:
       PLAYWRIGHT_BROWSERS: webkit
+      # Playwright 1.59.0 added Page.overridePlatform for WebKit device presets,
+      # which crashes WebKit on macOS ARM64 (microsoft/playwright#40009).
+      # Reverted upstream but no 1.59.2 release yet. Remove when upgrading Playwright.
+      PLAYWRIGHT_NO_UA_PLATFORM: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -173,6 +173,10 @@ jobs:
           ]
     env:
       PLAYWRIGHT_BROWSERS: webkit
+      # Playwright 1.59.0 added Page.overridePlatform for WebKit device presets,
+      # which crashes WebKit on macOS ARM64 (microsoft/playwright#40009).
+      # Reverted upstream but no 1.59.2 release yet. Remove when upgrading Playwright.
+      PLAYWRIGHT_NO_UA_PLATFORM: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -176,6 +176,10 @@ jobs:
           ]
     env:
       PLAYWRIGHT_BROWSERS: webkit
+      # Playwright 1.59.0 added Page.overridePlatform for WebKit device presets,
+      # which crashes WebKit on macOS ARM64 (microsoft/playwright#40009).
+      # Reverted upstream but no 1.59.2 release yet. Remove when upgrading Playwright.
+      PLAYWRIGHT_NO_UA_PLATFORM: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -85,9 +85,9 @@ export default defineConfig({
       ? 45 * 60 * 1000
       : undefined,
   fullyParallel: true,
-  // WebKit on macOS ARM crashes pages when running multiple workers in parallel
-  // (microsoft/playwright#35896, #30428). Run 1 worker to avoid crashes.
-  workers: process.env.PLAYWRIGHT_BROWSERS === "webkit" ? 1 : undefined,
+  // macOS ARM runners have 3 cores but Playwright defaults to 1 worker for
+  // WebKit, causing shards to hit their job timeout. Force 3 workers on macOS.
+  workers: process.env.PLAYWRIGHT_BROWSERS === "webkit" ? 3 : undefined,
   retries: process.env.CI ? 1 : 0,
   testDir: "../../quartz/",
   testMatch: /.*\.spec\.ts/,


### PR DESCRIPTION
## Summary

- Fix macOS WebKit "Page crashed" errors on mobile viewports (iPhone 12, iPad Pro) by disabling Playwright 1.59.0's `Page.overridePlatform` WebKit protocol command
- Root cause: Playwright 1.59.0 PR #39723 added `navigator.platform` syncing for device presets, which crashes WebKit on macOS ARM64 (microsoft/playwright#40009). Reverted upstream (PR #40016) but no 1.59.2 release yet.
- Desktop Safari was unaffected because it uses a custom viewport without a device preset (no custom user agent → no platform override)

## Changes

- Add `PLAYWRIGHT_NO_UA_PLATFORM: "1"` env var to macOS jobs in `playwright-tests.yaml`, `visual-testing.yaml`, and `playwright-flake-check.yaml`
- Revert worker count from 1 back to 3 (crashes were from platform override, not parallel memory pressure)

## Testing

- macOS WebKit tests only run on pushes to main — can't validate pre-merge
- The env var is the official Playwright workaround documented in the 1.59.0 release notes

https://claude.ai/code/session_01D3qRytvH6xCQY9duGtdDXn