### PR TITLE
docs: link subfont mention to optimized fork

### DIFF
--- a/website_content/design.md
+++ b/website_content/design.md
@@ -180,7 +180,7 @@ Quartz offers basic optimizations, such as [lazy loading](https://developer.mozi
 
 EB Garamond Regular 8pt takes 260KB as an `otf` file but compresses to 80KB under [the newer `woff2` format.](https://www.w3.org/TR/WOFF2/) In all, the font footprint shrinks from 1.5MB to about 609KB for most pages. I toyed around with manual [font subsetting](https://fonts.google.com/knowledge/glossary/subsetting) but it seemed too hard to predict which characters my site _never_ uses.
 
-Therefore, I use [`subfont`](https://github.com/Munter/subfont) to subset each font across my entire website. Further optimizations strip glyph hinting, drop dead OpenType tables, and filter out font features that the CSS never exercises.
+Therefore, I use [my optimized fork of `subfont`](/open-source#faster-font-subsetting) to subset each font across my entire website. Further optimizations strip glyph hinting, drop dead OpenType tables, and filter out font features that the CSS never exercises.
 
 <span class="populate-markdown-font-stats"></span>
 


### PR DESCRIPTION
## Summary

- In `website_content/design.md`, retarget the `subfont` reference from upstream (`github.com/Munter/subfont`) to the local "Faster font subsetting" section of `open-source.md`, and update the link text to "my optimized fork of `subfont`".

## Test plan

- [ ] Anchor `/open-source#faster-font-subsetting` resolves on the built site (the heading "## Faster font subsetting" exists at `website_content/open-source.md:132`).
- [ ] CI link checks pass.

https://claude.ai/code/session_01WJ8UdvCTnsrUC1qXjvbhPD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ8UdvCTnsrUC1qXjvbhPD)_