### PR TITLE
Collapse internal whitespace in paragraphs for spellcheck

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -2862,6 +2862,7 @@ reframing-impact
 regexes
 regularizer
 regularizers
+rehype
 reinforcer
 reinforcers
 relacionados
@@ -3235,6 +3236,7 @@ unstoppably
 unstyled
 untackled
 untethered
+untransformed
 unwisdom
 uparrow
 uptime

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -2621,6 +2621,11 @@ def _normalize_paragraph_text(element: Tag) -> str:
                 link.decompose()
 
     text = script_utils.get_non_code_text(el_copy).strip()
+    # Collapse internal whitespace (including newlines) into single spaces
+    # so each paragraph occupies exactly one line in the spellcheck tempfile;
+    # otherwise embedded newlines would desync the line_to_source mapping and
+    # misattribute later paragraphs' warnings to the wrong source file.
+    text = re.sub(r"\s+", " ", text)
     # Normalize smart quotes to ASCII so spellchecker treats
     # contractions like "I've" as single words instead of "I"+"ve"
     text = text.replace("\u2019", "'").replace("\u2018", "'")
@@ -2674,7 +2679,11 @@ def _write_paragraphs_to_tempfile(
     ) as tmp:
         for file_path, paragraphs in paragraph_map.items():
             for para in paragraphs:
-                tmp.write(f"{para}\n")
+                # Defensive: flatten any embedded newlines so each paragraph
+                # occupies one tempfile line and the line_to_source mapping
+                # stays in sync with spellchecker-cli's per-line warnings.
+                flattened = para.replace("\n", " ")
+                tmp.write(f"{flattened}\n")
                 line_to_source[line_num] = file_path
                 line_num += 1
         return Path(tmp.name), line_to_source

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2838,6 +2838,22 @@ def test_extract_flat_paragraph_texts_rejoins_dropcap_contractions():
     assert "I 've" not in result[0]
 
 
+def test_extract_flat_paragraph_texts_collapses_internal_whitespace():
+    """
+    Embedded newlines/tabs in paragraph HTML are collapsed to single spaces.
+
+    Each paragraph must occupy exactly one line in the spellcheck tempfile so
+    the line_to_source mapping stays in sync with per-line warnings.
+    """
+    html = "<article><p>First line\n\nsecond line\twith\ttabs.</p></article>"
+    soup = BeautifulSoup(html, "html.parser")
+    result = built_site_checks._extract_flat_paragraph_texts(soup)
+    assert len(result) == 1
+    assert "\n" not in result[0]
+    assert "\t" not in result[0]
+    assert "First line second line with tabs" in result[0]
+
+
 def test_extract_flat_paragraph_texts_skips_p_with_block_level_children():
     """
     A <p> containing block-level elements (e.g. from transclusion wrapping
@@ -2897,6 +2913,37 @@ def test_parse_spellcheck_output(stdout, line_to_source, expected):
         built_site_checks._parse_spellcheck_output(stdout, line_to_source)
         == expected
     )
+
+
+def test_write_paragraphs_to_tempfile_preserves_one_line_per_paragraph(
+    tmp_path, monkeypatch
+):
+    """
+    Each paragraph maps to exactly one tempfile line, even if it contains
+    embedded newlines.
+
+    Otherwise line_to_source misattributes later paragraphs' warnings to the
+    wrong source file.
+    """
+    monkeypatch.setattr(built_site_checks, "_GIT_ROOT", tmp_path)
+    paragraph_map = {
+        "first.html": ["paragraph one with\nembedded newline"],
+        "second.html": ["paragraph two on second file"],
+    }
+    tmp_file, line_to_source = built_site_checks._write_paragraphs_to_tempfile(
+        paragraph_map
+    )
+    try:
+        contents = tmp_file.read_text(encoding="utf-8")
+    finally:
+        tmp_file.unlink(missing_ok=True)
+
+    lines = contents.splitlines()
+    assert len(lines) == 2
+    assert line_to_source == {1: "first.html", 2: "second.html"}
+    assert "\n" not in lines[0]
+    # The paragraph for line 2 really belongs to the second file.
+    assert "second file" in lines[1]
 
 
 def test_spellcheck_flattened_paragraphs_empty():
@@ -3710,13 +3757,11 @@ def test_check_file_for_issues_markdown_check_called_with_valid_md(
     html_file_path = base_dir / "test.html"
     html_file_path.write_text("<html><body>Test</body></html>")
     md_file_path = content_dir / "test.md"
-    md_file_path.write_text(
-        """---
+    md_file_path.write_text("""---
 title: Test Title
 description: Test Description
 ---
-# Content here"""
-    )
+# Content here""")
     assert md_file_path.is_file()
 
     with (


### PR DESCRIPTION
## Summary
Fix a bug where embedded newlines and tabs in paragraph HTML were causing the spellchecker's line-to-source mapping to become desynchronized, resulting in warnings being misattributed to the wrong source files.

## Key Changes
- **Normalize paragraph text**: Added whitespace collapsing in `_normalize_paragraph_text()` to convert all internal whitespace (newlines, tabs, multiple spaces) into single spaces using regex substitution
- **Defensive flattening in tempfile writer**: Added an additional safeguard in `_write_paragraphs_to_tempfile()` to flatten any remaining newlines before writing to the temporary file
- **Test coverage**: Added two comprehensive tests:
  - `test_extract_flat_paragraph_texts_collapses_internal_whitespace()` - verifies that paragraph extraction properly collapses embedded whitespace
  - `test_write_paragraphs_to_tempfile_preserves_one_line_per_paragraph()` - ensures the tempfile maintains one paragraph per line and the line_to_source mapping stays accurate

## Implementation Details
The fix ensures that each paragraph occupies exactly one line in the spellcheck tempfile. This is critical because the spellchecker-cli tool reports warnings on a per-line basis, and any embedded newlines would cause the line number to advance without updating the line_to_source mapping, leading to subsequent paragraphs' warnings being attributed to incorrect source files.

The whitespace normalization is applied at two levels:
1. During paragraph text extraction (primary fix)
2. During tempfile writing (defensive measure to catch any edge cases)

https://claude.ai/code/session_018LnX2SMPppfYbHG1WNbSLv