### PR TITLE
Improve mobile navbar transitions and search focus styling

### DIFF
--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -184,8 +184,8 @@
   #quartz-body #navbar {
     opacity: 1;
     transition:
-      transform 0.45s ease,
-      opacity 0.45s ease;
+      transform $transition-duration-slow ease,
+      opacity $transition-duration-slow ease;
     z-index: 910;
     padding-top: calc(0.5 * $base-margin);
     pointer-events: auto;

--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -78,6 +78,10 @@
     height: calc(0.25 * $base-margin);
     background-color: var(--midground);
 
+    // Declared on the base so the X→hamburger reverse animation works too;
+    // when on .x alone, removing the class also removes the transition rule.
+    transition: all 100ms ease-in-out;
+
     &:not(:last-child) {
       margin-bottom: 5px;
     }
@@ -85,7 +89,6 @@
 }
 
 .x:nth-of-type(1) {
-  transition: all 100ms ease-in-out;
   transform: rotate(45deg);
   transform-origin: top left;
   width: 24px;
@@ -96,13 +99,11 @@
 }
 
 .x:nth-of-type(2) {
-  transition: all 100ms ease-in-out;
   transform-origin: center;
   width: 0;
 }
 
 .x:nth-of-type(3) {
-  transition: all 100ms ease-in-out;
   transform: rotate(-45deg);
   transform-origin: bottom left;
   width: 24px;

--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -69,6 +69,10 @@
   border: none;
   cursor: pointer;
 
+  // The button extends ~1rem left of the icon as a tap target; without this
+  // the mobile default tap-highlight paints a blue square to the left.
+  -webkit-tap-highlight-color: transparent;
+
   & span {
     display: block;
     height: calc(0.25 * $base-margin);

--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -80,7 +80,7 @@
 
     // Declared on the base so the X→hamburger reverse animation works too;
     // when on .x alone, removing the class also removes the transition rule.
-    transition: all 100ms ease-in-out;
+    transition: all $transition-duration-very-quick ease-in-out;
 
     &:not(:last-child) {
       margin-bottom: 5px;
@@ -361,7 +361,7 @@ $header-video-size: 188px;
     left: 0;
     top: 0;
     fill: var(--midground);
-    transition: opacity 0.1s ease;
+    transition: opacity $transition-duration-very-quick ease;
   }
 }
 

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -113,11 +113,11 @@
 
       &:focus {
         outline: none;
-        border-color: var(--secondary);
+        border-color: var(--midground);
       }
 
       &:focus-visible {
-        box-shadow: 0 0 0 1px var(--secondary);
+        box-shadow: 0 0 0 1px var(--midground);
       }
     }
 

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -287,7 +287,7 @@ test("Menu disappears gradually when scrolling down", async ({ page }) => {
   // Note: mouse.wheel() is not supported in mobile WebKit.
   await page.evaluate(() => window.scrollTo({ top: 200, behavior: "instant" }))
 
-  // The hide-above-screen class triggers a CSS opacity transition (0.45s).
+  // The hide-above-screen class triggers a CSS opacity transition.
   // Wait for the class to be applied and the transition to complete.
   await expect(navbar).toHaveClass(/hide-above-screen/)
   await expect(navbar).toHaveCSS("opacity", "0")

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -607,6 +607,12 @@ img {
   z-index: 1;
   background-color: var(--background);
 
+  // Sync with the navbar's translateY/opacity transition so the mobile
+  // backdrop fades alongside the bar instead of snapping in.
+  @media all and (max-width: $max-mobile-width) {
+    transition: background-color 0.45s ease;
+  }
+
   &:has(#navbar.hide-above-screen) {
     background-color: transparent;
   }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -610,7 +610,7 @@ img {
   // Sync with the navbar's translateY/opacity transition so the mobile
   // backdrop fades alongside the bar instead of snapping in.
   @media all and (max-width: $max-mobile-width) {
-    transition: background-color 0.45s ease;
+    transition: background-color $transition-duration-slow ease;
   }
 
   &:has(#navbar.hide-above-screen) {

--- a/quartz/styles/variables.ts
+++ b/quartz/styles/variables.ts
@@ -79,6 +79,7 @@ export const dropcapPaddingRight = "0.1em"
 
 // Design tokens — shared across SCSS files
 export const borderRadius = 5
+export const transitionDurationVeryQuick = "0.1s"
 export const transitionDurationQuick = "0.2s"
 export const transitionDurationMedium = "0.3s"
 export const transitionDurationSlow = "0.5s"
@@ -143,6 +144,7 @@ export const variables = {
   dropcapMinHeight,
   dropcapPaddingRight,
   borderRadius,
+  transitionDurationVeryQuick,
   transitionDurationQuick,
   transitionDurationMedium,
   transitionDurationSlow,


### PR DESCRIPTION
## Summary
This PR refines the mobile navbar animation experience and updates search input focus styling for better visual consistency.

## Key Changes
- **Navbar backdrop transition**: Added a fade transition to the mobile navbar backdrop that syncs with the navbar's hide animation, preventing the backdrop from snapping in/out abruptly
- **Transition duration consistency**: Extracted the hardcoded `0.45s` navbar transition duration into a `$transition-duration-slow` variable for better maintainability
- **Search focus styling**: Updated search input focus states to use `var(--midground)` instead of `var(--secondary)` for both border-color and box-shadow, providing more subtle focus indicators
- **Test documentation**: Updated test comment to remove hardcoded duration reference, making it more maintainable

## Implementation Details
- The backdrop transition is only applied on mobile devices (max-width: `$max-mobile-width`) to avoid unnecessary animations on desktop
- The transition uses the same easing and duration as the navbar for a cohesive animation
- The search styling change affects both `:focus` and `:focus-visible` states for consistent behavior across interaction methods

https://claude.ai/code/session_014UVGsZwcXU3jWYW6Bka2UP