### PR TITLE
Refactor test utilities to use Playwright locators and fix linting issues

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -116,7 +116,6 @@ runs:
         key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           playwright-${{ runner.os }}-
-        save-always: true
 
     - name: Cache Puppeteer browsers
       if: inputs.cache-puppeteer == 'true'

--- a/package.json
+++ b/package.json
@@ -71,8 +71,6 @@
   "dependencies": {
     "@clack/prompts": "0.10.0",
     "@napi-rs/simple-git": "0.1.22",
-    "@types/flexsearch": "0.7.6",
-    "@types/psl": "1.11.0",
     "@types/unist": "3.0.3",
     "@types/validator": "13.15.10",
     "async-mutex": "0.5.0",
@@ -207,7 +205,6 @@
     "@jest/globals": "29.7.0",
     "@playwright/test": "1.59.1",
     "@testing-library/jest-dom": "6.9.1",
-    "@types/cheerio": "1.0.0",
     "@types/clean-css": "4.2.11",
     "@types/cli-spinner": "0.2.3",
     "@types/d3": "7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,12 +78,6 @@ importers:
       '@napi-rs/simple-git':
         specifier: 0.1.22
         version: 0.1.22
-      '@types/flexsearch':
-        specifier: 0.7.6
-        version: 0.7.6
-      '@types/psl':
-        specifier: 1.11.0
-        version: 1.11.0
       '@types/unist':
         specifier: 3.0.3
         version: 3.0.3
@@ -361,9 +355,6 @@ importers:
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
-      '@types/cheerio':
-        specifier: 1.0.0
-        version: 1.0.0
       '@types/clean-css':
         specifier: 4.2.11
         version: 4.2.11
@@ -2406,10 +2397,6 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
-  '@types/cheerio@1.0.0':
-    resolution: {integrity: sha512-zAaImHWoh5RY2CLgU2mvg3bl2k3F65B0N5yphuII3ythFLPmJhL7sj1RDu6gSxcgqHlETbr/lhA2OBY+WF1fXQ==}
-    deprecated: This is a stub types definition. cheerio provides its own type definitions, so you do not need this installed.
-
   '@types/clean-css@4.2.11':
     resolution: {integrity: sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==}
 
@@ -2527,9 +2514,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/flexsearch@0.7.6':
-    resolution: {integrity: sha512-H5IXcRn96/gaDmo+rDl2aJuIJsob8dgOXDqf8K0t8rWZd1AFNaaspmRsElESiU+EWE33qfbFPgI0OC/B1g9FCA==}
-
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
@@ -2613,10 +2597,6 @@ packages:
 
   '@types/pretty-time@1.1.5':
     resolution: {integrity: sha512-5yl+BYwmnRWZb783W8YYoHXvPY8q/rp7ctHBVaGBB9RxlzGpHNJ72tGQMK7TrUSnxzl1dbDcBDuBCSbtfnSQGg==}
-
-  '@types/psl@1.11.0':
-    resolution: {integrity: sha512-OeASqmnreaSJyxwljqCZjRIf7jpbwswaqbSPahE99PZrizNAOXEl9HRWhXvCt3fkAc/WuF8wcZ6zkDHXaE7X4g==}
-    deprecated: This is a stub types definition. psl provides its own type definitions, so you do not need this installed.
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -11826,10 +11806,6 @@ snapshots:
       '@types/node': 22.13.8
       '@types/responselike': 1.0.3
 
-  '@types/cheerio@1.0.0':
-    dependencies:
-      cheerio: 1.2.0
-
   '@types/clean-css@4.2.11':
     dependencies:
       '@types/node': 22.13.8
@@ -11976,8 +11952,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/flexsearch@0.7.6': {}
-
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
@@ -12068,10 +12042,6 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pretty-time@1.1.5': {}
-
-  '@types/psl@1.11.0':
-    dependencies:
-      psl: 1.15.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:

--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -180,7 +180,7 @@ test.describe("Local Link Navigation", () => {
     })
 
     const currentUrl = page.url()
-    await page.click("#blank-link")
+    await page.locator("#blank-link").click()
 
     // The local link with target=_blank should not be intercepted
     expect(page.url()).toBe(currentUrl)
@@ -766,7 +766,7 @@ test.describe("Critical CSS", () => {
       document.body.appendChild(link)
     })
 
-    await triggerAndWaitForSPANav(page, () => page.click("#design-link"))
+    await triggerAndWaitForSPANav(page, () => page.locator("#design-link").click())
 
     await expect(cssLocator).toHaveCount(0)
   })
@@ -797,7 +797,7 @@ test.describe("Network Behavior", () => {
     }, finalAnchorId)
 
     // Click the link to trigger hash navigation
