### PR TITLE
fix: code quality improvements across TS, Python, and SCSS

### DIFF
--- a/config/typescript/tsconfig.json
+++ b/config/typescript/tsconfig.json
@@ -6,8 +6,6 @@
     "moduleResolution": "bundler",
     "target": "ESNext",
     "strict": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
     "incremental": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact"
 
-import { type RootContent, type Parent, type Text, type Element, type Root } from "hast"
+import { type RootContent, type Parent, type Element, type Root } from "hast"
 import { fromHtml } from "hast-util-from-html"
 // skipcq: JS-W1028
 import React from "react"
@@ -43,8 +43,11 @@ function elementToJsx(elt: RootContent): JSX.Element {
       return <>{elt.value}</>
     case "element":
       if (elt.tagName === "abbr") {
-        const abbrText = elt.children.length > 0 ? (elt.children[0] as Text).value : ""
-        const className = (elt.properties?.className as string[])?.join(" ") || ""
+        const firstChild = elt.children[0]
+        const abbrText = firstChild?.type === "text" ? firstChild.value : ""
+        const className = Array.isArray(elt.properties?.className)
+          ? (elt.properties.className as string[]).join(" ")
+          : ""
         return <abbr className={className}>{abbrText}</abbr>
       } else {
         return <span>{elt.children.map(elementToJsx)}</span>

--- a/quartz/components/TableOfContents.tsx
+++ b/quartz/components/TableOfContents.tsx
@@ -239,8 +239,11 @@ export function processHtmlAst(htmlAst: Root | Element, parent: Parent): void {
  * Renders an abbreviation element (<abbr>) in the TOC with the appropriate class names and text content.
  */
 const handleAbbr = (elt: Element): JSX.Element => {
-  const abbrText = elt.children.length > 0 ? (elt.children[0] as { value: string }).value : ""
-  const className = (elt.properties?.className as string[])?.join(" ") || ""
+  const firstChild = elt.children[0]
+  const abbrText = firstChild?.type === "text" ? firstChild.value : ""
+  const className = Array.isArray(elt.properties?.className)
+    ? (elt.properties.className as string[]).join(" ")
+    : ""
   return <abbr className={className}>{abbrText}</abbr>
 }
 
@@ -276,6 +279,7 @@ const handleSpan = (elt: Element): JSX.Element => {
 export function elementToJsx(elt: RootContent): JSX.Element | null {
   switch (elt.type) {
     case "text":
+      // skipcq: JS-0349 Preact renders raw strings as text nodes
       return elt.value as unknown as JSX.Element
     case "element":
       return elt.tagName === "abbr" ? handleAbbr(elt) : handleSpan(elt)

--- a/quartz/plugins/transformers/trout_hr.ts
+++ b/quartz/plugins/transformers/trout_hr.ts
@@ -1,4 +1,4 @@
-import type { Element, Parent, Root, Text } from "hast"
+import type { Element, Parent, Root } from "hast"
 
 import { visit } from "unist-util-visit"
 
@@ -66,25 +66,26 @@ export function maybeInsertOrnament(
   if (
     node.tagName === "section" &&
     node.properties?.["dataFootnotes"] !== undefined &&
-    (node.properties?.className as Array<string>)?.includes("footnotes")
+    Array.isArray(node.properties?.className) && node.properties.className.includes("footnotes")
   ) {
-    // <hr/> looks weird right before the trout hr, so remove it.
-    // Check if there's a newline and then an HR preceding
-    const prevElement = parent.children[index - 1] as Element | Text
+    const prevElement = parent.children[index - 1]
+    const prevPrevElement = parent.children[index - 2]
     if (
       index > 1 &&
-      prevElement.type === "text" &&
+      prevElement?.type === "text" &&
       prevElement.value === "\n" &&
-      (parent.children[index - 2] as Element).tagName === "hr"
+      prevPrevElement?.type === "element" &&
+      prevPrevElement.tagName === "hr"
     ) {
       parent.children.splice(index - 2, 1)
       index--
-
-      // Check if there's an HR right before the footnotes section
-    } else if (index > 0 && (prevElement as Element).tagName === "hr") {
-      // Remove the HR element
+    } else if (
+      index > 0 &&
+      prevElement?.type === "element" &&
+      prevElement.tagName === "hr"
+    ) {
       parent.children.splice(index - 1, 1)
-      index-- // Adjust index after removal
+      index--
     }
 
     // If it is, insert the ornament node before the footnotes section
@@ -108,9 +109,8 @@ export function insertOrnamentNode(tree: Root): void {
   })
 
   if (!ornamentInserted) {
-    // Check if the last child is an <hr> element
-    const lastChild = tree.children[tree.children.length - 1] as Element
-    if (lastChild && lastChild.type === "element" && lastChild.tagName === "hr") {
+    const lastChild = tree.children[tree.children.length - 1]
+    if (lastChild?.type === "element" && lastChild.tagName === "hr") {
       // Remove the last <hr> element
       tree.children.pop()
     }

--- a/quartz/plugins/transformers/trout_hr.ts
+++ b/quartz/plugins/transformers/trout_hr.ts
@@ -66,7 +66,8 @@ export function maybeInsertOrnament(
   if (
     node.tagName === "section" &&
     node.properties?.["dataFootnotes"] !== undefined &&
-    Array.isArray(node.properties?.className) && node.properties.className.includes("footnotes")
+    Array.isArray(node.properties?.className) &&
+    node.properties.className.includes("footnotes")
   ) {
     const prevElement = parent.children[index - 1]
     const prevPrevElement = parent.children[index - 2]
@@ -79,11 +80,7 @@ export function maybeInsertOrnament(
     ) {
       parent.children.splice(index - 2, 1)
       index--
-    } else if (
-      index > 0 &&
-      prevElement?.type === "element" &&
-      prevElement.tagName === "hr"
-    ) {
+    } else if (index > 0 && prevElement?.type === "element" && prevElement.tagName === "hr") {
       parent.children.splice(index - 1, 1)
       index--
     }

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -228,7 +228,7 @@ export function spliceAndWrapLastChars(
 
   // Remove the text node entirely if all text was moved into the span
   if (lastChars === text) {
-    const idx = parent.children.indexOf(lastTextNode as unknown as ElementContent)
+    const idx = parent.children.indexOf(lastTextNode)
     /* istanbul ignore next -- lastTextNode is always a child of parent */
     if (idx !== -1) {
       parent.children.splice(idx, 1)

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -77,6 +77,10 @@ function getMediaSrc(node: Element): string {
  * @param ancestors The list of ancestor Parent nodes, where the last element is the direct parent.
  * @param wrapperClassName The class name of the wrapper span to check for.
  */
+function isElement(node: Parent): node is Element {
+  return node.type === "element"
+}
+
 function skipNodeForVideo(
   videoNode: Element,
   ancestors: Parent[],
@@ -84,7 +88,7 @@ function skipNodeForVideo(
 ): boolean {
   const notVideo = videoNode.tagName !== "video"
   const directParent = ancestors[ancestors.length - 1]
-  const inVideoContainer = hasClass(directParent as Element, wrapperClassName)
+  const inVideoContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
   return notVideo || inVideoContainer
 }
 
@@ -109,7 +113,7 @@ function skipNodeForAudio(
 ): boolean {
   const notAudio = audioNode.tagName !== "audio"
   const directParent = ancestors[ancestors.length - 1]
-  const inAudioContainer = hasClass(directParent as Element, wrapperClassName)
+  const inAudioContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
   return notAudio || inAudioContainer
 }
 
@@ -132,14 +136,12 @@ function wrapAudio(audioNode: Element, ancestors: Parent[]): void {
  * @param ancestors The list of ancestor Parent nodes.
  */
 function skipNodeForFloatRight(element: Element, ancestors: Parent[]): boolean {
-  const directParent = ancestors[ancestors.length - 1] as Element
-
-  // Skip if already wrapped in figure
-  return directParent?.tagName === "figure"
+  const directParent = ancestors[ancestors.length - 1]
+  return isElement(directParent) && directParent.tagName === "figure"
 }
 
 function hasAncestorFigure(ancestors: Parent[]): boolean {
-  return ancestors.some((ancestor) => (ancestor as Element).tagName === "figure")
+  return ancestors.some((ancestor) => isElement(ancestor) && ancestor.tagName === "figure")
 }
 
 /**

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -70,6 +70,10 @@ function getMediaSrc(node: Element): string {
   return (sourceChild?.properties?.src as string) ?? ""
 }
 
+function isElement(node: Parent): node is Element {
+  return node.type === "element"
+}
+
 /**
  * Determines if a video node should be skipped based on its tag name and parent class.
  *
@@ -77,10 +81,6 @@ function getMediaSrc(node: Element): string {
  * @param ancestors The list of ancestor Parent nodes, where the last element is the direct parent.
  * @param wrapperClassName The class name of the wrapper span to check for.
  */
-function isElement(node: Parent): node is Element {
-  return node.type === "element"
-}
-
 function skipNodeForVideo(
   videoNode: Element,
   ancestors: Parent[],

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -61,13 +61,14 @@ function wrapElement(
  * Checks the element's `src` attribute first, then falls back to the first `<source>` child's `src`.
  */
 function getMediaSrc(node: Element): string {
-  const src = node.properties?.src as string | undefined
-  if (src) return src
+  const src = node.properties?.src
+  if (typeof src === "string") return src
 
   const sourceChild = node.children.find(
-    (child) => child.type === "element" && child.tagName === "source",
-  ) as Element | undefined
-  return (sourceChild?.properties?.src as string) ?? ""
+    (child): child is Element => child.type === "element" && child.tagName === "source",
+  )
+  const childSrc = sourceChild?.properties?.src
+  return typeof childSrc === "string" ? childSrc : ""
 }
 
 function isElement(node: Parent): node is Element {

--- a/quartz/styles/colors.scss
+++ b/quartz/styles/colors.scss
@@ -1,6 +1,20 @@
 @use "./variables" as *;
 @use "./palette" as *;
 
+@mixin dropcap-background-colors {
+  --dropcap-background-red: color-mix(in srgb, 55% var(--red), var(--midground-fainter));
+  --dropcap-background-maroon: color-mix(in srgb, 55% var(--maroon), var(--midground-fainter));
+  --dropcap-background-orange: color-mix(in srgb, 55% var(--orange), var(--midground-fainter));
+  --dropcap-background-gold: color-mix(in srgb, 65% var(--gold), var(--midground-fainter));
+  --dropcap-background-green: color-mix(in srgb, 65% var(--green), var(--midground-fainter));
+  --dropcap-background-teal: color-mix(in srgb, 65% var(--teal), var(--midground-fainter));
+  --dropcap-background-sky: color-mix(in srgb, 65% var(--sky), var(--midground-fainter));
+  --dropcap-background-blue: color-mix(in srgb, 65% var(--blue), var(--midground-fainter));
+  --dropcap-background-purple: color-mix(in srgb, 65% var(--purple), var(--midground-fainter));
+  --dropcap-background-lavender: color-mix(in srgb, 65% var(--lavender), var(--midground-fainter));
+  --dropcap-background-pink: color-mix(in srgb, 45% var(--pink), var(--midground-fainter));
+}
+
 // Default to light-mode colors so CSS custom properties are always defined,
 // even before detectInitialState.js sets the data-theme attribute.
 // Without this, color-mix() expressions that depend on --background etc. fail,
@@ -23,18 +37,7 @@
   --dark-gray: var(--midground-strong);
   --maroon: color-mix(in srgb, var(--red), var(--dark) 35%);
 
-  // Dropcap background colors
-  --dropcap-background-red: color-mix(in srgb, 55% var(--red), var(--midground-fainter));
-  --dropcap-background-maroon: color-mix(in srgb, 55% var(--maroon), var(--midground-fainter));
-  --dropcap-background-orange: color-mix(in srgb, 55% var(--orange), var(--midground-fainter));
-  --dropcap-background-gold: color-mix(in srgb, 65% var(--gold), var(--midground-fainter));
-  --dropcap-background-green: color-mix(in srgb, 65% var(--green), var(--midground-fainter));
-  --dropcap-background-teal: color-mix(in srgb, 65% var(--teal), var(--midground-fainter));
-  --dropcap-background-sky: color-mix(in srgb, 65% var(--sky), var(--midground-fainter));
-  --dropcap-background-blue: color-mix(in srgb, 65% var(--blue), var(--midground-fainter));
-  --dropcap-background-purple: color-mix(in srgb, 65% var(--purple), var(--midground-fainter));
-  --dropcap-background-lavender: color-mix(in srgb, 65% var(--lavender), var(--midground-fainter));
-  --dropcap-background-pink: color-mix(in srgb, 45% var(--pink), var(--midground-fainter));
+  @include dropcap-background-colors;
 
   // Derived color variables
   --midground-fainter: color-mix(in srgb, var(--background) 70%, var(--midground-faint));
@@ -84,18 +87,7 @@
   --dark: var(--background);
   --dark-gray: var(--midground-faint);
 
-  // Dropcap background colors
-  --dropcap-background-red: color-mix(in srgb, 55% var(--red), var(--midground-fainter));
-  --dropcap-background-maroon: color-mix(in srgb, 55% var(--maroon), var(--midground-fainter));
-  --dropcap-background-orange: color-mix(in srgb, 55% var(--orange), var(--midground-fainter));
-  --dropcap-background-gold: color-mix(in srgb, 65% var(--gold), var(--midground-fainter));
-  --dropcap-background-green: color-mix(in srgb, 65% var(--green), var(--midground-fainter));
-  --dropcap-background-teal: color-mix(in srgb, 65% var(--teal), var(--midground-fainter));
-  --dropcap-background-sky: color-mix(in srgb, 65% var(--sky), var(--midground-fainter));
-  --dropcap-background-blue: color-mix(in srgb, 65% var(--blue), var(--midground-fainter));
-  --dropcap-background-purple: color-mix(in srgb, 65% var(--purple), var(--midground-fainter));
-  --dropcap-background-lavender: color-mix(in srgb, 65% var(--lavender), var(--midground-fainter));
-  --dropcap-background-pink: color-mix(in srgb, 45% var(--pink), var(--midground-fainter));
+  @include dropcap-background-colors;
 
   & img,
   & video:not(:has(::backdrop)),
@@ -122,18 +114,7 @@
   --dark-gray: var(--midground-strong);
   --maroon: color-mix(in srgb, var(--red), var(--dark) 35%);
 
-  // Dropcap background colors
-  --dropcap-background-red: color-mix(in srgb, 55% var(--red), var(--midground-fainter));
-  --dropcap-background-maroon: color-mix(in srgb, 55% var(--maroon), var(--midground-fainter));
-  --dropcap-background-orange: color-mix(in srgb, 55% var(--orange), var(--midground-fainter));
-  --dropcap-background-gold: color-mix(in srgb, 65% var(--gold), var(--midground-fainter));
-  --dropcap-background-green: color-mix(in srgb, 65% var(--green), var(--midground-fainter));
-  --dropcap-background-teal: color-mix(in srgb, 65% var(--teal), var(--midground-fainter));
-  --dropcap-background-sky: color-mix(in srgb, 65% var(--sky), var(--midground-fainter));
-  --dropcap-background-blue: color-mix(in srgb, 65% var(--blue), var(--midground-fainter));
-  --dropcap-background-purple: color-mix(in srgb, 65% var(--purple), var(--midground-fainter));
-  --dropcap-background-lavender: color-mix(in srgb, 65% var(--lavender), var(--midground-fainter));
-  --dropcap-background-pink: color-mix(in srgb, 45% var(--pink), var(--midground-fainter));
+  @include dropcap-background-colors;
 
   & img:not([src$=".svg"]), // don't make SVGs fuzzy
   & video:not(:has(::backdrop)),

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1017,8 +1017,13 @@ img-comparison-slider {
   --default-handle-color: var(--foreground);
   --default-handle-shadow: 0 0 1px var(--background);
 
-  // Remove blue focus outline
   &:focus {
     outline: none;
+  }
+
+  &:focus-visible {
+    outline: 0.15rem solid var(--color-link);
+    outline-offset: 0.1rem;
+    border-radius: 0.15rem;
   }
 }

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1625,7 +1625,7 @@ def check_malformed_hrefs(soup: BeautifulSoup) -> list[str]:
         if not isinstance(href, str):  # pragma: no cover
             continue  # a simple typeguard
         if href.startswith("mailto:"):
-            email = href.split(":")[1]
+            email = href.removeprefix("mailto:")
             if not validators.email(email):
                 _append_to_list(
                     malformed_links,

--- a/scripts/convert_assets.py
+++ b/scripts/convert_assets.py
@@ -254,9 +254,14 @@ def convert_asset(
     if not input_file.is_file():
         raise FileNotFoundError(f"Error: File '{input_file}' not found.")
 
-    if "quartz/static" not in str(input_file):
+    input_parts = input_file.resolve().parts
+    if not (
+        "quartz" in input_parts
+        and "static" in input_parts
+        and input_parts.index("static") == input_parts.index("quartz") + 1
+    ):
         raise ValueError(
-            f"Error: Input file '{input_file}' is notin the quartz/static directory."
+            f"Error: Input file '{input_file}' is not in the quartz/static directory."
         )
 
     if md_references_dir and not md_references_dir.is_dir():

--- a/scripts/notebooks/download_images.py
+++ b/scripts/notebooks/download_images.py
@@ -52,12 +52,12 @@ def replace_urls_in_file(file_path: Path, url: str, new_url: str) -> None:
             f"File path {file_path} is not in the website_content directory."
         )
 
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         content = f.read()
 
     new_content = content.replace(url, new_url)
 
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write(new_content)
 
 

--- a/scripts/notebooks/download_images.py
+++ b/scripts/notebooks/download_images.py
@@ -72,7 +72,7 @@ def main(markdown_files: list[Path]) -> None:
     # 1. Find all image URLs in Markdown files
     asset_urls: set[str] = set()
     for file in markdown_files:
-        with open(file) as f:
+        with open(file, encoding="utf-8") as f:
             content = f.read()
             urls = re.findall(r"(https?://.*?\." + SUFFIX_REGEX + r")", content)
             asset_urls.update(url for url, _ in urls)

--- a/scripts/r2_upload.py
+++ b/scripts/r2_upload.py
@@ -146,7 +146,7 @@ def upload_to_r2(
             If the file exists without overwrite.
         FileNotFoundError: If the file is not found.
     """
-    if "quartz/" not in str(file_path):
+    if "quartz" not in file_path.resolve().parts:
         raise ValueError(f"{str(file_path)} does not contain 'quartz/'.")
 
     if not file_path.is_file():

--- a/scripts/tests/test_convert_assets.py
+++ b/scripts/tests/test_convert_assets.py
@@ -301,6 +301,16 @@ def test_ignores_non_static_path(setup_test_env):
         )
 
 
+def test_rejects_non_adjacent_quartz_static(tmp_path: Path):
+    """Reject paths where 'quartz' and 'static' exist but are not adjacent."""
+    non_adjacent = tmp_path / "quartz" / "other" / "static" / "file.png"
+    non_adjacent.parent.mkdir(parents=True, exist_ok=True)
+    non_adjacent.touch()
+
+    with pytest.raises(ValueError, match="quartz/static.*directory"):
+        convert_assets.convert_asset(non_adjacent)
+
+
 @pytest.mark.parametrize(
     "input_path,expected_output",
     [


### PR DESCRIPTION
## Summary
- Replace unsafe `as` type assertions with proper type guards and runtime checks across multiple TypeScript files
- Fix path validation vulnerabilities, missing encodings, and a typo in Python scripts
- Improve accessibility and reduce SCSS duplication

## Changes

### TypeScript type safety
- **wrapNakedElements.ts**: Add `isElement` type guard replacing 4 `as Element` casts; replace `as string | undefined` with `typeof` checks and type predicates in `getMediaSrc`
- **trout_hr.ts**: Replace `as Element | Text`, `as Element`, and `as Array<string>` casts with `?.type === "element"` guards and `Array.isArray()`
- **Backlinks.tsx, TableOfContents.tsx**: Replace `as Text` / `as { value: string }` with `?.type === "text"` type guards
- **utils.ts**: Remove unnecessary double cast (`Text` is already `ElementContent`)

### TypeScript config
- **tsconfig.json**: Remove redundant `strictNullChecks` and `noImplicitAny` (already implied by `strict: true`)

### Python fixes
- **convert_assets.py**: Replace fragile `"quartz/static" not in str(path)` with `Path.resolve().parts` adjacency check; fix typo "notin" → "not in"
- **r2_upload.py**: Same `Path.resolve().parts` fix for `"quartz/"` substring check
- **built_site_checks.py**: Use `removeprefix("mailto:")` instead of `split(":")[1]`
- **download_images.py**: Add explicit `encoding="utf-8"` to all `open()` calls

### SCSS
- **colors.scss**: Extract 3× duplicated dropcap background color block into `@mixin dropcap-background-colors`
- **custom.scss**: Add `:focus-visible` style for `img-comparison-slider` (keyboard accessibility)

### Tests
- **test_convert_assets.py**: Add test for non-adjacent `quartz`/`static` path rejection

## Testing
- All 3660 TypeScript tests pass with 100% coverage
- All 647 built_site_checks tests pass
- All 34 r2_upload tests pass
- Type checking (`tsc --noEmit`) clean
- Stylelint clean
- Prettier clean
- New `test_rejects_non_adjacent_quartz_static` test validates path adjacency logic

https://claude.ai/code/session_01QndKYwiuxC4KAfuDEvH3Mb