### PR TITLE
Improve Lost Pixel workflow error handling and retry logic

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -388,6 +388,17 @@ jobs:
           fi
 
           echo "approved=false" >> "$GITHUB_OUTPUT"
+
+          # Terminal non-success states won't self-heal via polling (platform
+          # processing errors, cancelled builds, timed-out runs). Fail fast and
+          # let a human investigate + manually re-dispatch.
+          case "$LP_CONCLUSION" in
+            failure|cancelled|timed_out)
+              echo "::error::Lost Pixel check concluded with '$LP_CONCLUSION' — not retrying. Investigate at https://app.lost-pixel.com/ and manually re-dispatch this workflow once resolved."
+              exit 1
+              ;;
+          esac
+
           if [ "$ATTEMPT" -ge "$MAX" ]; then
             echo "::error::Lost Pixel still not approved after $MAX attempts. Approve at https://app.lost-pixel.com/ and re-dispatch this workflow."
             exit 1
@@ -396,6 +407,7 @@ jobs:
           NEXT=$((ATTEMPT + 1))
           echo "LP not approved yet (conclusion: ${LP_CONCLUSION:-pending}). Dispatching attempt $NEXT/$MAX..."
           gh workflow run deploy.yaml \
+            --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
             -f sha="$SHA" \
             -f run_id="$RUN_ID" \


### PR DESCRIPTION
## Summary
Enhanced the Lost Pixel deployment workflow to fail fast on terminal error states and improve workflow dispatch reliability.

## Key Changes
- **Terminal state detection**: Added explicit handling for non-recoverable Lost Pixel check states (`failure`, `cancelled`, `timed_out`) that won't self-heal through polling. The workflow now fails immediately with a clear error message directing users to investigate and manually re-dispatch.
- **Improved workflow dispatch**: Added explicit `--repo` flag to the `gh workflow run` command to ensure the workflow is dispatched to the correct repository, improving reliability in complex CI/CD scenarios.

## Implementation Details
- Terminal error states now exit with status code 1 and provide a direct link to the Lost Pixel dashboard for investigation
- The fail-fast behavior prevents wasted retry attempts on issues that require manual intervention
- The `--repo` parameter ensures the workflow dispatch command targets the correct repository context, which is especially important in workflows that may run across multiple repositories

https://claude.ai/code/session_01PqFWbEiRskfQU9xgtUPGbt