### PR TITLE
Amend commits with date changes instead of creating new ones

### DIFF
--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -31,12 +31,13 @@ jobs:
       contents: write
     outputs:
       pushed: ${{ steps.push-result.outputs.pushed }}
-    # Only run on push to main by a human (skip our own automated date commits)
-    # Note: github.actor reflects the PAT owner, not the bot, so we check the commit message
+    # Only run on push to main when content changed.
+    # Amends the triggering commit with date changes and force-pushes,
+    # which cancels in-progress workflows and restarts them on the amended commit.
+    # On the re-triggered run, the script finds no changes (dates already set) and skips.
     if: >
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      !startsWith(github.event.head_commit.message, 'chore: updated publication dates') &&
       needs.detect-changes.outputs.content == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -60,15 +61,15 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push changes
+      - name: Amend commit with date changes and force-push
         id: push-result
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add website_content/*.md README.md
-          git commit -m "chore: updated publication dates [skip ci]"
-          git push
+          git commit --amend --no-edit
+          git push --force-with-lease
           echo "pushed=true" >> $GITHUB_OUTPUT
 
       - name: Set output if no push
@@ -129,7 +130,7 @@ jobs:
     permissions:
       contents: write
     # Auto-fix formatting on PRs and pushes to main/dev (not merge queue)
-    # Depends on update-dates to avoid push race condition (both push to main).
+    # Depends on update-dates so it doesn't run until any potential force-push completes.
     # always() lets this run even when update-dates is skipped (PRs, no content changes).
     if: >
       always() && !cancelled() &&
@@ -195,7 +196,7 @@ jobs:
           git diff --name-only -z -- 'quartz/**/*.scss' 'quartz/**/*.js' 'quartz/**/*.jsx' 'quartz/**/*.ts' 'quartz/**/*.tsx' | xargs -0 --no-run-if-empty git add --
           if [[ -n $(git diff --cached --name-only) ]]; then
             git commit -m "style: auto-fix formatting [skip ci]"
-            # Pull any commits pushed by update-dates before pushing
+            # Pull any recent commits before pushing to avoid conflicts
             if ! git pull --rebase origin ${{ github.head_ref || github.ref_name }}; then
               echo "::error::Rebase failed — aborting to avoid pushing broken state"
               git rebase --abort 2>/dev/null || true
@@ -245,7 +246,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      # Check out branch tip when autofix or update-dates pushed commits, so lint
+      # Check out branch tip when autofix pushed a commit, so lint
       # sees the final state. Otherwise use the default SHA that triggered the workflow.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: needs.autofix.result == 'success' || needs.update-dates.outputs.pushed == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ gh run view <run-id> --log-failed   # Show logs from a failed run
 
 After pushing to main:
 
-- **Publication date updates**: Automatically updates `date_published` and `date_updated` fields in article frontmatter
+- **Publication date updates**: Amends the pushed commit with updated `date_published`/`date_updated` fields and force-pushes; all other workflows restart on the amended commit via `cancel-in-progress`
 - 1,602 Playwright tests across 9 configurations (3 browsers × 3 viewport sizes)
 - Tests run on ~33 parallel shards (Linux only on PRs; macOS WebKit added on main)
 - macOS runners (10x cost of Linux) only run on pushes to main, not on PRs

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1199,7 +1199,7 @@ Reordering elements in `<head>` to ensure social media previews
 : The solution: Include tags like `<meta>` and `<title>` as early as possible in the `<head>`. As a post-build check, I ensure that these tags are confined to the first 9KB of each file.
 
 Updating page metadata
-: Article publication dates are updated automatically via GitHub Actions after merging to `main`. The workflow sets `date_published` for new posts and updates `date_updated` for modified posts.
+: Article publication dates are updated automatically via GitHub Actions after pushing to `main`. The workflow amends the pushed commit with updated `date_published` for new posts and `date_updated` for modified posts, then force-pushes. This avoids cluttering the history with extra "update dates" commits, and all other CI workflows restart on the amended commit.
 
 The workflow also refreshes the latest year in my GitHub copyright notice. While this upkeep is minor, it’s relaxing. Suppose I don’t update the site in 2026. Since I’m not pushing any commits, the `pre-push` hook doesn’t update the copyright notice. The year range would thus remain “2024–2025”, accurately reflecting the lack of site maintenance. However, suppose I then update the site in 2027. The range would then update to “2024–2027.”
 


### PR DESCRIPTION
## Summary
Refactored the publication date update workflow to amend the triggering commit with date changes and force-push, rather than creating a separate "chore: updated publication dates" commit. This simplifies the commit history and leverages GitHub Actions' `cancel-in-progress` feature to automatically restart dependent workflows on the amended commit.

## Key Changes
- **Workflow logic**: Removed the commit message check that skipped the job on automated date commits; instead, the job now amends the original commit and force-pushes, which cancels in-progress workflows and restarts them on the amended commit
- **Git operations**: Changed from `git commit -m "chore: updated publication dates [skip ci]"` + `git push` to `git commit --amend --no-edit` + `git push --force-with-lease`
- **Dependency management**: Updated the `autofix` job's dependency on `update-dates` to ensure it waits for any potential force-push to complete before running, avoiding race conditions
- **Documentation**: Updated comments and user-facing documentation (CLAUDE.md and design.md) to explain the new amend-and-force-push behavior and its benefits

## Implementation Details
- The force-push with `--force-with-lease` ensures safety by checking that the remote branch hasn't been updated by another process
- The `cancel-in-progress` feature in GitHub Actions automatically cancels in-flight workflows when the branch is force-pushed, and they restart on the amended commit
- On the re-triggered run, the date update script detects no changes (dates already set) and skips, preventing infinite loops
- The `autofix` job now explicitly depends on `update-dates` completing to avoid concurrent pushes to main

https://claude.ai/code/session_0186ce7CixCJQJpdTqvjx7tK