### PR TITLE
fix: improve type safety, fix coerceToArray trim bug, harden CSV parsing

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -489,7 +489,7 @@ export default async (argv: Argv, mut: Mutex, clientRefresh: () => void) => {
   try {
     return await buildQuartz(argv, mut, clientRefresh)
   } catch (err) {
-    trace("\nExiting Quartz due to a fatal error", err as Error)
+    trace("\nExiting Quartz due to a fatal error", err)
     return () => {
       // No cleanup needed on fatal error (process will exit)
     }

--- a/quartz/plugins/transformers/countFavicons.ts
+++ b/quartz/plugins/transformers/countFavicons.ts
@@ -29,7 +29,7 @@ export const faviconCounter = new Map<string, number>()
 /**
  * Gets favicon counts from memory, or reads from file if memory is empty.
  * This handles cases where counts are needed in a different process than where they were generated.
- * @returns A Map of favicon path to count
+ * @returns A ReadonlyMap of favicon path to count
  */
 export async function getFaviconCounts(): Promise<ReadonlyMap<string, number>> {
   // If in-memory map has data, use it (normal build-time usage)

--- a/quartz/plugins/transformers/countFavicons.ts
+++ b/quartz/plugins/transformers/countFavicons.ts
@@ -31,7 +31,7 @@ export const faviconCounter = new Map<string, number>()
  * This handles cases where counts are needed in a different process than where they were generated.
  * @returns A Map of favicon path to count
  */
-export async function getFaviconCounts(): Promise<Map<string, number>> {
+export async function getFaviconCounts(): Promise<ReadonlyMap<string, number>> {
   // If in-memory map has data, use it (normal build-time usage)
   if (faviconCounter.size > 0) {
     logger.info(`Using in-memory favicon counts: ${faviconCounter.size} entries`)

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -1415,6 +1415,14 @@ describe("favicons.readFaviconUrls", () => {
     ],
     ["", new Map(), "empty file"],
     [
+      "example.com,https://example.com/path?a=1,2\ntest.com,https://test.com/favicon.png",
+      new Map([
+        ["example.com", "https://example.com/path?a=1,2"],
+        ["test.com", "https://test.com/favicon.png"],
+      ]),
+      "URL containing comma",
+    ],
+    [
       "example.com,https://example.com/favicon.ico\ninvalid_line\ntest.com,https://test.com/favicon.png",
       new Map([
         ["example.com", "https://example.com/favicon.ico"],

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -184,9 +184,9 @@ export function writeCacheToFile(): void {
 }
 
 /**
- * Reads favicon counts from the faviconCountsFile and returns them as a Map.
+ * Reads favicon counts from the faviconCountsFile and returns them as a ReadonlyMap.
  *
- * @returns A Map of favicon path to count, or empty Map if file doesn't exist or can't be read.
+ * @returns A ReadonlyMap of favicon path to count, or empty Map if file doesn't exist or can't be read.
  */
 export async function readFaviconCounts(): Promise<ReadonlyMap<string, number>> {
   try {
@@ -216,9 +216,9 @@ export async function readFaviconCounts(): Promise<ReadonlyMap<string, number>> 
 }
 
 /**
- * Reads favicon URLs from the faviconUrlsFile and returns them as a Map.
+ * Reads favicon URLs from the faviconUrlsFile and returns them as a ReadonlyMap.
  *
- * @returns A Promise that resolves to a Map of basename to URL strings.
+ * @returns A Promise that resolves to a ReadonlyMap of basename to URL strings.
  */
 export async function readFaviconUrls(): Promise<ReadonlyMap<string, string>> {
   try {

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -156,7 +156,7 @@ export function getQuartzPath(hostname: string): string {
   return path
 }
 
-const defaultCache = new Map<string, string>([
+const defaultCache: ReadonlyMap<string, string> = new Map<string, string>([
   [specialFaviconPaths.turntrout, specialFaviconPaths.turntrout],
 ])
 // skipcq: JS-D1001
@@ -188,7 +188,7 @@ export function writeCacheToFile(): void {
  *
  * @returns A Map of favicon path to count, or empty Map if file doesn't exist or can't be read.
  */
-export async function readFaviconCounts(): Promise<Map<string, number>> {
+export async function readFaviconCounts(): Promise<ReadonlyMap<string, number>> {
   try {
     await fs.promises.access(faviconCountsFile, fs.constants.F_OK)
   } catch {
@@ -220,13 +220,16 @@ export async function readFaviconCounts(): Promise<Map<string, number>> {
  *
  * @returns A Promise that resolves to a Map of basename to URL strings.
  */
-export async function readFaviconUrls(): Promise<Map<string, string>> {
+export async function readFaviconUrls(): Promise<ReadonlyMap<string, string>> {
   try {
     const data = await fs.promises.readFile(faviconUrlsFile, "utf8")
     const lines = data.split("\n")
     const urlMap = new Map<string, string>()
     for (const line of lines) {
-      const [basename, url] = line.split(",")
+      const commaIndex = line.indexOf(",")
+      if (commaIndex === -1) continue
+      const basename = line.slice(0, commaIndex)
+      const url = line.slice(commaIndex + 1)
       if (basename && url) {
         urlMap.set(basename, url)
       }
@@ -811,7 +814,7 @@ function shouldSkipFavicon(node: Element, href: string): boolean {
 export function shouldIncludeFavicon(
   imgPath: string,
   countKey: string,
-  faviconCounts: Map<string, number>,
+  faviconCounts: ReadonlyMap<string, number>,
 ): boolean {
   const isBlacklisted = faviconSubstringBlacklistComputed.some((entry: string) =>
     imgPath.includes(entry),
@@ -843,7 +846,7 @@ export function normalizeUrl(href: string): string {
 async function handleLink(
   href: string,
   node: Element,
-  faviconCounts: Map<string, number>,
+  faviconCounts: ReadonlyMap<string, number>,
 ): Promise<void> {
   try {
     const finalURL = new URL(href)
@@ -894,7 +897,7 @@ async function handleLink(
 export async function ModifyNode(
   node: Element,
   parent: Parent,
-  faviconCounts: Map<string, number>,
+  faviconCounts: ReadonlyMap<string, number>,
 ): Promise<void> {
   logger.debug(`Modifying node: ${node.tagName}`)
   if (node.tagName !== "a" || !node.properties.href) {

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -65,7 +65,8 @@ function coerceToArray(input: string | string[], lowercase = true): string[] | u
   // coerce to array
   if (!Array.isArray(input)) {
     const parts = input.toString().split(",")
-    input = lowercase ? parts.map((tag: string) => tag.toLowerCase()) : parts.map((s) => s.trim())
+    const trimmed = parts.map((s) => s.trim())
+    input = lowercase ? trimmed.map((tag) => tag.toLowerCase()) : trimmed
   }
 
   // remove all non-strings

--- a/quartz/processors/emit.ts
+++ b/quartz/processors/emit.ts
@@ -30,7 +30,7 @@ export async function emitContent(ctx: BuildCtx, content: ProcessedContent[]) {
         }
       }
     } catch (err) {
-      trace(`Failed to emit from plugin \`${emitter.name}\``, err as Error)
+      trace(`Failed to emit from plugin \`${emitter.name}\``, err)
     }
   }
 

--- a/quartz/processors/parse.ts
+++ b/quartz/processors/parse.ts
@@ -152,7 +152,7 @@ export function createFileParser(ctx: BuildCtx, fps: FilePath[]) {
           console.log(`[process] ${fp} -> ${file.data.slug} (${perf.timeSince()})`)
         }
       } catch (err) {
-        trace(`\nFailed to process \`${fp}\``, err as Error)
+        trace(`\nFailed to process \`${fp}\``, err)
       }
     }
 

--- a/quartz/util/favicon-config.ts
+++ b/quartz/util/favicon-config.ts
@@ -65,7 +65,7 @@ export function normalizeFaviconListEntry(entry: string): string {
  * Whitelist uses substring matching, so raw entries work fine (e.g., "apple_com"
  * matches any path containing that substring). No PSL normalization needed.
  */
-export const faviconCountWhitelistComputed = [
+export const faviconCountWhitelistComputed: readonly string[] = [
   ...Object.values(specialFaviconPaths),
   ...faviconCountWhitelist,
   ...googleSubdomainWhitelist.map((subdomain) => `${subdomain.replaceAll(".", "_")}_google_com`),
@@ -77,5 +77,5 @@ export const faviconCountWhitelistComputed = [
  * reduced to their registered domain form (e.g., "csir_co_za") to match
  * what getQuartzPath produces.
  */
-export const faviconSubstringBlacklistComputed =
+export const faviconSubstringBlacklistComputed: readonly string[] =
   faviconSubstringBlacklist.map(normalizeFaviconListEntry)

--- a/quartz/util/trace.ts
+++ b/quartz/util/trace.ts
@@ -3,14 +3,15 @@ import process from "process"
 import { isMainThread } from "workerpool"
 
 const rootFile = /.*at file:/
-export function trace(msg: string, err: Error): never {
-  const stack = err.stack ?? ""
+export function trace(msg: string, err: unknown): never {
+  const error = err instanceof Error ? err : new Error(String(err))
+  const stack = error.stack ?? ""
 
   const lines: string[] = []
 
   lines.push("")
   lines.push(
-    `\n${chalk.bgRed.black.bold(" ERROR ")}\n\n${chalk.red(` ${msg}`)}${err.message.length > 0 ? `: ${err.message}` : ""}`,
+    `\n${chalk.bgRed.black.bold(" ERROR ")}\n\n${chalk.red(` ${msg}`)}${error.message.length > 0 ? `: ${error.message}` : ""}`,
   )
 
   let reachedEndOfLegibleTrace = false


### PR DESCRIPTION
## Summary
- Fix bug where comma-separated frontmatter tags weren't trimmed when lowercased, producing tags with leading whitespace
- Harden favicon URL cache parsing to split on first comma only, preventing silent data truncation
- Improve type safety across the build pipeline by accepting `unknown` errors in `trace()` and using `ReadonlyMap`/`readonly` types for collections that shouldn't be mutated

## Changes
- **frontmatter.ts**: Fix `coerceToArray` to always trim whitespace from comma-separated string inputs before lowercasing
- **favicons.ts**: Replace `line.split(",")` with `indexOf`-based split in `readFaviconUrls` to handle values containing commas; add `ReadonlyMap` return types for `readFaviconCounts`/`readFaviconUrls`; make `defaultCache` a `ReadonlyMap`; update `shouldIncludeFavicon`/`handleLink`/`ModifyNode` parameters to `ReadonlyMap`
- **countFavicons.ts**: Update `getFaviconCounts` return type to `ReadonlyMap`
- **trace.ts**: Change `trace()` second parameter from `Error` to `unknown`, wrapping non-Error values with `new Error(String(err))`
- **build.ts, parse.ts, emit.ts**: Remove unsafe `err as Error` casts at `trace()` call sites
- **favicon-config.ts**: Add `readonly string[]` type to `faviconCountWhitelistComputed` and `faviconSubstringBlacklistComputed`
- **favicons.test.ts**: Add regression test for comma-in-URL parsing

## Testing
- All 3618 tests pass with 100% coverage
- TypeScript type checker passes (`pnpm check`)
- Pre-push hooks pass (linting, formatting, SCSS cleanup)

https://claude.ai/code/session_01JkzmYQ3abE72TdyT6wU4no