### PR TITLE
fix: improve type safety, error handling, and test coverage

### DIFF
--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -231,9 +231,9 @@ jobs:
 
   lint:
     needs: [update-dates, detect-changes, autofix]
-    # Run if detect-changes found changes, and not a deepsource PR
-    # update-dates is allowed to be skipped (runs only on push to main by users)
-    # Skip if update-dates pushed changes (the new commit will trigger a fresh workflow)
+    # Run if detect-changes found changes, and not a deepsource PR.
+    # update-dates is allowed to be skipped (runs only on push to main by users).
+    # always() ensures this runs even when update-dates or autofix are skipped.
     if: >
       !startsWith(github.head_ref, 'deepsource-') &&
       (needs.detect-changes.outputs.content == 'true' ||
@@ -241,20 +241,19 @@ jobs:
        needs.detect-changes.outputs.styles == 'true' ||
        needs.detect-changes.outputs.source-checks == 'true') &&
       always() && !cancelled() &&
-      needs.detect-changes.result == 'success' &&
-      needs.update-dates.outputs.pushed != 'true'
+      needs.detect-changes.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      # When autofix ran (PRs/dev), check out the branch tip to get any fix commit.
-      # Otherwise (main/merge_group), use the default SHA that triggered the workflow.
+      # Check out branch tip when autofix or update-dates pushed commits, so lint
+      # sees the final state. Otherwise use the default SHA that triggered the workflow.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: needs.autofix.result == 'success'
+        if: needs.autofix.result == 'success' || needs.update-dates.outputs.pushed == 'true'
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: needs.autofix.result != 'success'
+        if: needs.autofix.result != 'success' && needs.update-dates.outputs.pushed != 'true'
 
       - name: Setup site
         uses: ./.github/actions/setup-site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,7 @@ The build follows a three-stage pipeline: **Transform → Filter → Emit**
 - **`config/quartz/quartz.config.ts`**: Main configuration defining transformer/emitter/filter pipeline
 - **`config/quartz/quartz.layout.ts`**: Page layout and component arrangement
 - **`config/typescript/tsconfig.json`**: Strict TypeScript config with Preact JSX
