### PR TITLE
Implement Lost Pixel approval polling with retry mechanism

### DIFF
--- a/.github/workflows/deploy-reusable.yaml
+++ b/.github/workflows/deploy-reusable.yaml
@@ -1,0 +1,52 @@
+name: Deploy to Cloudflare (reusable)
+
+# Reusable deploy job. Called by deploy.yaml (for the normal main/dev deploy
+# path) and lp-recheck.yaml (when LP approval comes through after the initial
+# env-wait check). Keeps the Cloudflare deploy defined in one place.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout"
+        required: true
+        type: string
+      run_id:
+        description: "Workflow run ID to download public-dir artifact from"
+        required: true
+        type: string
+      branch:
+        description: "Cloudflare Pages branch name"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Download prepared site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: public-dir
+          path: public/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: ./.github/actions/deploy-to-cloudflare
+        with:
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          project-name: turntrout
+          branch: ${{ inputs.branch }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -365,22 +365,9 @@ jobs:
   deploy:
     needs: [prepare-deploy, verify-test-results, verify-lp-approval]
     if: ${{ github.event_name == 'push' && ((always() && github.ref_name == 'dev') || (needs.verify-test-results.result == 'success' && (needs.verify-lp-approval.result == 'skipped' || (needs.verify-lp-approval.result == 'success' && needs.verify-lp-approval.outputs.approved == 'true')))) }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Download prepared site
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: public-dir
-          path: public/
-
-      - name: Deploy to Cloudflare Pages
-        uses: ./.github/actions/deploy-to-cloudflare
-        with:
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
-          project-name: turntrout
-          branch: ${{ github.ref_name }}
+    uses: ./.github/workflows/deploy-reusable.yaml
+    with:
+      ref: ${{ github.sha }}
+      run_id: ${{ github.run_id }}
+      branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ on:
       - ".github/actions/**"
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   id-token: write
   pages: write
@@ -322,8 +322,10 @@ jobs:
 
   # Re-check LP approval after a delay (environment wait timer avoids runner costs).
   # One-time setup: create a "delayed-lp-check" environment in repo Settings >
-  # Environments with a 360-minute (6h) wait timer. Anyone with write access can
-  # click "Review deployments" in the Actions UI to approve early.
+  # Environments with a 10-minute wait timer. If LP still isn't approved at the
+  # check, we dispatch lp-recheck.yaml to poll again (also via the 10-min env
+  # wait), up to max_attempts total (~6h budget at 10-min cadence). Anyone with
+  # write access can click "Review deployments" in the Actions UI to approve early.
   verify-lp-approval:
     needs: verify-test-results
     if: needs.verify-test-results.outputs.lp-pending == 'true'
@@ -331,10 +333,14 @@ jobs:
     timeout-minutes: 10
     environment:
       name: delayed-lp-check
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
     steps:
       - name: Re-check Lost Pixel approval status
+        id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_ATTEMPTS: "36"
         run: |
           echo "Checking Lost Pixel status for commit ${{ github.sha }}..."
           LP_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
@@ -344,14 +350,21 @@ jobs:
           echo "Lost Pixel conclusion: $LP_CONCLUSION"
           if [ "$LP_CONCLUSION" = "success" ]; then
             echo "Lost Pixel changes have been approved!"
+            echo "approved=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::Lost Pixel changes still not approved (conclusion: ${LP_CONCLUSION:-pending}). Approve changes at https://app.lost-pixel.com/ and re-run this job."
-            exit 1
+            echo "Lost Pixel not approved yet (conclusion: ${LP_CONCLUSION:-pending}). Dispatching recheck attempt 2/$MAX_ATTEMPTS..."
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            gh workflow run lp-recheck.yaml \
+              --ref "${{ github.ref_name }}" \
+              -f sha="${{ github.sha }}" \
+              -f run_id="${{ github.run_id }}" \
+              -f attempt="2" \
+              -f max_attempts="$MAX_ATTEMPTS"
           fi
 
   deploy:
     needs: [prepare-deploy, verify-test-results, verify-lp-approval]
-    if: ${{ github.event_name == 'push' && ((always() && github.ref_name == 'dev') || (needs.verify-test-results.result == 'success' && (needs.verify-lp-approval.result == 'success' || needs.verify-lp-approval.result == 'skipped'))) }}
+    if: ${{ github.event_name == 'push' && ((always() && github.ref_name == 'dev') || (needs.verify-test-results.result == 'success' && (needs.verify-lp-approval.result == 'skipped' || (needs.verify-lp-approval.result == 'success' && needs.verify-lp-approval.outputs.approved == 'true')))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/lp-recheck.yaml
+++ b/.github/workflows/lp-recheck.yaml
@@ -1,0 +1,105 @@
+name: Lost Pixel Recheck
+
+# Dispatched by deploy.yaml's verify-lp-approval when LP wasn't approved at the
+# first check. Keeps re-entering the delayed-lp-check environment (10-min wait
+# timer) until LP is approved, the attempt cap is hit, or a new deploy run
+# cancels us via the shared concurrency group.
+
+concurrency:
+  # Match deploy.yaml so a fresh push to the same branch cancels pending rechecks.
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to check LP status for"
+        required: true
+      run_id:
+        description: "Original deploy workflow run ID (for artifact download)"
+        required: true
+      attempt:
+        description: "Current attempt number (1-indexed)"
+        required: true
+      max_attempts:
+        description: "Maximum number of attempts before giving up"
+        required: true
+
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+  pages: write
+
+jobs:
+  recheck:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: delayed-lp-check
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Re-check Lost Pixel approval status
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.inputs.sha }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
+          ATTEMPT: ${{ github.event.inputs.attempt }}
+          MAX: ${{ github.event.inputs.max_attempts }}
+        run: |
+          echo "Checking Lost Pixel status for $SHA (attempt $ATTEMPT/$MAX)..."
+          LP_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name | test("lost.pixel"; "i"))] | sort_by(.started_at) | last | .conclusion // empty' \
+            2>/dev/null || echo "")
+
+          echo "Lost Pixel conclusion: $LP_CONCLUSION"
+          if [ "$LP_CONCLUSION" = "success" ]; then
+            echo "Lost Pixel approved on attempt $ATTEMPT"
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "approved=false" >> "$GITHUB_OUTPUT"
+          if [ "$ATTEMPT" -ge "$MAX" ]; then
+            echo "::error::Lost Pixel still not approved after $MAX attempts. Approve at https://app.lost-pixel.com/ and re-run deploy."
+            exit 1
+          fi
+
+          NEXT=$((ATTEMPT + 1))
+          echo "LP not approved yet (conclusion: ${LP_CONCLUSION:-pending}). Dispatching attempt $NEXT/$MAX..."
+          gh workflow run lp-recheck.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f sha="$SHA" \
+            -f run_id="$RUN_ID" \
+            -f attempt="$NEXT" \
+            -f max_attempts="$MAX"
+
+  deploy:
+    needs: recheck
+    if: needs.recheck.outputs.approved == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: Download prepared site from original deploy run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: public-dir
+          path: public/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.inputs.run_id }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: ./.github/actions/deploy-to-cloudflare
+        with:
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          project-name: turntrout
+          branch: ${{ github.ref_name }}

