### PR TITLE
Remove no-smallcaps wrapper and add text cursor to dropcaps

### DIFF
--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -324,6 +324,7 @@ code {
   position: relative;
   text-transform: uppercase;
   margin-right: 0.05rem;
+  cursor: text;
 
   // Inline dropcaps should be slightly higher than the baseline
   p & {

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -353,6 +353,7 @@ article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
   font-family: var(--font-main);
   position: relative;
   min-height: #{$dropcap-min-height};
+  cursor: text;
 
   // Float spacer: controls text wrapping with fixed width, preventing CLS
   // when dropcap fonts load (::first-letter doesn't support width)

--- a/website_content/open-source.md
+++ b/website_content/open-source.md
@@ -26,11 +26,7 @@ date_updated: 2026-04-10 04:21:11.395410
 
 # Punctilio for meticulous typography
 
-<div class="no-smallcaps">
-  
 <span class="populate-markdown-punctilio"></span>
-
-</div>
 
 # This website
 

--- a/website_content/punctilio.md
+++ b/website_content/punctilio.md
@@ -9,7 +9,6 @@ description: Meticulously beautify your text using my "punctilio" library. No in
 tags:
   - website
   - open-source
-  - smallcaps
 aliases:
   - prettify
   - text-prettify

--- a/website_content/punctilio.md
+++ b/website_content/punctilio.md
@@ -9,6 +9,7 @@ description: Meticulously beautify your text using my "punctilio" library. No in
 tags:
   - website
   - open-source
+  - smallcaps
 aliases:
   - prettify
   - text-prettify


### PR DESCRIPTION
## Summary
This PR makes two refinements to the typography styling: removes an unnecessary wrapper div from the Punctilio section and improves the user experience for dropcap elements by adding text cursor styling.

## Key Changes
- **Removed `no-smallcaps` wrapper**: Deleted the `<div class="no-smallcaps">` container around the Punctilio markdown population span in `open-source.md`, simplifying the HTML structure
- **Added text cursor to dropcaps**: Added `cursor: text;` CSS property to both inline dropcap and article dropcap styles in `fonts.scss` to indicate that the text is selectable

## Implementation Details
- The dropcap cursor styling is applied to both `.dropcap` elements (inline dropcaps) and `article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type::first-letter` (article dropcaps)
- This improves UX by providing visual feedback that dropcap text can be selected and interacted with, consistent with standard text selection behavior

https://claude.ai/code/session_01V4WHFsnJEcsCWE8ZvqY4MU