### PR TITLE
Extract diff rendering logic into dedicated module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,8 @@ The build follows a three-stage pipeline: **Transform → Filter → Emit**
 - Most quality checks (linting, tests, spellcheck, link validation) run in CI
 - Can resume from last failure: `RESUME=true git push`
 
+**Dev branch workflow**: Whenever making changes to the `dev` branch, first merge `main` into `dev`, push `dev`, and then start the new feature branch from `dev`.
+
 ## Content Structure
 
 - **`website_content/`**: Markdown source files with YAML frontmatter

--- a/quartz/components/scripts/punctilio-demo-diff.test.ts
+++ b/quartz/components/scripts/punctilio-demo-diff.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "@jest/globals"
+
+import {
+  MAX_CHAR_DIFF_LENGTH,
+  escapeForOutput,
+  renderCharDiff,
+  renderChangedLinePair,
+  renderDiffHtml,
+  renderPrefixSuffixDiff,
+} from "./punctilio-demo-diff"
+
+describe("escapeForOutput", () => {
+  it.each([
+    ["plain text", "plain text"],
+    ["<b>bold</b>", "&lt;b&gt;bold&lt;/b&gt;"],
+    ['"quoted"', "&quot;quoted&quot;"],
+    ["a & b", "a &amp; b"],
+    ["line1\nline2", "line1<br>line2"],
+    ["a\nb\nc", "a<br>b<br>c"],
+    ["", ""],
+  ])("escapes %j to %j", (input, expected) => {
+    expect(escapeForOutput(input)).toBe(expected)
+  })
+})
+
+describe("renderCharDiff", () => {
+  const change = (value: string, flags: { added?: boolean; removed?: boolean } = {}) => ({
+    value,
+    added: flags.added ?? false,
+    removed: flags.removed ?? false,
+    count: value.length,
+  })
+
+  it("renders unchanged text as plain", () => {
+    expect(renderCharDiff([change("abc")])).toBe("abc")
+  })
+
+  it("wraps added text in diff-insert span", () => {
+    expect(renderCharDiff([change("xyz", { added: true })])).toBe(
+      '<span class="diff-insert">xyz</span>',
+    )
+  })
+
+  it("drops removed text entirely", () => {
+    expect(renderCharDiff([change("gone", { removed: true })])).toBe("")
+  })
+
+  it("escapes HTML in all branches and replaces newlines with <br>", () => {
+    expect(
+      renderCharDiff([
+        change("a\n<"),
+        change('b"', { added: true }),
+        change("c&", { removed: true }),
+      ]),
+    ).toBe('a<br>&lt;<span class="diff-insert">b&quot;</span>')
+  })
+
+  it("returns empty string for no changes", () => {
+    expect(renderCharDiff([])).toBe("")
+  })
+})
+
+describe("renderPrefixSuffixDiff", () => {
+  it.each([
+    // Full replacement (no shared chars)
+    ["abc", "xyz", '<span class="diff-insert">xyz</span>'],
+    // Identical -> no highlight
+    ["same", "same", "same"],
+    // Change in the middle
+    ["abXcd", "abYZcd", 'ab<span class="diff-insert">YZ</span>cd'],
+    // Pure append (new longer)
+    ["abc", "abcXYZ", 'abc<span class="diff-insert">XYZ</span>'],
+    // Pure truncation (old longer, new is prefix)
+    ["abcXYZ", "abc", "abc"],
+    // Pure prepend
+    ["cd", "abcd", '<span class="diff-insert">ab</span>cd'],
+    // Empty old
+    ["", "new", '<span class="diff-insert">new</span>'],
+    // Empty new
+    ["old", "", ""],
+    // Both empty
+    ["", "", ""],
+    // Single-char difference
+    ["hello", "hallo", 'h<span class="diff-insert">a</span>llo'],
+  ])("diffs %j -> %j as %j", (oldText, newText, expected) => {
+    expect(renderPrefixSuffixDiff(oldText, newText)).toBe(expected)
+  })
+
+  it("escapes HTML in prefix, middle, and suffix", () => {
+    expect(renderPrefixSuffixDiff('<a>"x"</a>', '<a>"y"</a>')).toBe(
+      '&lt;a&gt;&quot;<span class="diff-insert">y</span>&quot;&lt;/a&gt;',
+    )
+  })
+
+  it("merges multiple disjoint changes into one span (documented trade-off)", () => {
+    // Two separate edits: "X" -> "Y" and "P" -> "Q". Prefix/suffix collapses
+    // everything between the first and last divergence into a single span.
+    expect(renderPrefixSuffixDiff("aXbbbPc", "aYbbbQc")).toBe(
+      'a<span class="diff-insert">YbbbQ</span>c',
+    )
+  })
+})
+
+describe("renderChangedLinePair", () => {
+  it("uses precise char-diff below the threshold", () => {
+    const html = renderChangedLinePair("hello", "hallo")
+    // Myers char-diff splits the single-char substitution into a char-granular span
+    expect(html).toContain('<span class="diff-insert">a</span>')
+    expect(html).not.toContain('<span class="diff-insert">allo</span>')
+  })
+
+  it("falls back to prefix/suffix above the threshold", () => {
+    // Build inputs whose combined length exceeds MAX_CHAR_DIFF_LENGTH, with
+    // edits scattered enough that char-diff would produce multiple spans.
+    const size = MAX_CHAR_DIFF_LENGTH
+    const oldText = "X" + "a".repeat(size) + "Y" + "b".repeat(size) + "Z"
+    const newText = "P" + "a".repeat(size) + "Q" + "b".repeat(size) + "R"
+    const html = renderChangedLinePair(oldText, newText)
+    // Prefix/suffix merges the three separate edits into exactly one span
+    expect(html.match(/class="diff-insert"/g)?.length).toBe(1)
+    // And that span contains the entire divergent middle of the new text
+    expect(html).toContain(`P${"a".repeat(size)}Q${"b".repeat(size)}R`)
+  })
+})
+
+describe("renderDiffHtml", () => {
+  it("returns unchanged text as-is when source equals result", () => {
+    expect(renderDiffHtml("hello world", "hello world")).toBe("hello world")
+  })
+
+  it("returns empty string for two empty inputs", () => {
+    expect(renderDiffHtml("", "")).toBe("")
+  })
+
+  it("highlights char-level edits on a single line", () => {
+    const html = renderDiffHtml('"hi"', "\u201chi\u201d")
+    expect(html).toContain('<span class="diff-insert">\u201c</span>')
+    expect(html).toContain('<span class="diff-insert">\u201d</span>')
+    // The unchanged "hi" in the middle must not be wrapped in a diff-insert
+    expect(html).toMatch(/<\/span>hi<span/)
+  })
+
+  it("escapes HTML in both unchanged and added text", () => {
+    expect(renderDiffHtml("<a>", '<a>"')).toBe('&lt;a&gt;<span class="diff-insert">&quot;</span>')
+  })
+
+  it("renders newlines in unchanged lines as <br>", () => {
+    expect(renderDiffHtml("a\nb\n", "a\nb\n")).toBe("a<br>b<br>")
+  })
+
+  it("handles multi-line input: unchanged lines are plain, changed lines are refined", () => {
+    const source = "line one\nline two\nline three\n"
+    const result = 'line one\nline "two"\nline three\n'
+    const html = renderDiffHtml(source, result)
+    expect(html).toContain("line one<br>")
+    expect(html).toContain("line three<br>")
+    // Only the middle line carries diff-insert markers
+    expect(html).toContain('<span class="diff-insert">&quot;</span>')
+  })
+
+  it("wraps a pure line insertion (no paired removal) in a single diff-insert span", () => {
+    const html = renderDiffHtml("a\nc\n", "a\nb\nc\n")
+    expect(html).toBe('a<br><span class="diff-insert">b<br></span>c<br>')
+  })
+
+  it("emits nothing for a pure line removal", () => {
+    const html = renderDiffHtml("a\nb\nc\n", "a\nc\n")
+    expect(html).toBe("a<br>c<br>")
+    expect(html).not.toContain("diff-insert")
+  })
+
+  it("uses the linear fallback on long single-line input without corrupting output", () => {
+    // Single-line input well above the char-diff threshold with one edit in
+    // the middle. Linear prefix/suffix must produce the same visible result.
+    const filler = "a".repeat(MAX_CHAR_DIFF_LENGTH)
+    const source = `${filler}X${filler}`
+    const result = `${filler}Y${filler}`
+    expect(renderDiffHtml(source, result)).toBe(
+      `${filler}<span class="diff-insert">Y</span>${filler}`,
+    )
+  })
+})

