### PR TITLE
fix: eliminate duplicate calls, stale DOM refs, and duplicated logic

### DIFF
--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -243,10 +243,9 @@ export const renderNextPostJsx = (fileData: QuartzPluginData) => {
  * Renders sequence information, including title, previous, and next posts.
  */
 export const renderSequenceInfo = (fileData: QuartzPluginData): JSX.Element | null => {
-  const sequenceTitle = renderSequenceTitleJsx(fileData)
-  if (!sequenceTitle) return null
-
   const sequenceTitleJsx = renderSequenceTitleJsx(fileData)
+  if (!sequenceTitleJsx) return null
+
   const previousPostJsx = renderPreviousPostJsx(fileData)
   const nextPostJsx = renderNextPostJsx(fileData)
 

--- a/quartz/components/scripts/hamburgerMenu.ts
+++ b/quartz/components/scripts/hamburgerMenu.ts
@@ -1,44 +1,62 @@
-const hamburger = document.querySelector("#menu-button")
-const menu = document.querySelector(".menu")
-const bars = document.querySelectorAll(".bar")
-
-function closeMenu() {
-  menu?.classList.remove("visible")
-  bars.forEach((bar) => bar.classList.remove("x"))
-  updateAriaExpanded()
-}
-
-function updateAriaExpanded() {
-  const isVisible = menu?.classList.contains("visible") ?? false
-  hamburger?.setAttribute("aria-expanded", String(isVisible))
-}
-
-// Toggle menu visibility and animate hamburger icon when clicked
-hamburger?.addEventListener("click", () => {
-  menu?.classList.toggle("visible")
-  bars.forEach((bar) => bar.classList.toggle("x")) // Hamburger animation
-  updateAriaExpanded()
-})
+let cleanupController: AbortController | null = null
 
 export function setupHamburgerMenu() {
+  if (cleanupController) {
+    cleanupController.abort()
+  }
+  cleanupController = new AbortController()
+  const { signal } = cleanupController
+
+  const hamburger = document.querySelector("#menu-button")
+  const menu = document.querySelector(".menu")
+  const bars = document.querySelectorAll(".bar")
+
+  function closeMenu() {
+    menu?.classList.remove("visible")
+    bars.forEach((bar) => bar.classList.remove("x"))
+    updateAriaExpanded()
+  }
+
+  function updateAriaExpanded() {
+    const isVisible = menu?.classList.contains("visible") ?? false
+    hamburger?.setAttribute("aria-expanded", String(isVisible))
+  }
+
+  // Toggle menu visibility and animate hamburger icon when clicked
+  hamburger?.addEventListener(
+    "click",
+    () => {
+      menu?.classList.toggle("visible")
+      bars.forEach((bar) => bar.classList.toggle("x"))
+      updateAriaExpanded()
+    },
+    { signal },
+  )
+
   // Handle clicks outside the menu to close it
-  document.addEventListener("click", (event) => {
-    // Check if the menu is visible and the click is outside the menu and hamburger
-    if (
-      menu?.classList.contains("visible") &&
-      !menu.contains(event.target as Node) &&
-      !hamburger?.contains(event.target as Node)
-    ) {
-      closeMenu()
-    }
-  })
+  document.addEventListener(
+    "click",
+    (event) => {
+      if (
+        menu?.classList.contains("visible") &&
+        !menu.contains(event.target as Node) &&
+        !hamburger?.contains(event.target as Node)
+      ) {
+        closeMenu()
+      }
+    },
+    { signal },
+  )
 
   // Close menu on Escape key
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && menu?.classList.contains("visible")) {
-      closeMenu()
-      // Return focus to the hamburger button
-      ;(hamburger as HTMLElement | null)?.focus()
-    }
-  })
+  document.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key === "Escape" && menu?.classList.contains("visible")) {
+        closeMenu()
+        ;(hamburger as HTMLElement | null)?.focus()
+      }
+    },
+    { signal },
+  )
 }

--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -155,7 +155,7 @@ function setupPondVideo(): void {
   // timeupdate events)
   const saveTimeThrottled = throttle(() => {
     sessionStorage.setItem(sessionStoragePondVideoKey, videoElement.currentTime.toString())
-  }, 2000)
+  }, 500)
   videoElement.addEventListener("timeupdate", saveTimeThrottled, { signal })
 }
 

--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -1,4 +1,5 @@
 import { sessionStoragePondVideoKey, autoplayStorageKey, pondVideoId } from "../constants"
+import { throttle } from "./component_script_utils"
 import { setupDarkMode } from "./darkmode"
 import { setupHamburgerMenu } from "./hamburgerMenu"
 import { setupScrollHandler } from "./scrollHandler"
@@ -149,14 +150,13 @@ function setupPondVideo(): void {
   window.addEventListener("beforeunload", saveTimestamp, { signal })
   window.addEventListener("pagehide", saveTimestamp, { signal })
 
-  // Save timestamp periodically during playback
-  videoElement.addEventListener(
-    "timeupdate",
-    () => {
-      sessionStorage.setItem(sessionStoragePondVideoKey, videoElement.currentTime.toString())
-    },
-    { signal },
-  )
+  // Save timestamp periodically during playback (throttled to avoid
+  // excessive synchronous sessionStorage writes from high-frequency
+  // timeupdate events)
+  const saveTimeThrottled = throttle(() => {
+    sessionStorage.setItem(sessionStoragePondVideoKey, videoElement.currentTime.toString())
+  }, 2000)
+  videoElement.addEventListener("timeupdate", saveTimeThrottled, { signal })
 }
 
 // Initial setup