-- **`jest.config.js`**: Test config enforcing 100% coverage thresholds (at root due to Jest's module resolution requirements)
-- **`.cursorrules`**: Coding guidelines (minimal diffs, derive style from context, security-first)
+- **`config/javascript/jest.config.js`**: Test config enforcing 100% coverage thresholds (see `coveragePathIgnorePatterns` for excluded paths)
 
 ## Git Workflow
 
@@ -126,7 +125,7 @@ The build follows a three-stage pipeline: **Transform → Filter → Emit**
 ## Testing Requirements
 
 - **Zero flakiness tolerance**: Every CI check must pass every time. Prioritize root-cause fixes for anything we control (fix the test, fix the timeout, fix the code). For external services outside our control (e.g. Cloudflare API 504s), add retry logic as a last resort. No flakiness is acceptable regardless of source.
-- **TypeScript**: 100% branch/statement/function/line coverage enforced by Jest
+- **TypeScript**: 100% branch/statement/function/line coverage enforced by Jest for non-excluded files (see `coveragePathIgnorePatterns` in jest config)
 - **Python**: 100% line coverage enforced locally
 - Tests live alongside implementation files (`.test.ts` suffix)
 - Visual regression tests use Playwright with `lost-pixel`
@@ -221,7 +220,7 @@ After pushing to main:
 
 ## Design Philosophy
 
-Per `.cursorrules` and `design.md`:
+Per `design.md`:
 
 - Minimal, targeted changes only
 - Verify all information before generating code

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -16,6 +16,12 @@ import { wrapScrollables } from "./scroll-indicator-utils"
 // Global function injected by renderPage.tsx to lazy-load content index
 declare global {
   function getContentIndex(): Promise<{ [key: string]: ContentDetails }>
+  interface Window {
+    /** Set by onNav() after search event handlers are fully registered. */
+    __searchHandlersReady: boolean
+    /** Set once the search index has been built; never reset across SPA navigations. */
+    __searchIndexReady: boolean
+  }
 }
 
 const { debounceSearchDelay, mouseFocusDelay, searchPlaceholderDesktop, searchPlaceholderMobile } =
@@ -735,8 +741,7 @@ let cleanupListeners: (() => void) | undefined
 /* istanbul ignore next */
 function onNav(e: CustomEventMap["nav"]) {
   // Reset ready flag so tests wait for re-registration after SPA navigation.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(window as any).__searchHandlersReady = false
+  window.__searchHandlersReady = false
 
   // Clean up previous listeners and preview manager if they exist
   if (cleanupListeners) {
@@ -842,8 +847,7 @@ function onNav(e: CustomEventMap["nav"]) {
   }
 
   // Signal that search event handlers are fully registered for this page.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(window as any).__searchHandlersReady = true
+  window.__searchHandlersReady = true
 }
 
 /**
@@ -1122,9 +1126,7 @@ const resultToHTML = ({ slug, title, content }: Item, enablePreview: boolean) =>
  */
 export function navigateWithSearchTerm(href: string, searchTerm: string) {
   if (!searchTerm) {
-    console.error(
-      "[navigateWithSearchTerm] No search term available for result card navigation - this should not happen",
-    )
+    throw new Error("[navigateWithSearchTerm] No search term available for result card navigation")
   }
 
   const targetUrl = new URL(href)
@@ -1321,7 +1323,7 @@ async function initializeSearch(): Promise<void> {
       console.error("Can't locate the #search-bar element.")
       return
     }
-    const originalPlaceholder = searchBar?.placeholder
+    const originalPlaceholder = searchBar.placeholder
     searchBar.placeholder = "Loading search..."
 
     try {
@@ -1339,8 +1341,7 @@ async function initializeSearch(): Promise<void> {
         searchInitialized = true
         // Signal to tests that the index is ready. Unlike __searchHandlersReady,
         // this is never reset — the index persists across SPA navigations.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(window as any).__searchIndexReady = true
+        window.__searchIndexReady = true
         document.dispatchEvent(new CustomEvent("search-index-ready", { detail: undefined }))
       } else {
         // Data fetch failed — don't mark as initialized so retry is possible

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -710,14 +710,12 @@ describe("navigateWithSearchTerm", () => {
     expect(calledUrl.hash).toBe("#:~:text=test%20query")
   })
 
-  it("should log error when search term is empty", () => {
+  it("should throw when search term is empty", () => {
     const href = "https://example.com/page"
     const searchTerm = ""
 
-    navigateWithSearchTerm(href, searchTerm)
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "[navigateWithSearchTerm] No search term available for result card navigation - this should not happen",
+    expect(() => navigateWithSearchTerm(href, searchTerm)).toThrow(
+      "[navigateWithSearchTerm] No search term available for result card navigation",
     )
   })
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -367,12 +367,7 @@ export async function getNextElementMatchingSelector(
 export async function openSearch(page: Page) {
   // After SPA navigation (e.g. goBack), onNav() re-registers all search
   // event handlers asynchronously. Wait for the flag it sets at completion.
-  await page.waitForFunction(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    () => (window as any).__searchHandlersReady === true,
-    null,
-    { timeout: 15_000 },
-  )
+  await page.waitForFunction(() => window.__searchHandlersReady === true, null, { timeout: 15_000 })
 
   const searchContainer = page.locator("#search-container")
   const searchBar = page.locator("#search-bar")
@@ -409,12 +404,7 @@ export async function search(page: Page, term: string) {
 
   // Wait for the search index to load before filling (avoids resetting
   // the 400ms debounce timer with repeated fill() retries).
-  await page.waitForFunction(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    () => (window as any).__searchIndexReady === true,
-    null,
-    { timeout: 30_000 },
-  )
+  await page.waitForFunction(() => window.__searchIndexReady === true, null, { timeout: 30_000 })
 
   // If results are already displayed from a previous search, clear them
   // directly via the DOM. We can't rely on the app's debounced input handler

--- a/quartz/plugins/filters/draft.test.ts
+++ b/quartz/plugins/filters/draft.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "@jest/globals"
+
+import { type BuildCtx } from "../../util/ctx"
+import { type FilePath } from "../../util/path"
+import { defaultProcessedContent } from "../vfile"
+import { RemoveDrafts } from "./draft"
+
+const filter = RemoveDrafts()
+
+function shouldPublish(filePath: string): boolean {
+  const content = defaultProcessedContent({ filePath: filePath as FilePath })
+  return filter.shouldPublish({} as BuildCtx, content)
+}
+
+describe("RemoveDrafts", () => {
+  it("has the correct name", () => {
+    expect(filter.name).toBe("RemoveDrafts")
+  })
+
+  it.each([
+    ["website_content/posts/my-article.md", true],
+    ["website_content/about.md", true],
+    ["some/path/without/drafts.md", true],
+  ])("publishes non-draft file %s", (filePath, expected) => {
+    expect(shouldPublish(filePath)).toBe(expected)
+  })
+
+  it.each([
+    ["website_content/drafts/wip.md", false],
+    ["drafts/something.md", false],
+    ["some/nested/drafts/file.md", false],
+  ])("filters out draft file %s", (filePath, expected) => {
+    expect(shouldPublish(filePath)).toBe(expected)
+  })
+
+  it.each([
+    ["website_content/drafts/templates/my-template.md", true],
+    ["drafts/templates/base.md", true],
+  ])("publishes template even inside drafts/ %s", (filePath, expected) => {
+    expect(shouldPublish(filePath)).toBe(expected)
+  })
+
+  it("falls back to vfile.path when data.filePath is undefined", () => {
+    const content = defaultProcessedContent({})
+    content[1].path = "website_content/posts/article.md"
+    expect(filter.shouldPublish({} as BuildCtx, content)).toBe(true)
+  })
+
+  it("falls back to empty string when both filePath and path are undefined", () => {
+    const content = defaultProcessedContent({})
+    // With empty string, includes("drafts/") is false → publishes
+    expect(filter.shouldPublish({} as BuildCtx, content)).toBe(true)
+  })
+})

--- a/quartz/plugins/filters/draft.ts
+++ b/quartz/plugins/filters/draft.ts
@@ -3,7 +3,8 @@ import { type QuartzFilterPlugin } from "../types"
 export const RemoveDrafts: QuartzFilterPlugin = () => ({
   name: "RemoveDrafts",
   shouldPublish(_ctx, [, vfile]) {
-    // Use data.filePath which survives worker thread serialization
+    // Use data.filePath which survives worker thread serialization.
+    // Falls back to empty string if path is unknown — defaults to "publish".
     const filePath = vfile.data.filePath ?? vfile.path ?? ""
     return !filePath.includes("drafts/") || filePath.includes("templates/")
   },

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -1436,14 +1436,12 @@ describe("favicons.readFaviconUrls", () => {
 
   it("should handle file read errors and return an empty Map", async () => {
     const mockError = new Error("File read error")
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined)
     jest.spyOn(fs.promises, "readFile").mockRejectedValue(mockError)
 
     const result = await favicons.readFaviconUrls()
 
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
-    expect(consoleWarnSpy).toHaveBeenCalledWith(mockError)
   })
 })
 

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -234,7 +234,6 @@ export async function readFaviconUrls(): Promise<Map<string, string>> {
     return urlMap
   } catch (error) {
     logger.warn(`Error reading favicon URLs file: ${error}`)
-    console.warn(error)
     return new Map<string, string>()
   }
 }

--- a/quartz/util/favicon-config.test.ts
+++ b/quartz/util/favicon-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "@jest/globals"
+
+import {
+  normalizeHostname,
+  normalizeFaviconListEntry,
+  faviconCountWhitelistComputed,
+  faviconSubstringBlacklistComputed,
+} from "./favicon-config"
+
+describe("normalizeHostname", () => {
+  it.each([
+    ["blog.openai.com", "openai.com"],
+    ["docs.python.org", "python.org"],
+    ["www.example.com", "example.com"],
+    ["subdomain.example.co.uk", "example.co.uk"],
+  ])("strips subdomains: %s → %s", (input, expected) => {
+    expect(normalizeHostname(input)).toBe(expected)
+  })
+
+  it.each([
+    ["math.stackexchange.com", "math.stackexchange.com"],
+    ["gaming.stackexchange.com", "gaming.stackexchange.com"],
+  ])("preserves StackExchange subdomains: %s", (input, expected) => {
+    expect(normalizeHostname(input)).toBe(expected)
+  })
+
+  it("returns original hostname when PSL parsing fails", () => {
+    expect(normalizeHostname("localhost")).toBe("localhost")
+  })
+
+  it.each([
+    ["example.com", "example.com"],
+    ["github.com", "github.com"],
+  ])("keeps root domains unchanged: %s", (input, expected) => {
+    expect(normalizeHostname(input)).toBe(expected)
+  })
+
+  it("applies special domain mappings", () => {
+    expect(normalizeHostname("transformer-circuits.pub")).toBe("anthropic.com")
+  })
+})
+
+describe("normalizeFaviconListEntry", () => {
+  it("converts underscored hostnames through PSL pipeline", () => {
+    const result = normalizeFaviconListEntry("blog_example_com")
+    expect(result).toBe("example_com")
+  })
+
+  it("preserves StackExchange entries", () => {
+    expect(normalizeFaviconListEntry("math_stackexchange_com")).toBe("math_stackexchange_com")
+  })
+
+  it("handles simple domains", () => {
+    expect(normalizeFaviconListEntry("github_com")).toBe("github_com")
+  })
+})
+
+describe("computed lists", () => {
+  it("faviconCountWhitelistComputed is a non-empty array", () => {
+    expect(Array.isArray(faviconCountWhitelistComputed)).toBe(true)
+    expect(faviconCountWhitelistComputed.length).toBeGreaterThan(0)
+  })
+
+  it("faviconCountWhitelistComputed contains special favicon paths", () => {
+    const joined = faviconCountWhitelistComputed.join(",")
+    expect(joined).toContain("turntrout_com")
+  })
+
+  it("faviconSubstringBlacklistComputed is an array", () => {
+    expect(Array.isArray(faviconSubstringBlacklistComputed)).toBe(true)
+  })
+
+  it("blacklist entries are normalized (no deep subdomains)", () => {
+    for (const entry of faviconSubstringBlacklistComputed) {
+      // Each entry should be a simple underscore-separated domain
+      expect(typeof entry).toBe("string")
+      expect(entry.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -354,7 +354,10 @@ def check_sequence_relationships(
         key for key, value in sequence_data.items() if value is current_mapping
     }
 
-    for key, target_field_prefix in (("next", "prev"), ("prev", "next")):
+    direction_pairs: tuple[
+        tuple[SequenceDirection, str], tuple[SequenceDirection, str]
+    ] = (("next", "prev"), ("prev", "next"))
+    for key, target_field_prefix in direction_pairs:
         slug_field = f"{key}-post-slug"
         if slug_field not in current_mapping:
             continue
@@ -381,7 +384,7 @@ def check_sequence_relationships(
                 current_mapping,
                 target_mapping,
                 target_slug,
-                key,  # type: ignore[arg-type]
+                key,
             )
         )
 

--- a/scripts/strip_quotes.py
+++ b/scripts/strip_quotes.py
@@ -68,9 +68,6 @@ def strip_quote_blocks(text: str) -> str:
                 result.append(next_line)
                 break
             result.append("")
-        else:
-            # Quote block extends to end of file (no break hit)
-            pass
 
     return "\n".join(result)
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -2,6 +2,7 @@
 
 import functools
 import json
+import logging
 import shutil
 import subprocess
 from pathlib import Path
@@ -198,9 +199,10 @@ def get_files(
                 ValueError,
                 RuntimeError,
                 subprocess.CalledProcessError,
-            ):
-                # If Git operations fail, continue without Git filtering
-                pass
+            ) as exc:
+                logging.debug(
+                    "Git filtering failed, continuing without it: %s", exc
+                )
     return tuple(files)
 
 


### PR DESCRIPTION
## Summary
- Eliminate `(window as any)` casts in search code with proper `Window` interface augmentation, fix a silent error path that produced malformed URLs, and add missing unit tests for two previously uncovered modules
- Fix stale documentation in CLAUDE.md (non-existent `.cursorrules` reference, incorrect jest config path, misleading coverage claims)
- Clean up Python code: remove dead code, add logging to silent catch block, eliminate a `type: ignore` suppression
- Fix CI race condition where lint was silently skipped when `update-dates` pushed a `[skip ci]` commit

## Changes
- **search.ts**: Add `Window` interface for `__searchHandlersReady`/`__searchIndexReady`, replacing 5 `(window as any)` casts and removing 4 `eslint-disable` comments
- **search.ts**: `navigateWithSearchTerm` now throws on empty `searchTerm` instead of logging and continuing with malformed URL fragment (aligns with "fail loudly" policy)
- **search.ts**: Remove redundant `?.` on already-null-checked `searchBar`
- **visual_utils.ts**: Update `waitForFunction` calls to use typed `window` properties
- **favicons.ts**: Remove duplicate `console.warn(error)` (already logged via winston `logger.warn`)
- **draft.ts**: Add clarifying comment about unknown-path default behavior
- **draft.test.ts** (new): 11 tests covering all branches of `RemoveDrafts` filter (100% coverage)
- **favicon-config.test.ts** (new): 17 tests for `normalizeHostname`, `normalizeFaviconListEntry`, and computed whitelist/blacklist arrays (100% coverage)
- **source_file_checks.py**: Properly type `direction_pairs` tuple to eliminate `type: ignore[arg-type]`
- **strip_quotes.py**: Remove dead `else: pass` block
- **utils.py**: Replace silent `except: pass` with `logging.debug` message
- **CLAUDE.md**: Remove references to non-existent `.cursorrules`, correct jest config path, clarify coverage exclusion policy
- **lint-and-validate.yaml**: Fix CI race condition — lint was skipped when `update-dates` pushed because the `[skip ci]` commit prevented the fresh workflow run that was assumed. Removed the skip guard and extended the branch-tip checkout to cover the `update-dates` case.

## Testing
- Full TypeScript test suite: 3561 tests passing, 100% coverage on all non-excluded files
- `pnpm check` (tsc + prettier + stylelint): all green
- Python tests for `strip_quotes`, `source_file_checks`, and `utils`: all passing
- Pre-push checks: all 6 checks passed on every push
- Self-critique sub-agent reviewed the diff and found no issues
- CI race condition fix verified by tracing the workflow logic: `update-dates` commits use `[skip ci]` so no fresh workflow triggers, meaning the previous `needs.update-dates.outputs.pushed != 'true'` guard silently dropped lint

https://claude.ai/code/session_01WLMDYNJToemUE6ihBniU8e