--- a/.github/workflows/lp-recheck.yaml
+++ b/.github/workflows/lp-recheck.yaml
@@ -80,26 +80,9 @@ jobs:
   deploy:
     needs: recheck
     if: needs.recheck.outputs.approved == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.inputs.sha }}
-
-      - name: Download prepared site from original deploy run
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: public-dir
-          path: public/
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
-
-      - name: Deploy to Cloudflare Pages
-        uses: ./.github/actions/deploy-to-cloudflare
-        with:
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
-          project-name: turntrout
-          branch: ${{ github.ref_name }}
+    uses: ./.github/workflows/deploy-reusable.yaml
+    with:
+      ref: ${{ github.event.inputs.sha }}
+      run_id: ${{ github.event.inputs.run_id }}
+      branch: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Replaces the single-check Lost Pixel approval verification with a polling mechanism that automatically retries up to 36 times (approximately 6 hours at 10-minute intervals) before failing. This allows deployments to proceed once visual regression tests are approved without manual re-runs.

## Key Changes
- **New workflow**: Added `.github/workflows/lp-recheck.yaml` that implements a recursive polling pattern
  - Checks Lost Pixel approval status for a given commit SHA
  - Automatically dispatches itself for the next attempt if not approved and attempts remain
  - Shares concurrency group with deploy workflow to cancel pending rechecks on new pushes
  - Outputs approval status for downstream jobs

- **Modified deploy workflow** (`.github/workflows/deploy.yaml`):
  - Updated `verify-lp-approval` job to dispatch `lp-recheck.yaml` instead of failing immediately
  - Changed environment wait timer from 360 minutes to 10 minutes (with up to 36 attempts for ~6h total budget)
  - Added `approved` output to track approval status
  - Updated `deploy` job condition to check the approval output explicitly
  - Elevated `actions` permission from `read` to `write` to enable workflow dispatch

## Implementation Details
- The polling mechanism uses GitHub's `workflow_dispatch` to chain retry attempts, avoiding long-running jobs
- Each retry waits 10 minutes via the `delayed-lp-check` environment before checking status
- Maximum 36 attempts provides approximately 6 hours of total wait time
- Concurrency group ensures fresh pushes cancel pending rechecks, preventing stale approvals from blocking new deployments
- Users can still manually approve early via the "Review deployments" UI button

https://claude.ai/code/session_01NVFRp4eShnz3mkqEMLLpa7