### PR TITLE
Add fallbacks for browsers without light-dark() support

### DIFF
--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -22,6 +22,7 @@ const NotFound: QuartzComponent = () => {
           id="trout-reading"
           className="no-select"
           alt="Alex in a trout costume, reading a book."
+          loading="lazy"
           width={1280}
           height={1152}
         />

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -11,10 +11,14 @@
 
 .admonition {
   --border: color-mix(in srgb, var(--color) 60%, var(--background));
+  /* stylelint-disable declaration-block-no-duplicate-custom-properties --
+     Fallback for browsers without light-dark() support */
+  --bg: color-mix(in srgb, var(--color) 4%, var(--background));
   --bg: light-dark(
     color-mix(in srgb, var(--color) 4%, var(--background)),
     color-mix(in srgb, var(--color) 2%, var(--background))
   );
+  /* stylelint-enable declaration-block-no-duplicate-custom-properties */
   --admonition-icon-note: url("https://assets.turntrout.com/static/icons/note.svg");
   --admonition-icon-abstract: url("https://assets.turntrout.com/static/icons/abstract.svg");
   --admonition-icon-info: url("https://assets.turntrout.com/static/icons/info.svg");

--- a/quartz/styles/checkboxes.scss
+++ b/quartz/styles/checkboxes.scss
@@ -62,10 +62,14 @@ input.checkbox-toggle {
   }
 
   &:checked {
+    /* stylelint-disable declaration-block-no-duplicate-custom-properties --
+       Fallback for browsers without light-dark() support */
+    --checkbox-color: color-mix(in srgb, var(--green), var(--light) 20%);
     --checkbox-color: light-dark(
       color-mix(in srgb, var(--green), var(--light) 20%),
       color-mix(in srgb, var(--green), var(--dark) 45%)
     );
+    /* stylelint-enable declaration-block-no-duplicate-custom-properties */
 
     background-color: var(--checkbox-color);
     border-color: var(--checkbox-color);

--- a/quartz/styles/colors.scss
+++ b/quartz/styles/colors.scss
@@ -39,18 +39,25 @@
   // Derived color variables
   --midground-fainter: color-mix(in srgb, var(--background) 70%, var(--midground-faint));
   --midground-faintest: color-mix(in srgb, var(--background) 90%, var(--midground-faint));
+  /* stylelint-disable declaration-block-no-duplicate-custom-properties --
+     Duplicate custom properties are intentional fallbacks for browsers
+     without light-dark() support (Chrome <123, Firefox <128, Safari <17.5). */
+  --color-link: color-mix(in srgb, var(--secondary) 30%, var(--foreground));
   --color-link: light-dark(
     color-mix(in srgb, var(--secondary) 30%, var(--foreground)),
     var(--secondary)
   );
+  --color-link-visited: color-mix(in srgb, var(--purple) 40%, var(--color-link));
   --color-link-visited: light-dark(
     color-mix(in srgb, var(--purple) 40%, var(--color-link)),
     color-mix(in srgb, var(--purple) 25%, var(--color-link))
   );
+  --color-link-hover: color-mix(in srgb, var(--sky) 50%, var(--color-link));
   --color-link-hover: light-dark(
     color-mix(in srgb, var(--sky) 50%, var(--color-link)),
     color-mix(in srgb, var(--sky) 35%, var(--color-link))
   );
+  /* stylelint-enable declaration-block-no-duplicate-custom-properties */
 
   @each $color in ("red", "pink", "green", "teal", "blue", "purple", "orange", "yellow") {
     --background-#{$color}: color-mix(in srgb, var(--#{$color}) 30%, var(--background));

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -269,6 +269,7 @@ sup {
     font-size: 3rem;
     filter: saturate(90%);
     color: var(--blue);
+    opacity: 0.6;
     opacity: light-dark(0.6, 0.7);
   }
 
@@ -282,7 +283,9 @@ sup {
     width: calc(6 * $base-margin);
     margin-top: calc(2 * $base-margin);
     margin-bottom: calc(2 * $base-margin);
+    filter: none !important;
     filter: light-dark(none, invert(66%)) !important;
+    opacity: 0.5;
     opacity: light-dark(0.5, 1);
   }
 

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -427,5 +427,6 @@ article .ordinal-num {
   color: var(--gold);
 
   // Make it easier to see on light themes
+  -webkit-text-stroke: 0.2px black;
   -webkit-text-stroke: 0.2px light-dark(black, transparent);
 }


### PR DESCRIPTION
## Summary
This PR adds CSS fallback values for the `light-dark()` function to improve compatibility with browsers that don't yet support this feature (Chrome <123, Firefox <128, Safari <17.5). The fallbacks use the light theme values as defaults, allowing the styling to degrade gracefully in older browsers.

## Key Changes
- **colors.scss**: Added fallback values for `--color-link`, `--color-link-visited`, and `--color-link-hover` custom properties with stylelint directives to suppress duplicate property warnings
- **admonitions.scss**: Added fallback for `--bg` custom property used in admonition styling
- **checkboxes.scss**: Added fallback for `--checkbox-color` in checked state styling
- **custom.scss**: Added fallbacks for `opacity` and `filter` properties on decorative elements (trout illustration and footer image)
- **404.tsx**: Added `loading="lazy"` attribute to the hero image for performance optimization
- **fonts.scss**: Added fallback for `-webkit-text-stroke` on ordinal numbers

## Implementation Details
- Fallback values are placed immediately before the `light-dark()` declarations, allowing browsers to use the fallback if they don't understand the newer syntax
- Stylelint disable/enable comments are used where duplicate custom properties would otherwise trigger warnings
- The fallback strategy uses light theme values as the default, ensuring reasonable appearance across all browsers

https://claude.ai/code/session_01T6Trdod1oG9CJSmY3ypNCg