--- a/quartz/components/scripts/punctilio-demo-diff.ts
+++ b/quartz/components/scripts/punctilio-demo-diff.ts
@@ -1,0 +1,88 @@
+import { diffChars, diffLines, type Change } from "diff"
+
+import { escapeHtml } from "./component_script_utils"
+
+// Per-changed-line-pair cap for Myers char-diff. Beyond this combined length,
+// we fall back to a linear prefix+suffix diff — which highlights the divergent
+// middle as a single block. Myers diffChars is ~O((N+M)·D) and scales badly:
+// ~5ms at 1.6K chars, ~55ms at 6.6K, ~850ms at 25K on punctilio-style edits.
+// 4K keeps the worst case around 25ms per line pair.
+export const MAX_CHAR_DIFF_LENGTH = 4_000
+
+export function escapeForOutput(text: string): string {
+  return escapeHtml(text).replace(/\n/g, "<br>")
+}
+
+/** Render char-level Myers changes, keeping only additions (green) and unchanged text. */
+export function renderCharDiff(changes: readonly Change[]): string {
+  let html = ""
+  for (const change of changes) {
+    if (change.removed) continue
+    const escaped = escapeForOutput(change.value)
+    html += change.added ? `<span class="diff-insert">${escaped}</span>` : escaped
+  }
+  return html
+}
+
+/**
+ * Linear O(N) fallback for long changed line pairs. Finds the common prefix
+ * and suffix, then highlights everything between them as one span. Less
+ * precise than Myers when a line has multiple disjoint changes (they merge
+ * into one span) but avoids the quadratic-ish blowup diffChars hits on long
+ * inputs with many edits.
+ */
+export function renderPrefixSuffixDiff(oldText: string, newText: string): string {
+  const shorter = Math.min(oldText.length, newText.length)
+  let prefix = 0
+  while (prefix < shorter && oldText[prefix] === newText[prefix]) prefix++
+  let suffix = 0
+  const suffixLimit = shorter - prefix
+  while (
+    suffix < suffixLimit &&
+    oldText[oldText.length - 1 - suffix] === newText[newText.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+  const before = newText.slice(0, prefix)
+  const middle = newText.slice(prefix, newText.length - suffix)
+  const after = newText.slice(newText.length - suffix)
+  let html = escapeForOutput(before)
+  if (middle) html += `<span class="diff-insert">${escapeForOutput(middle)}</span>`
+  html += escapeForOutput(after)
+  return html
+}
+
+export function renderChangedLinePair(oldText: string, newText: string): string {
+  if (oldText.length + newText.length <= MAX_CHAR_DIFF_LENGTH) {
+    return renderCharDiff(diffChars(oldText, newText))
+  }
+  return renderPrefixSuffixDiff(oldText, newText)
+}
+
+/**
+ * Two-level diff: line-level first, then per-line-pair refinement. Line pairs
+ * under MAX_CHAR_DIFF_LENGTH combined use Myers char-diff; longer ones fall
+ * back to a linear prefix/suffix diff. Worst case is linear in the input.
+ */
+export function renderDiffHtml(sourceText: string, resultText: string): string {
+  const lineChanges = diffLines(sourceText, resultText)
+  let html = ""
+  for (let i = 0; i < lineChanges.length; i++) {
+    const change = lineChanges[i]
+    if (!change.added && !change.removed) {
+      html += escapeForOutput(change.value)
+      continue
+    }
+    const next = lineChanges[i + 1]
+    if (change.removed && next?.added) {
+      html += renderChangedLinePair(change.value, next.value)
+      i++
+      continue
+    }
+    if (change.added) {
+      html += `<span class="diff-insert">${escapeForOutput(change.value)}</span>`
+    }
+    // A pure removal with no paired addition contributes nothing to the output.
+  }
+  return html
+}

--- a/quartz/components/scripts/punctilio-demo.inline.ts
+++ b/quartz/components/scripts/punctilio-demo.inline.ts
@@ -1,4 +1,3 @@
-import { diffChars, type Change } from "diff"
 import { transform, type TransformOptions } from "punctilio"
 import { rehypePunctilio } from "punctilio/rehype"
 import { remarkPunctilio } from "punctilio/remark"
@@ -8,11 +7,8 @@ import remarkParse from "remark-parse"
 import remarkStringify from "remark-stringify"
 import { unified } from "unified"
 
-import { debounce, escapeHtml, setupCopyButton } from "./component_script_utils"
-
-// Maximum combined input+output length for character-level diff.
-// Beyond this, show plain output to avoid excessive memory use.
-const MAX_DIFF_LENGTH = 10_000
+import { debounce, setupCopyButton } from "./component_script_utils"
+import { renderDiffHtml } from "./punctilio-demo-diff"
 
 const STORAGE_KEY_INPUT = "punctilio-input"
 const STORAGE_KEY_MODE = "punctilio-mode"
@@ -83,32 +79,22 @@ function transformHtmlText(html: string, config: TransformOptions): string {
 }
 
 function doTransform(text: string, mode: TransformMode, config: TransformOptions): string {
+  // Skip punctilio's internal idempotency check (runs the whole transform
+  // twice). It's a library self-test, not a correctness requirement here, and
+  // the remark/rehype plugins already default it off.
+  const fastConfig: TransformOptions = { ...config, checkIdempotency: false }
   switch (mode) {
     case "plaintext":
-      return transform(text, config)
+      return transform(text, fastConfig)
     case "markdown":
-      return transformMarkdownText(text, config)
+      return transformMarkdownText(text, fastConfig)
     case "html":
-      return transformHtmlText(text, config)
+      return transformHtmlText(text, fastConfig)
     default: {
       const exhaustive: never = mode
       throw new Error(`Unknown mode: ${exhaustive}`)
     }
   }
-}
-
-// ─── Inline diff highlighting ────────────────────────────────────────
-
-/** Render diff changes as HTML spans, showing only additions (green) and unchanged text. */
-function renderDiffHtml(changes: ReturnType<typeof diffChars>): string {
-  return changes
-    .filter((change: Change) => !change.removed)
-    .map((change: Change) => {
-      const escaped = escapeHtml(change.value).replace(/\n/g, "<br>")
-      if (change.added) return `<span class="diff-insert">${escaped}</span>`
-      return escaped
-    })
-    .join("")
 }
 
 // ─── Main nav handler ────────────────────────────────────────────────
@@ -172,12 +158,7 @@ document.addEventListener("nav", () => {
       outputContent.dataset.placeholder = result
     } else {
       delete outputContent.dataset.placeholder
-      if (sourceText.length + result.length > MAX_DIFF_LENGTH) {
-        outputContent.textContent = result
-      } else {
-        const segments = diffChars(sourceText, result)
-        outputContent.innerHTML = renderDiffHtml(segments)
-      }
+      outputContent.innerHTML = renderDiffHtml(sourceText, result)
     }
     outputContent.classList.toggle("ghost", isEmpty)
 


### PR DESCRIPTION
## Summary
Refactored the diff highlighting functionality in the punctilio demo from inline code into a dedicated, well-tested module. This improves code organization, testability, and performance by introducing a two-level diff strategy with intelligent fallback.

## Key Changes

- **New module `punctilio-demo-diff.ts`**: Extracted and enhanced diff rendering logic with:
  - `renderCharDiff()`: Renders character-level Myers diffs (additions only)
  - `renderPrefixSuffixDiff()`: Linear O(N) fallback for long inputs that finds common prefix/suffix and highlights the divergent middle
  - `renderChangedLinePair()`: Intelligently chooses between Myers char-diff (for inputs under 4KB combined) and prefix/suffix diff (for longer inputs)
  - `renderDiffHtml()`: Two-level diff strategy—line-level first, then per-line-pair refinement
  - `escapeForOutput()`: Centralized HTML escaping with newline-to-`<br>` conversion

- **Comprehensive test suite `punctilio-demo-diff.test.ts`**: 182 lines of tests covering:
  - HTML escaping edge cases
  - Character-level diff rendering
  - Prefix/suffix diff algorithm correctness
  - Fallback behavior and performance thresholds
  - Multi-line diff handling
  - Line insertion/removal scenarios

- **Updated `punctilio-demo.inline.ts`**:
  - Removed inline diff logic and `MAX_DIFF_LENGTH` constant
  - Replaced with import of `renderDiffHtml` from new module
  - Added `checkIdempotency: false` optimization to skip punctilio's internal self-test (library feature, not correctness requirement)
  - Simplified output rendering from 8 lines to 1 line

## Implementation Details

The new two-level diff strategy provides both precision and performance:
- **Line-level**: Uses `diffLines` to identify changed lines
- **Per-line refinement**: For changed line pairs, uses Myers char-diff if combined length ≤ 4KB (typical case), otherwise falls back to linear prefix/suffix diff
- **Performance**: Avoids quadratic-ish blowup of Myers algorithm on long inputs with many edits (~5ms at 1.6K chars vs ~850ms at 25K)
- **Trade-off**: Prefix/suffix diff merges multiple disjoint changes into one span (documented in tests), but maintains correct output and avoids performance degradation

The `MAX_CHAR_DIFF_LENGTH` constant (4KB) was tuned to keep worst-case performance around 25ms per line pair.

https://claude.ai/code/session_01VyWHQpdsd351FCJ74RK1sg