### PR TITLE
fix(ci): remove stale asset-dimensions cache that broke autofix

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -62,15 +62,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
-    - name: Restore asset dimensions cache
-      id: asset-dimensions-cache
-      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-      with:
-        path: quartz/plugins/transformers/.asset_dimensions.json
-        key: ${{ runner.os }}-asset-dimensions-${{ github.ref }}
-        restore-keys: |
-          ${{ runner.os }}-asset-dimensions-refs/heads/main
-
     - name: Install Node Dependencies
       if: inputs.install-node-deps == 'true'
       run: |


### PR DESCRIPTION
## Summary

The `autofix` job on `lint-and-validate.yaml` was intermittently failing with `cannot pull with rebase: You have unstaged changes` (e.g. [this run](https://github.com/alexander-turner/TurnTrout.com/actions/runs/24652179632)). The autofix commit succeeded, but `git pull --rebase` refused because a tracked file was still dirty. Root cause: the `Restore asset dimensions cache` step in `setup-site` was overwriting the checked-out `quartz/plugins/transformers/.asset_dimensions.json` with stale cached content.

## Changes

- `.github/actions/setup-site/action.yaml`: remove the `Restore asset dimensions cache` step. It uses `actions/cache/restore@v5` (restore-only), and a repo-wide grep confirms no `actions/cache/save` or `actions/cache@` step ever populates the `<os>-asset-dimensions-<ref>` key. The cache is orphaned — presumably a save step existed in the past and was removed — so every run has been silently stomping on the committed file.

## Why this works

`.asset_dimensions.json` is tracked in git and is the source of truth. Build runs that update it commit the new content back. Removing the cache restore means CI always starts from the committed version, which is exactly what we want.

## Testing

- YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Followed the fail-loudly principle per `CLAUDE.md`: I considered adding `--autostash` as defense-in-depth, but dropped it so any future regression that mutates a tracked file pre-commit will fail the rebase loudly instead of being silently stashed.

https://claude.ai/code/session_01TGto975u2Vg9sfaQUvKCfQ