### PR TITLE
fix(ci): fix popover tests on Desktop Safari and spellcheck errors

### DIFF
--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -138,7 +138,10 @@ test("Multiple popovers don't stack without wait", async ({ page }) => {
     await moveMouseToSafePosition(page)
   }
 
-  await expect(page.locator(".popover")).toHaveCount(0)
+  // Use toPass to retry — WebKit may still be animating popovers away
+  await expect(async () => {
+    await expect(page.locator(".popover")).toHaveCount(0)
+  }).toPass({ timeout: 5_000 })
 })
 
 test("Popover updates position on window resize", async ({ page, dummyLink }) => {
@@ -259,6 +262,12 @@ test("Popovers do not appear in search previews", async ({ page }) => {
 
   const previewContainer = page.locator("#preview-container")
   await expect(previewContainer).toBeVisible({ timeout: 10_000 })
+
+  // Click the "Test page" result card to explicitly trigger preview loading.
+  // The auto-focus after search may not reliably trigger fetchAndUpdateContent
+  // on WebKit — clicking ensures the preview manager fetches the content.
+  const testPageCard = page.locator('.result-card[id*="test-page"]').first()
+  await testPageCard.click()
 
   // Wait for the link inside the preview content to render (fetched async)
   const searchDummyLink = previewContainer.locator("a#first-link-test-page")

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1069,7 +1069,7 @@ I have thousands of JavaScript unit tests and hundreds of Python tests. I am _qu
 
 ### Simulating site interactions
 
-Pure unit tests cannot test the end-to-end experience of my site, nor can they easily interact with a local server. [Playwright](https://playwright.dev/) lets me test dynamic features like search, spoiler blocks, and light / dark mode. I can also guard against bugs like [flashes of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) upon page load. What's more, I test these features across a range of browsers and viewport dimensions (mobile vs desktop).
+Pure unit tests cannot test the end-to-end experience of my site, nor can they easily interact with a local server. [Playwright](https://playwright.dev/) lets me test dynamic features like search, spoiler blocks, and light / dark mode. I can also guard against bugs like [flashes of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) upon page load. What's more, I test these features across a range of browsers and viewport dimensions (mobile vs desktop). macOS WebKit runs Desktop Safari only, since Playwright's WebKit crashes on mobile device emulation on Apple Silicon.
 
 ### Visual regression testing
 
@@ -1087,7 +1087,7 @@ However, it's not practical to test every single page. So I have a [test page](/
 > [!money] Cost of running CI on GitHub Actions
 > My GitHub Pro subscription allows 3,000 free minutes each month. A full push to `main` runs Chromium, Firefox, and WebKit tests across Linux and macOS runners. GitHub [prices Linux 2-core systems at \$0.008 per minute](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-standard-runners) and macOS M1 runners at \$0.08/min (10x).
 >
-> To control costs: macOS and Firefox only run on `main`, PRs run Chromium-only on Linux, and CI labels are per-commit (one-shot). macOS WebKit runs Desktop Safari only — Playwright 1.58+ crashes on mobile device emulation (iPhone/iPad) on ARM64, so mobile viewports are covered by Linux Chromium and Firefox.
+> To control costs: macOS and Firefox only run on `main`, PRs run Chromium-only on Linux, and CI labels are per-commit (one-shot).
 
 ### Validating links
 


### PR DESCRIPTION
## Summary

- Fix two popover test failures on Desktop Safari (macOS WebKit)
- Fix spellcheck failures in design.md from previous PR

## Changes

- **popover.spec.ts:254** ("Popovers do not appear in search previews"): Click the result card to explicitly trigger preview loading — WebKit's auto-focus after search doesn't reliably trigger `fetchAndUpdateContent`
- **popover.spec.ts:130** ("Multiple popovers don't stack"): Use `toPass` retry for popover count assertion — WebKit may still be animating popovers away
- **design.md**: Reword to avoid spellcheck-flagged terms (`ARM64`, `viewports`), move macOS Desktop-only note to platforms section instead of cost section

## Testing

- Can't validate macOS WebKit pre-merge (only runs on main)
- Spellcheck fix addresses the `retext-spell` errors from the previous push

https://claude.ai/code/session_01D3qRytvH6xCQY9duGtdDXn