-    await page.click("#link-to-anchor")
+    await page.locator("#link-to-anchor").click()
 
     // Wait for the URL to reflect the hash change
     await page.waitForURL(`**/*#${finalAnchorId}`)

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -18,8 +18,12 @@ import {
 } from "./visual_utils"
 
 test.beforeEach(async ({ page }, testInfo) => {
-  // Safari/WebKit is consistently slow for search operations in CI
-  test.slow(testInfo.project.name.includes("Safari"), "Safari/WebKit is slow for search in CI")
+  // Safari/WebKit is consistently slow for search operations in CI.
+  // Use setTimeout instead of test.slow() so individual tests can also use
+  // test.slow() without triggering no-duplicate-slow lint warnings.
+  if (testInfo.project.name.includes("Safari")) {
+    test.setTimeout(testInfo.timeout * 3)
+  }
 
   // Log any console errors
   page.on("pageerror", (err) => console.error(err))
@@ -204,6 +208,7 @@ test("Preview panel shows on desktop and hides on mobile", async ({ page }) => {
 
   const previewContainer = page.locator("#preview-container")
 
+  // eslint-disable-next-line playwright/no-conditional-in-test -- viewport varies by project config
   const isDesktop = (page.viewportSize()?.width ?? 0) > tabletBreakpoint
   await expect(previewContainer).toBeVisible({ visible: isDesktop })
 })
@@ -319,7 +324,8 @@ test("Preview element persists after closing and reopening search", async ({ pag
 
   // Search again and trigger preview
   await search(page, "Steering")
-  await waitForArticlePreview(page)
+  const preview = await waitForArticlePreview(page)
+  await expect(preview).toBeVisible()
 })
 
 test.describe("Search accuracy", () => {

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -43,7 +43,7 @@ test.describe("wrapH1SectionsInSpans", () => {
   test("wraps each H1 and its subsequent content into a span", async ({ page }) => {
     await wrapH1SectionsInSpans(page)
 
-    const html = await page.innerHTML("body")
+    const html = await page.locator("body").innerHTML()
     expect(html).toContain('<span id="h1-span-first-h1">')
     expect(html).toContain('<span id="h1-span-second-h1">')
     expect(html).toContain('<span id="h1-span-third-h1">')
@@ -64,13 +64,13 @@ test.describe("wrapH1SectionsInSpans", () => {
     await wrapH1SectionsInSpans(page)
     const initialSpans = page.locator("span[id^='h1-span-']")
     await expect(initialSpans).toHaveCount(4)
-    const initialHtml = await page.innerHTML("body")
+    const initialHtml = await page.locator("body").innerHTML()
 
     // Second call
     await wrapH1SectionsInSpans(page)
     const finalSpans = page.locator("span[id^='h1-span-']")
     await expect(finalSpans).toHaveCount(4)
-    const finalHtml = await page.innerHTML("body")
+    const finalHtml = await page.locator("body").innerHTML()
 
     // The DOM should not have changed
     expect(finalHtml).toEqual(initialHtml)
@@ -107,7 +107,7 @@ test.describe("wrapH1SectionsInSpans", () => {
 
     await wrapH1SectionsInSpans(page)
 
-    const html = await page.innerHTML("body")
+    const html = await page.locator("body").innerHTML()
     // The main heading gets its own span
     expect(html).toContain('<span id="h1-span-main-heading">')
     // The footnote section gets its own span
@@ -141,10 +141,10 @@ test.describe("wrapH1SectionsInSpans", () => {
     `)
 
     await wrapH1SectionsInSpans(page)
-    const initialHtml = await page.innerHTML("body")
+    const initialHtml = await page.locator("body").innerHTML()
 
     await wrapH1SectionsInSpans(page)
-    const finalHtml = await page.innerHTML("body")
+    const finalHtml = await page.locator("body").innerHTML()
 
     expect(finalHtml).toEqual(initialHtml)
     await expect(page.locator("span[id^='h1-span-']")).toHaveCount(2)


### PR DESCRIPTION
## Summary
This PR modernizes Playwright test code to use the recommended locator API instead of deprecated page methods, fixes linting warnings, and removes unused type dependencies.

## Key Changes

- **Playwright API Updates**: Replaced deprecated `page.click()` and `page.innerHTML()` calls with the modern locator-based API (`page.locator().click()` and `page.locator().innerHTML()`)
  - Updated 4 test files across search, visual utilities, and SPA navigation tests
  
- **Test Timeout Handling**: Replaced `test.slow()` with `test.setTimeout()` in search tests to avoid duplicate slow lint warnings when individual tests also use `test.slow()`

- **Linting Fixes**: Added eslint-disable comment for conditional viewport check in preview panel test (legitimate use case for project-specific configuration)

- **Test Assertions**: Enhanced preview panel test with explicit visibility assertion after waiting for preview element

- **Dependency Cleanup**: Removed unused type dependencies from package.json:
  - `@types/flexsearch`
  - `@types/psl`
  - `@types/cheerio`

- **CI Configuration**: Removed `save-always: true` from Playwright cache action to optimize cache behavior

## Implementation Details
The changes maintain full test functionality while adopting Playwright best practices. The locator API provides better element selection semantics and improved error messages compared to the deprecated page methods.

https://claude.ai/code/session_01KTsHXX92yVXEw3GvL4F4oD