### PR TITLE
fix(ci): parse Lost Pixel 'Label: N' output format

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -283,9 +283,9 @@ jobs:
 
           # Extract counts for changed, added, and deleted images
           # Handles both "N changed" and "Differences: N" formats
-          CHANGED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(changed|visual|difference|diff))|(difference|diff)[s:]?\s*\K\d+)' | head -1)
-          ADDED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(added|new|created))|addition[s:]?\s*\K\d+)' | head -1)
-          DELETED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(deleted|removed))|deletion[s:]?\s*\K\d+)' | head -1)
+          CHANGED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(changed|visual|difference|diff))|differences?:\s*\K\d+)' | head -1)
+          ADDED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(added|new|created))|additions?:\s*\K\d+)' | head -1)
+          DELETED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(deleted|removed))|deletions?:\s*\K\d+)' | head -1)
 
           # If no counts parsed, use conclusion to decide
           if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -282,9 +282,10 @@ jobs:
           fi
 
           # Extract counts for changed, added, and deleted images
-          CHANGED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(changed|visual|difference|diff))' | head -1)
-          ADDED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(added|new|created))' | head -1)
-          DELETED=$(echo "$PARSE_SOURCE" | grep -oP '\d+(?=\s*(deleted|removed))' | head -1)
+          # Handles both "N changed" and "Differences: N" formats
+          CHANGED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(changed|visual|difference|diff))|(difference|diff)[s:]?\s*\K\d+)' | head -1)
+          ADDED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(added|new|created))|addition[s:]?\s*\K\d+)' | head -1)
+          DELETED=$(echo "$PARSE_SOURCE" | grep -oP '(\d+(?=\s*(deleted|removed))|deletion[s:]?\s*\K\d+)' | head -1)
 
           # If no counts parsed, use conclusion to decide
           if [ -z "$CHANGED" ] && [ -z "$ADDED" ] && [ -z "$DELETED" ]; then


### PR DESCRIPTION
## Summary

Fix the deploy verify-test-results parser that couldn't read Lost Pixel's output format.

## Changes

- Add alternation to grep patterns to handle both `N changed` and `Differences: N` formats

## Note

The 187 deletions and 114 differences are expected from removing mobile Safari viewports (PR #1122). These need manual approval in Lost Pixel before deploy can succeed.

https://claude.ai/code/session_01D3qRytvH6xCQY9duGtdDXn