### PR TITLE
Add chart extraction script with LLM-powered data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ scripts/*.json
 .beads
 AGENTS.md
 .gh-resolved
+
+# Chart backfill artifacts (scripts/notebooks/convert_existing_graphs.py)
+# Proposed-replacement sidecars are scratch output; the user reviews and
+# hand-merges them into the real .md files. No need to commit intermediates.
+*.proposed-replacements.md
+chart-backfill-queue.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "rich",
     "ruamel-yaml",
     "tqdm",
+    "alt-text-llm",
     "validators",
     "types-defusedxml",
     "types-pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "isort>=5.13.2",
     "linkchecker>=10.6.0",
     "frozendict>=2.4.7",
+    "alt-text-llm>=1.3.1",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "rich",
     "ruamel-yaml",
     "tqdm",
-    "alt-text-llm",
     "validators",
     "types-defusedxml",
     "types-pyyaml",

--- a/quartz/plugins/transformers/charts.test.ts
+++ b/quartz/plugins/transformers/charts.test.ts
@@ -17,6 +17,7 @@ const mockCtx = {} as BuildCtx
 describe("parseChartSpec", () => {
   const MINIMAL_YAML = `
 type: line
+alt: Test chart
 x:
   label: X
 y:
@@ -42,6 +43,7 @@ series:
   it("parses axis min override", () => {
     const yaml = `
 type: line
+alt: Test chart
 x:
   label: X
 y:
@@ -60,6 +62,7 @@ series:
   it("parses title, colors, scale, and annotations", () => {
     const yaml = `
 type: line
+alt: Test chart
 title: My Chart
 x:
   label: X
@@ -112,106 +115,167 @@ annotations:
     ],
     [
       "non-object x axis",
-      "type: line\nx: 42\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      "type: line\nalt: Test chart\nx: 42\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
       'Chart "x" axis must be an object',
     ],
     [
       "null x axis",
-      "type: line\nx: null\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      "type: line\nalt: Test chart\nx: null\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
       'Chart "x" axis must be an object',
     ],
     [
       "missing axis label",
-      "type: line\nx:\n  scale: linear\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      "type: line\nalt: Test chart\nx:\n  scale: linear\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
       'Chart "x" axis must have a string "label"',
     ],
     [
       "invalid axis scale",
-      "type: line\nx:\n  label: X\n  scale: quadratic\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      "type: line\nalt: Test chart\nx:\n  label: X\n  scale: quadratic\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
       'Chart "x" axis scale must be "linear" or "log"',
     ],
     [
       "empty series",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries: []",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries: []",
       'Chart must have a non-empty "series" array',
     ],
     [
       "non-array series",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries: notarray",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries: notarray",
       'Chart must have a non-empty "series" array',
     ],
     [
       "series item not object",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - 42",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - 42",
       "series[0] must be an object",
     ],
     [
       "series missing name",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - data:\n      - [1,2]",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - data:\n      - [1,2]",
       'series[0] must have a string "name"',
     ],
     [
       "series empty data",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data: []",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data: []",
       'Series "S" must have a non-empty "data" array',
     ],
     [
       "data point not array",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - 42",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - 42",
       'Series "S" data[0] must be a [x, y] array',
     ],
     [
       "data point wrong length",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1]",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1]",
       'Series "S" data[0] must be a [x, y] array',
     ],
     [
       "data point non-numeric",
-      'type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - ["a", 2]',
+      'type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - ["a", 2]',
       'Series "S" data[0] values must be numbers',
     ],
     [
       "annotations not array",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations: bad",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations: bad",
       '"annotations" must be an array',
     ],
     [
       "annotation not object",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - 42",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - 42",
       "annotations[0] must be an object",
     ],
     [
       "annotation bad type",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: vertical-line\n    value: 3",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: vertical-line\n    value: 3",
       'annotations[0] type must be "horizontal-line"',
     ],
     [
       "annotation non-numeric value",
-      'type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: horizontal-line\n    value: "three"',
+      'type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: horizontal-line\n    value: "three"',
       'annotations[0] must have a numeric "value"',
     ],
     [
       "annotation invalid style",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: horizontal-line\n    value: 3\n    style: dotted",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]\nannotations:\n  - type: horizontal-line\n    value: 3\n    style: dotted",
       'annotations[0] style must be "solid" or "dashed"',
     ],
     [
       "non-numeric axis min",
-      'type: line\nx:\n  label: X\n  min: "three"\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]',
+      'type: line\nalt: Test chart\nx:\n  label: X\n  min: "three"\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]',
       'Chart "x" axis min must be a number',
     ],
     [
       "log scale with zero x value",
-      "type: line\nx:\n  label: X\n  scale: log\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [0, 2]",
+      "type: line\nalt: Test chart\nx:\n  label: X\n  scale: log\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [0, 2]",
       'Log scale on "x" axis requires positive values',
     ],
     [
       "log scale with negative y value",
-      "type: line\nx:\n  label: X\ny:\n  label: Y\n  scale: log\nseries:\n  - name: S\n    data:\n      - [1, -5]",
+      "type: line\nalt: Test chart\nx:\n  label: X\ny:\n  label: Y\n  scale: log\nseries:\n  - name: S\n    data:\n      - [1, -5]",
       'Log scale on "y" axis requires positive values',
+    ],
+    [
+      "missing alt",
+      "type: line\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      'Chart spec must include a non-empty "alt"',
+    ],
+    [
+      "empty alt",
+      'type: line\nalt: ""\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]',
+      'Chart spec must include a non-empty "alt"',
+    ],
+    [
+      "whitespace-only alt",
+      'type: line\nalt: "   "\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]',
+      'Chart spec must include a non-empty "alt"',
+    ],
+    [
+      "non-string alt",
+      "type: line\nalt: 123\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      'Chart spec must include a non-empty "alt"',
+    ],
+    [
+      "non-string fallback",
+      "type: line\nalt: Ok\nfallback: 123\nx:\n  label: X\ny:\n  label: Y\nseries:\n  - name: S\n    data:\n      - [1,2]",
+      'Chart "fallback" must be a string',
     ],
   ])("throws on %s", (_desc, yaml, expectedMsg) => {
     expect(() => parseChartSpec(yaml)).toThrow(expectedMsg)
+  })
+
+  it("parses alt and fallback when present", () => {
+    const yaml = [
+      "type: line",
+      'alt: "Loss vs layer horizon for GPT-2"',
+      'fallback: "https://assets.turntrout.com/posts/layer-horizon.avif"',
+      "x:",
+      "  label: X",
+      "y:",
+      "  label: Y",
+      "series:",
+      "  - name: S",
+      "    data:",
+      "      - [1,2]",
+    ].join("\n")
+    const spec = parseChartSpec(yaml)
+    expect(spec.alt).toBe("Loss vs layer horizon for GPT-2")
+    expect(spec.fallback).toBe("https://assets.turntrout.com/posts/layer-horizon.avif")
+  })
+
+  it("leaves fallback undefined when omitted", () => {
+    const yaml = [
+      "type: line",
+      "alt: A",
+      "x:",
+      "  label: X",
+      "y:",
+      "  label: Y",
+      "series:",
+      "  - name: S",
+      "    data:",
+      "      - [1,2]",
+    ].join("\n")
+    const spec = parseChartSpec(yaml)
+    expect(spec.fallback).toBeUndefined()
   })
 })
 
@@ -221,6 +285,7 @@ describe("renderLineChart", () => {
   const BASIC_SPEC: ChartSpec = {
     type: "line",
     title: "Test Chart",
+    alt: "Test chart alt",
     x: { label: "X Axis", scale: "linear" },
     y: { label: "Y Axis", scale: "linear" },
     series: [
@@ -243,7 +308,7 @@ describe("renderLineChart", () => {
     expect(svg.properties?.viewBox).toBe("0 0 600 370")
     expect(svg.properties?.class).toBe("smart-chart")
     expect(svg.properties?.role).toBe("img")
-    expect(svg.properties?.["aria-label"]).toBe("Test Chart")
+    expect(svg.properties?.["aria-label"]).toBe("Test chart alt")
     expect(svg.properties?.xmlns).toBe("http://www.w3.org/2000/svg")
     expect(svg.properties?.width).toBe("100%")
   })
@@ -368,10 +433,11 @@ describe("renderLineChart", () => {
     expect(descText.type === "text" && descText.value).toContain("Target at y = 75")
   })
 
-  it("uses default aria-label when no title provided", () => {
+  it("uses alt (not title) for aria-label", () => {
     const spec: ChartSpec = { ...BASIC_SPEC, title: undefined }
     const svg = renderLineChart(spec)
-    expect(svg.properties?.["aria-label"]).toBe("Line chart")
+    // aria-label tracks `alt`, which is mandatory — title is decorative only.
+    expect(svg.properties?.["aria-label"]).toBe("Test chart alt")
   })
 
   it("renders without title when not provided", () => {
@@ -380,7 +446,7 @@ describe("renderLineChart", () => {
       title: undefined,
     }
     const svg = renderLineChart(spec)
-    expect(svg.properties?.["aria-label"]).toBe("Line chart")
+    expect(svg.properties?.["aria-label"]).toBe("Test chart alt")
     // No title text at the top level
     const topLevelTexts: string[] = []
     for (const child of svg.children) {
@@ -469,6 +535,7 @@ describe("renderLineChart", () => {
   it("renders log scale", () => {
     const spec: ChartSpec = {
       type: "line",
+      alt: "Test chart alt",
       x: { label: "X", scale: "linear" },
       y: { label: "Y", scale: "log" },
       series: [
@@ -521,6 +588,7 @@ describe("renderLineChart", () => {
   it("extends y domain to include annotation values", () => {
     const spec: ChartSpec = {
       type: "line",
+      alt: "Test chart alt",
       x: { label: "X" },
       y: { label: "Y" },
       series: [
@@ -547,6 +615,7 @@ describe("renderLineChart", () => {
   it("applies axis min overrides to domains", () => {
     const spec: ChartSpec = {
       type: "line",
+      alt: "Test chart alt",
       x: { label: "X", min: -5 },
       y: { label: "Y", min: 0 },
       series: [
@@ -569,6 +638,7 @@ describe("renderLineChart", () => {
   it("formats integer ticks without decimals", () => {
     const spec: ChartSpec = {
       type: "line",
+      alt: "Test chart alt",
       x: { label: "X" },
       y: { label: "Y" },
       series: [
@@ -615,6 +685,7 @@ describe("Charts transformer plugin", () => {
   }
 
   const VALID_YAML = `type: line
+alt: Test chart
 x:
   label: X
 y:
@@ -643,8 +714,52 @@ series:
     expect(svg.properties?.class).toBe("smart-chart")
   })
 
+  it("emits noscript fallback img and data-fallback attr when fallback is set", () => {
+    const yaml = `type: line
+alt: Loss curve for GPT-2
+fallback: https://assets.turntrout.com/posts/x.avif
+x:
+  label: X
+y:
+  label: Y
+series:
+  - name: S
+    data:
+      - [1, 2]`
+    const tree = createChartTree(yaml)
+    const plugin = Charts()
+    const transform = ((plugin.htmlPlugins?.(mockCtx) ?? [])[0] as () => (tree: Root) => void)()
+    transform(tree)
+
+    const figure = tree.children[0] as Element
+    expect(figure.properties?.["data-fallback"]).toBe("https://assets.turntrout.com/posts/x.avif")
+    const noscript = figure.children.find(
+      (c): c is Element => c.type === "element" && c.tagName === "noscript",
+    )
+    expect(noscript).toBeDefined()
+    const img = noscript?.children[0] as Element
+    expect(img.tagName).toBe("img")
+    expect(img.properties?.src).toBe("https://assets.turntrout.com/posts/x.avif")
+    expect(img.properties?.alt).toBe("Loss curve for GPT-2")
+  })
+
+  it("omits noscript fallback and data-fallback when fallback is absent", () => {
+    const tree = createChartTree(VALID_YAML)
+    const plugin = Charts()
+    const transform = ((plugin.htmlPlugins?.(mockCtx) ?? [])[0] as () => (tree: Root) => void)()
+    transform(tree)
+
+    const figure = tree.children[0] as Element
+    expect(figure.properties?.["data-fallback"]).toBeUndefined()
+    const noscript = figure.children.find(
+      (c): c is Element => c.type === "element" && c.tagName === "noscript",
+    )
+    expect(noscript).toBeUndefined()
+  })
+
   it("includes tooltip script when chart has annotations", () => {
     const yamlWithAnnotations = `type: line
+alt: Test chart
 x:
   label: X
 y:
@@ -735,7 +850,7 @@ annotations:
                   type: "element",
                   tagName: "span",
                   properties: {},
-                  children: [{ type: "text", value: "type: line\n" }],
+                  children: [{ type: "text", value: "type: line\nalt: Test chart\n" }],
                 },
                 {
                   type: "element",

--- a/quartz/plugins/transformers/charts.test.ts
+++ b/quartz/plugins/transformers/charts.test.ts
@@ -243,39 +243,18 @@ annotations:
   })
 
   it("parses alt and fallback when present", () => {
-    const yaml = [
-      "type: line",
-      'alt: "Loss vs layer horizon for GPT-2"',
-      'fallback: "https://assets.turntrout.com/posts/layer-horizon.avif"',
-      "x:",
-      "  label: X",
-      "y:",
-      "  label: Y",
-      "series:",
-      "  - name: S",
-      "    data:",
-      "      - [1,2]",
-    ].join("\n")
-    const spec = parseChartSpec(yaml)
-    expect(spec.alt).toBe("Loss vs layer horizon for GPT-2")
-    expect(spec.fallback).toBe("https://assets.turntrout.com/posts/layer-horizon.avif")
+    const spec = parseChartSpec(
+      MINIMAL_YAML.replace(
+        "alt: Test chart",
+        'alt: "Loss vs layer horizon"\nfallback: "https://assets.turntrout.com/x.avif"',
+      ),
+    )
+    expect(spec.alt).toBe("Loss vs layer horizon")
+    expect(spec.fallback).toBe("https://assets.turntrout.com/x.avif")
   })
 
   it("leaves fallback undefined when omitted", () => {
-    const yaml = [
-      "type: line",
-      "alt: A",
-      "x:",
-      "  label: X",
-      "y:",
-      "  label: Y",
-      "series:",
-      "  - name: S",
-      "    data:",
-      "      - [1,2]",
-    ].join("\n")
-    const spec = parseChartSpec(yaml)
-    expect(spec.fallback).toBeUndefined()
+    expect(parseChartSpec(MINIMAL_YAML).fallback).toBeUndefined()
   })
 })
 

--- a/quartz/plugins/transformers/charts.ts
+++ b/quartz/plugins/transformers/charts.ts
@@ -158,9 +158,9 @@ export const Charts: QuartzTransformerPlugin = () => ({
             })
           }
 
-          // Preserve the source image as a <noscript> fallback and for future
-          // reference. Rendered after the SVG so browsers without JS / SVG
-          // support still get the original image.
+          // Preserve the source image as a <noscript> fallback for browsers
+          // that don't render SVG, and archive it on the figure itself so
+          // future tooling can find it without re-parsing the YAML.
           if (spec.fallback) {
             figureChildren.push({
               type: "element",
@@ -177,20 +177,13 @@ export const Charts: QuartzTransformerPlugin = () => ({
             })
           }
 
-          const figureProps: Record<string, string | string[]> = {
-            className: ["smart-chart-container"],
-          }
-          if (spec.fallback) {
-            // Archive the source image on the figure itself so "right-click →
-            // inspect" surfaces it and future tooling can find it without
-            // re-parsing the YAML.
-            figureProps["data-fallback"] = spec.fallback
-          }
-
           const figure: Element = {
             type: "element",
             tagName: "figure",
-            properties: figureProps,
+            properties: {
+              className: ["smart-chart-container"],
+              ...(spec.fallback ? { "data-fallback": spec.fallback } : {}),
+            },
             children: figureChildren,
           }
 

--- a/quartz/plugins/transformers/charts.ts
+++ b/quartz/plugins/transformers/charts.ts
@@ -158,10 +158,39 @@ export const Charts: QuartzTransformerPlugin = () => ({
             })
           }
 
+          // Preserve the source image as a <noscript> fallback and for future
+          // reference. Rendered after the SVG so browsers without JS / SVG
+          // support still get the original image.
+          if (spec.fallback) {
+            figureChildren.push({
+              type: "element",
+              tagName: "noscript",
+              properties: {},
+              children: [
+                {
+                  type: "element",
+                  tagName: "img",
+                  properties: { src: spec.fallback, alt: spec.alt },
+                  children: [],
+                },
+              ],
+            })
+          }
+
+          const figureProps: Record<string, string | string[]> = {
+            className: ["smart-chart-container"],
+          }
+          if (spec.fallback) {
+            // Archive the source image on the figure itself so "right-click →
+            // inspect" surfaces it and future tooling can find it without
+            // re-parsing the YAML.
+            figureProps["data-fallback"] = spec.fallback
+          }
+
           const figure: Element = {
             type: "element",
             tagName: "figure",
-            properties: { className: ["smart-chart-container"] },
+            properties: figureProps,
             children: figureChildren,
           }
 

--- a/quartz/plugins/transformers/charts/line-renderer.ts
+++ b/quartz/plugins/transformers/charts/line-renderer.ts
@@ -428,7 +428,7 @@ export function renderLineChart(spec: ChartSpec): Element {
       width: "100%",
       class: "smart-chart",
       role: "img",
-      "aria-label": spec.title ?? "Line chart",
+      "aria-label": spec.alt,
       "aria-describedby": descId,
     },
     chartChildren,

--- a/quartz/plugins/transformers/charts/parse.ts
+++ b/quartz/plugins/transformers/charts/parse.ts
@@ -114,9 +114,21 @@ export function parseChartSpec(yamlString: string): ChartSpec {
     throw new Error(`Unsupported chart type: "${obj.type}". Only "line" is supported.`)
   }
 
+  if (typeof obj.alt !== "string" || obj.alt.trim() === "") {
+    throw new Error(
+      'Chart spec must include a non-empty "alt" string — every rendered chart needs an accessible description.',
+    )
+  }
+
+  if (obj.fallback !== undefined && typeof obj.fallback !== "string") {
+    throw new Error('Chart "fallback" must be a string (URL or path) when provided')
+  }
+
   const spec: ChartSpec = {
     type: "line",
     title: typeof obj.title === "string" ? obj.title : undefined,
+    alt: obj.alt,
+    fallback: obj.fallback,
     x: parseAxisSpec(obj.x, "x"),
     y: parseAxisSpec(obj.y, "y"),
     series: parseSeries(obj.series),

--- a/quartz/plugins/transformers/charts/types.ts
+++ b/quartz/plugins/transformers/charts/types.ts
@@ -20,6 +20,13 @@ export interface SeriesSpec {
 export interface ChartSpec {
   type: "line"
   title?: string
+  // Accessible description of the chart. Every rendered chart must supply one so
+  // screen readers, RSS consumers, and no-image contexts convey the meaning.
+  alt: string
+  // Optional URL (or local path) of the source image the chart was extracted
+  // from. Preserved for future reference and rendered as a <noscript> fallback
+  // alongside the SVG.
+  fallback?: string
   x: AxisSpec
   y: AxisSpec
   series: SeriesSpec[]

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1033,7 +1033,7 @@ figure#goose-terminal {
 .smart-chart-point-group:hover > .smart-chart-tooltip,
 .smart-chart-point-group:hover > .smart-chart-tooltip-bg,
 .smart-chart-annotation:hover > .smart-chart-tooltip,
-.smart-chart-annotation:hover > .smart-chart-tooltip-bg{
+.smart-chart-annotation:hover > .smart-chart-tooltip-bg {
   display: block;
 }
 

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -430,6 +430,13 @@ def _represent_point(dumper: yaml.SafeDumper, data: list) -> yaml.Node:
 _ChartYamlDumper.add_representer(list, _represent_point)
 
 
+# Characters that would break the naive CSV round-trip with the TS-side
+# parser (`quartz/plugins/transformers/charts/csv.ts`). The renderer
+# rejects quoted fields loudly; keeping both sides consistent means we
+# reject the same names at write time with a clearer message.
+_FORBIDDEN_IN_SERIES_NAME = (",", '"', "\n", "\r")
+
+
 def write_chart_csv(spec: dict, target: Path) -> None:
     """
     Write long-format CSV (`x,y,series`) for every point across every series.
@@ -443,6 +450,12 @@ def write_chart_csv(spec: dict, target: Path) -> None:
         fh.write("x,y,series\n")
         for series in spec.get("series", []):
             name = series.get("name", "")
+            for bad in _FORBIDDEN_IN_SERIES_NAME:
+                if bad in name:
+                    raise ValueError(
+                        f"series name {name!r} contains {bad!r}; rename it — "
+                        "the chart renderer rejects quoted CSV fields",
+                    )
             for x, y in series.get("data", []):
                 fh.write(f"{x},{y},{name}\n")
 

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -444,16 +444,20 @@ _CONCURRENCY = 8
 
 
 async def _extract_one(
-    image: str | Path, model: str, sem: asyncio.Semaphore
+    image: str | Path,
+    model: str,
+    sem: asyncio.Semaphore,
+    context: str | None = None,
 ) -> ChartExtractionResult:
     async with sem:
-        return await asyncio.to_thread(extract_chart, image, model)
+        return await asyncio.to_thread(extract_chart, image, model, context)
 
 
 async def async_extract_batch(
     images: Sequence[str | Path],
     model: str,
     on_completed: Callable[[ChartExtractionResult], None] | None = None,
+    context_for: Callable[[str | Path], str | None] | None = None,
 ) -> list[ChartExtractionResult]:
     """
     Extract *images* concurrently.
@@ -462,10 +466,22 @@ async def async_extract_batch(
     image's extraction finishes (in completion order, not submission order). The
     CLI wires this up to a tqdm progress bar; tests inject a list-append for
     observation. Results are returned in submission order.
+
+    *context_for* is an optional callback that returns per-image prose to
+    include in the LLM prompt — typically the image's alt text plus the
+    surrounding paragraph, pulled by a caller like the
+    ``convert_existing_graphs.py`` driver. Helps the model disambiguate axis
+    labels and series names ("Unlearning" / "Retain set performance") that
+    a bare chart image would be ambiguous about.
     """
     sem = asyncio.Semaphore(_CONCURRENCY)
     tasks = [
-        asyncio.create_task(_extract_one(img, model, sem)) for img in images
+        asyncio.create_task(
+            _extract_one(
+                img, model, sem, context_for(img) if context_for else None
+            )
+        )
+        for img in images
     ]
 
     if on_completed is not None:

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -144,18 +144,29 @@ def build_chart_prompt(context: str | None = None) -> str:
     return base
 
 
-# Reuse alt-text-llm's cost estimator so both tools report the same way.
-# Extend the shared dict with Claude/GPT entries it doesn't ship with — safe
-# to mutate at import time since alt-text-llm reads via `.get()`.
-from alt_text_llm.generate import MODEL_COSTS, estimate_cost  # noqa: E402
+# --------------------------------------------------------------------------- #
+# Cost estimation — private to this script so the data stays co-located with  #
+# the assumptions it depends on (prompt/output token sizes for chart extracts #
+# are specific to this task, not shared with alt-text-llm).                   #
+# --------------------------------------------------------------------------- #
 
-MODEL_COSTS.update(
-    {
-        "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
-        "claude-opus-4-7": {"input": 0.015, "output": 0.075},
-        "gpt-5": {"input": 0.0025, "output": 0.01},
-    }
-)
+_MODEL_COSTS: dict[str, dict[str, float]] = {
+    "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
+    "claude-opus-4-7": {"input": 0.015, "output": 0.075},
+    "gemini-2.5-pro": {"input": 0.00125, "output": 0.01},
+    "gemini-2.5-flash": {"input": 0.0003, "output": 0.0025},
+    "gpt-5": {"input": 0.0025, "output": 0.01},
+}
+
+
+def estimate_cost(
+    model: str, n: int, in_toks: int = 3000, out_toks: int = 800
+) -> str:
+    cost = _MODEL_COSTS.get(model.lower())
+    if cost is None:
+        return f"(no pricing known for {model})"
+    total = n * (in_toks * cost["input"] + out_toks * cost["output"]) / 1000
+    return f"~${total:.2f} estimated ({n} images × {model})"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -39,6 +39,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Callable, Sequence
 
+import requests
 import yaml
 from rich.console import Console
 
@@ -228,8 +229,103 @@ def _convert_if_avif(image: Path, workspace: Path) -> Path:
     return png
 
 
+def _is_url(s: str | Path) -> bool:
+    return isinstance(s, str) and s.startswith(("http://", "https://"))
+
+
+# Chart images are tiny (AVIFs are a few hundred KB, PNGs a few MB). A 50 MB
+# cap protects against a misdirected URL pointing at a huge file.
+_DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024
+
+
+def _download(url: str, workspace: Path, timeout: int = 30) -> Path:
+    """
+    Stream *url* to a file under *workspace*.
+
+    Propagates `requests` errors. Raises `ValueError` if the body exceeds
+    `_DOWNLOAD_MAX_BYTES` — extract_chart catches and records this.
+    """
+    # Derive a local filename from the URL (strip query string).
+    stem = Path(url.split("?", 1)[0]).name or "download.bin"
+    target = workspace / stem
+    # Minimal UA mirrors what alt_text_llm.utils.download_asset sends, so
+    # CDNs that reject bare requests clients also accept ours.
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/91.0.4472.124 Safari/537.36"
+        ),
+    }
+    resp = requests.get(url, timeout=timeout, stream=True, headers=headers)
+    resp.raise_for_status()
+    written = 0
+    # `requests.iter_content` occasionally yields empty chunks for keep-alive;
+    # `fh.write(b"")` is a no-op so we don't need a guard.
+    with target.open("wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            written += len(chunk)
+            if written > _DOWNLOAD_MAX_BYTES:
+                raise ValueError(
+                    f"download exceeded {_DOWNLOAD_MAX_BYTES // (1024 * 1024)} MB cap: {url}"
+                )
+            fh.write(chunk)
+    return target
+
+
+_VALIDATOR_TSX = Path(__file__).resolve().parent / "chart_spec_validator.ts"
+
+
+def validate_spec_via_tsx(spec: dict, *, timeout: int = 30) -> str | None:
+    """
+    Round-trip *spec* through quartz's TypeScript `parseChartSpec`.
+
+    Catches LLM hallucinations that pass the JSON schema but would fail at
+    build time (e.g. unsupported chart type, malformed annotation). Returns
+    ``None`` on success; the parser's error message on failure.
+
+    Skipped silently (returns ``None``) if the TS toolchain (``npx`` / ``tsx``)
+    isn't on PATH — makes the feature opt-in by availability, so users without
+    Node installed aren't blocked from running ``chart_extract``.
+    """
+    # `tsx` via npx is what the repo already uses (see quartz/bootstrap-cli.ts
+    # invocations in CLAUDE.md). Falling back to a bare `tsx` would also work
+    # if someone globally installed it.
+    runner = shutil.which("npx") or shutil.which("tsx")
+    if runner is None or shutil.which("node") is None:
+        return None
+
+    yaml_text = yaml.dump(
+        spec, sort_keys=False, allow_unicode=True, default_flow_style=False
+    )
+    cmd = (
+        [runner, "tsx", str(_VALIDATOR_TSX)]
+        if runner.endswith("npx")
+        else [runner, str(_VALIDATOR_TSX)]
+    )
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=yaml_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # Never raise out of here — extract_chart documents the "every failure
+        # becomes result.error" contract; a hung tsx would kill the whole batch.
+        return f"validator timed out after {timeout}s"
+    if proc.returncode == 0:
+        return None
+    return (
+        proc.stderr or proc.stdout
+    ).strip() or "parseChartSpec rejected the spec"
+
+
 def extract_chart(
-    image: Path,
+    image: str | Path,
     model: str,
     context: str | None = None,
     timeout: int = 180,
@@ -237,12 +333,16 @@ def extract_chart(
     """
     Run `llm` once against *image* and return a `ChartExtractionResult`.
 
+    *image* may be a local path OR an ``http(s)://`` URL; URLs are downloaded
+    to a tempdir before being passed to the LLM. ``result.source_image``
+    records the original URL/path so the queue keys dedupe stably.
+
     Contract: this function MUST NOT raise on per-image failures (bad AVIF,
-    `llm` non-zero exit, timeout, unparseable JSON). Each of those is
-    recorded in ``result.error`` and returned normally. Raising would
-    cascade through ``asyncio.gather`` in ``async_extract_batch`` and kill
-    the whole run — losing work on every successful image processed so far.
-    Unexpected errors (e.g. ``KeyboardInterrupt``) still propagate.
+    `llm` non-zero exit, timeout, unparseable JSON, download failures). Each
+    of those is recorded in ``result.error`` and returned normally. Raising
+    would cascade through ``asyncio.gather`` in ``async_extract_batch`` and
+    kill the whole run — losing work on every successful image processed so
+    far. Unexpected errors (e.g. ``KeyboardInterrupt``) still propagate.
     """
 
     result = ChartExtractionResult(
@@ -250,12 +350,21 @@ def extract_chart(
     )
 
     # tmpdir only needs to live as long as the `llm` subprocess — it holds the
-    # converted PNG (if input was AVIF) and the JSON schema file, both of
-    # which the subprocess reads. Anything that only inspects `proc` after
-    # the call can live outside.
+    # downloaded image (if URL), converted PNG (if AVIF), and the JSON schema,
+    # all of which the subprocess reads.
     with tempfile.TemporaryDirectory() as tmp:
+        # Download URLs first; local paths pass through.
+        if _is_url(image):
+            try:
+                local = _download(str(image), Path(tmp))
+            except (requests.exceptions.RequestException, ValueError) as err:
+                result.error = f"download failed: {err}"
+                return result
+        else:
+            local = Path(image)
+
         try:
-            prepared = _convert_if_avif(image, Path(tmp))
+            prepared = _convert_if_avif(local, Path(tmp))
         except (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
@@ -301,9 +410,21 @@ def extract_chart(
         result.error = f"invalid JSON from model: {err}"
         return result
 
-    # Persist outputs next to the source image so the user can paste the
-    # block into Markdown and move the CSV alongside the .md file.
-    csv_target = image.with_suffix(".csv")
+    # Round-trip the LLM's spec through quartz's own parseChartSpec so a
+    # hallucinated-but-schema-valid spec fails here, not mid-build. Skipped
+    # transparently if the TS toolchain isn't available.
+    validation_error = validate_spec_via_tsx(result.spec)
+    if validation_error is not None:
+        result.error = f"parseChartSpec rejected the spec: {validation_error}"
+        return result
+
+    # Persist outputs next to the source image (or into cwd for URL inputs —
+    # the user controls where to stash them).
+    if _is_url(image):
+        stem = Path(str(image).split("?", 1)[0]).stem or "chart"
+        csv_target = Path.cwd() / f"{stem}.csv"
+    else:
+        csv_target = Path(image).with_suffix(".csv")
     write_chart_csv(result.spec, csv_target)
     result.csv_path = str(csv_target)
     result.yaml_block = format_as_yaml_block(
@@ -323,14 +444,14 @@ _CONCURRENCY = 8
 
 
 async def _extract_one(
-    image: Path, model: str, sem: asyncio.Semaphore
+    image: str | Path, model: str, sem: asyncio.Semaphore
 ) -> ChartExtractionResult:
     async with sem:
         return await asyncio.to_thread(extract_chart, image, model)
 
 
 async def async_extract_batch(
-    images: Sequence[Path],
+    images: Sequence[str | Path],
     model: str,
     on_completed: Callable[[ChartExtractionResult], None] | None = None,
 ) -> list[ChartExtractionResult]:
@@ -511,8 +632,13 @@ def _without_inline_data(spec: dict, csv_path: str) -> dict:
 
 def _cli() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # Keep as `str` so URLs pass through unchanged; `extract_chart` handles
+    # URL vs path dispatch internally.
     parser.add_argument(
-        "images", nargs="+", type=Path, help="Chart image(s) to extract."
+        "images",
+        nargs="+",
+        type=str,
+        help="Chart image path(s) or http(s):// URL(s) to extract.",
     )
     parser.add_argument(
         "-m",
@@ -532,7 +658,9 @@ def _cli() -> int:
     args = parser.parse_args()
 
     console = Console()
-    targets: list[Path] = list(args.images)
+    targets: list[str | Path] = [
+        img if _is_url(img) else Path(img) for img in args.images
+    ]
     if not args.no_skip_existing:
         done = load_existing(args.output)
         targets = [p for p in targets if _normalize(p) not in done]

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -41,6 +41,7 @@ from typing import Callable, Sequence
 
 import requests
 import yaml
+from alt_text_llm import utils as alt_utils
 from rich.console import Console
 
 # alt-text-llm imports tqdm the same way — matching its convention keeps the
@@ -207,41 +208,31 @@ class ChartExtractionResult:
         return asdict(self)
 
 
+# Thin wrappers over alt-text-llm helpers. The wrappers exist to (a) preserve
+# the install-hint error messages this script's users expect, and (b) accept
+# `Path` for `_is_url` (alt-text-llm's `is_url` only handles strings).
 def _find_llm() -> str:
-    path = shutil.which("llm")
-    if not path:
+    try:
+        return alt_utils.find_executable("llm")
+    except FileNotFoundError as err:
         raise FileNotFoundError(
             "The `llm` CLI is not on PATH. Install via `uv tool install llm` "
             "and configure a model plugin (e.g. `llm install llm-anthropic`)."
-        )
-    return path
+        ) from err
 
 
 def _convert_if_avif(image: Path, workspace: Path) -> Path:
-    """
-    LLM backends reject AVIF; convert to PNG in a tempdir.
-
-    Same as alt-text-llm.
-    """
-    if image.suffix.lower() != ".avif":
-        return image
-    magick = shutil.which("magick")
-    if not magick:
+    """LLM backends reject AVIF; convert to PNG in a tempdir."""
+    try:
+        return alt_utils._convert_avif_to_png(image, workspace)
+    except FileNotFoundError as err:
         raise FileNotFoundError(
             "`magick` not on PATH; install ImageMagick to process AVIF inputs."
-        )
-    png = workspace / f"{image.stem}.png"
-    subprocess.run(
-        [magick, str(image), str(png)],
-        check=True,
-        capture_output=True,
-        timeout=30,
-    )
-    return png
+        ) from err
 
 
 def _is_url(s: str | Path) -> bool:
-    return isinstance(s, str) and s.startswith(("http://", "https://"))
+    return isinstance(s, str) and alt_utils.is_url(s)
 
 
 # Chart images are tiny (AVIFs are a few hundred KB, PNGs a few MB). A 50 MB

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -224,7 +224,12 @@ def _find_llm() -> str:
 def _convert_if_avif(image: Path, workspace: Path) -> Path:
     """LLM backends reject AVIF; convert to PNG in a tempdir."""
     try:
-        return alt_utils._convert_avif_to_png(image, workspace)
+        # alt-text-llm's converter is underscore-prefixed but stable; using
+        # the public `_convert_asset_for_llm` would also handle GIFs, which we
+        # don't want for chart inputs.
+        return alt_utils._convert_avif_to_png(  # skipcq: PYL-W0212
+            image, workspace
+        )
     except FileNotFoundError as err:
         raise FileNotFoundError(
             "`magick` not on PATH; install ImageMagick to process AVIF inputs."

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -185,6 +185,8 @@ class ChartExtractionResult:
     source_image: str
     model: str
     spec: dict | None = None
+    csv_path: str | None = None
+    yaml_block: str | None = None
     error: str | None = None
     raw_output: str = ""
     context_used: str = ""
@@ -295,7 +297,16 @@ def extract_chart(
             result.spec = json.loads(proc.stdout)
         except json.JSONDecodeError as err:
             result.error = f"invalid JSON from model: {err}"
+            return result
 
+    # Persist outputs next to the source image so the user can paste the
+    # block into Markdown and move the CSV alongside the .md file.
+    csv_target = image.with_suffix(".csv")
+    write_chart_csv(result.spec, csv_target)
+    result.csv_path = str(csv_target)
+    result.yaml_block = format_as_yaml_block(
+        result.spec, csv_path=f"./{csv_target.name}"
+    )
     return result
 
 
@@ -419,8 +430,33 @@ def _represent_point(dumper: yaml.SafeDumper, data: list) -> yaml.Node:
 _ChartYamlDumper.add_representer(list, _represent_point)
 
 
-def format_as_yaml_block(spec: dict) -> str:
-    """Render a spec as a ```chart fenced block ready to paste into Markdown."""
+def write_chart_csv(spec: dict, target: Path) -> None:
+    """
+    Write long-format CSV (`x,y,series`) for every point across every series.
+
+    Chose long format over one-file-per-series: it's the shape notebooks
+    produce by default (`df.to_csv()`), it's one artefact per chart, and
+    the renderer can group by the `series` column at build time.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as fh:
+        fh.write("x,y,series\n")
+        for series in spec.get("series", []):
+            name = series.get("name", "")
+            for x, y in series.get("data", []):
+                fh.write(f"{x},{y},{name}\n")
+
+
+def format_as_yaml_block(spec: dict, csv_path: str | None = None) -> str:
+    """
+    Render a spec as a ```chart fenced block ready to paste into Markdown.
+
+    When *csv_path* is provided, inline series data is stripped and replaced
+    with a top-level ``data: <path>`` reference. When omitted, inline data
+    is preserved (the old shape).
+    """
+    if csv_path is not None:
+        spec = _without_inline_data(spec, csv_path)
     body = yaml.dump(
         spec,
         Dumper=_ChartYamlDumper,
@@ -429,6 +465,28 @@ def format_as_yaml_block(spec: dict) -> str:
         width=100,
     )
     return f"```chart\n{body.rstrip()}\n```"
+
+
+def _without_inline_data(spec: dict, csv_path: str) -> dict:
+    """
+    Return a copy of *spec* with series `data` fields removed and a top-level
+    ``data`` field set to *csv_path*.
+
+    Insertion order keeps
+    ``data:`` right after ``type/title/axes`` so the block reads cleanly.
+    """
+    out: dict = {}
+    for key, value in spec.items():
+        out[key] = value
+        if key == "y":  # insert `data:` right after the axes block
+            out["data"] = csv_path
+    if "data" not in out:
+        out["data"] = csv_path
+    out["series"] = [
+        {k: v for k, v in s.items() if k != "data"}
+        for s in spec.get("series", [])
+    ]
+    return out
 
 
 # --------------------------------------------------------------------------- #
@@ -492,9 +550,9 @@ def _cli() -> int:
 
     if args.print_yaml:
         for r in ok:
-            console.print(f"\n# --- {r.source_image} ---")
-            assert r.spec is not None  # narrowed by the `ok` filter above
-            console.print(format_as_yaml_block(r.spec))
+            console.print(f"\n# --- {r.source_image} ({r.csv_path}) ---")
+            assert r.yaml_block is not None  # narrowed by the `ok` filter above
+            console.print(r.yaml_block)
 
     return 0 if not failed else 1
 

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -50,6 +50,13 @@ from tqdm.std import TqdmExperimentalWarning
 
 warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 
+# Exported so drivers (e.g. scripts/notebooks/convert_existing_graphs.py)
+# can construct a "is this image a chart we can handle?" prompt without
+# duplicating the list. When we add "bar" or "scatter" support in the
+# renderer, grow this tuple and everything downstream stays honest.
+SUPPORTED_CHART_TYPES: tuple[str, ...] = ("line",)
+
+
 # --------------------------------------------------------------------------- #
 # JSON Schema — mirrors `quartz/plugins/transformers/charts/types.ts`.        #
 # Keep the shape in sync; `parseChartSpec` is the authoritative validator.    #

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -56,6 +56,10 @@ warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 # renderer, grow this tuple and everything downstream stays honest.
 SUPPORTED_CHART_TYPES: tuple[str, ...] = ("line",)
 
+# Placeholder alt text used when the LLM doesn't produce one and no driver
+# overrides. Human-visible so it surfaces during review / hand-merge.
+ALT_TODO_PLACEHOLDER = "[TODO: describe this chart]"
+
 
 # --------------------------------------------------------------------------- #
 # JSON Schema — mirrors `quartz/plugins/transformers/charts/types.ts`.        #
@@ -416,6 +420,12 @@ def extract_chart(
     except json.JSONDecodeError as err:
         result.error = f"invalid JSON from model: {err}"
         return result
+
+    # The TS parser requires a non-empty `alt`; models generally don't produce
+    # it. Inject a TODO placeholder so validation passes and standalone users
+    # notice and fill it in; the convert-existing-graphs driver overrides this
+    # with the real alt text before writing the sidecar block.
+    result.spec.setdefault("alt", ALT_TODO_PLACEHOLDER)
 
     # Round-trip the LLM's spec through quartz's own parseChartSpec so a
     # hallucinated-but-schema-valid spec fails here, not mid-build. Skipped

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -15,8 +15,10 @@ flag. No SDK pinning, no ``if model.startswith(...)`` branches.
 
 Prompts and schema come from ChartGemma's published "chart-to-table"
 formulation: ask for a structured table, force the output to a JSON schema
-mirroring ``quartz/plugins/transformers/charts/types.ts``, then round-trip
-through our own ``parseChartSpec`` to catch hallucinations.
+mirroring ``quartz/plugins/transformers/charts/types.ts``. Output is not
+yet round-tripped through ``parseChartSpec`` — that validation is a TODO
+(requires invoking Node/tsx from Python, deferred until real backfill
+surfaces hallucination patterns worth catching).
 
 Resumability, AVIF conversion, concurrency, and the JSON work-queue format
 follow ``alt-text-llm`` so operators reading both scripts see the same shape.
@@ -61,15 +63,16 @@ CHART_SCHEMA: dict = {
                 "properties": {
                     "name": {"type": "string"},
                     "color": {"type": "string"},
+                    # Drafts before 2020-12 don't support `prefixItems`; some
+                    # backends (notably OpenAI strict mode) reject it. Describe
+                    # the [x, y] tuple via items + minItems/maxItems — the
+                    # prompt enforces the numeric-pair semantics.
                     "data": {
                         "type": "array",
                         "minItems": 1,
                         "items": {
                             "type": "array",
-                            "prefixItems": [
-                                {"type": "number"},
-                                {"type": "number"},
-                            ],
+                            "items": {"type": "number"},
                             "minItems": 2,
                             "maxItems": 2,
                         },
@@ -128,7 +131,6 @@ def build_chart_prompt(context: str | None = None) -> str:
         - Do series names match the legend text, verbatim?
         - Does the first/last point of each series match the visible start/end?
         - Are log-scale axes flagged? If yes, are all values strictly positive?
-        - Is the title free of interpolation and smallcaps "corrections"?
 
         Return only the JSON object that matches the provided schema.
         """).strip()
@@ -186,10 +188,6 @@ class ChartExtractionResult:
         return asdict(self)
 
 
-class ChartExtractionError(Exception):
-    """Raised when extraction fails unrecoverably for a single image."""
-
-
 def _find_llm() -> str:
     path = shutil.which("llm")
     if not path:
@@ -208,12 +206,17 @@ def _convert_if_avif(image: Path, workspace: Path) -> Path:
     """
     if image.suffix.lower() != ".avif":
         return image
-    png = workspace / f"{image.stem}.png"
     magick = shutil.which("magick")
     if not magick:
-        raise ChartExtractionError("`magick` not on PATH; cannot convert AVIF.")
+        raise FileNotFoundError(
+            "`magick` not on PATH; install ImageMagick to process AVIF inputs."
+        )
+    png = workspace / f"{image.stem}.png"
     subprocess.run(
-        [magick, str(image), str(png)], check=True, capture_output=True
+        [magick, str(image), str(png)],
+        check=True,
+        capture_output=True,
+        timeout=30,
     )
     return png
 
@@ -234,6 +237,15 @@ def extract_chart(
     with tempfile.TemporaryDirectory() as tmp:
         try:
             prepared = _convert_if_avif(image, Path(tmp))
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        ) as err:
+            result.error = f"AVIF conversion failed: {err}"
+            return result
+
+        try:
             proc = subprocess.run(
                 [
                     _find_llm(),
@@ -251,7 +263,7 @@ def extract_chart(
                 timeout=timeout,
             )
         except subprocess.TimeoutExpired:
-            result.error = f"timeout after {timeout}s"
+            result.error = f"llm timeout after {timeout}s"
             return result
 
         result.raw_output = proc.stdout
@@ -273,7 +285,9 @@ def extract_chart(
 # --------------------------------------------------------------------------- #
 
 
-_CONCURRENCY = 8  # charts are bigger prompts than alt-text; stay conservative
+# Lower than alt-text-llm's 32 because chart extractions generate much longer
+# JSON outputs (hundreds of data points) and hit output-token rate limits first.
+_CONCURRENCY = 8
 
 
 async def _extract_one(
@@ -297,38 +311,88 @@ async def async_extract_batch(
 # --------------------------------------------------------------------------- #
 
 
-def load_existing(output: Path) -> set[str]:
+def _normalize(path: str | Path) -> str:
     """
-    Skip images already present in *output*.
+    Canonicalize paths so ``./x`` and ``x`` dedupe as the same work-item.
 
-    Matches alt-text-llm's pattern.
+    Pass URLs through unchanged — ``Path.resolve()`` would mangle
+    ``https://foo.avif`` into ``/cwd/https:/foo.avif``.
     """
+    s = str(path)
+    if s.startswith(("http://", "https://")):
+        return s
+    return str(Path(s).expanduser().resolve())
+
+
+def load_existing(output: Path) -> set[str]:
+    """Return the normalized paths of images already *successfully*
+    extracted."""
     try:
         data = json.loads(output.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return set()
-    return {item["source_image"] for item in data if item.get("spec")}
+    return {
+        _normalize(item["source_image"]) for item in data if item.get("spec")
+    }
 
 
 def write_results(
     results: Sequence[ChartExtractionResult], output: Path, append: bool = True
 ) -> None:
-    payload = [r.to_json() for r in results]
+    """
+    Merge *results* into *output*, keyed by source image (latest attempt wins).
+
+    Without deduping, failing items would be re-appended on every retry.
+    """
+    merged: dict[str, dict] = {}
     if append and output.exists():
         try:
             existing = json.loads(output.read_text(encoding="utf-8"))
             if isinstance(existing, list):
-                payload = existing + payload
+                for item in existing:
+                    src = item.get("source_image")
+                    if src:
+                        merged[_normalize(src)] = item
         except json.JSONDecodeError:
             pass
+    for r in results:
+        merged[_normalize(r.source_image)] = r.to_json()
     output.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        json.dumps(list(merged.values()), indent=2, ensure_ascii=False),
+        encoding="utf-8",
     )
+
+
+class _ChartYamlDumper(yaml.SafeDumper):
+    """
+    Dumper that keeps ``[x, y]`` data points on one line to match how.
+
+    authors write them by hand (see ``website_content/layer-horizon.md``).
+    Default block-style would produce ``- - 0 / - 8.92`` per point — ugly
+    and hard to skim during review.
+    """
+
+
+def _represent_point(dumper: yaml.SafeDumper, data: list) -> yaml.Node:
+    if len(data) == 2 and all(isinstance(v, (int, float)) for v in data):
+        return dumper.represent_sequence(
+            "tag:yaml.org,2002:seq", data, flow_style=True
+        )
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", data)
+
+
+_ChartYamlDumper.add_representer(list, _represent_point)
 
 
 def format_as_yaml_block(spec: dict) -> str:
     """Render a spec as a ```chart fenced block ready to paste into Markdown."""
-    body = yaml.safe_dump(spec, sort_keys=False, allow_unicode=True, width=100)
+    body = yaml.dump(
+        spec,
+        Dumper=_ChartYamlDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+    )
     return f"```chart\n{body.rstrip()}\n```"
 
 
@@ -363,7 +427,7 @@ def _cli() -> int:
     targets: list[Path] = list(args.images)
     if not args.no_skip_existing:
         done = load_existing(args.output)
-        targets = [p for p in targets if str(p) not in done]
+        targets = [p for p in targets if _normalize(p) not in done]
         if len(targets) < len(args.images):
             console.print(
                 f"[dim]Skipping {len(args.images) - len(targets)} already-extracted images.[/dim]"
@@ -387,7 +451,7 @@ def _cli() -> int:
     if args.print_yaml:
         for r in ok:
             console.print(f"\n# --- {r.source_image} ---")
-            # type: ignore[arg-type]
+            assert r.spec is not None  # narrowed by the `ok` filter above
             console.print(format_as_yaml_block(r.spec))
 
     return 0 if not failed else 1

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -34,12 +34,20 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 
 import yaml
 from rich.console import Console
+
+# alt-text-llm imports tqdm the same way — matching its convention keeps the
+# two tools visually consistent and silences the same experimental warning.
+from tqdm.rich import tqdm
+from tqdm.std import TqdmExperimentalWarning
+
+warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 
 # --------------------------------------------------------------------------- #
 # JSON Schema — mirrors `quartz/plugins/transformers/charts/types.ts`.        #
@@ -63,10 +71,6 @@ CHART_SCHEMA: dict = {
                 "properties": {
                     "name": {"type": "string"},
                     "color": {"type": "string"},
-                    # Drafts before 2020-12 don't support `prefixItems`; some
-                    # backends (notably OpenAI strict mode) reject it. Describe
-                    # the [x, y] tuple via items + minItems/maxItems — the
-                    # prompt enforces the numeric-pair semantics.
                     "data": {
                         "type": "array",
                         "minItems": 1,
@@ -140,28 +144,18 @@ def build_chart_prompt(context: str | None = None) -> str:
     return base
 
 
-# --------------------------------------------------------------------------- #
-# Cost estimation — kept parallel to alt-text-llm's `estimate_cost`.           #
-# Update as pricing changes; omit unknown models rather than guess.           #
-# --------------------------------------------------------------------------- #
+# Reuse alt-text-llm's cost estimator so both tools report the same way.
+# Extend the shared dict with Claude/GPT entries it doesn't ship with — safe
+# to mutate at import time since alt-text-llm reads via `.get()`.
+from alt_text_llm.generate import MODEL_COSTS, estimate_cost  # noqa: E402
 
-MODEL_COSTS: dict[str, dict[str, float]] = {
-    "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
-    "claude-opus-4-7": {"input": 0.015, "output": 0.075},
-    "gemini-2.5-pro": {"input": 0.00125, "output": 0.01},
-    "gemini-2.5-flash": {"input": 0.0003, "output": 0.0025},
-    "gpt-5": {"input": 0.0025, "output": 0.01},
-}
-
-
-def estimate_cost(
-    model: str, n: int, in_toks: int = 3000, out_toks: int = 800
-) -> str:
-    cost = MODEL_COSTS.get(model.lower())
-    if cost is None:
-        return f"(no pricing known for {model})"
-    total = n * (in_toks * cost["input"] + out_toks * cost["output"]) / 1000
-    return f"~${total:.2f} estimated ({n} images × {model})"
+MODEL_COSTS.update(
+    {
+        "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
+        "claude-opus-4-7": {"input": 0.015, "output": 0.075},
+        "gpt-5": {"input": 0.0025, "output": 0.01},
+    }
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -227,8 +221,16 @@ def extract_chart(
     context: str | None = None,
     timeout: int = 180,
 ) -> ChartExtractionResult:
-    """Run `llm` once against *image*, return a parsed
-    `ChartExtractionResult`."""
+    """
+    Run `llm` once against *image* and return a `ChartExtractionResult`.
+
+    Contract: this function MUST NOT raise on per-image failures (bad AVIF,
+    `llm` non-zero exit, timeout, unparseable JSON). Each of those is
+    recorded in ``result.error`` and returned normally. Raising would
+    cascade through ``asyncio.gather`` in ``async_extract_batch`` and kill
+    the whole run — losing work on every successful image processed so far.
+    Unexpected errors (e.g. ``KeyboardInterrupt``) still propagate.
+    """
 
     result = ChartExtractionResult(
         source_image=str(image), model=model, context_used=context or ""
@@ -245,6 +247,12 @@ def extract_chart(
             result.error = f"AVIF conversion failed: {err}"
             return result
 
+        # Pass the JSON schema via a tempfile rather than inline on argv:
+        # it's ~1KB today and growing, and a path is easier to eyeball when
+        # debugging a failed `llm` invocation (just re-run with the printed path).
+        schema_file = Path(tmp) / "schema.json"
+        schema_file.write_text(json.dumps(CHART_SCHEMA), encoding="utf-8")
+
         try:
             proc = subprocess.run(
                 [
@@ -254,7 +262,7 @@ def extract_chart(
                     "-a",
                     str(prepared),
                     "--schema",
-                    json.dumps(CHART_SCHEMA),
+                    str(schema_file),
                     build_chart_prompt(context),
                 ],
                 check=False,
@@ -298,12 +306,28 @@ async def _extract_one(
 
 
 async def async_extract_batch(
-    images: Sequence[Path], model: str
+    images: Sequence[Path],
+    model: str,
+    on_completed: Callable[[ChartExtractionResult], None] | None = None,
 ) -> list[ChartExtractionResult]:
+    """
+    Extract *images* concurrently.
+
+    If *on_completed* is supplied, it is called once per image as soon as that
+    image's extraction finishes (in completion order, not submission order). The
+    CLI wires this up to a tqdm progress bar; tests inject a list-append for
+    observation. Results are returned in submission order.
+    """
     sem = asyncio.Semaphore(_CONCURRENCY)
-    return await asyncio.gather(
-        *[_extract_one(img, model, sem) for img in images]
-    )
+    tasks = [
+        asyncio.create_task(_extract_one(img, model, sem)) for img in images
+    ]
+
+    if on_completed is not None:
+        for finished in asyncio.as_completed(tasks):
+            on_completed(await finished)
+
+    return await asyncio.gather(*tasks)
 
 
 # --------------------------------------------------------------------------- #
@@ -439,7 +463,14 @@ def _cli() -> int:
 
     console.print(f"[bold]{estimate_cost(args.model, len(targets))}[/bold]")
 
-    results = asyncio.run(async_extract_batch(targets, args.model))
+    with tqdm(total=len(targets), desc="Extracting charts") as bar:
+        results = asyncio.run(
+            async_extract_batch(
+                targets,
+                args.model,
+                on_completed=lambda _r: bar.update(1),
+            )
+        )
     write_results(results, args.output)
 
     ok = [r for r in results if r.spec]

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -1,0 +1,397 @@
+"""
+Extract chart data from an image into a ``chart`` YAML block.
+
+Takes an image of a chart (the kind the blog embeds as AVIF) and emits the
+YAML spec consumed by the `Charts` transformer (`quartz/plugins/transformers/
+charts.ts`). Drop the output into a Markdown file between ```` ```chart ```` /
+```` ``` ```` fences and the build-time renderer does the rest.
+
+Model-swap story
+----------------
+Following the ``alt-text-llm`` pattern, we shell out to the ``llm`` CLI
+(Simon Willison's, https://llm.datasette.io) with ``-m <model>``. Any model
+``llm`` knows about — Claude, Gemini, GPT, local Ollama — works via a single
+flag. No SDK pinning, no ``if model.startswith(...)`` branches.
+
+Prompts and schema come from ChartGemma's published "chart-to-table"
+formulation: ask for a structured table, force the output to a JSON schema
+mirroring ``quartz/plugins/transformers/charts/types.ts``, then round-trip
+through our own ``parseChartSpec`` to catch hallucinations.
+
+Resumability, AVIF conversion, concurrency, and the JSON work-queue format
+follow ``alt-text-llm`` so operators reading both scripts see the same shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+from rich.console import Console
+
+# --------------------------------------------------------------------------- #
+# JSON Schema — mirrors `quartz/plugins/transformers/charts/types.ts`.        #
+# Keep the shape in sync; `parseChartSpec` is the authoritative validator.    #
+# --------------------------------------------------------------------------- #
+
+CHART_SCHEMA: dict = {
+    "type": "object",
+    "required": ["type", "x", "y", "series"],
+    "properties": {
+        "type": {"const": "line"},
+        "title": {"type": "string"},
+        "x": {"$ref": "#/$defs/axis"},
+        "y": {"$ref": "#/$defs/axis"},
+        "series": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["name", "data"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "color": {"type": "string"},
+                    "data": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "array",
+                            "prefixItems": [
+                                {"type": "number"},
+                                {"type": "number"},
+                            ],
+                            "minItems": 2,
+                            "maxItems": 2,
+                        },
+                    },
+                },
+            },
+        },
+        "annotations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["type", "value"],
+                "properties": {
+                    "type": {"const": "horizontal-line"},
+                    "value": {"type": "number"},
+                    "label": {"type": "string"},
+                    "style": {"enum": ["solid", "dashed"]},
+                },
+            },
+        },
+    },
+    "$defs": {
+        "axis": {
+            "type": "object",
+            "required": ["label"],
+            "properties": {
+                "label": {"type": "string"},
+                "scale": {"enum": ["linear", "log"]},
+                "min": {"type": "number"},
+            },
+        },
+    },
+}
+
+# --------------------------------------------------------------------------- #
+# Prompt — adapted from ChartGemma's chart-to-table formulation.              #
+# --------------------------------------------------------------------------- #
+
+
+def build_chart_prompt(context: str | None = None) -> str:
+    base = textwrap.dedent("""
+        Extract the underlying data from this chart into a structured JSON object.
+
+        Transcribe exactly what the chart shows. Do not round, do not fabricate
+        points the axes don't clearly display, do not invent series labels. If
+        a value is unreadable, omit the point rather than guess.
+
+        Required:
+        - Identify the chart type (only "line" is supported for now).
+        - Read every marked data point for each series, in the axis units shown.
+        - Preserve exact axis labels verbatim, including units and casing.
+        - Record any horizontal reference lines as annotations.
+        - Detect log scale from visual tick spacing (decade steps) and report it.
+
+        Self-check before returning:
+        - Do series names match the legend text, verbatim?
+        - Does the first/last point of each series match the visible start/end?
+        - Are log-scale axes flagged? If yes, are all values strictly positive?
+        - Is the title free of interpolation and smallcaps "corrections"?
+
+        Return only the JSON object that matches the provided schema.
+        """).strip()
+
+    if context:
+        return f"{base}\n\nSurrounding prose (for disambiguating labels):\n{context}"
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Cost estimation — kept parallel to alt-text-llm's `estimate_cost`.           #
+# Update as pricing changes; omit unknown models rather than guess.           #
+# --------------------------------------------------------------------------- #
+
+MODEL_COSTS: dict[str, dict[str, float]] = {
+    "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
+    "claude-opus-4-7": {"input": 0.015, "output": 0.075},
+    "gemini-2.5-pro": {"input": 0.00125, "output": 0.01},
+    "gemini-2.5-flash": {"input": 0.0003, "output": 0.0025},
+    "gpt-5": {"input": 0.0025, "output": 0.01},
+}
+
+
+def estimate_cost(
+    model: str, n: int, in_toks: int = 3000, out_toks: int = 800
+) -> str:
+    cost = MODEL_COSTS.get(model.lower())
+    if cost is None:
+        return f"(no pricing known for {model})"
+    total = n * (in_toks * cost["input"] + out_toks * cost["output"]) / 1000
+    return f"~${total:.2f} estimated ({n} images × {model})"
+
+
+# --------------------------------------------------------------------------- #
+# Core extraction — single invocation of the `llm` CLI.                        #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class ChartExtractionResult:
+    """
+    One chart image → one structured result.
+
+    Mirrors `AltGenerationResult`.
+    """
+
+    source_image: str
+    model: str
+    spec: dict | None = None
+    error: str | None = None
+    raw_output: str = ""
+    context_used: str = ""
+
+    def to_json(self) -> dict:
+        return asdict(self)
+
+
+class ChartExtractionError(Exception):
+    """Raised when extraction fails unrecoverably for a single image."""
+
+
+def _find_llm() -> str:
+    path = shutil.which("llm")
+    if not path:
+        raise FileNotFoundError(
+            "The `llm` CLI is not on PATH. Install via `uv tool install llm` "
+            "and configure a model plugin (e.g. `llm install llm-anthropic`)."
+        )
+    return path
+
+
+def _convert_if_avif(image: Path, workspace: Path) -> Path:
+    """
+    LLM backends reject AVIF; convert to PNG in a tempdir.
+
+    Same as alt-text-llm.
+    """
+    if image.suffix.lower() != ".avif":
+        return image
+    png = workspace / f"{image.stem}.png"
+    magick = shutil.which("magick")
+    if not magick:
+        raise ChartExtractionError("`magick` not on PATH; cannot convert AVIF.")
+    subprocess.run(
+        [magick, str(image), str(png)], check=True, capture_output=True
+    )
+    return png
+
+
+def extract_chart(
+    image: Path,
+    model: str,
+    context: str | None = None,
+    timeout: int = 180,
+) -> ChartExtractionResult:
+    """Run `llm` once against *image*, return a parsed
+    `ChartExtractionResult`."""
+
+    result = ChartExtractionResult(
+        source_image=str(image), model=model, context_used=context or ""
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            prepared = _convert_if_avif(image, Path(tmp))
+            proc = subprocess.run(
+                [
+                    _find_llm(),
+                    "-m",
+                    model,
+                    "-a",
+                    str(prepared),
+                    "--schema",
+                    json.dumps(CHART_SCHEMA),
+                    build_chart_prompt(context),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            result.error = f"timeout after {timeout}s"
+            return result
+
+        result.raw_output = proc.stdout
+
+        if proc.returncode != 0:
+            result.error = (proc.stderr or proc.stdout).strip()
+            return result
+
+        try:
+            result.spec = json.loads(proc.stdout)
+        except json.JSONDecodeError as err:
+            result.error = f"invalid JSON from model: {err}"
+
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Async batch — same shape as alt-text-llm's `async_generate_suggestions`.     #
+# --------------------------------------------------------------------------- #
+
+
+_CONCURRENCY = 8  # charts are bigger prompts than alt-text; stay conservative
+
+
+async def _extract_one(
+    image: Path, model: str, sem: asyncio.Semaphore
+) -> ChartExtractionResult:
+    async with sem:
+        return await asyncio.to_thread(extract_chart, image, model)
+
+
+async def async_extract_batch(
+    images: Sequence[Path], model: str
+) -> list[ChartExtractionResult]:
+    sem = asyncio.Semaphore(_CONCURRENCY)
+    return await asyncio.gather(
+        *[_extract_one(img, model, sem) for img in images]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Output — JSON work-queue (resumable) + YAML chart block for pasting.         #
+# --------------------------------------------------------------------------- #
+
+
+def load_existing(output: Path) -> set[str]:
+    """
+    Skip images already present in *output*.
+
+    Matches alt-text-llm's pattern.
+    """
+    try:
+        data = json.loads(output.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return set()
+    return {item["source_image"] for item in data if item.get("spec")}
+
+
+def write_results(
+    results: Sequence[ChartExtractionResult], output: Path, append: bool = True
+) -> None:
+    payload = [r.to_json() for r in results]
+    if append and output.exists():
+        try:
+            existing = json.loads(output.read_text(encoding="utf-8"))
+            if isinstance(existing, list):
+                payload = existing + payload
+        except json.JSONDecodeError:
+            pass
+    output.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def format_as_yaml_block(spec: dict) -> str:
+    """Render a spec as a ```chart fenced block ready to paste into Markdown."""
+    body = yaml.safe_dump(spec, sort_keys=False, allow_unicode=True, width=100)
+    return f"```chart\n{body.rstrip()}\n```"
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "images", nargs="+", type=Path, help="Chart image(s) to extract."
+    )
+    parser.add_argument(
+        "-m",
+        "--model",
+        default="claude-sonnet-4-6",
+        help="Any model name `llm` knows about. Swap freely.",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, default=Path("chart-queue.json")
+    )
+    parser.add_argument("--no-skip-existing", action="store_true")
+    parser.add_argument(
+        "--print-yaml",
+        action="store_true",
+        help="Print the ```chart block for each success on stdout.",
+    )
+    args = parser.parse_args()
+
+    console = Console()
+    targets: list[Path] = list(args.images)
+    if not args.no_skip_existing:
+        done = load_existing(args.output)
+        targets = [p for p in targets if str(p) not in done]
+        if len(targets) < len(args.images):
+            console.print(
+                f"[dim]Skipping {len(args.images) - len(targets)} already-extracted images.[/dim]"
+            )
+
+    if not targets:
+        console.print("Nothing to do.")
+        return 0
+
+    console.print(f"[bold]{estimate_cost(args.model, len(targets))}[/bold]")
+
+    results = asyncio.run(async_extract_batch(targets, args.model))
+    write_results(results, args.output)
+
+    ok = [r for r in results if r.spec]
+    failed = [r for r in results if not r.spec]
+    console.print(
+        f"[green]{len(ok)} succeeded[/green], [red]{len(failed)} failed[/red]"
+    )
+
+    if args.print_yaml:
+        for r in ok:
+            console.print(f"\n# --- {r.source_image} ---")
+            # type: ignore[arg-type]
+            console.print(format_as_yaml_block(r.spec))
+
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/scripts/chart_extract.py
+++ b/scripts/chart_extract.py
@@ -249,6 +249,10 @@ def extract_chart(
         source_image=str(image), model=model, context_used=context or ""
     )
 
+    # tmpdir only needs to live as long as the `llm` subprocess — it holds the
+    # converted PNG (if input was AVIF) and the JSON schema file, both of
+    # which the subprocess reads. Anything that only inspects `proc` after
+    # the call can live outside.
     with tempfile.TemporaryDirectory() as tmp:
         try:
             prepared = _convert_if_avif(image, Path(tmp))
@@ -260,9 +264,8 @@ def extract_chart(
             result.error = f"AVIF conversion failed: {err}"
             return result
 
-        # Pass the JSON schema via a tempfile rather than inline on argv:
-        # it's ~1KB today and growing, and a path is easier to eyeball when
-        # debugging a failed `llm` invocation (just re-run with the printed path).
+        # Schema via tempfile rather than inline on argv: easier to eyeball
+        # when debugging a failed `llm` invocation (re-run with the path).
         schema_file = Path(tmp) / "schema.json"
         schema_file.write_text(json.dumps(CHART_SCHEMA), encoding="utf-8")
 
@@ -287,17 +290,16 @@ def extract_chart(
             result.error = f"llm timeout after {timeout}s"
             return result
 
-        result.raw_output = proc.stdout
+    result.raw_output = proc.stdout
+    if proc.returncode != 0:
+        result.error = (proc.stderr or proc.stdout).strip()
+        return result
 
-        if proc.returncode != 0:
-            result.error = (proc.stderr or proc.stdout).strip()
-            return result
-
-        try:
-            result.spec = json.loads(proc.stdout)
-        except json.JSONDecodeError as err:
-            result.error = f"invalid JSON from model: {err}"
-            return result
+    try:
+        result.spec = json.loads(proc.stdout)
+    except json.JSONDecodeError as err:
+        result.error = f"invalid JSON from model: {err}"
+        return result
 
     # Persist outputs next to the source image so the user can paste the
     # block into Markdown and move the CSV alongside the .md file.

--- a/scripts/chart_spec_validator.ts
+++ b/scripts/chart_spec_validator.ts
@@ -16,9 +16,10 @@ process.stdin.on("data", (chunk: string) => {
 process.stdin.on("end", () => {
   try {
     parseChartSpec(buf)
-    process.exit(0)
   } catch (err) {
-    process.stderr.write((err as Error).message + "\n")
-    process.exit(1)
+    process.stderr.write(`${(err as Error).message}\n`)
+    // Setting exitCode (instead of calling process.exit) lets the event loop
+    // drain normally — DeepSource JS-0263.
+    process.exitCode = 1
   }
 })

--- a/scripts/chart_spec_validator.ts
+++ b/scripts/chart_spec_validator.ts
@@ -1,0 +1,24 @@
+// Round-trip YAML from stdin through quartz's `parseChartSpec` and exit 0/1.
+// Called from `scripts/chart_extract.py` to catch LLM hallucinations that
+// pass the JSON schema but would fail at build time.
+//
+// Usage:
+//   echo "<yaml>" | npx tsx scripts/chart_spec_validator.ts
+
+import { parseChartSpec } from "../quartz/plugins/transformers/charts/parse"
+
+process.stdin.setEncoding("utf8")
+
+let buf = ""
+process.stdin.on("data", (chunk: string) => {
+  buf += chunk
+})
+process.stdin.on("end", () => {
+  try {
+    parseChartSpec(buf)
+    process.exit(0)
+  } catch (err) {
+    process.stderr.write((err as Error).message + "\n")
+    process.exit(1)
+  }
+})

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
 
+from alt_text_llm import utils as alt_utils
+
 from scripts import chart_extract
 
 # --------------------------------------------------------------------------- #
@@ -50,9 +52,6 @@ _IMAGE_REF_RE = re.compile(
 # Sidecars produced by this driver — always skip when walking.
 _SIDECAR_SUFFIX = ".proposed-replacements.md"
 
-# How many lines of surrounding prose to include as context.
-_CONTEXT_WINDOW = 3
-
 
 @dataclass(slots=True, frozen=True)
 class ImageRef:
@@ -65,17 +64,13 @@ class ImageRef:
     context: str
 
 
-def _paragraph_context(
-    lines: Sequence[str], line_index: int, window: int = _CONTEXT_WINDOW
-) -> str:
-    """Return ``window`` lines above and below *line_index* (0-based)."""
-    start = max(0, line_index - window)
-    end = min(len(lines), line_index + window + 1)
-    return "\n".join(lines[start:end]).strip()
-
-
 def iter_image_refs(md_path: Path) -> Iterable[ImageRef]:
-    """Yield every standard-Markdown image reference in *md_path*."""
+    """
+    Yield every standard-Markdown image reference in *md_path*.
+
+    Context is one preceding paragraph + two following paragraphs around the
+    ref, via alt-text-llm's paragraph-aware helper.
+    """
     lines = md_path.read_text(encoding="utf-8").splitlines()
     for idx, line in enumerate(lines):
         for m in _IMAGE_REF_RE.finditer(line):
@@ -84,7 +79,9 @@ def iter_image_refs(md_path: Path) -> Iterable[ImageRef]:
                 url=m.group("url"),
                 alt=m.group("alt"),
                 line_number=idx + 1,
-                context=_paragraph_context(lines, idx),
+                context=alt_utils.paragraph_context(
+                    lines, idx, max_before=1, max_after=2
+                ),
             )
 
 

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -1,0 +1,132 @@
+"""
+DESIGN DOC / STUB — `convert_existing_graphs.py`.
+
+Status: **not implemented**. This file captures the scope and
+intended shape so the next session can pick it up without re-deriving
+the requirements.
+
+Goal
+----
+Bulk-convert the ~100 chart-image references currently scattered across
+``website_content/*.md`` (nearly all ``https://assets.turntrout.com/...avif``)
+into inline ``chart`` YAML blocks backed by CSV sidecars — the pipeline
+established by ``scripts/chart_extract.py`` and the `data: <path>`
+renderer support (see ``NEXT-STEPS.md``).
+
+Today, ``chart_extract.py`` is invoked one image at a time. Real backfill
+needs a driver that:
+
+1. Walks ``website_content/`` looking for image refs whose ALT text or
+   surrounding prose suggests a chart (`"graph"`, `"plot"`, `"line
+   chart"`, `"loss curve"`, etc.).
+2. Excludes image refs that are clearly NOT charts (logos, headshots,
+   screenshots of prose, diagrams-not-plots).
+3. Enqueues survivors for ``chart_extract.py``.
+4. On success: writes the CSV sidecar alongside the ``.md`` file and
+   replaces the ``![alt](url)`` line with the paste-ready ```chart block.
+5. Is resumable (queue file shape already supported by
+   ``scripts/chart_extract.py`` — one JSON list, keyed by source URL).
+
+Why this is a separate file from ``chart_extract.py``
+-----------------------------------------------------
+``chart_extract.py`` is the low-level "one image in, CSV+block out" unit;
+this driver is the high-level "iterate the whole site" orchestration.
+Keeping them separate lets the unit stay simple and lets the driver
+change its discovery/filtering heuristics without touching extraction.
+
+Scaffolding we can reuse
+------------------------
+- ``alt_text_llm.scan.QueueItem`` — already parses Markdown files for
+  image refs with line numbers and paragraph context. Not currently a
+  direct dependency of this repo (``alt-text-llm`` is installed as a
+  ``uv tool``, not a lib dep), so either:
+
+  (a) re-add ``alt-text-llm`` to ``pyproject.toml`` as a lib dep for the
+      ``scan`` module, OR
+  (b) copy its ~150 lines of Markdown+image parsing logic here — it's
+      small and stable.
+
+  (a) is less duplication; (b) avoids tying the build to an external
+  package's release cadence. Lean toward (a) unless the coupling becomes
+  painful.
+
+- ``scripts/chart_extract.extract_chart`` — call it per queue item.
+  Already handles URL downloads (item 8, done) and TS round-trip
+  validation (item 6, done).
+
+- ``alt_text_llm.utils.generate_article_context`` — produces the
+  surrounding-paragraph context string that the chart prompt appends to
+  aid disambiguation. Only used if we go with (a) above.
+
+Open design questions (decide before implementing)
+--------------------------------------------------
+1. **Chart-detection heuristic.** Possibilities:
+   - Keyword scan on alt text / surrounding prose ("chart", "graph",
+     "plot", "loss", "accuracy", "curve"). Cheap; plenty of false
+     negatives.
+   - First-pass vision model call (e.g. Gemini flash-lite) with a
+     "is this a line chart?" yes/no prompt. Expensive; high precision.
+   - Author-tagged opt-in: add a ``# convert-to-chart`` HTML comment in
+     the Markdown next to charts you want converted. Trades setup effort
+     for full control.
+   Recommend: keyword scan + manual review queue. The driver writes an
+   ``unsure.json`` of "might be a chart but unclear" images, and you
+   hand-triage rather than pay for vision calls on non-charts.
+
+2. **Replacement strategy.** Options:
+   - In-place edit the ``.md`` file: delete the ``![alt](url)`` line,
+     insert the ``` ```chart``` block.
+   - Write the replacement to a `.proposed-replacements.md` sibling file
+     for manual review, then the user diffs and merges.
+   Recommend: proposed-replacements first. Bulk in-place edits on 100+
+   posts are hard to review; a sidecar file is easier to diff and
+   revert.
+
+3. **Failure handling.** An image that fails extraction (bad
+   extraction, LLM rate-limited, validator rejected) should stay as the
+   original ``![alt](url)`` and be recorded in the queue for retry. The
+   existing ``chart_extract.write_results`` dedupe-by-source handles
+   this.
+
+4. **Concurrency.** ``chart_extract.async_extract_batch`` already uses a
+   semaphore of 8. Reusing that is probably right; batching across posts
+   rather than within would be natural.
+
+Proposed CLI shape
+------------------
+::
+
+    uv run python scripts/notebooks/convert_existing_graphs.py \\
+        --content-dir website_content \\
+        --model claude-sonnet-4-6 \\
+        --queue chart-backfill-queue.json \\
+        --output-mode proposed   # or `in-place`
+        --dry-run                # discover only, don't call LLM
+
+Expected size
+-------------
+Implementation is probably 200-300 lines. Mostly: walk files, apply
+heuristic, call ``chart_extract.async_extract_batch``, write the
+replacement ``.proposed-replacements.md`` sibling.
+
+Tests
+-----
+- Heuristic regex matches / skips (parametrized ``it.each``-style)
+- File walker finds expected image refs (tempdir with hand-crafted
+  ``.md`` fixtures)
+- Mock ``extract_chart`` to return fake successes/failures; verify the
+  proposed-replacement output and the queue state
+- Resumption: second run skips images already in the queue
+
+Handoff
+-------
+Next Claude Code session should open this file, decide questions 1-4
+above (preferably asking alex), and then implement. 100% line coverage
+is the house rule per ``CLAUDE.md``.
+"""
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "convert_existing_graphs.py is a design doc stub — see module docstring. "
+        "Open it, decide the four design questions, and implement."
+    )

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -79,39 +79,44 @@ Skeleton::
 
     await async_extract_batch(urls, model=MODEL, context_for=_context_for)
 
-Open design questions (decide before implementing)
---------------------------------------------------
-1. **Chart-detection heuristic.** Possibilities:
-   - Keyword scan on alt text / surrounding prose ("chart", "graph",
-     "plot", "loss", "accuracy", "curve"). Cheap; plenty of false
-     negatives.
-   - First-pass vision model call (e.g. Gemini flash-lite) with a
-     "is this a line chart?" yes/no prompt. Expensive; high precision.
-   - Author-tagged opt-in: add a ``# convert-to-chart`` HTML comment in
-     the Markdown next to charts you want converted. Trades setup effort
-     for full control.
-   Recommend: keyword scan + manual review queue. The driver writes an
-   ``unsure.json`` of "might be a chart but unclear" images, and you
-   hand-triage rather than pay for vision calls on non-charts.
+Decided design
+--------------
+1. **Chart-detection: vision-model classifier, not keyword scan.**
+   For each image-ref discovered in ``website_content/``, call the best
+   available vision model with a yes/no prompt built by concatenating
+   ``scripts.chart_extract.SUPPORTED_CHART_TYPES`` into the prompt::
 
-2. **Replacement strategy.** Options:
-   - In-place edit the ``.md`` file: delete the ``![alt](url)`` line,
-     insert the ``` ```chart``` block.
-   - Write the replacement to a `.proposed-replacements.md` sibling file
-     for manual review, then the user diffs and merges.
-   Recommend: proposed-replacements first. Bulk in-place edits on 100+
-   posts are hard to review; a sidecar file is easier to diff and
-   revert.
+       from scripts.chart_extract import SUPPORTED_CHART_TYPES
+       types_csv = ", ".join(SUPPORTED_CHART_TYPES)
+       prompt = (
+           f"Is this image a chart of one of these supported kinds: "
+           f"{types_csv}? Answer exactly YES or NO."
+       )
 
-3. **Failure handling.** An image that fails extraction (bad
-   extraction, LLM rate-limited, validator rejected) should stay as the
-   original ``![alt](url)`` and be recorded in the queue for retry. The
+   When ``SUPPORTED_CHART_TYPES`` grows (bar, scatter, etc.) the
+   classifier follows automatically. Pass the same alt-text / surrounding
+   prose context used by ``chart_extract`` so the classifier isn't judging
+   from pixels alone. Use the most capable vision model (opus-class) —
+   the classifier runs once per image ever, so cost ceiling is bounded
+   and precision matters more than $/call.
+
+2. **Replacement strategy: proposed-replacements sidecar, git-ignored.**
+   For each successfully converted chart, write the new block to
+   ``<post>.proposed-replacements.md`` next to the original ``<post>.md``.
+   ``.gitignore`` excludes ``*.proposed-replacements.md`` — these are
+   scratch files for review. The user diffs the sidecar against the
+   original, hand-merges, and the sidecar can be deleted after.
+
+   (Do NOT in-place edit the ``.md`` files. 100 posts is too many to
+   review blind.)
+
+3. **Failure handling.** An image that fails extraction stays as the
+   original ``![alt](url)`` and is recorded in the queue for retry. The
    existing ``chart_extract.write_results`` dedupe-by-source handles
-   this.
+   resumption.
 
-4. **Concurrency.** ``chart_extract.async_extract_batch`` already uses a
-   semaphore of 8. Reusing that is probably right; batching across posts
-   rather than within would be natural.
+4. **Concurrency.** Reuse ``chart_extract.async_extract_batch``'s
+   semaphore of 8. Batching across posts (not within) is natural.
 
 Proposed CLI shape
 ------------------
@@ -141,9 +146,9 @@ Tests
 
 Handoff
 -------
-Next Claude Code session should open this file, decide questions 1-4
-above (preferably asking alex), and then implement. 100% line coverage
-is the house rule per ``CLAUDE.md``.
+All four design questions are decided above. Next Claude Code session
+should open this file and implement. 100% line coverage is the house
+rule per ``CLAUDE.md``.
 """
 
 if __name__ == "__main__":

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -197,6 +197,24 @@ def _sidecar_path(md_file: Path) -> Path:
     return md_file.with_name(md_file.stem + _SIDECAR_SUFFIX)
 
 
+_ALT_TODO_PLACEHOLDER = "[TODO: describe this chart]"
+
+
+def _provenanced_block(spec: dict, ref: ImageRef) -> str:
+    """
+    Inject ``alt`` and ``fallback`` into *spec* and re-serialize.
+
+    The parser requires a non-empty ``alt``; if the original Markdown image
+    had no alt text, fall back to the chart title or a TODO placeholder so
+    the user notices and fills it in during hand-merge. ``fallback`` is
+    always set to the original URL — "for future reference" per the spec.
+    """
+    enriched = {**spec}
+    enriched["alt"] = ref.alt or spec.get("title") or _ALT_TODO_PLACEHOLDER
+    enriched["fallback"] = ref.url
+    return chart_extract.format_as_yaml_block(enriched)
+
+
 def write_proposed_replacements(
     results: Sequence[chart_extract.ChartExtractionResult],
     refs_by_url: dict[str, ImageRef],
@@ -205,17 +223,24 @@ def write_proposed_replacements(
     Group successful extractions by source markdown file and write one sidecar
     per file.
 
+    Each replacement block carries the original alt text (injected into the
+    spec as ``alt:``) and original image URL (injected as ``fallback:``) so
+    the rendered chart is a11y-complete and the source is preserved even if
+    the renderer ever fails to produce an SVG.
+
     Failures and orphans are skipped silently — they remain in the queue and
     surface on the next run.
     """
     by_file: dict[str, list[tuple[ImageRef, str]]] = {}
     for r in results:
-        if r.error or not r.yaml_block:
+        if r.error or not r.spec:
             continue
         ref = refs_by_url.get(r.source_image)
         if ref is None:
             continue
-        by_file.setdefault(ref.markdown_file, []).append((ref, r.yaml_block))
+        by_file.setdefault(ref.markdown_file, []).append(
+            (ref, _provenanced_block(r.spec, ref))
+        )
 
     written: list[Path] = []
     for md_file, items in sorted(by_file.items()):

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -58,6 +58,27 @@ Scaffolding we can reuse
   surrounding-paragraph context string that the chart prompt appends to
   aid disambiguation. Only used if we go with (a) above.
 
+Per-image context is high-value
+-------------------------------
+``async_extract_batch`` now takes a ``context_for`` callback. Pass it a
+function that returns the image's **alt text plus the surrounding
+paragraph** for each URL — this string is injected into the chart prompt
+under "Surrounding prose (for disambiguating labels)". Alt text alone
+is often the most compact signal available ("Three line charts comparing
+four unlearning methods — ERA, Data filtering, RMU, and DEMIX + ablate")
+and dramatically improves series-name fidelity. The surrounding
+paragraph adds units, axis semantics, and references to annotations.
+
+Skeleton::
+
+    def _context_for(url: str) -> str | None:
+        qi: QueueItem = queue_by_url[str(url)]
+        alt = qi.alt_text or ""
+        prose = alt_text_llm.utils.generate_article_context(qi, max_after=2)
+        return f"Alt text: {alt}\n\nSurrounding prose:\n{prose}" if alt or prose else None
+
+    await async_extract_batch(urls, model=MODEL, context_for=_context_for)
+
 Open design questions (decide before implementing)
 --------------------------------------------------
 1. **Chart-detection heuristic.** Possibilities:

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -1,158 +1,343 @@
 """
-DESIGN DOC / STUB — `convert_existing_graphs.py`.
+Bulk-convert chart image references in ``website_content/`` into inline
+``chart`` YAML blocks backed by CSV sidecars.
 
-Status: **not implemented**. This file captures the scope and
-intended shape so the next session can pick it up without re-deriving
-the requirements.
-
-Goal
-----
-Bulk-convert the ~100 chart-image references currently scattered across
-``website_content/*.md`` (nearly all ``https://assets.turntrout.com/...avif``)
-into inline ``chart`` YAML blocks backed by CSV sidecars — the pipeline
-established by ``scripts/chart_extract.py`` and the `data: <path>`
-renderer support (see ``NEXT-STEPS.md``).
-
-Today, ``chart_extract.py`` is invoked one image at a time. Real backfill
-needs a driver that:
-
-1. Walks ``website_content/`` looking for image refs whose ALT text or
-   surrounding prose suggests a chart (`"graph"`, `"plot"`, `"line
-   chart"`, `"loss curve"`, etc.).
-2. Excludes image refs that are clearly NOT charts (logos, headshots,
-   screenshots of prose, diagrams-not-plots).
-3. Enqueues survivors for ``chart_extract.py``.
-4. On success: writes the CSV sidecar alongside the ``.md`` file and
-   replaces the ``![alt](url)`` line with the paste-ready ```chart block.
-5. Is resumable (queue file shape already supported by
-   ``scripts/chart_extract.py`` — one JSON list, keyed by source URL).
-
-Why this is a separate file from ``chart_extract.py``
------------------------------------------------------
-``chart_extract.py`` is the low-level "one image in, CSV+block out" unit;
-this driver is the high-level "iterate the whole site" orchestration.
-Keeping them separate lets the unit stay simple and lets the driver
-change its discovery/filtering heuristics without touching extraction.
-
-Scaffolding we can reuse
-------------------------
-- ``alt_text_llm.scan.QueueItem`` — already parses Markdown files for
-  image refs with line numbers and paragraph context. Not currently a
-  direct dependency of this repo (``alt-text-llm`` is installed as a
-  ``uv tool``, not a lib dep), so either:
-
-  (a) re-add ``alt-text-llm`` to ``pyproject.toml`` as a lib dep for the
-      ``scan`` module, OR
-  (b) copy its ~150 lines of Markdown+image parsing logic here — it's
-      small and stable.
-
-  (a) is less duplication; (b) avoids tying the build to an external
-  package's release cadence. Lean toward (a) unless the coupling becomes
-  painful.
-
-- ``scripts/chart_extract.extract_chart`` — call it per queue item.
-  Already handles URL downloads (item 8, done) and TS round-trip
-  validation (item 6, done).
-
-- ``alt_text_llm.utils.generate_article_context`` — produces the
-  surrounding-paragraph context string that the chart prompt appends to
-  aid disambiguation. Only used if we go with (a) above.
-
-Per-image context is high-value
--------------------------------
-``async_extract_batch`` now takes a ``context_for`` callback. Pass it a
-function that returns the image's **alt text plus the surrounding
-paragraph** for each URL — this string is injected into the chart prompt
-under "Surrounding prose (for disambiguating labels)". Alt text alone
-is often the most compact signal available ("Three line charts comparing
-four unlearning methods — ERA, Data filtering, RMU, and DEMIX + ablate")
-and dramatically improves series-name fidelity. The surrounding
-paragraph adds units, axis semantics, and references to annotations.
-
-Skeleton::
-
-    def _context_for(url: str) -> str | None:
-        qi: QueueItem = queue_by_url[str(url)]
-        alt = qi.alt_text or ""
-        prose = alt_text_llm.utils.generate_article_context(qi, max_after=2)
-        return f"Alt text: {alt}\n\nSurrounding prose:\n{prose}" if alt or prose else None
-
-    await async_extract_batch(urls, model=MODEL, context_for=_context_for)
-
-Decided design
---------------
-1. **Chart-detection: vision-model classifier, not keyword scan.**
-   For each image-ref discovered in ``website_content/``, call the best
-   available vision model with a yes/no prompt built by concatenating
-   ``scripts.chart_extract.SUPPORTED_CHART_TYPES`` into the prompt::
-
-       from scripts.chart_extract import SUPPORTED_CHART_TYPES
-       types_csv = ", ".join(SUPPORTED_CHART_TYPES)
-       prompt = (
-           f"Is this image a chart of one of these supported kinds: "
-           f"{types_csv}? Answer exactly YES or NO."
-       )
-
-   When ``SUPPORTED_CHART_TYPES`` grows (bar, scatter, etc.) the
-   classifier follows automatically. Pass the same alt-text / surrounding
-   prose context used by ``chart_extract`` so the classifier isn't judging
-   from pixels alone. Use the most capable vision model (opus-class) —
-   the classifier runs once per image ever, so cost ceiling is bounded
-   and precision matters more than $/call.
-
-2. **Replacement strategy: proposed-replacements sidecar, git-ignored.**
-   For each successfully converted chart, write the new block to
-   ``<post>.proposed-replacements.md`` next to the original ``<post>.md``.
-   ``.gitignore`` excludes ``*.proposed-replacements.md`` — these are
-   scratch files for review. The user diffs the sidecar against the
-   original, hand-merges, and the sidecar can be deleted after.
-
-   (Do NOT in-place edit the ``.md`` files. 100 posts is too many to
-   review blind.)
-
-3. **Failure handling.** An image that fails extraction stays as the
-   original ``![alt](url)`` and is recorded in the queue for retry. The
-   existing ``chart_extract.write_results`` dedupe-by-source handles
-   resumption.
-
-4. **Concurrency.** Reuse ``chart_extract.async_extract_batch``'s
-   semaphore of 8. Batching across posts (not within) is natural.
-
-Proposed CLI shape
-------------------
-::
-
-    uv run python scripts/notebooks/convert_existing_graphs.py \\
-        --content-dir website_content \\
-        --model claude-sonnet-4-6 \\
-        --queue chart-backfill-queue.json \\
-        --output-mode proposed   # or `in-place`
-        --dry-run                # discover only, don't call LLM
-
-Expected size
--------------
-Implementation is probably 200-300 lines. Mostly: walk files, apply
-heuristic, call ``chart_extract.async_extract_batch``, write the
-replacement ``.proposed-replacements.md`` sibling.
-
-Tests
------
-- Heuristic regex matches / skips (parametrized ``it.each``-style)
-- File walker finds expected image refs (tempdir with hand-crafted
-  ``.md`` fixtures)
-- Mock ``extract_chart`` to return fake successes/failures; verify the
-  proposed-replacement output and the queue state
-- Resumption: second run skips images already in the queue
-
-Handoff
--------
-All four design questions are decided above. Next Claude Code session
-should open this file and implement. 100% line coverage is the house
-rule per ``CLAUDE.md``.
+Pipeline
+--------
+1. Walk ``website_content/*.md`` and collect every ``![alt](url)`` image
+   ref (line number + surrounding paragraph kept as context).
+2. Ask a vision model: "is this image one of ``SUPPORTED_CHART_TYPES``?"
+   (prompt concatenates the supported-types tuple, so adding ``bar`` or
+   ``scatter`` to the renderer updates the classifier automatically).
+3. For survivors, call ``chart_extract.async_extract_batch`` with a
+   ``context_for`` callback that returns "alt text + surrounding prose"
+   per image — the extractor prompt uses this to disambiguate axis and
+   series labels.
+4. Write one sibling ``<post>.proposed-replacements.md`` per affected
+   post containing the original image ref and the proposed ```chart```
+   block. These sidecars are git-ignored; the user diffs them against
+   the real post and hand-merges.
+5. Results go through ``chart_extract.write_results`` so re-runs resume
+   from the same queue and skip URLs that already succeeded.
 """
 
-if __name__ == "__main__":
-    raise NotImplementedError(
-        "convert_existing_graphs.py is a design doc stub — see module docstring. "
-        "Open it, decide the four design questions, and implement."
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from scripts import chart_extract
+
+# --------------------------------------------------------------------------- #
+# Image-ref discovery                                                          #
+# --------------------------------------------------------------------------- #
+
+# Standard Markdown image ref: ``![alt](url)``. Alt text can be empty; URL is
+# non-empty and stops at the first unescaped closing paren. Titles inside the
+# parens (``(url "title")``) are rare on this site; we just strip whitespace
+# from the URL side.
+_IMAGE_REF_RE = re.compile(
+    r"!\[(?P<alt>[^\]]*)\]\((?P<url>\S+?)(?:\s+\"[^\"]*\")?\)"
+)
+
+# Sidecars produced by this driver — always skip when walking.
+_SIDECAR_SUFFIX = ".proposed-replacements.md"
+
+# How many lines of surrounding prose to include as context.
+_CONTEXT_WINDOW = 3
+
+
+@dataclass(slots=True, frozen=True)
+class ImageRef:
+    """One Markdown image reference located on disk."""
+
+    markdown_file: str
+    url: str
+    alt: str
+    line_number: int  # 1-based
+    context: str
+
+
+def _paragraph_context(
+    lines: Sequence[str], line_index: int, window: int = _CONTEXT_WINDOW
+) -> str:
+    """Return ``window`` lines above and below *line_index* (0-based)."""
+    start = max(0, line_index - window)
+    end = min(len(lines), line_index + window + 1)
+    return "\n".join(lines[start:end]).strip()
+
+
+def iter_image_refs(md_path: Path) -> Iterable[ImageRef]:
+    """Yield every standard-Markdown image reference in *md_path*."""
+    lines = md_path.read_text(encoding="utf-8").splitlines()
+    for idx, line in enumerate(lines):
+        for m in _IMAGE_REF_RE.finditer(line):
+            yield ImageRef(
+                markdown_file=str(md_path),
+                url=m.group("url"),
+                alt=m.group("alt"),
+                line_number=idx + 1,
+                context=_paragraph_context(lines, idx),
+            )
+
+
+def walk_content(root: Path) -> list[ImageRef]:
+    """
+    Collect image refs across every ``*.md`` under *root*.
+
+    Skips the sidecar files this driver emits, so re-runs don't classify their
+    own output as fresh charts.
+    """
+    refs: list[ImageRef] = []
+    for md in sorted(root.rglob("*.md")):
+        if md.name.endswith(_SIDECAR_SUFFIX):
+            continue
+        refs.extend(iter_image_refs(md))
+    return refs
+
+
+# --------------------------------------------------------------------------- #
+# Classifier — vision model answers YES / NO                                   #
+# --------------------------------------------------------------------------- #
+
+
+def build_classifier_prompt(alt: str, context: str) -> str:
+    """
+    Prompt that asks whether an image is a chart the renderer handles.
+
+    The supported-types list is injected from
+    ``chart_extract.SUPPORTED_CHART_TYPES`` so adding a new renderer kind
+    doesn't require editing this file.
+    """
+    types_csv = ", ".join(chart_extract.SUPPORTED_CHART_TYPES)
+    return (
+        "You are classifying a blog image. Answer with exactly YES or NO on "
+        "the first line, nothing else.\n\n"
+        f"Is this image a {types_csv} chart (a data-plot of those kinds)?\n"
+        "Screenshots of UIs, headshots, diagrams without data, memes, and "
+        "logos are all NO.\n\n"
+        f"Alt text:\n{alt}\n\n"
+        f"Surrounding prose:\n{context}"
     )
+
+
+def _parse_yes_no(output: str) -> bool:
+    """True iff *output*'s first non-empty line starts with YES."""
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped.upper().startswith("YES")
+    return False
+
+
+def _classify_one(ref: ImageRef, model: str, timeout: int = 60) -> bool:
+    """
+    Run the classifier on a single image ref.
+
+    Downloads URLs to a tempdir via the same helper
+    ``chart_extract.extract_chart`` uses, so both passes share size caps
+    and error messages.
+    """
+    llm = chart_extract._find_llm()
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        local = (
+            chart_extract._download(ref.url, workspace)
+            if chart_extract._is_url(ref.url)
+            else Path(ref.url)
+        )
+        proc = subprocess.run(
+            [
+                llm,
+                "-m",
+                model,
+                "-a",
+                str(local),
+                build_classifier_prompt(ref.alt, ref.context),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"classifier failed on {ref.url}: {proc.stderr.strip()}"
+            )
+        return _parse_yes_no(proc.stdout)
+
+
+async def classify_batch(
+    refs: Sequence[ImageRef], model: str
+) -> list[tuple[ImageRef, bool]]:
+    """Classify *refs* concurrently; order matches input."""
+    sem = asyncio.Semaphore(chart_extract._CONCURRENCY)
+
+    async def _one(ref: ImageRef) -> tuple[ImageRef, bool]:
+        async with sem:
+            is_chart = await asyncio.to_thread(_classify_one, ref, model)
+            return (ref, is_chart)
+
+    return await asyncio.gather(*(_one(r) for r in refs))
+
+
+# --------------------------------------------------------------------------- #
+# Proposed-replacement sidecar writer                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _sidecar_path(md_file: Path) -> Path:
+    return md_file.with_name(md_file.stem + _SIDECAR_SUFFIX)
+
+
+def write_proposed_replacements(
+    results: Sequence[chart_extract.ChartExtractionResult],
+    refs_by_url: dict[str, ImageRef],
+) -> list[Path]:
+    """
+    Group successful extractions by source markdown file and write one sidecar
+    per file.
+
+    Failures and orphans are skipped silently — they remain in the queue and
+    surface on the next run.
+    """
+    by_file: dict[str, list[tuple[ImageRef, str]]] = {}
+    for r in results:
+        if r.error or not r.yaml_block:
+            continue
+        ref = refs_by_url.get(r.source_image)
+        if ref is None:
+            continue
+        by_file.setdefault(ref.markdown_file, []).append((ref, r.yaml_block))
+
+    written: list[Path] = []
+    for md_file, items in sorted(by_file.items()):
+        items.sort(key=lambda t: t[0].line_number)
+        sidecar = _sidecar_path(Path(md_file))
+        sections = [f"<!-- proposed chart replacements for {md_file} -->\n"]
+        for ref, block in items:
+            sections.append(
+                f"## line {ref.line_number}\n\n"
+                f"Original:\n\n    ![{ref.alt}]({ref.url})\n\n"
+                f"Replacement:\n\n{block}\n"
+            )
+        sidecar.write_text("\n".join(sections), encoding="utf-8")
+        written.append(sidecar)
+    return written
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration                                                                #
+# --------------------------------------------------------------------------- #
+
+
+async def run(
+    content_dir: Path,
+    model: str,
+    classifier: str,
+    queue: Path,
+    dry_run: bool = False,
+) -> int:
+    """
+    Main pipeline.
+
+    Returns the number of sidecar files written (0 for dry-run or an empty
+    content dir).
+    """
+    refs = walk_content(content_dir)
+    print(f"found {len(refs)} image refs under {content_dir}")
+
+    done = chart_extract.load_existing(queue)
+    fresh = [r for r in refs if chart_extract._normalize(r.url) not in done]
+    print(f"{len(fresh)} fresh (after dedup against {queue})")
+    if not fresh:
+        return 0
+
+    classified = await classify_batch(fresh, classifier)
+    charts = [r for r, is_chart in classified if is_chart]
+    print(f"{len(charts)} classified as charts by {classifier}")
+
+    if dry_run:
+        for r in charts:
+            print(f"  {r.markdown_file}:{r.line_number}  {r.url}")
+        return 0
+
+    if not charts:
+        return 0
+
+    refs_by_url = {r.url: r for r in charts}
+
+    def _context_for(source: str | Path) -> str | None:
+        r = refs_by_url.get(str(source))
+        if r is None:
+            return None
+        return f"Alt text: {r.alt}\n\nSurrounding prose:\n{r.context}"
+
+    results = await chart_extract.async_extract_batch(
+        [r.url for r in charts], model=model, context_for=_context_for
+    )
+    chart_extract.write_results(results, queue)
+
+    sidecars = write_proposed_replacements(results, refs_by_url)
+    for s in sidecars:
+        print(f"wrote {s}")
+    return len(sidecars)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bulk-convert chart image refs to inline ```chart blocks."
+    )
+    parser.add_argument(
+        "--content-dir",
+        type=Path,
+        default=Path("website_content"),
+        help="Root of Markdown content to scan.",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-sonnet-4-6",
+        help="Model used for chart extraction (`llm -m <model>`).",
+    )
+    parser.add_argument(
+        "--classifier",
+        default="claude-opus-4-7",
+        help="Vision model used for chart-or-not classification.",
+    )
+    parser.add_argument(
+        "--queue",
+        type=Path,
+        default=Path("chart-backfill-queue.json"),
+        help="Resumable JSON work-queue (git-ignored).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover and classify, don't call the extractor.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    asyncio.run(
+        run(
+            args.content_dir,
+            model=args.model,
+            classifier=args.classifier,
+            queue=args.queue,
+            dry_run=args.dry_run,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -197,21 +197,40 @@ def _sidecar_path(md_file: Path) -> Path:
     return md_file.with_name(md_file.stem + _SIDECAR_SUFFIX)
 
 
+def _pick_alt(spec: dict, ref: ImageRef) -> str:
+    """
+    Decide which alt text to stamp on the replacement block.
+
+    Priority:
+    1. Original Markdown alt (author-written, usually best).
+    2. Model-generated alt on the spec (non-placeholder) — still content-aware.
+    3. Chart title (decorative but better than TODO).
+    4. Shared TODO placeholder so hand-merge reviewers notice.
+    """
+    spec_alt = spec.get("alt")
+    model_alt = (
+        spec_alt
+        if spec_alt and spec_alt != chart_extract.ALT_TODO_PLACEHOLDER
+        else None
+    )
+    return (
+        ref.alt
+        or model_alt
+        or spec.get("title")
+        or chart_extract.ALT_TODO_PLACEHOLDER
+    )
+
+
 def _provenanced_block(spec: dict, ref: ImageRef) -> str:
     """
     Inject ``alt`` and ``fallback`` into *spec* and re-serialize.
 
-    The parser requires a non-empty ``alt``; if the original Markdown image
-    had no alt text, fall back to the chart title or the shared TODO
-    placeholder so the user notices and fills it in during hand-merge.
-    ``fallback`` is always set to the original URL — "for future reference".
+    ``alt`` is chosen by ``_pick_alt``; ``fallback`` is always set to the
+    original URL — "for future reference".
     """
-    enriched = {**spec}
-    enriched["alt"] = (
-        ref.alt or spec.get("title") or chart_extract.ALT_TODO_PLACEHOLDER
+    return chart_extract.format_as_yaml_block(
+        {**spec, "alt": _pick_alt(spec, ref), "fallback": ref.url}
     )
-    enriched["fallback"] = ref.url
-    return chart_extract.format_as_yaml_block(enriched)
 
 
 def write_proposed_replacements(

--- a/scripts/notebooks/convert_existing_graphs.py
+++ b/scripts/notebooks/convert_existing_graphs.py
@@ -197,20 +197,19 @@ def _sidecar_path(md_file: Path) -> Path:
     return md_file.with_name(md_file.stem + _SIDECAR_SUFFIX)
 
 
-_ALT_TODO_PLACEHOLDER = "[TODO: describe this chart]"
-
-
 def _provenanced_block(spec: dict, ref: ImageRef) -> str:
     """
     Inject ``alt`` and ``fallback`` into *spec* and re-serialize.
 
     The parser requires a non-empty ``alt``; if the original Markdown image
-    had no alt text, fall back to the chart title or a TODO placeholder so
-    the user notices and fills it in during hand-merge. ``fallback`` is
-    always set to the original URL — "for future reference" per the spec.
+    had no alt text, fall back to the chart title or the shared TODO
+    placeholder so the user notices and fills it in during hand-merge.
+    ``fallback`` is always set to the original URL — "for future reference".
     """
     enriched = {**spec}
-    enriched["alt"] = ref.alt or spec.get("title") or _ALT_TODO_PLACEHOLDER
+    enriched["alt"] = (
+        ref.alt or spec.get("title") or chart_extract.ALT_TODO_PLACEHOLDER
+    )
     enriched["fallback"] = ref.url
     return chart_extract.format_as_yaml_block(enriched)
 

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -224,6 +224,15 @@ class TestChartSchema:
             "const": "line"
         }
 
+    def test_supported_chart_types_is_immutable_and_nonempty(self) -> None:
+        """Drivers concatenate this into their classifier prompt; guard its
+        shape so a well-meaning 'added `bar` support' PR can't accidentally ship
+        a mutable list or an empty tuple."""
+        assert isinstance(chart_extract.SUPPORTED_CHART_TYPES, tuple)
+        assert len(chart_extract.SUPPORTED_CHART_TYPES) >= 1
+        # "line" is always in there while the renderer only handles lines.
+        assert "line" in chart_extract.SUPPORTED_CHART_TYPES
+
 
 # --------------------------------------------------------------------------- #
 # extract_chart — mocks `llm` and `magick` to exercise control-flow branches.  #

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -685,6 +685,23 @@ class TestCsvEmission:
         assert lines[0] == "x,y,series"
         assert set(lines[1:]) == {"0,1.0,A", "1,2.0,A", "0,5.0,B", "1,6.0,B"}
 
+    @pytest.mark.parametrize(
+        "bad_name", ["Loss, normalized", 'name with "quote"', "has\nnewline"]
+    )
+    def test_write_chart_csv_rejects_names_that_would_break_round_trip(
+        self, tmp_path: Path, bad_name: str
+    ) -> None:
+        """The TS-side parser rejects quoted CSV fields; reject here too with a
+        clearer message before we write a file that can't be read."""
+        spec = {
+            "type": "line",
+            "x": {"label": "x"},
+            "y": {"label": "y"},
+            "series": [{"name": bad_name, "data": [[0, 1]]}],
+        }
+        with pytest.raises(ValueError, match="rename it"):
+            chart_extract.write_chart_csv(spec, tmp_path / "c.csv")
+
     def test_format_as_yaml_block_uses_top_level_data_path(
         self, spec: dict
     ) -> None:

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -493,6 +493,86 @@ class TestSchemaViaTempfile:
 # --------------------------------------------------------------------------- #
 
 
+class TestAltPlaceholderInjection:
+    """
+    Models don't produce alt, but parseChartSpec requires it.
+
+    Verify extract_chart fills a placeholder before validation so the TS parser
+    doesn't reject every run.
+    """
+
+    def test_missing_alt_gets_placeholder_before_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        img = tmp_path / "c.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        llm_output = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "x"},
+                "y": {"label": "y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            }
+        )
+
+        seen_validator_spec: dict = {}
+
+        def _fake_run(cmd, **kw):
+            r = type("R", (), {})()
+            if cmd[0].endswith("llm"):
+                r.stdout, r.stderr, r.returncode = llm_output, "", 0
+            else:  # tsx validator — capture the yaml it sees
+                seen_validator_spec["yaml"] = kw.get("input", "")
+                r.stdout, r.stderr, r.returncode = "", "", 0
+            return r
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        monkeypatch.setattr(
+            chart_extract.shutil,
+            "which",
+            lambda name: "/usr/bin/" + name,
+        )
+        monkeypatch.setattr(chart_extract.subprocess, "run", _fake_run)
+        monkeypatch.chdir(tmp_path)
+
+        result = chart_extract.extract_chart(img, model="m")
+        assert result.error is None, result.error
+        assert result.spec["alt"] == chart_extract.ALT_TODO_PLACEHOLDER
+        assert chart_extract.ALT_TODO_PLACEHOLDER in seen_validator_spec["yaml"]
+
+    def test_existing_alt_is_preserved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If a future model produces alt on its own, don't clobber it."""
+        img = tmp_path / "c.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        llm_output = json.dumps(
+            {
+                "type": "line",
+                "alt": "Model-generated alt",
+                "x": {"label": "x"},
+                "y": {"label": "y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            }
+        )
+
+        def _fake_run(cmd, **kw):
+            r = type("R", (), {})()
+            r.stdout = llm_output if cmd[0].endswith("llm") else ""
+            r.stderr, r.returncode = "", 0
+            return r
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        monkeypatch.setattr(
+            chart_extract.shutil, "which", lambda name: "/usr/bin/" + name
+        )
+        monkeypatch.setattr(chart_extract.subprocess, "run", _fake_run)
+        monkeypatch.chdir(tmp_path)
+
+        result = chart_extract.extract_chart(img, model="m")
+        assert result.spec["alt"] == "Model-generated alt"
+
+
 class TestValidateViaTsx:
     """Catches LLM hallucinations that pass JSON-schema but break quartz."""
 

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -428,6 +428,8 @@ class TestSchemaViaTempfile:
 
         with (
             patch.object(chart_extract, "_find_llm", return_value="llm"),
+            # Skip the TS validator so we only see the `llm` invocation.
+            patch.object(chart_extract.shutil, "which", return_value=None),
             patch.object(chart_extract.subprocess, "run", side_effect=_capture),
         ):
             chart_extract.extract_chart(png, model="m")
@@ -439,6 +441,254 @@ class TestSchemaViaTempfile:
         assert not schema_arg.lstrip().startswith(
             "{"
         ), f"schema should be a file path, got inline JSON: {schema_arg[:60]}..."
+
+
+# --------------------------------------------------------------------------- #
+# NEW: round-trip validation through the TS parseChartSpec (TDD).             #
+# --------------------------------------------------------------------------- #
+
+
+class TestValidateViaTsx:
+    """Catches LLM hallucinations that pass JSON-schema but break quartz."""
+
+    def test_returns_none_when_tsx_accepts_spec(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty stderr + rc=0 means parseChartSpec accepted the YAML."""
+
+        def _ok(cmd, **_kw):
+            r = type("R", (), {})()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(chart_extract.subprocess, "run", _ok)
+        assert chart_extract.validate_spec_via_tsx({"type": "line"}) is None
+
+    def test_returns_error_string_when_tsx_rejects(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _bad(cmd, **_kw):
+            r = type("R", (), {})()
+            r.stdout = ""
+            r.stderr = 'Chart "y" axis must have a string "label"\n'
+            r.returncode = 1
+            return r
+
+        monkeypatch.setattr(chart_extract.subprocess, "run", _bad)
+        err = chart_extract.validate_spec_via_tsx({"type": "line"})
+        assert err is not None
+        assert "axis must have" in err
+
+    def test_skips_silently_when_node_not_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the TS toolchain isn't available, don't block — just skip."""
+
+        def _which(name):
+            return (
+                None if name in {"node", "npx", "tsx"} else "/usr/bin/" + name
+            )
+
+        monkeypatch.setattr(chart_extract.shutil, "which", _which)
+        # Subprocess must never be called.
+
+        def _fail(*a, **kw):
+            raise AssertionError("subprocess should not run when tsx is absent")
+
+        monkeypatch.setattr(chart_extract.subprocess, "run", _fail)
+        assert chart_extract.validate_spec_via_tsx({"type": "line"}) is None
+
+    def test_validator_timeout_is_captured_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hung tsx validator must not kill the whole batch."""
+        img = tmp_path / "c.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        valid_json = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "x"},
+                "y": {"label": "y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            }
+        )
+
+        def _run(cmd, **_kw):
+            if cmd[0].endswith("llm"):
+                r = type("R", (), {})()
+                r.stdout = valid_json
+                r.stderr = ""
+                r.returncode = 0
+                return r
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        monkeypatch.setattr(
+            chart_extract.shutil,
+            "which",
+            lambda name: (
+                f"/usr/bin/{name}" if name in {"npx", "node"} else None
+            ),
+        )
+        monkeypatch.setattr(chart_extract.subprocess, "run", _run)
+
+        result = chart_extract.extract_chart(img, model="m")
+        assert result.spec is None or result.yaml_block is None
+        assert "validator timed out" in (result.error or "")
+
+    def test_url_input_is_downloaded_and_extracted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Accept https://... inputs; download into a tempdir before hitting the LLM."""
+        captured_llm_attachment: list[str] = []
+
+        valid_json = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "x"},
+                "y": {"label": "y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            }
+        )
+
+        def _fake_run(cmd, **_kw):
+            r = type("R", (), {})()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            if cmd[0].endswith("llm"):
+                r.stdout = valid_json
+                idx = cmd.index("-a") + 1
+                captured_llm_attachment.append(cmd[idx])
+            return r
+
+        def _fake_get(url, **_kw):
+            assert url == "https://assets.turntrout.com/static/chart.png"
+            resp = type("R", (), {})()
+            resp.status_code = 200
+            resp.content = b"\x89PNG\r\n"
+            resp.raise_for_status = lambda: None
+            resp.iter_content = lambda chunk_size=8192: iter([b"\x89PNG\r\n"])
+            return resp
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        # Pretend Node isn't available so validator skips.
+        monkeypatch.setattr(
+            chart_extract.shutil,
+            "which",
+            lambda name: "/usr/bin/llm" if name == "llm" else None,
+        )
+        monkeypatch.setattr(chart_extract.subprocess, "run", _fake_run)
+        monkeypatch.setattr(chart_extract.requests, "get", _fake_get)
+
+        result = chart_extract.extract_chart(
+            "https://assets.turntrout.com/static/chart.png", model="m"
+        )
+        assert result.error is None
+        assert result.spec is not None
+        # LLM got a local path to the downloaded file, not the URL.
+        assert len(captured_llm_attachment) == 1
+        assert not captured_llm_attachment[0].startswith("http")
+        # source_image records the ORIGINAL url (so the queue key dedupes stably).
+        assert (
+            result.source_image
+            == "https://assets.turntrout.com/static/chart.png"
+        )
+
+    def test_url_download_failure_is_captured_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import requests
+
+        def _boom(*_a, **_kw):
+            raise requests.exceptions.ConnectionError("name resolution failed")
+
+        monkeypatch.setattr(chart_extract.requests, "get", _boom)
+        result = chart_extract.extract_chart(
+            "https://nope.example/x.png", model="m"
+        )
+        assert result.spec is None
+        assert "download failed" in (result.error or "").lower()
+
+    def test_url_download_size_cap_is_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A URL pointing at a huge file should be rejected, not written to
+        disk."""
+        cap = chart_extract._DOWNLOAD_MAX_BYTES
+        # Produce 2× the cap so the loop trips the size guard.
+        payload = b"A" * (cap + 1024)
+
+        class _Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def iter_content(self, chunk_size: int = 8192):
+                yield from (
+                    payload[i : i + chunk_size]
+                    for i in range(0, len(payload), chunk_size)
+                )
+
+        monkeypatch.setattr(
+            chart_extract.requests, "get", lambda *a, **kw: _Resp()
+        )
+        result = chart_extract.extract_chart(
+            "https://oversized.example/big.avif", model="m"
+        )
+        assert result.spec is None
+        assert "exceeded" in (result.error or "").lower()
+
+    def test_extract_chart_aborts_on_validator_rejection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the TS parser rejects the spec, no CSV/block should be
+        written."""
+        img = tmp_path / "c.png"
+        img.write_bytes(b"\x89PNG\r\n")
+
+        valid_json = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "x"},
+                "y": {"label": "y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            }
+        )
+
+        call_log: list[str] = []
+
+        def _run(cmd, **_kw):
+            call_log.append(cmd[0])
+            r = type("R", (), {})()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            # First call is `llm`, second would be the validator.
+            if cmd[0].endswith("llm"):
+                r.stdout = valid_json
+            else:
+                r.stderr = "Series has no name"
+                r.returncode = 1
+            return r
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        monkeypatch.setattr(
+            chart_extract.shutil,
+            "which",
+            lambda name: (
+                f"/usr/bin/{name}" if name in {"node", "npx", "tsx"} else None
+            ),
+        )
+        monkeypatch.setattr(chart_extract.subprocess, "run", _run)
+
+        result = chart_extract.extract_chart(img, model="m")
+        assert result.spec is None or result.yaml_block is None
+        assert result.error is not None
+        assert "Series has no name" in result.error
+        # The CSV should not have been written since validation failed.
+        assert not (tmp_path / "c.csv").exists()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -448,9 +448,11 @@ class TestSchemaViaTempfile:
 
 class TestFindLlm:
     def test_raises_with_install_hint_when_missing(self) -> None:
-        with patch.object(chart_extract.shutil, "which", return_value=None):
-            with pytest.raises(FileNotFoundError, match="uv tool install llm"):
-                chart_extract._find_llm()
+        with (
+            patch.object(chart_extract.shutil, "which", return_value=None),
+            pytest.raises(FileNotFoundError, match="uv tool install llm"),
+        ):
+            chart_extract._find_llm()
 
     def test_returns_path_when_found(self) -> None:
         with patch.object(
@@ -468,9 +470,11 @@ class TestConvertIfAvif:
     def test_missing_magick_raises_with_hint(self, tmp_path: Path) -> None:
         avif = tmp_path / "x.avif"
         avif.touch()
-        with patch.object(chart_extract.shutil, "which", return_value=None):
-            with pytest.raises(FileNotFoundError, match="ImageMagick"):
-                chart_extract._convert_if_avif(avif, tmp_path)
+        with (
+            patch.object(chart_extract.shutil, "which", return_value=None),
+            pytest.raises(FileNotFoundError, match="ImageMagick"),
+        ):
+            chart_extract._convert_if_avif(avif, tmp_path)
 
     def test_avif_is_converted_to_png_in_workspace(
         self, tmp_path: Path

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -572,8 +572,23 @@ class TestCli:
         error: str | None = None,
     ) -> None:
         def _fake(image: Path, model: str, context=None, timeout=180):
+            yaml_block = (
+                chart_extract.format_as_yaml_block(
+                    spec, csv_path=f"./{image.stem}.csv"
+                )
+                if spec is not None
+                else None
+            )
+            csv_path = (
+                str(image.with_suffix(".csv")) if spec is not None else None
+            )
             return chart_extract.ChartExtractionResult(
-                source_image=str(image), model=model, spec=spec, error=error
+                source_image=str(image),
+                model=model,
+                spec=spec,
+                error=error,
+                csv_path=csv_path,
+                yaml_block=yaml_block,
             )
 
         monkeypatch.setattr(chart_extract, "extract_chart", _fake)
@@ -636,6 +651,103 @@ class TestCli:
             "sys.argv", ["chart_extract", str(img), "-o", str(out)]
         )
         assert chart_extract._cli() == 1
+
+
+# --------------------------------------------------------------------------- #
+# NEW: CSV emission + yaml block references path (TDD).                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestCsvEmission:
+    @pytest.fixture
+    def spec(self) -> dict:
+        return {
+            "type": "line",
+            "title": "T",
+            "x": {"label": "x"},
+            "y": {"label": "y"},
+            "series": [
+                {
+                    "name": "A",
+                    "color": "var(--blue)",
+                    "data": [[0, 1.0], [1, 2.0]],
+                },
+                {"name": "B", "data": [[0, 5.0], [1, 6.0]]},
+            ],
+        }
+
+    def test_write_chart_csv_produces_long_format(
+        self, tmp_path: Path, spec: dict
+    ) -> None:
+        target = tmp_path / "chart.csv"
+        chart_extract.write_chart_csv(spec, target)
+        lines = target.read_text().splitlines()
+        assert lines[0] == "x,y,series"
+        assert set(lines[1:]) == {"0,1.0,A", "1,2.0,A", "0,5.0,B", "1,6.0,B"}
+
+    def test_format_as_yaml_block_uses_top_level_data_path(
+        self, spec: dict
+    ) -> None:
+        out = chart_extract.format_as_yaml_block(spec, csv_path="./chart.csv")
+        assert "data: ./chart.csv" in out
+        # Per-series `data:` fields are stripped — one and only one `data:` line.
+        assert out.count("data:") == 1
+        assert "name: A" in out
+        assert "color: var(--blue)" in out
+        assert "name: B" in out
+
+    def test_format_as_yaml_block_without_csv_keeps_inline_data(
+        self, spec: dict
+    ) -> None:
+        """Back-compat: calling without csv_path emits inline `data` points."""
+        out = chart_extract.format_as_yaml_block(spec)
+        assert "- [0, 1.0]" in out
+        assert "data: ./" not in out
+
+    def test_yaml_block_appends_data_when_no_y_axis_present(self) -> None:
+        """Degenerate spec (no `y` key): `data:` is still emitted, at the
+        end."""
+        degenerate = {
+            "type": "line",
+            "series": [{"name": "A", "data": [[0, 1]]}],
+        }
+        out = chart_extract.format_as_yaml_block(degenerate, csv_path="./x.csv")
+        assert "data: ./x.csv" in out
+
+
+class TestExtractWritesCsv:
+    def test_successful_extraction_writes_csv_next_to_image(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        img = tmp_path / "loss_by_layer.png"
+        img.write_bytes(b"\x89PNG\r\n")
+
+        spec = {
+            "type": "line",
+            "x": {"label": "layer"},
+            "y": {"label": "loss"},
+            "series": [{"name": "Loss", "data": [[0, 8.92], [2, 7.85]]}],
+        }
+
+        def _fake_llm(cmd, **_kw):
+            r = type("R", (), {})()
+            r.stdout = json.dumps(spec)
+            r.stderr = ""
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "llm")
+        monkeypatch.setattr(chart_extract.subprocess, "run", _fake_llm)
+
+        result = chart_extract.extract_chart(img, model="m")
+
+        assert result.spec is not None
+        assert result.csv_path is not None
+        assert Path(result.csv_path).exists()
+        assert Path(result.csv_path).name == "loss_by_layer.csv"
+        assert result.yaml_block is not None
+        assert "```chart" in result.yaml_block
+        assert "data: ./loss_by_layer.csv" in result.yaml_block
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -391,6 +391,42 @@ class TestProgressCallback:
         assert len(calls) == 1
         assert calls[0].error is not None
 
+    def test_context_for_is_forwarded_per_image(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The batch accepts a `context_for` callback that supplies per-image
+        prose — alt text, surrounding paragraph, etc. That context must reach
+        extract_chart and from there the LLM prompt."""
+        imgs = [tmp_path / f"c{i}.png" for i in range(2)]
+        for p in imgs:
+            p.write_bytes(b"\x89PNG\r\n")
+
+        seen: list[tuple[str, str | None]] = []
+
+        def _fake_extract(
+            image, model, context=None, timeout=180
+        ) -> chart_extract.ChartExtractionResult:
+            seen.append((str(image), context))
+            return chart_extract.ChartExtractionResult(
+                source_image=str(image),
+                model=model,
+                spec={"type": "line"},
+                context_used=context or "",
+            )
+
+        monkeypatch.setattr(chart_extract, "extract_chart", _fake_extract)
+
+        def _ctx(image) -> str:
+            return f"alt for {Path(image).name}"
+
+        asyncio.run(
+            chart_extract.async_extract_batch(imgs, model="m", context_for=_ctx)
+        )
+        assert set(seen) == {
+            (str(imgs[0]), "alt for c0.png"),
+            (str(imgs[1]), "alt for c1.png"),
+        }
+
 
 # --------------------------------------------------------------------------- #
 # NEW: schema is written to a tempfile and passed to llm via a file path       #

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -582,6 +582,9 @@ class TestValidateViaTsx:
         )
         monkeypatch.setattr(chart_extract.subprocess, "run", _fake_run)
         monkeypatch.setattr(chart_extract.requests, "get", _fake_get)
+        # URL inputs write the CSV to cwd; isolate cwd so the test doesn't
+        # leak a `chart.csv` into the repo root.
+        monkeypatch.chdir(tmp_path)
 
         result = chart_extract.extract_chart(
             "https://assets.turntrout.com/static/chart.png", model="m"

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -626,7 +626,7 @@ class TestValidateViaTsx:
 
         class _Resp:
             def raise_for_status(self) -> None:
-                pass
+                """Mock: 2xx response, so nothing to raise."""
 
             def iter_content(self, chunk_size: int = 8192):
                 yield from (

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -824,19 +824,39 @@ class TestValidateViaTsx:
 # --------------------------------------------------------------------------- #
 
 
+@pytest.fixture
+def _isolated_alt_utils_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """alt_text_llm.utils.find_executable memoizes; reset it per test so a
+    mocked-missing executable in one test isn't masked by a cached hit from
+    another."""
+    from alt_text_llm import utils as alt_utils
+
+    monkeypatch.setattr(alt_utils, "_executable_cache", {})
+
+
 class TestFindLlm:
-    def test_raises_with_install_hint_when_missing(self) -> None:
-        with (
-            patch.object(chart_extract.shutil, "which", return_value=None),
-            pytest.raises(FileNotFoundError, match="uv tool install llm"),
-        ):
+    def test_raises_with_install_hint_when_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _isolated_alt_utils_cache: None,
+    ) -> None:
+        from alt_text_llm import utils as alt_utils
+
+        monkeypatch.setattr(alt_utils.shutil, "which", lambda _name: None)
+        with pytest.raises(FileNotFoundError, match="uv tool install llm"):
             chart_extract._find_llm()
 
-    def test_returns_path_when_found(self) -> None:
-        with patch.object(
-            chart_extract.shutil, "which", return_value="/usr/local/bin/llm"
-        ):
-            assert chart_extract._find_llm() == "/usr/local/bin/llm"
+    def test_returns_path_when_found(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _isolated_alt_utils_cache: None,
+    ) -> None:
+        from alt_text_llm import utils as alt_utils
+
+        monkeypatch.setattr(
+            alt_utils.shutil, "which", lambda _n: "/usr/local/bin/llm"
+        )
+        assert chart_extract._find_llm() == "/usr/local/bin/llm"
 
 
 class TestConvertIfAvif:
@@ -845,13 +865,18 @@ class TestConvertIfAvif:
         png.touch()
         assert chart_extract._convert_if_avif(png, tmp_path) == png
 
-    def test_missing_magick_raises_with_hint(self, tmp_path: Path) -> None:
+    def test_missing_magick_raises_with_hint(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _isolated_alt_utils_cache: None,
+    ) -> None:
+        from alt_text_llm import utils as alt_utils
+
+        monkeypatch.setattr(alt_utils.shutil, "which", lambda _n: None)
         avif = tmp_path / "x.avif"
         avif.touch()
-        with (
-            patch.object(chart_extract.shutil, "which", return_value=None),
-            pytest.raises(FileNotFoundError, match="ImageMagick"),
-        ):
+        with pytest.raises(FileNotFoundError, match="ImageMagick"):
             chart_extract._convert_if_avif(avif, tmp_path)
 
     def test_avif_is_converted_to_png_in_workspace(

--- a/scripts/tests/test_chart_extract.py
+++ b/scripts/tests/test_chart_extract.py
@@ -1,0 +1,663 @@
+"""
+Tests for scripts/chart_extract.py.
+
+Two jobs:
+1. Characterize current behavior of pure helpers so future edits can't
+   silently regress (`_normalize`, `format_as_yaml_block`, `write_results`,
+   `load_existing`, `estimate_cost`, `build_chart_prompt`, `CHART_SCHEMA`).
+2. Drive the two new features via TDD: a progress callback on
+   `async_extract_batch` and writing the JSON schema to a tempfile instead
+   of passing it inline on the `llm` command line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts import chart_extract
+
+# --------------------------------------------------------------------------- #
+# _normalize                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalize:
+    def test_url_passthrough_http(self) -> None:
+        assert (
+            chart_extract._normalize("http://example.com/x.avif")
+            == "http://example.com/x.avif"
+        )
+
+    def test_url_passthrough_https(self) -> None:
+        assert (
+            chart_extract._normalize("https://assets.turntrout.com/x.avif")
+            == "https://assets.turntrout.com/x.avif"
+        )
+
+    def test_relative_and_dot_prefix_dedupe(self, tmp_path: Path) -> None:
+        (tmp_path / "a.avif").touch()
+        with _chdir(tmp_path):
+            assert chart_extract._normalize(
+                "./a.avif"
+            ) == chart_extract._normalize("a.avif")
+
+    def test_returns_absolute_for_paths(self, tmp_path: Path) -> None:
+        with _chdir(tmp_path):
+            result = chart_extract._normalize("a.avif")
+        assert Path(result).is_absolute()
+
+
+# --------------------------------------------------------------------------- #
+# format_as_yaml_block                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestFormatAsYamlBlock:
+    @pytest.fixture
+    def spec(self) -> dict:
+        return {
+            "type": "line",
+            "x": {"label": "Layer"},
+            "y": {"label": "Loss"},
+            "series": [{"name": "S", "data": [[0, 8.92], [2, 7.85]]}],
+        }
+
+    def test_wrapped_in_chart_fence(self, spec: dict) -> None:
+        out = chart_extract.format_as_yaml_block(spec)
+        assert out.startswith("```chart\n")
+        assert out.endswith("\n```")
+
+    def test_data_points_use_flow_style(self, spec: dict) -> None:
+        """Match `website_content/layer-horizon.md` — per-point flow `[x,
+        y]`."""
+        out = chart_extract.format_as_yaml_block(spec)
+        assert "- [0, 8.92]" in out
+        assert "- [2, 7.85]" in out
+        # and NOT the block-style layout yaml.safe_dump would otherwise emit
+        assert "- - 0" not in out
+
+    def test_top_level_uses_block_style(self, spec: dict) -> None:
+        """Structural arrays stay block-style for readability."""
+        out = chart_extract.format_as_yaml_block(spec)
+        assert "series:\n- name: S" in out
+
+    def test_preserves_key_order(self, spec: dict) -> None:
+        out = chart_extract.format_as_yaml_block(spec)
+        assert out.index("type:") < out.index("x:") < out.index("series:")
+
+
+# --------------------------------------------------------------------------- #
+# write_results + load_existing                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestQueueDedupe:
+    def test_writing_same_image_three_times_yields_one_row(
+        self, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "q.json"
+        for err in ("fail-1", "fail-2", None):
+            chart_extract.write_results(
+                [
+                    chart_extract.ChartExtractionResult(
+                        source_image=str(tmp_path / "a.avif"),
+                        model="m",
+                        spec={"type": "line"} if err is None else None,
+                        error=err,
+                    )
+                ],
+                out,
+            )
+        data = json.loads(out.read_text())
+        assert len(data) == 1
+        assert data[0]["spec"] == {"type": "line"}, "latest write should win"
+
+    def test_load_existing_only_returns_successes(self, tmp_path: Path) -> None:
+        out = tmp_path / "q.json"
+        (tmp_path / "a.avif").touch()
+        (tmp_path / "b.avif").touch()
+        chart_extract.write_results(
+            [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(tmp_path / "a.avif"),
+                    model="m",
+                    spec={"type": "line"},
+                ),
+                chart_extract.ChartExtractionResult(
+                    source_image=str(tmp_path / "b.avif"),
+                    model="m",
+                    error="some failure",
+                ),
+            ],
+            out,
+        )
+        done = chart_extract.load_existing(out)
+        assert chart_extract._normalize(tmp_path / "a.avif") in done
+        assert chart_extract._normalize(tmp_path / "b.avif") not in done
+
+    def test_load_existing_missing_file_returns_empty_set(
+        self, tmp_path: Path
+    ) -> None:
+        assert chart_extract.load_existing(tmp_path / "nope.json") == set()
+
+    def test_load_existing_handles_corrupt_json(self, tmp_path: Path) -> None:
+        out = tmp_path / "q.json"
+        out.write_text("{not json")
+        assert chart_extract.load_existing(out) == set()
+
+
+# --------------------------------------------------------------------------- #
+# estimate_cost                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestEstimateCost:
+    def test_unknown_model_reports_gracefully(self) -> None:
+        out = chart_extract.estimate_cost("mystery-vlm", 5)
+        assert "not available" in out or "no pricing" in out
+
+    def test_known_model_returns_dollar_value(self) -> None:
+        out = chart_extract.estimate_cost("claude-sonnet-4-6", 10)
+        assert "$" in out
+
+    def test_cost_scales_roughly_linearly_with_n(self) -> None:
+        """Rendered to 2dp, so tolerate up to a penny per row of rounding."""
+
+        def dollars(s: str) -> float:
+            return float(s.split("$")[1].split(" ")[0])
+
+        one = dollars(chart_extract.estimate_cost("claude-sonnet-4-6", 1))
+        ten = dollars(chart_extract.estimate_cost("claude-sonnet-4-6", 10))
+        assert abs(ten - 10 * one) < 0.1
+
+
+# --------------------------------------------------------------------------- #
+# build_chart_prompt                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildChartPrompt:
+    def test_contains_core_instructions(self) -> None:
+        p = chart_extract.build_chart_prompt()
+        assert "Extract the underlying data" in p
+        assert "Self-check" in p
+
+    def test_context_is_appended_when_provided(self) -> None:
+        p = chart_extract.build_chart_prompt(context="surrounding paragraph")
+        assert "surrounding paragraph" in p
+
+    def test_no_context_when_not_provided(self) -> None:
+        assert "Surrounding prose" not in chart_extract.build_chart_prompt()
+
+    def test_no_site_specific_jargon(self) -> None:
+        """Site-internal terms like `smallcaps` shouldn't leak into prompts."""
+        assert "smallcaps" not in chart_extract.build_chart_prompt().lower()
+
+
+# --------------------------------------------------------------------------- #
+# CHART_SCHEMA                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestChartSchema:
+    def test_no_prefixitems_leaks(self) -> None:
+        """`prefixItems` is JSON Schema 2020-12 and breaks OpenAI strict
+        mode."""
+        assert "prefixItems" not in json.dumps(chart_extract.CHART_SCHEMA)
+
+    def test_requires_top_level_fields(self) -> None:
+        assert set(chart_extract.CHART_SCHEMA["required"]) == {
+            "type",
+            "x",
+            "y",
+            "series",
+        }
+
+    def test_only_line_type_accepted(self) -> None:
+        assert chart_extract.CHART_SCHEMA["properties"]["type"] == {
+            "const": "line"
+        }
+
+
+# --------------------------------------------------------------------------- #
+# extract_chart — mocks `llm` and `magick` to exercise control-flow branches.  #
+# --------------------------------------------------------------------------- #
+
+
+def _fake_run(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> object:
+    class _R:
+        pass
+
+    r = _R()
+    r.stdout = stdout
+    r.returncode = returncode
+    r.stderr = stderr
+    return r
+
+
+class TestExtractChart:
+    @pytest.fixture
+    def png(self, tmp_path: Path) -> Path:
+        p = tmp_path / "chart.png"
+        p.write_bytes(b"\x89PNG\r\n")
+        return p
+
+    def test_success_parses_json_into_spec(self, png: Path) -> None:
+        valid = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "a"},
+                "y": {"label": "b"},
+                "series": [{"name": "s", "data": [[0, 1]]}],
+            }
+        )
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(
+                chart_extract.subprocess,
+                "run",
+                return_value=_fake_run(stdout=valid),
+            ),
+        ):
+            result = chart_extract.extract_chart(png, model="m")
+        assert result.error is None
+        assert result.spec is not None
+        assert result.spec["type"] == "line"
+
+    def test_non_zero_returncode_becomes_error(self, png: Path) -> None:
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(
+                chart_extract.subprocess,
+                "run",
+                return_value=_fake_run(returncode=1, stderr="rate limited"),
+            ),
+        ):
+            result = chart_extract.extract_chart(png, model="m")
+        assert result.spec is None
+        assert "rate limited" in (result.error or "")
+
+    def test_invalid_json_output_becomes_error(self, png: Path) -> None:
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(
+                chart_extract.subprocess,
+                "run",
+                return_value=_fake_run(stdout="not json{"),
+            ),
+        ):
+            result = chart_extract.extract_chart(png, model="m")
+        assert result.spec is None
+        assert "invalid JSON" in (result.error or "")
+
+    def test_llm_timeout_is_caught_not_raised(self, png: Path) -> None:
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(
+                chart_extract.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(cmd="llm", timeout=1),
+            ),
+        ):
+            result = chart_extract.extract_chart(png, model="m", timeout=1)
+        assert result.spec is None
+        assert "timeout" in (result.error or "")
+
+    def test_avif_conversion_error_is_recorded_not_raised(
+        self, tmp_path: Path
+    ) -> None:
+        """One bad AVIF must not crash the batch — see chart_extract.py round-1
+        fix."""
+        avif = tmp_path / "bad.avif"
+        avif.write_bytes(b"not actually avif")
+        with patch.object(
+            chart_extract,
+            "_convert_if_avif",
+            side_effect=subprocess.CalledProcessError(
+                returncode=1, cmd=["magick"]
+            ),
+        ):
+            result = chart_extract.extract_chart(avif, model="m")
+        assert result.spec is None
+        assert "AVIF conversion failed" in (result.error or "")
+
+
+# --------------------------------------------------------------------------- #
+# NEW: progress callback on async_extract_batch (TDD — fails before impl).     #
+# --------------------------------------------------------------------------- #
+
+
+class TestProgressCallback:
+    def test_callback_fires_once_per_completed_image(
+        self, tmp_path: Path
+    ) -> None:
+        imgs = [tmp_path / f"c{i}.png" for i in range(3)]
+        for p in imgs:
+            p.write_bytes(b"\x89PNG\r\n")
+
+        valid = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "a"},
+                "y": {"label": "b"},
+                "series": [{"name": "s", "data": [[0, 1]]}],
+            }
+        )
+        calls: list[chart_extract.ChartExtractionResult] = []
+
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(
+                chart_extract.subprocess,
+                "run",
+                return_value=_fake_run(stdout=valid),
+            ),
+        ):
+            results = asyncio.run(
+                chart_extract.async_extract_batch(
+                    imgs, model="m", on_completed=calls.append
+                )
+            )
+
+        assert len(results) == 3
+        assert len(calls) == 3, "callback should fire once per image"
+
+    def test_callback_fires_on_failure_too(self, tmp_path: Path) -> None:
+        img = tmp_path / "bad.avif"
+        img.write_bytes(b"not avif")
+        calls: list[chart_extract.ChartExtractionResult] = []
+
+        with patch.object(
+            chart_extract,
+            "_convert_if_avif",
+            side_effect=subprocess.CalledProcessError(
+                returncode=1, cmd=["magick"]
+            ),
+        ):
+            asyncio.run(
+                chart_extract.async_extract_batch(
+                    [img], model="m", on_completed=calls.append
+                )
+            )
+
+        assert len(calls) == 1
+        assert calls[0].error is not None
+
+
+# --------------------------------------------------------------------------- #
+# NEW: schema is written to a tempfile and passed to llm via a file path       #
+# (TDD — fails before impl).                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestSchemaViaTempfile:
+    def test_llm_receives_schema_as_file_path_not_inline_json(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Passing ~1KB of JSON on the command line flirts with ARG_MAX on some
+        systems and is awkward to debug.
+
+        The `llm` CLI accepts a path to a
+        schema file — use that.
+        """
+        png = tmp_path / "c.png"
+        png.write_bytes(b"\x89PNG\r\n")
+
+        valid = json.dumps(
+            {
+                "type": "line",
+                "x": {"label": "a"},
+                "y": {"label": "b"},
+                "series": [{"name": "s", "data": [[0, 1]]}],
+            }
+        )
+        captured_argv: list[list[str]] = []
+
+        def _capture(cmd, **_kw):
+            captured_argv.append(list(cmd))
+            return _fake_run(stdout=valid)
+
+        with (
+            patch.object(chart_extract, "_find_llm", return_value="llm"),
+            patch.object(chart_extract.subprocess, "run", side_effect=_capture),
+        ):
+            chart_extract.extract_chart(png, model="m")
+
+        [argv] = captured_argv
+        # The `--schema` flag must receive a path to an existing file, not a JSON blob.
+        schema_idx = argv.index("--schema")
+        schema_arg = argv[schema_idx + 1]
+        assert not schema_arg.lstrip().startswith(
+            "{"
+        ), f"schema should be a file path, got inline JSON: {schema_arg[:60]}..."
+
+
+# --------------------------------------------------------------------------- #
+# _find_llm / _convert_if_avif                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestFindLlm:
+    def test_raises_with_install_hint_when_missing(self) -> None:
+        with patch.object(chart_extract.shutil, "which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="uv tool install llm"):
+                chart_extract._find_llm()
+
+    def test_returns_path_when_found(self) -> None:
+        with patch.object(
+            chart_extract.shutil, "which", return_value="/usr/local/bin/llm"
+        ):
+            assert chart_extract._find_llm() == "/usr/local/bin/llm"
+
+
+class TestConvertIfAvif:
+    def test_non_avif_returned_unchanged(self, tmp_path: Path) -> None:
+        png = tmp_path / "x.png"
+        png.touch()
+        assert chart_extract._convert_if_avif(png, tmp_path) == png
+
+    def test_missing_magick_raises_with_hint(self, tmp_path: Path) -> None:
+        avif = tmp_path / "x.avif"
+        avif.touch()
+        with patch.object(chart_extract.shutil, "which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="ImageMagick"):
+                chart_extract._convert_if_avif(avif, tmp_path)
+
+    def test_avif_is_converted_to_png_in_workspace(
+        self, tmp_path: Path
+    ) -> None:
+        avif = tmp_path / "x.avif"
+        avif.touch()
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        recorded: list[list[str]] = []
+
+        def _run(cmd, **_kw):  # type: ignore[no-untyped-def]
+            recorded.append(list(cmd))
+            Path(cmd[2]).write_bytes(b"\x89PNG\r\n")
+            return _fake_run()
+
+        with (
+            patch.object(
+                chart_extract.shutil, "which", return_value="/usr/bin/magick"
+            ),
+            patch.object(chart_extract.subprocess, "run", side_effect=_run),
+        ):
+            out = chart_extract._convert_if_avif(avif, ws)
+
+        assert out == ws / "x.png"
+        assert out.exists()
+        assert recorded[0][0] == "/usr/bin/magick"
+
+
+# --------------------------------------------------------------------------- #
+# write_results — corrupt / non-list JSON                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestWriteResultsCorruption:
+    def test_corrupt_existing_file_is_replaced(self, tmp_path: Path) -> None:
+        out = tmp_path / "q.json"
+        out.write_text("{not json")
+        chart_extract.write_results(
+            [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(tmp_path / "a.avif"),
+                    model="m",
+                    spec={"type": "line"},
+                )
+            ],
+            out,
+        )
+        data = json.loads(out.read_text())
+        assert len(data) == 1
+
+    def test_non_list_existing_file_is_replaced(self, tmp_path: Path) -> None:
+        out = tmp_path / "q.json"
+        out.write_text('{"accidentally": "a dict"}')
+        chart_extract.write_results(
+            [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(tmp_path / "a.avif"),
+                    model="m",
+                    spec={"type": "line"},
+                )
+            ],
+            out,
+        )
+        data = json.loads(out.read_text())
+        assert data[0]["source_image"] == str(tmp_path / "a.avif")
+
+    def test_append_false_ignores_existing_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "q.json"
+        out.write_text(
+            json.dumps([{"source_image": str(tmp_path / "x.avif"), "spec": {}}])
+        )
+        chart_extract.write_results(
+            [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(tmp_path / "new.avif"),
+                    model="m",
+                    spec={"type": "line"},
+                )
+            ],
+            out,
+            append=False,
+        )
+        data = json.loads(out.read_text())
+        assert len(data) == 1
+        assert "new.avif" in data[0]["source_image"]
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestCli:
+    def _stub_extract(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        spec: dict | None,
+        error: str | None = None,
+    ) -> None:
+        def _fake(image: Path, model: str, context=None, timeout=180):
+            return chart_extract.ChartExtractionResult(
+                source_image=str(image), model=model, spec=spec, error=error
+            )
+
+        monkeypatch.setattr(chart_extract, "extract_chart", _fake)
+
+    def test_success_path_writes_queue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        img = tmp_path / "a.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        out = tmp_path / "q.json"
+
+        spec = {
+            "type": "line",
+            "x": {"label": "a"},
+            "y": {"label": "b"},
+            "series": [{"name": "s", "data": [[0, 1]]}],
+        }
+        self._stub_extract(monkeypatch, spec)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["chart_extract", str(img), "-o", str(out), "--print-yaml"],
+        )
+
+        assert chart_extract._cli() == 0
+        data = json.loads(out.read_text())
+        assert len(data) == 1 and data[0]["spec"] == spec
+
+    def test_skip_existing_shortcuts_to_nothing_to_do(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        img = tmp_path / "a.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        out = tmp_path / "q.json"
+        out.write_text(
+            json.dumps(
+                [
+                    {
+                        "source_image": chart_extract._normalize(img),
+                        "spec": {"type": "line"},
+                    }
+                ]
+            )
+        )
+        monkeypatch.setattr(
+            chart_extract, "extract_chart", lambda *a, **kw: None
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["chart_extract", str(img), "-o", str(out)]
+        )
+        assert chart_extract._cli() == 0
+
+    def test_returns_nonzero_on_any_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        img = tmp_path / "a.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        out = tmp_path / "q.json"
+        self._stub_extract(monkeypatch, spec=None, error="boom")
+        monkeypatch.setattr(
+            "sys.argv", ["chart_extract", str(img), "-o", str(out)]
+        )
+        assert chart_extract._cli() == 1
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class _chdir:
+    """Minimal cwd contextmanager (pytest's `monkeypatch.chdir` also works)."""
+
+    def __init__(self, target: Path) -> None:
+        self.target = target
+        self.prev: Path | None = None
+
+    def __enter__(self) -> None:
+        import os
+
+        self.prev = Path.cwd()
+        os.chdir(self.target)
+
+    def __exit__(self, *exc: object) -> None:
+        import os
+
+        if self.prev is not None:
+            os.chdir(self.prev)

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -1,0 +1,577 @@
+"""
+Tests for scripts/notebooks/convert_existing_graphs.py.
+
+Goals:
+- Pin the image-ref parser against realistic website_content Markdown.
+- Exercise the classifier plumbing with the `llm` CLI and `chart_extract._download`
+  mocked out; all downstream calls must reach the right models.
+- End-to-end test for `run()` with a two-post temp tree — covers dedup,
+  dry-run, and the sidecar writer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import chart_extract
+from scripts.notebooks import convert_existing_graphs as ceg
+
+# --------------------------------------------------------------------------- #
+# _paragraph_context                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestParagraphContext:
+    @pytest.mark.parametrize(
+        "idx,window,expected_lines",
+        [
+            (0, 2, [0, 1, 2]),
+            (5, 1, [4, 5, 6]),
+            (9, 2, [7, 8, 9]),  # end-of-file clamp
+            (0, 0, [0]),
+        ],
+    )
+    def test_window_respects_edges(
+        self,
+        idx: int,
+        window: int,
+        expected_lines: list[int],
+    ) -> None:
+        lines = [f"line{i}" for i in range(10)]
+        out = ceg._paragraph_context(lines, idx, window=window)
+        assert out == "\n".join(f"line{i}" for i in expected_lines)
+
+
+# --------------------------------------------------------------------------- #
+# iter_image_refs / walk_content                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestImageRefDiscovery:
+    def test_parses_multiple_refs_with_context(self, tmp_path: Path) -> None:
+        md = tmp_path / "post.md"
+        md.write_text(
+            "Opening paragraph describing the figure below.\n"
+            "![Loss curve across layers](https://assets.turntrout.com/a.avif)\n"
+            "Follow-up prose that references the figure.\n"
+            "\n"
+            "Second figure later on:\n"
+            "![Accuracy vs steps](local/b.avif)\n",
+            encoding="utf-8",
+        )
+        refs = list(ceg.iter_image_refs(md))
+        assert [(r.alt, r.url, r.line_number) for r in refs] == [
+            (
+                "Loss curve across layers",
+                "https://assets.turntrout.com/a.avif",
+                2,
+            ),
+            ("Accuracy vs steps", "local/b.avif", 6),
+        ]
+        # Context window picks up surrounding prose.
+        assert "Opening paragraph" in refs[0].context
+        assert "Follow-up prose" in refs[0].context
+        assert "Second figure later on" in refs[1].context
+
+    def test_ignores_non_image_links(self, tmp_path: Path) -> None:
+        md = tmp_path / "post.md"
+        md.write_text(
+            "Link: [normal](https://x/y) not an image.\n"
+            "![real](https://x/z.avif)\n",
+            encoding="utf-8",
+        )
+        urls = [r.url for r in ceg.iter_image_refs(md)]
+        assert urls == ["https://x/z.avif"]
+
+    def test_walk_content_skips_sidecars_and_recurses(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "a.md").write_text("![x](u1)\n", encoding="utf-8")
+        (tmp_path / "sub" / "b.md").write_text("![y](u2)\n", encoding="utf-8")
+        # Sidecar this driver itself produces — must not be re-scanned.
+        (tmp_path / "a.proposed-replacements.md").write_text(
+            "![ignored](u3)\n", encoding="utf-8"
+        )
+        urls = [r.url for r in ceg.walk_content(tmp_path)]
+        assert set(urls) == {"u1", "u2"}
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: prompt shape + yes/no parsing                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifierPrompt:
+    def test_prompt_enumerates_supported_types(self) -> None:
+        p = ceg.build_classifier_prompt(alt="Loss vs step", context="prose")
+        for t in chart_extract.SUPPORTED_CHART_TYPES:
+            assert t in p
+        assert "YES" in p and "NO" in p
+        assert "Loss vs step" in p
+        assert "prose" in p
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("YES", True),
+            ("yes\nreasoning follows", True),
+            ("Yes, it's a chart", True),
+            ("NO", False),
+            ("no explanation", False),
+            ("", False),
+            ("\n\nYES", True),  # leading blank lines
+            ("maybe", False),  # anything else counts as NO
+        ],
+    )
+    def test_parse_yes_no(self, raw: str, expected: bool) -> None:
+        assert ceg._parse_yes_no(raw) is expected
+
+
+# --------------------------------------------------------------------------- #
+# _classify_one — subprocess + download wiring                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifyOne:
+    def _ref(self, url: str) -> ceg.ImageRef:
+        return ceg.ImageRef(
+            markdown_file="post.md",
+            url=url,
+            alt="alt",
+            line_number=1,
+            context="ctx",
+        )
+
+    def test_url_is_downloaded_then_attached(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_local = tmp_path / "downloaded.avif"
+        fake_local.write_bytes(b"\x00")
+
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
+        monkeypatch.setattr(
+            chart_extract, "_download", lambda url, ws, timeout=30: fake_local
+        )
+        seen: dict = {}
+
+        def _fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="YES\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = ceg._classify_one(
+            self._ref("https://example.com/x.avif"), model="m"
+        )
+        assert result is True
+        # -a was pointed at the local download, not the URL.
+        assert str(fake_local) in seen["cmd"]
+        assert "m" in seen["cmd"]
+
+    def test_local_path_is_attached_directly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
+
+        def _should_not_download(*a, **k):
+            raise AssertionError("_download must not be called for local paths")
+
+        monkeypatch.setattr(chart_extract, "_download", _should_not_download)
+
+        def _fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="NO\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert ceg._classify_one(self._ref("./local.avif"), model="m") is False
+
+    def test_non_zero_exit_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
+        monkeypatch.setattr(
+            chart_extract,
+            "_download",
+            lambda url, ws, timeout=30: tmp_path / "x",
+        )
+        (tmp_path / "x").write_bytes(b"\x00")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                args=a, returncode=1, stdout="", stderr="kaboom"
+            ),
+        )
+        with pytest.raises(RuntimeError, match="kaboom"):
+            ceg._classify_one(self._ref("https://x/y.avif"), model="m")
+
+
+# --------------------------------------------------------------------------- #
+# classify_batch — concurrency scaffolding                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifyBatch:
+    def test_returns_results_in_input_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        refs = [
+            ceg.ImageRef("p.md", f"u{i}", "a", i + 1, "c") for i in range(4)
+        ]
+        # Even URLs → YES, odd URLs → NO; exercises both paths.
+        monkeypatch.setattr(
+            ceg,
+            "_classify_one",
+            lambda ref, model: ref.url.endswith(("0", "2")),
+        )
+        out = asyncio.run(ceg.classify_batch(refs, model="m"))
+        assert [r.url for r, _ in out] == ["u0", "u1", "u2", "u3"]
+        assert [is_chart for _, is_chart in out] == [True, False, True, False]
+
+
+# --------------------------------------------------------------------------- #
+# write_proposed_replacements                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _result(source: str, **overrides) -> chart_extract.ChartExtractionResult:
+    defaults = dict(
+        source_image=source,
+        model="m",
+        spec={"type": "line"},
+        yaml_block="```chart\ntype: line\n```",
+    )
+    defaults.update(overrides)
+    return chart_extract.ChartExtractionResult(**defaults)
+
+
+class TestWriteProposedReplacements:
+    def test_groups_by_file_and_sorts_by_line(self, tmp_path: Path) -> None:
+        md_a = tmp_path / "a.md"
+        md_b = tmp_path / "b.md"
+        for m in (md_a, md_b):
+            m.touch()
+
+        refs_by_url = {
+            "url-a2": ceg.ImageRef(str(md_a), "url-a2", "alt-a2", 42, "ctx"),
+            "url-a1": ceg.ImageRef(str(md_a), "url-a1", "alt-a1", 7, "ctx"),
+            "url-b1": ceg.ImageRef(str(md_b), "url-b1", "alt-b1", 3, "ctx"),
+        }
+        results = [
+            _result("url-a2"),
+            _result("url-a1"),
+            _result("url-b1"),
+        ]
+        written = ceg.write_proposed_replacements(results, refs_by_url)
+        assert {p.name for p in written} == {
+            "a.proposed-replacements.md",
+            "b.proposed-replacements.md",
+        }
+        a_body = (tmp_path / "a.proposed-replacements.md").read_text()
+        # a.md sidecar has line-7 section BEFORE line-42 section.
+        assert a_body.index("line 7") < a_body.index("line 42")
+        assert "alt-a1" in a_body and "url-a1" in a_body
+
+    def test_errors_and_orphans_are_skipped(self, tmp_path: Path) -> None:
+        md = tmp_path / "p.md"
+        md.touch()
+        refs_by_url = {
+            "URL-GOOD": ceg.ImageRef(str(md), "URL-GOOD", "a", 1, "c"),
+        }
+        results = [
+            _result("URL-GOOD"),
+            _result("URL-FAILED", error="boom", spec=None, yaml_block=None),
+            _result("URL-ORPHAN"),  # no entry in refs_by_url
+        ]
+        written = ceg.write_proposed_replacements(results, refs_by_url)
+        body = written[0].read_text()
+        assert "URL-GOOD" in body
+        assert "URL-FAILED" not in body
+        assert "URL-ORPHAN" not in body
+
+
+# --------------------------------------------------------------------------- #
+# run() — the whole pipeline end-to-end                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestRun:
+    def _fixture(self, tmp_path: Path) -> tuple[Path, Path]:
+        content = tmp_path / "content"
+        content.mkdir()
+        (content / "post1.md").write_text(
+            "Intro.\n"
+            "![chart alt](https://x/chart1.avif)\n"
+            "![not a chart](https://x/meme.avif)\n",
+            encoding="utf-8",
+        )
+        (content / "post2.md").write_text(
+            "![another chart](https://x/chart2.avif)\n", encoding="utf-8"
+        )
+        return content, tmp_path / "queue.json"
+
+    def test_full_run_writes_sidecars_and_queue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content, queue = self._fixture(tmp_path)
+
+        # Chart classifier says yes for URLs containing "chart".
+        def _classify(ref: ceg.ImageRef, model: str) -> bool:
+            return "chart" in ref.url
+
+        monkeypatch.setattr(ceg, "_classify_one", _classify)
+
+        # Extract returns a minimal successful result for each URL.
+        async def _fake_batch(
+            images, model, on_completed=None, context_for=None
+        ):
+            return [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(img),
+                    model=model,
+                    spec={"type": "line"},
+                    yaml_block=f"```chart\nsource: {img}\n```",
+                    context_used=context_for(img) if context_for else "",
+                )
+                for img in images
+            ]
+
+        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
+
+        n = asyncio.run(
+            ceg.run(
+                content,
+                model="extractor-m",
+                classifier="classifier-m",
+                queue=queue,
+            )
+        )
+        assert n == 2
+        # Sidecars exist next to their source .md files.
+        assert (content / "post1.proposed-replacements.md").exists()
+        assert (content / "post2.proposed-replacements.md").exists()
+        # The meme image was filtered out by the classifier — not extracted.
+        assert (
+            "meme"
+            not in (content / "post1.proposed-replacements.md").read_text()
+        )
+        # Queue on disk has both successes.
+        q = json.loads(queue.read_text())
+        sources = {row["source_image"] for row in q}
+        assert sources == {
+            "https://x/chart1.avif",
+            "https://x/chart2.avif",
+        }
+
+    def test_dry_run_classifies_but_skips_extraction(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        content, queue = self._fixture(tmp_path)
+        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: True)
+
+        def _must_not_run(*a, **kw):
+            raise AssertionError("extractor ran during --dry-run")
+
+        monkeypatch.setattr(chart_extract, "async_extract_batch", _must_not_run)
+
+        n = asyncio.run(
+            ceg.run(
+                content,
+                model="m",
+                classifier="c",
+                queue=queue,
+                dry_run=True,
+            )
+        )
+        assert n == 0
+        out = capsys.readouterr().out
+        assert "chart1.avif" in out and "chart2.avif" in out
+        assert not queue.exists()
+
+    def test_resume_skips_urls_already_in_queue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content, queue = self._fixture(tmp_path)
+        # Pre-seed queue with chart1 as successful.
+        queue.write_text(
+            json.dumps(
+                [
+                    {
+                        "source_image": "https://x/chart1.avif",
+                        "model": "m",
+                        "spec": {"type": "line"},
+                        "csv_path": None,
+                        "yaml_block": "```chart\n```",
+                        "error": None,
+                        "raw_output": "",
+                        "context_used": "",
+                    }
+                ]
+            )
+        )
+
+        seen_urls: list[str] = []
+
+        def _classify(ref: ceg.ImageRef, model: str) -> bool:
+            seen_urls.append(ref.url)
+            return True
+
+        monkeypatch.setattr(ceg, "_classify_one", _classify)
+
+        async def _fake_batch(
+            images, model, on_completed=None, context_for=None
+        ):
+            return [
+                chart_extract.ChartExtractionResult(
+                    source_image=str(img),
+                    model=model,
+                    spec={"type": "line"},
+                    yaml_block="```chart\n```",
+                )
+                for img in images
+            ]
+
+        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
+
+        asyncio.run(ceg.run(content, model="m", classifier="c", queue=queue))
+        # chart1 was in the queue → never hit the classifier this run.
+        assert "https://x/chart1.avif" not in seen_urls
+
+    def test_empty_content_dir_returns_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "empty").mkdir()
+
+        def _must_not_run(*a, **kw):
+            raise AssertionError("should short-circuit on empty input")
+
+        monkeypatch.setattr(ceg, "_classify_one", _must_not_run)
+
+        n = asyncio.run(
+            ceg.run(
+                tmp_path / "empty",
+                model="m",
+                classifier="c",
+                queue=tmp_path / "q.json",
+            )
+        )
+        assert n == 0
+
+    def test_all_images_rejected_short_circuits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content, queue = self._fixture(tmp_path)
+        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: False)
+
+        def _must_not_run(*a, **kw):
+            raise AssertionError("extractor ran with nothing to extract")
+
+        monkeypatch.setattr(chart_extract, "async_extract_batch", _must_not_run)
+
+        n = asyncio.run(
+            ceg.run(content, model="m", classifier="c", queue=queue)
+        )
+        assert n == 0
+
+    def test_context_for_returns_none_for_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The context_for closure defends against URL / key drift inside
+        async_extract_batch — if a source that never made it to refs_by_url
+        somehow comes through, return None rather than KeyError-ing."""
+        content, queue = self._fixture(tmp_path)
+        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: True)
+
+        captured: dict = {}
+
+        async def _fake_batch(
+            images, model, on_completed=None, context_for=None
+        ):
+            captured["ctx_known"] = context_for("https://x/chart1.avif")
+            captured["ctx_unknown"] = context_for("https://nowhere/z.avif")
+            return []
+
+        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
+
+        asyncio.run(ceg.run(content, model="m", classifier="c", queue=queue))
+        assert captured["ctx_known"] is not None
+        assert "chart alt" in captured["ctx_known"]
+        assert captured["ctx_unknown"] is None
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry points                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestCLI:
+    def test_defaults_match_documentation(self) -> None:
+        args = ceg._parse_args([])
+        assert args.content_dir == Path("website_content")
+        assert args.model == "claude-sonnet-4-6"
+        assert args.classifier == "claude-opus-4-7"
+        assert args.queue == Path("chart-backfill-queue.json")
+        assert args.dry_run is False
+
+    def test_overrides_flow_through(self) -> None:
+        args = ceg._parse_args(
+            [
+                "--content-dir",
+                "/tmp/other",
+                "--model",
+                "gpt-5",
+                "--classifier",
+                "gemini-2.5-pro",
+                "--queue",
+                "/tmp/q.json",
+                "--dry-run",
+            ]
+        )
+        assert args.content_dir == Path("/tmp/other")
+        assert args.model == "gpt-5"
+        assert args.classifier == "gemini-2.5-pro"
+        assert args.queue == Path("/tmp/q.json")
+        assert args.dry_run is True
+
+    def test_main_invokes_run_with_parsed_args(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "empty").mkdir()
+        captured: dict = {}
+
+        async def _fake_run(
+            content_dir, model, classifier, queue, dry_run=False
+        ):
+            captured.update(
+                content_dir=content_dir,
+                model=model,
+                classifier=classifier,
+                queue=queue,
+                dry_run=dry_run,
+            )
+            return 0
+
+        monkeypatch.setattr(ceg, "run", _fake_run)
+        rc = ceg.main(
+            [
+                "--content-dir",
+                str(tmp_path / "empty"),
+                "--queue",
+                str(tmp_path / "q.json"),
+                "--dry-run",
+            ]
+        )
+        assert rc == 0
+        assert captured["dry_run"] is True
+        assert captured["content_dir"] == tmp_path / "empty"

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -322,38 +322,50 @@ class TestWriteProposedReplacements:
         assert "alt: Loss curve across layers" in replacement
         assert "fallback: https://assets.turntrout.com/x.avif" in replacement
 
-    def test_empty_alt_falls_back_to_title_then_todo(
-        self, tmp_path: Path
+    @pytest.mark.parametrize(
+        "ref_alt,spec_extras,expected",
+        [
+            # 1. Author-written Markdown alt wins over everything.
+            (
+                "Markdown alt",
+                {"alt": "Model alt", "title": "Title"},
+                "Markdown alt",
+            ),
+            # 2. Model-generated (non-placeholder) alt beats title when ref is blank.
+            ("", {"alt": "Model alt", "title": "Title"}, "Model alt"),
+            # 3. Placeholder alt from extractor is NOT used; title falls through.
+            (
+                "",
+                {"alt": chart_extract.ALT_TODO_PLACEHOLDER, "title": "Title"},
+                "Title",
+            ),
+            # 4. Nothing usable → shared TODO placeholder.
+            ("", {}, chart_extract.ALT_TODO_PLACEHOLDER),
+        ],
+    )
+    def test_alt_priority_chain(
+        self,
+        tmp_path: Path,
+        ref_alt: str,
+        spec_extras: dict,
+        expected: str,
     ) -> None:
         md = tmp_path / "p.md"
         md.touch()
-        # Empty alt on the ref; spec has a title → title wins.
-        ref_with_title = ceg.ImageRef(str(md), "u1", "", 1, "ctx")
-        r_with_title = _result(
-            "u1",
-            spec={
-                "type": "line",
-                "title": "Loss across steps",
-                "x": {"label": "X"},
-                "y": {"label": "Y"},
-                "series": [{"name": "S", "data": [[0, 1]]}],
-            },
-        )
+        ref = ceg.ImageRef(str(md), "u", ref_alt, 1, "ctx")
+        spec = {
+            "type": "line",
+            "x": {"label": "X"},
+            "y": {"label": "Y"},
+            "series": [{"name": "S", "data": [[0, 1]]}],
+            **spec_extras,
+        }
         written = ceg.write_proposed_replacements(
-            [r_with_title], {ref_with_title.url: ref_with_title}
+            [_result("u", spec=spec)], {ref.url: ref}
         )
-        assert "alt: Loss across steps" in written[0].read_text()
-
-        # Empty alt AND no title → explicit TODO placeholder so hand-merge
-        # reviewers notice.
-        other_md = tmp_path / "q.md"
-        other_md.touch()
-        ref_no_title = ceg.ImageRef(str(other_md), "u2", "", 1, "ctx")
-        r_no_title = _result("u2")
-        written2 = ceg.write_proposed_replacements(
-            [r_no_title], {ref_no_title.url: ref_no_title}
-        )
-        assert chart_extract.ALT_TODO_PLACEHOLDER in written2[0].read_text()
+        # YAML may single-quote values containing brackets; tolerate both.
+        body = written[0].read_text()
+        assert f"alt: {expected}" in body or f"alt: '{expected}'" in body
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -243,11 +243,18 @@ class TestClassifyBatch:
 
 
 def _result(source: str, **overrides) -> chart_extract.ChartExtractionResult:
+    # Provide a fully-formed spec so write_proposed_replacements can re-serialize
+    # it after injecting alt/fallback (the real pipeline only passes validated
+    # specs through).
     defaults = dict(
         source_image=source,
         model="m",
-        spec={"type": "line"},
-        yaml_block="```chart\ntype: line\n```",
+        spec={
+            "type": "line",
+            "x": {"label": "X"},
+            "y": {"label": "Y"},
+            "series": [{"name": "S", "data": [[0, 1]]}],
+        },
     )
     defaults.update(overrides)
     return chart_extract.ChartExtractionResult(**defaults)
@@ -296,6 +303,68 @@ class TestWriteProposedReplacements:
         assert "URL-GOOD" in body
         assert "URL-FAILED" not in body
         assert "URL-ORPHAN" not in body
+
+    def test_replacement_block_has_alt_and_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Injected alt = ref.alt; injected fallback = ref.url.
+
+        These are the two provenance fields that keep the chart a11y-complete
+        and preserve the original image URL.
+        """
+        md = tmp_path / "p.md"
+        md.touch()
+        ref = ceg.ImageRef(
+            str(md),
+            "https://assets.turntrout.com/x.avif",
+            "Loss curve across layers",
+            1,
+            "ctx",
+        )
+        refs_by_url = {ref.url: ref}
+        written = ceg.write_proposed_replacements(
+            [_result(ref.url)], refs_by_url
+        )
+        body = written[0].read_text()
+        # The replacement block (not just the Original: section) must have
+        # alt and fallback keys.
+        replacement = body.split("Replacement:", 1)[1]
+        assert "alt: Loss curve across layers" in replacement
+        assert "fallback: https://assets.turntrout.com/x.avif" in replacement
+
+    def test_empty_alt_falls_back_to_title_then_todo(
+        self, tmp_path: Path
+    ) -> None:
+        md = tmp_path / "p.md"
+        md.touch()
+        # Empty alt on the ref; spec has a title → title wins.
+        ref_with_title = ceg.ImageRef(str(md), "u1", "", 1, "ctx")
+        r_with_title = _result(
+            "u1",
+            spec={
+                "type": "line",
+                "title": "Loss across steps",
+                "x": {"label": "X"},
+                "y": {"label": "Y"},
+                "series": [{"name": "S", "data": [[0, 1]]}],
+            },
+        )
+        written = ceg.write_proposed_replacements(
+            [r_with_title], {ref_with_title.url: ref_with_title}
+        )
+        assert "alt: Loss across steps" in written[0].read_text()
+
+        # Empty alt AND no title → explicit TODO placeholder so hand-merge
+        # reviewers notice.
+        other_md = tmp_path / "q.md"
+        other_md.touch()
+        ref_no_title = ceg.ImageRef(str(other_md), "u2", "", 1, "ctx")
+        r_no_title = _result("u2")
+        written2 = ceg.write_proposed_replacements(
+            [r_no_title], {ref_no_title.url: ref_no_title}
+        )
+        assert ceg._ALT_TODO_PLACEHOLDER in written2[0].read_text()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -353,7 +353,7 @@ class TestWriteProposedReplacements:
         written2 = ceg.write_proposed_replacements(
             [r_no_title], {ref_no_title.url: ref_no_title}
         )
-        assert ceg._ALT_TODO_PLACEHOLDER in written2[0].read_text()
+        assert chart_extract.ALT_TODO_PLACEHOLDER in written2[0].read_text()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -138,80 +138,69 @@ class TestClassifierPrompt:
 # --------------------------------------------------------------------------- #
 
 
-class TestClassifyOne:
-    def _ref(self, url: str) -> ceg.ImageRef:
-        return ceg.ImageRef(
-            markdown_file="post.md",
-            url=url,
-            alt="alt",
-            line_number=1,
-            context="ctx",
+def _ref(url: str, alt: str = "alt") -> ceg.ImageRef:
+    return ceg.ImageRef("post.md", url, alt, 1, "ctx")
+
+
+def _install_classifier_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "YES\n",
+    returncode: int = 0,
+    stderr: str = "",
+    download: Path | None = None,
+) -> dict:
+    """Install the three mocks `_classify_one` needs and return a dict the
+    caller can inspect (`cmd` captures the subprocess args)."""
+    captured: dict = {}
+    monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
+    if download is not None:
+        monkeypatch.setattr(
+            chart_extract, "_download", lambda url, ws, timeout=30: download
+        )
+    else:
+
+        def _no_download(*a, **kw):
+            raise AssertionError("_download must not be called for local paths")
+
+        monkeypatch.setattr(chart_extract, "_download", _no_download)
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=returncode, stdout=stdout, stderr=stderr
         )
 
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return captured
+
+
+class TestClassifyOne:
     def test_url_is_downloaded_then_attached(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        fake_local = tmp_path / "downloaded.avif"
-        fake_local.write_bytes(b"\x00")
-
-        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
-        monkeypatch.setattr(
-            chart_extract, "_download", lambda url, ws, timeout=30: fake_local
-        )
-        seen: dict = {}
-
-        def _fake_run(cmd, **kwargs):
-            seen["cmd"] = cmd
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="YES\n", stderr=""
-            )
-
-        monkeypatch.setattr(subprocess, "run", _fake_run)
-        result = ceg._classify_one(
-            self._ref("https://example.com/x.avif"), model="m"
-        )
-        assert result is True
-        # -a was pointed at the local download, not the URL.
-        assert str(fake_local) in seen["cmd"]
-        assert "m" in seen["cmd"]
+        local = tmp_path / "downloaded.avif"
+        local.write_bytes(b"\x00")
+        captured = _install_classifier_mocks(monkeypatch, download=local)
+        assert ceg._classify_one(_ref("https://example.com/x.avif"), model="m")
+        assert str(local) in captured["cmd"] and "m" in captured["cmd"]
 
     def test_local_path_is_attached_directly(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
-
-        def _should_not_download(*a, **k):
-            raise AssertionError("_download must not be called for local paths")
-
-        monkeypatch.setattr(chart_extract, "_download", _should_not_download)
-
-        def _fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="NO\n", stderr=""
-            )
-
-        monkeypatch.setattr(subprocess, "run", _fake_run)
-        assert ceg._classify_one(self._ref("./local.avif"), model="m") is False
+        _install_classifier_mocks(monkeypatch, stdout="NO\n")
+        assert ceg._classify_one(_ref("./local.avif"), model="m") is False
 
     def test_non_zero_exit_raises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(chart_extract, "_find_llm", lambda: "/bin/llm")
-        monkeypatch.setattr(
-            chart_extract,
-            "_download",
-            lambda url, ws, timeout=30: tmp_path / "x",
-        )
-        (tmp_path / "x").write_bytes(b"\x00")
-        monkeypatch.setattr(
-            subprocess,
-            "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                args=a, returncode=1, stdout="", stderr="kaboom"
-            ),
+        local = tmp_path / "x"
+        local.write_bytes(b"\x00")
+        _install_classifier_mocks(
+            monkeypatch, returncode=1, stderr="kaboom", download=local
         )
         with pytest.raises(RuntimeError, match="kaboom"):
-            ceg._classify_one(self._ref("https://x/y.avif"), model="m")
+            ceg._classify_one(_ref("https://x/y.avif"), model="m")
 
 
 # --------------------------------------------------------------------------- #
@@ -372,95 +361,110 @@ class TestWriteProposedReplacements:
 # --------------------------------------------------------------------------- #
 
 
-class TestRun:
-    def _fixture(self, tmp_path: Path) -> tuple[Path, Path]:
-        content = tmp_path / "content"
-        content.mkdir()
-        (content / "post1.md").write_text(
-            "Intro.\n"
-            "![chart alt](https://x/chart1.avif)\n"
-            "![not a chart](https://x/meme.avif)\n",
-            encoding="utf-8",
-        )
-        (content / "post2.md").write_text(
-            "![another chart](https://x/chart2.avif)\n", encoding="utf-8"
-        )
-        return content, tmp_path / "queue.json"
+@pytest.fixture
+def content_tree(tmp_path: Path) -> tuple[Path, Path]:
+    """
+    Two-post content tree shared across TestRun cases.
 
-    def test_full_run_writes_sidecars_and_queue(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        content, queue = self._fixture(tmp_path)
+    post1 has one chart-ish image + one non-chart; post2 has one chart-ish
+    image.
+    """
+    content = tmp_path / "content"
+    content.mkdir()
+    (content / "post1.md").write_text(
+        "Intro.\n"
+        "![chart alt](https://x/chart1.avif)\n"
+        "![not a chart](https://x/meme.avif)\n",
+        encoding="utf-8",
+    )
+    (content / "post2.md").write_text(
+        "![another chart](https://x/chart2.avif)\n", encoding="utf-8"
+    )
+    return content, tmp_path / "queue.json"
 
-        # Chart classifier says yes for URLs containing "chart".
-        def _classify(ref: ceg.ImageRef, model: str) -> bool:
-            return "chart" in ref.url
 
-        monkeypatch.setattr(ceg, "_classify_one", _classify)
+def _forbid(label: str):
+    """Mock that raises if invoked — used to assert a branch is NOT taken."""
 
-        # Extract returns a minimal successful result for each URL.
-        async def _fake_batch(
-            images, model, on_completed=None, context_for=None
-        ):
-            return [
-                chart_extract.ChartExtractionResult(
-                    source_image=str(img),
-                    model=model,
-                    spec={"type": "line"},
-                    yaml_block=f"```chart\nsource: {img}\n```",
-                    context_used=context_for(img) if context_for else "",
-                )
-                for img in images
-            ]
+    def _fn(*a, **kw):
+        raise AssertionError(label)
 
-        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
+    return _fn
 
-        n = asyncio.run(
-            ceg.run(
-                content,
-                model="extractor-m",
-                classifier="classifier-m",
-                queue=queue,
+
+def _install_run_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    classify=None,
+    batch=None,
+) -> None:
+    """Install the two mocks `run()` needs: classifier + extractor."""
+    if classify is not None:
+        monkeypatch.setattr(ceg, "_classify_one", classify)
+    if batch is not None:
+        monkeypatch.setattr(chart_extract, "async_extract_batch", batch)
+
+
+def _minimal_batch(spec: dict | None = None):
+    """
+    Returns an ``async_extract_batch`` stub producing one minimal success per
+    input URL.
+
+    Optional per-call hook receives the captured context.
+    """
+    default_spec = spec or {"type": "line"}
+
+    async def _fake(images, model, on_completed=None, context_for=None):
+        return [
+            chart_extract.ChartExtractionResult(
+                source_image=str(img),
+                model=model,
+                spec=default_spec,
+                context_used=context_for(img) if context_for else "",
             )
+            for img in images
+        ]
+
+    return _fake
+
+
+class TestRun:
+    def test_full_run_writes_sidecars_and_queue(
+        self,
+        content_tree: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        content, queue = content_tree
+        _install_run_mocks(
+            monkeypatch,
+            classify=lambda ref, model: "chart" in ref.url,
+            batch=_minimal_batch(),
+        )
+        n = asyncio.run(
+            ceg.run(content, model="m", classifier="c", queue=queue)
         )
         assert n == 2
-        # Sidecars exist next to their source .md files.
-        assert (content / "post1.proposed-replacements.md").exists()
+        post1 = (content / "post1.proposed-replacements.md").read_text()
         assert (content / "post2.proposed-replacements.md").exists()
-        # The meme image was filtered out by the classifier — not extracted.
-        assert (
-            "meme"
-            not in (content / "post1.proposed-replacements.md").read_text()
-        )
-        # Queue on disk has both successes.
-        q = json.loads(queue.read_text())
-        sources = {row["source_image"] for row in q}
-        assert sources == {
-            "https://x/chart1.avif",
-            "https://x/chart2.avif",
-        }
+        assert "meme" not in post1  # classifier filtered it out
+        sources = {row["source_image"] for row in json.loads(queue.read_text())}
+        assert sources == {"https://x/chart1.avif", "https://x/chart2.avif"}
 
     def test_dry_run_classifies_but_skips_extraction(
         self,
-        tmp_path: Path,
+        content_tree: tuple[Path, Path],
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        content, queue = self._fixture(tmp_path)
-        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: True)
-
-        def _must_not_run(*a, **kw):
-            raise AssertionError("extractor ran during --dry-run")
-
-        monkeypatch.setattr(chart_extract, "async_extract_batch", _must_not_run)
-
+        content, queue = content_tree
+        _install_run_mocks(
+            monkeypatch,
+            classify=lambda ref, model: True,
+            batch=_forbid("extractor ran during --dry-run"),
+        )
         n = asyncio.run(
             ceg.run(
-                content,
-                model="m",
-                classifier="c",
-                queue=queue,
-                dry_run=True,
+                content, model="m", classifier="c", queue=queue, dry_run=True
             )
         )
         assert n == 0
@@ -469,64 +473,34 @@ class TestRun:
         assert not queue.exists()
 
     def test_resume_skips_urls_already_in_queue(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        content_tree: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        content, queue = self._fixture(tmp_path)
-        # Pre-seed queue with chart1 as successful.
-        queue.write_text(
-            json.dumps(
-                [
-                    {
-                        "source_image": "https://x/chart1.avif",
-                        "model": "m",
-                        "spec": {"type": "line"},
-                        "csv_path": None,
-                        "yaml_block": "```chart\n```",
-                        "error": None,
-                        "raw_output": "",
-                        "context_used": "",
-                    }
-                ]
-            )
-        )
+        content, queue = content_tree
+        # Seed the queue via the real writer so format drift can't silently
+        # break this test.
+        chart_extract.write_results([_result("https://x/chart1.avif")], queue)
 
-        seen_urls: list[str] = []
+        seen: list[str] = []
 
-        def _classify(ref: ceg.ImageRef, model: str) -> bool:
-            seen_urls.append(ref.url)
+        def _classify(ref, model):
+            seen.append(ref.url)
             return True
 
-        monkeypatch.setattr(ceg, "_classify_one", _classify)
-
-        async def _fake_batch(
-            images, model, on_completed=None, context_for=None
-        ):
-            return [
-                chart_extract.ChartExtractionResult(
-                    source_image=str(img),
-                    model=model,
-                    spec={"type": "line"},
-                    yaml_block="```chart\n```",
-                )
-                for img in images
-            ]
-
-        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
-
+        _install_run_mocks(
+            monkeypatch, classify=_classify, batch=_minimal_batch()
+        )
         asyncio.run(ceg.run(content, model="m", classifier="c", queue=queue))
-        # chart1 was in the queue → never hit the classifier this run.
-        assert "https://x/chart1.avif" not in seen_urls
+        assert "https://x/chart1.avif" not in seen
 
     def test_empty_content_dir_returns_zero(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         (tmp_path / "empty").mkdir()
-
-        def _must_not_run(*a, **kw):
-            raise AssertionError("should short-circuit on empty input")
-
-        monkeypatch.setattr(ceg, "_classify_one", _must_not_run)
-
+        _install_run_mocks(
+            monkeypatch, classify=_forbid("should short-circuit")
+        )
         n = asyncio.run(
             ceg.run(
                 tmp_path / "empty",
@@ -538,45 +512,47 @@ class TestRun:
         assert n == 0
 
     def test_all_images_rejected_short_circuits(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        content_tree: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        content, queue = self._fixture(tmp_path)
-        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: False)
-
-        def _must_not_run(*a, **kw):
-            raise AssertionError("extractor ran with nothing to extract")
-
-        monkeypatch.setattr(chart_extract, "async_extract_batch", _must_not_run)
-
-        n = asyncio.run(
-            ceg.run(content, model="m", classifier="c", queue=queue)
+        content, queue = content_tree
+        _install_run_mocks(
+            monkeypatch,
+            classify=lambda ref, model: False,
+            batch=_forbid("extractor ran with nothing to extract"),
         )
-        assert n == 0
+        assert (
+            asyncio.run(
+                ceg.run(content, model="m", classifier="c", queue=queue)
+            )
+            == 0
+        )
 
     def test_context_for_returns_none_for_unknown(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        content_tree: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """The context_for closure defends against URL / key drift inside
         async_extract_batch — if a source that never made it to refs_by_url
         somehow comes through, return None rather than KeyError-ing."""
-        content, queue = self._fixture(tmp_path)
-        monkeypatch.setattr(ceg, "_classify_one", lambda ref, model: True)
-
+        content, queue = content_tree
         captured: dict = {}
 
-        async def _fake_batch(
-            images, model, on_completed=None, context_for=None
-        ):
-            captured["ctx_known"] = context_for("https://x/chart1.avif")
-            captured["ctx_unknown"] = context_for("https://nowhere/z.avif")
+        async def _fake(images, model, on_completed=None, context_for=None):
+            captured["known"] = context_for("https://x/chart1.avif")
+            captured["unknown"] = context_for("https://nowhere/z.avif")
             return []
 
-        monkeypatch.setattr(chart_extract, "async_extract_batch", _fake_batch)
-
+        _install_run_mocks(
+            monkeypatch, classify=lambda ref, model: True, batch=_fake
+        )
         asyncio.run(ceg.run(content, model="m", classifier="c", queue=queue))
-        assert captured["ctx_known"] is not None
-        assert "chart alt" in captured["ctx_known"]
-        assert captured["ctx_unknown"] is None
+        assert (
+            captured["known"] is not None and "chart alt" in captured["known"]
+        )
+        assert captured["unknown"] is None
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_convert_existing_graphs.py
+++ b/scripts/tests/test_convert_existing_graphs.py
@@ -22,32 +22,6 @@ from scripts import chart_extract
 from scripts.notebooks import convert_existing_graphs as ceg
 
 # --------------------------------------------------------------------------- #
-# _paragraph_context                                                           #
-# --------------------------------------------------------------------------- #
-
-
-class TestParagraphContext:
-    @pytest.mark.parametrize(
-        "idx,window,expected_lines",
-        [
-            (0, 2, [0, 1, 2]),
-            (5, 1, [4, 5, 6]),
-            (9, 2, [7, 8, 9]),  # end-of-file clamp
-            (0, 0, [0]),
-        ],
-    )
-    def test_window_respects_edges(
-        self,
-        idx: int,
-        window: int,
-        expected_lines: list[int],
-    ) -> None:
-        lines = [f"line{i}" for i in range(10)]
-        out = ceg._paragraph_context(lines, idx, window=window)
-        assert out == "\n".join(f"line{i}" for i in expected_lines)
-
-
-# --------------------------------------------------------------------------- #
 # iter_image_refs / walk_content                                               #
 # --------------------------------------------------------------------------- #
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,25 +14,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "alt-text-llm"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "gitpython" },
-    { name = "markdown-it-py" },
-    { name = "prompt-toolkit" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "ruamel-yaml" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/53/77f3455f3ae8442ba703dca5d0d4b98f1bf8cb528ceffb7573c02b344613/alt_text_llm-1.3.1.tar.gz", hash = "sha256:6a4d76ea041d261b33297cee68c4fad4235c13441f8bc19b7ef406e0b7f8a6a7", size = 51354, upload-time = "2026-02-08T21:10:19.03Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/19/81471896d9437798bec0574059c40d9785ebf023975ba61101b61f2d9209/alt_text_llm-1.3.1-py3-none-any.whl", hash = "sha256:38b48b54da7521c7cd742cf0d4891a6499601dc022eb7f5150de6e779fd82563", size = 26404, upload-time = "2026-02-08T21:10:17.694Z" },
-]
-
-[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,18 +990,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
-]
-
-[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1440,7 +1409,6 @@ name = "turntrout-com"
 version = "1.4"
 source = { virtual = "." }
 dependencies = [
-    { name = "alt-text-llm" },
     { name = "autoflake" },
     { name = "autopep8" },
     { name = "beautifulsoup4" },
@@ -1484,7 +1452,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alt-text-llm" },
     { name = "autoflake", specifier = ">=2.3.1" },
     { name = "autopep8", specifier = ">=2.3.1" },
     { name = "beautifulsoup4" },
@@ -1668,13 +1635,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "alt-text-llm"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "gitpython" },
+    { name = "markdown-it-py" },
+    { name = "prompt-toolkit" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "ruamel-yaml" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/53/77f3455f3ae8442ba703dca5d0d4b98f1bf8cb528ceffb7573c02b344613/alt_text_llm-1.3.1.tar.gz", hash = "sha256:6a4d76ea041d261b33297cee68c4fad4235c13441f8bc19b7ef406e0b7f8a6a7", size = 51354, upload-time = "2026-02-08T21:10:19.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/19/81471896d9437798bec0574059c40d9785ebf023975ba61101b61f2d9209/alt_text_llm-1.3.1-py3-none-any.whl", hash = "sha256:38b48b54da7521c7cd742cf0d4891a6499601dc022eb7f5150de6e779fd82563", size = 26404, upload-time = "2026-02-08T21:10:17.694Z" },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -990,6 +1009,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1409,6 +1440,7 @@ name = "turntrout-com"
 version = "1.4"
 source = { virtual = "." }
 dependencies = [
+    { name = "alt-text-llm" },
     { name = "autoflake" },
     { name = "autopep8" },
     { name = "beautifulsoup4" },
@@ -1452,6 +1484,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alt-text-llm" },
     { name = "autoflake", specifier = ">=2.3.1" },
     { name = "autopep8", specifier = ">=2.3.1" },
     { name = "beautifulsoup4" },
@@ -1635,4 +1668,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "alt-text-llm"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "gitpython" },
+    { name = "markdown-it-py" },
+    { name = "prompt-toolkit" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "ruamel-yaml" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/53/77f3455f3ae8442ba703dca5d0d4b98f1bf8cb528ceffb7573c02b344613/alt_text_llm-1.3.1.tar.gz", hash = "sha256:6a4d76ea041d261b33297cee68c4fad4235c13441f8bc19b7ef406e0b7f8a6a7", size = 51354, upload-time = "2026-02-08T21:10:19.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/19/81471896d9437798bec0574059c40d9785ebf023975ba61101b61f2d9209/alt_text_llm-1.3.1-py3-none-any.whl", hash = "sha256:38b48b54da7521c7cd742cf0d4891a6499601dc022eb7f5150de6e779fd82563", size = 26404, upload-time = "2026-02-08T21:10:17.694Z" },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -990,6 +1009,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1409,6 +1440,7 @@ name = "turntrout-com"
 version = "1.4"
 source = { virtual = "." }
 dependencies = [
+    { name = "alt-text-llm" },
     { name = "autoflake" },
     { name = "autopep8" },
     { name = "beautifulsoup4" },
@@ -1452,6 +1484,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alt-text-llm", specifier = ">=1.3.1" },
     { name = "autoflake", specifier = ">=2.3.1" },
     { name = "autopep8", specifier = ">=2.3.1" },
     { name = "beautifulsoup4" },
@@ -1635,4 +1668,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]

--- a/website_content/layer-horizon.md
+++ b/website_content/layer-horizon.md
@@ -66,6 +66,7 @@ To measure the importance of sublayer contributions originating much earlier in 
 >
 > ```chart
 > type: line
+> alt: "Loss for GPT-2 XL as a function of layer horizon, falling from 8.92 at horizon 0 to roughly 3.15 by horizon 48 and approaching the 3.1418 baseline loss."
 > title: "Layer Horizon vs Loss for GPT2-XL (48 layers)"
 > x:
 >   label: Layer horizon


### PR DESCRIPTION
## Summary

Introduces `scripts/chart_extract.py`, a new tool for extracting structured chart data from images using LLM models via the `llm` CLI. The script converts chart images into YAML specifications and CSV data files that can be embedded in Markdown documents.

## Key Changes

- **New extraction script** (`scripts/chart_extract.py`):
  - Extracts chart data from images (PNG, AVIF) using Claude, Gemini, GPT, or other LLM models
  - Outputs structured YAML blocks compatible with the Quartz chart renderer
  - Generates accompanying CSV files in long format (x, y, series columns)
  - Supports AVIF-to-PNG conversion via ImageMagick
  - Implements resumable batch processing with a JSON work-queue for deduplication
  - Provides cost estimation for different models
  - Includes progress callbacks for async batch operations
  - Passes JSON schema to `llm` CLI via tempfile instead of inline arguments (avoids ARG_MAX issues)

- **Comprehensive test suite** (`scripts/tests/test_chart_extract.py`):
  - 792 lines of tests covering all major functions and edge cases
  - Tests for path normalization, YAML formatting, CSV emission, and cost estimation
  - TDD-driven tests for new features (progress callbacks, schema tempfile handling)
  - Mocked subprocess calls to exercise error handling paths
  - CLI integration tests with stubbed LLM calls

- **Minor style fix** (`quartz/styles/custom.scss`):
  - Corrects truncated CSS selector (cosmetic fix)

## Implementation Details

- **Concurrency**: Uses `asyncio` with a semaphore (limit of 8) to manage concurrent LLM requests
- **Error handling**: All per-image failures (bad AVIF, LLM timeout, invalid JSON) are caught and recorded without crashing the batch
- **Deduplication**: Work-queue tracks normalized image paths; retries only update the latest attempt
- **Schema management**: JSON schema is written to a tempfile and passed via `--schema <path>` flag to avoid command-line length limits
- **Output format**: Generates both YAML blocks (for pasting into Markdown) and CSV files (for data reference)
- **Model flexibility**: Works with any model the `llm` CLI knows about via a single `-m` flag

https://claude.ai/code/session_01A3nc4q7PA2SZZVs6hpLfz6