### PR TITLE
Fix CSS formatting: add space before opening brace

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1033,7 +1033,7 @@ figure#goose-terminal {
 .smart-chart-point-group:hover > .smart-chart-tooltip,
 .smart-chart-point-group:hover > .smart-chart-tooltip-bg,
 .smart-chart-annotation:hover > .smart-chart-tooltip,
-.smart-chart-annotation:hover > .smart-chart-tooltip-bg{
+.smart-chart-annotation:hover > .smart-chart-tooltip-bg {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a minor CSS formatting inconsistency in the custom styles file.

## Key Changes
- Added missing space before the opening brace in the `.smart-chart-annotation:hover > .smart-chart-tooltip-bg` selector to maintain consistent CSS formatting with the other selectors in the same rule group

## Details
This change ensures the CSS follows proper formatting conventions where there should be a space between the selector and the opening brace. The modification aligns this selector with the formatting style used in the other selectors within the same hover state rule group.

https://claude.ai/code/session_01A3nc4q7PA2SZZVs6hpLfz6