@@ -169,6 +169,7 @@ setupAutoplayToggle()
 
 // Re-run setup functions after SPA navigation
 document.addEventListener("nav", () => {
+  setupHamburgerMenu()
   setupPondVideo()
   setupAutoplayToggle()
 })

--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -1,5 +1,4 @@
 import { sessionStoragePondVideoKey, autoplayStorageKey, pondVideoId } from "../constants"
-import { throttle } from "./component_script_utils"
 import { setupDarkMode } from "./darkmode"
 import { setupHamburgerMenu } from "./hamburgerMenu"
 import { setupScrollHandler } from "./scrollHandler"
@@ -150,13 +149,14 @@ function setupPondVideo(): void {
   window.addEventListener("beforeunload", saveTimestamp, { signal })
   window.addEventListener("pagehide", saveTimestamp, { signal })
 
-  // Save timestamp periodically during playback (throttled to avoid
-  // excessive synchronous sessionStorage writes from high-frequency
-  // timeupdate events)
-  const saveTimeThrottled = throttle(() => {
-    sessionStorage.setItem(sessionStoragePondVideoKey, videoElement.currentTime.toString())
-  }, 500)
-  videoElement.addEventListener("timeupdate", saveTimeThrottled, { signal })
+  // Save timestamp during playback
+  videoElement.addEventListener(
+    "timeupdate",
+    () => {
+      sessionStorage.setItem(sessionStoragePondVideoKey, videoElement.currentTime.toString())
+    },
+    { signal },
+  )
 }
 
 // Initial setup

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -862,14 +862,9 @@ async function handleLink(
       return
     }
 
-    const countKey = normalizePathForCounting(getQuartzPath(finalURL.hostname))
-    const count = faviconCounts.get(countKey) || 0
-
-    const isWhitelisted = faviconCountWhitelistComputed.some((entry) => imgPath.includes(entry))
-    if (!isWhitelisted && count < minFaviconCount) {
-      logger.debug(
-        `Favicon ${imgPath} (count key: ${countKey}) appears ${count} times (minimum ${minFaviconCount}), skipping`,
-      )
+    const countKey = getQuartzPath(finalURL.hostname)
+    if (!shouldIncludeFavicon(imgPath, countKey, faviconCounts)) {
+      logger.debug(`Favicon ${imgPath} (count key: ${countKey}) below threshold, skipping`)
       return
     }
 

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -32,12 +32,7 @@ const defaultOptions: Options = {
 function gatherAllText(tree: Root): string {
   let allText = ""
   visit(tree, (node) => {
-    if (
-      // @ts-expect-error: mixing AST node types
-      (node.type === "text" || node.type === "inlineCode") &&
-      "value" in node &&
-      typeof node.value === "string"
-    ) {
+    if ("value" in node && typeof node.value === "string") {
       allText += `${node.value} `
     }
   })

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -31,8 +31,15 @@ const defaultOptions: Options = {
  */
 function gatherAllText(tree: Root): string {
   let allText = ""
+  const textNodeTypes: ReadonlySet<string> = new Set([
+    "text",
+    "inlineCode",
+    "code",
+    "math",
+    "inlineMath",
+  ])
   visit(tree, (node) => {
-    if ("value" in node && typeof node.value === "string") {
+    if (textNodeTypes.has(node.type) && "value" in node && typeof node.value === "string") {
       allText += `${node.value} `
     }
   })


### PR DESCRIPTION
## Summary
- Fix several code quality issues found during a thorough codebase audit: a duplicate function call, stale DOM references after SPA navigation, duplicated favicon logic, and an unnecessary `@ts-expect-error`

## Changes
- **ContentMeta.tsx**: Remove duplicate `renderSequenceTitleJsx()` call that computed the same JSX twice per render
- **hamburgerMenu.ts**: Move DOM queries inside `setupHamburgerMenu()` so they re-query fresh elements after SPA navigation; use AbortController for proper listener cleanup (prevents accumulation)
- **navbar.inline.ts**: Re-run `setupHamburgerMenu()` on `nav` events so the menu works after SPA page transitions
- **favicons.ts**: Replace inlined whitelist/count/blacklist logic in `handleLink` with the existing `shouldIncludeFavicon()` helper — eliminates duplication and adds the previously-missing blacklist check
- **frontmatter.ts**: Replace `@ts-expect-error` with explicit `ReadonlySet` of wanted MDAST node types (`text`, `inlineCode`, `code`, `math`, `inlineMath`) for search indexing

## Testing
- All 3660 Jest tests pass with 100% branch coverage
- `pnpm check` (tsc + prettier + stylelint) passes clean
- All pre-push checks pass

https://claude.ai/code/session_014i9Wv3nc9Ksc5Eq5YVcmsp