### PR TITLE
fix: type safety, error handling, and CI filtering improvements

### DIFF
--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   should-run:
     name: lighthouse-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -32,7 +32,7 @@ jobs:
   # Skip entirely for bot actors (dependabot, renovate, etc.).
   should-run:
     name: playwright-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -270,8 +270,8 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
-            echo "Tests were skipped (no label)"
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+            echo "Tests were skipped (no label or filtered branch)"
             exit 0
           fi
           if [[ "${{ needs.playwright-tests-linux.result }}" != "success" ]]; then

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -287,8 +287,8 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
-            echo "Tests were skipped (no label)"
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+            echo "Tests were skipped (no label or filtered branch)"
             exit 0
           fi
           if [[ "${{ needs.visual-testing-linux.result }}" != "success" ]]; then

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -33,6 +33,7 @@ jobs:
   # which is needed for the unified "visual-testing" required status check.
   should-run:
     name: visual-should-run
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
       "shellcheck"
     ],
     "*.py": [
-      "ruff check --fix",
       "autoflake --in-place",
       "isort",
       "autopep8 --in-place",

--- a/quartz/components/Authors.tsx
+++ b/quartz/components/Authors.tsx
@@ -2,7 +2,6 @@ import React from "react"
 
 import type { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
-import { type GlobalConfiguration } from "../util/config"
 import { RenderPublicationInfo } from "./ContentMeta"
 
 // skipcq: JS-D1001
@@ -22,7 +21,7 @@ const Authors: QuartzComponent = ({ fileData, cfg }: QuartzComponentProps) => {
   const authorsText = `By ${formatAuthors(authorList)}`
 
   // Add the publication info
-  const publicationInfo = RenderPublicationInfo(cfg as GlobalConfiguration, fileData)
+  const publicationInfo = RenderPublicationInfo(cfg, fileData)
 
   return (
     <div className="authors">

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -190,7 +190,8 @@ export const renderTags = (props: QuartzComponentProps): JSX.Element => {
 export const renderSequenceTitleJsx = (fileData: QuartzPluginData) => {
   const sequence = fileData.frontmatter?.["lw-sequence-title"]
   if (!sequence) return null
-  const sequenceLink: string = fileData.frontmatter?.["sequence-link"] as string
+  const sequenceLink = fileData.frontmatter?.["sequence-link"] as string | undefined
+  if (!sequenceLink) return null
 
   return (
     <span>

--- a/quartz/components/tests/ContentMeta.test.tsx
+++ b/quartz/components/tests/ContentMeta.test.tsx
@@ -354,6 +354,14 @@ describe("renderSequenceTitleJsx", () => {
     expect(result).toBeNull()
   })
 
+  it("should return null if sequence title exists but link is missing", () => {
+    const fileData = createFileData({
+      "lw-sequence-title": SEQUENCE_TITLE,
+    })
+    const result = renderSequenceTitleJsx(fileData)
+    expect(result).toBeNull()
+  })
+
   it("should render sequence title", () => {
     const fileData = createFileData({
       "lw-sequence-title": SEQUENCE_TITLE,

--- a/quartz/plugins/emitters/aliases.test.ts
+++ b/quartz/plugins/emitters/aliases.test.ts
@@ -144,7 +144,7 @@ describe("AliasRedirects", () => {
       port: 3000,
       wsPort: 3001,
     },
-    cfg: {} as QuartzConfig,
+    cfg: { configuration: {} } as QuartzConfig,
     allSlugs: [],
   }
 

--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -2,7 +2,6 @@ import path from "path"
 
 import { locale } from "../../components/constants"
 import DepGraph from "../../depgraph"
-import { type GlobalConfiguration } from "../../util/config"
 import { renderHead } from "../../util/head"
 import { type FilePath, type FullSlug, joinSegments, resolveRelative } from "../../util/path"
 import { type QuartzEmitterPlugin } from "../types"
@@ -99,7 +98,7 @@ export const AliasRedirects: QuartzEmitterPlugin = () => ({
 
         // Generate redirect HTML with full metadata for SEO
         const redirectMetadata = renderHead({
-          cfg: ctx.cfg as unknown as GlobalConfiguration,
+          cfg: ctx.cfg.configuration,
           fileData: file.data,
           slug: file.data.slug as FullSlug,
           redirect: { slug, to: file.data.slug as FullSlug },

--- a/quartz/plugins/transformers/countFavicons.test.ts
+++ b/quartz/plugins/transformers/countFavicons.test.ts
@@ -315,16 +315,13 @@ describe("countAllLinks", () => {
     expect(renameCall[1]).toBe(faviconCountsFile)
   })
 
-  it("should handle write errors gracefully", async () => {
+  it("should propagate write errors", async () => {
     jest.spyOn(fs, "writeFileSync").mockImplementation(() => {
       throw new Error("Write failed")
     })
     const filePath = await createTestFile("[test](mailto:test@example.com)")
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined)
 
-    await expect(countAllFavicons(mockCtx, [filePath])).resolves.not.toThrow()
-
-    errorSpy.mockRestore()
+    await expect(countAllFavicons(mockCtx, [filePath])).rejects.toThrow("Write failed")
   })
 
   it("should reset counter at the start of each build run", async () => {
@@ -346,13 +343,10 @@ describe("countAllLinks", () => {
     expect(countsAfterSecondBuild.get(specialFaviconPaths.mail)).toBe(1)
   })
 
-  it("should handle invalid markdown files gracefully", async () => {
+  it("should propagate errors for missing files", async () => {
     const invalidPath = path.join(tempDir, "nonexistent.md") as FilePath
-    const errorSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined)
 
-    await expect(countAllFavicons(mockCtx, [invalidPath])).resolves.not.toThrow()
-
-    errorSpy.mockRestore()
+    await expect(countAllFavicons(mockCtx, [invalidPath])).rejects.toThrow()
   })
 
   it.each([

--- a/quartz/plugins/transformers/countFavicons.ts
+++ b/quartz/plugins/transformers/countFavicons.ts
@@ -107,13 +107,9 @@ function writeCountsToFile(): void {
 
   // Write atomically using a temporary file then rename
   const tempFile = `${faviconCountsFile}.tmp`
-  try {
-    fs.writeFileSync(tempFile, content, { flag: "w" })
-    fs.renameSync(tempFile, faviconCountsFile)
-    logger.info(`Wrote ${faviconCounter.size} favicon counts to ${faviconCountsFile}`)
-  } catch (error) {
-    logger.error(`Failed to write favicon counts file: ${error}`)
-  }
+  fs.writeFileSync(tempFile, content, { flag: "w" })
+  fs.renameSync(tempFile, faviconCountsFile)
+  logger.info(`Wrote ${faviconCounter.size} favicon counts to ${faviconCountsFile}`)
 }
 
 /**
@@ -164,15 +160,11 @@ export async function countAllFavicons(ctx: BuildCtx, filePaths: FilePath[]): Pr
   const processor = unified().use(remarkParse)
 
   for (const filePath of filePaths) {
-    try {
-      const file = await read(filePath)
-      const rawContent = file.value.toString().trim()
-      const transformedContent = applyTextTransforms(ctx, rawContent)
-      const tree = processor.parse(transformedContent) as MDRoot
-      countLinksInMarkdownTree(tree)
-    } catch (error) {
-      logger.error(`Failed to count links in ${filePath}: ${error}`)
-    }
+    const file = await read(filePath)
+    const rawContent = file.value.toString().trim()
+    const transformedContent = applyTextTransforms(ctx, rawContent)
+    const tree = processor.parse(transformedContent) as MDRoot
+    countLinksInMarkdownTree(tree)
   }
 
   writeCountsToFile()

--- a/quartz/util/head.ts
+++ b/quartz/util/head.ts
@@ -53,7 +53,7 @@ function renderImageTags(cardImage: string, altText: string | undefined): string
     <meta property="og:image" content="${escapeHTML(cardImage)}" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="${escapeHTML(altText as string)}" />
+    <meta property="og:image:alt" content="${escapeHTML(altText ?? "")}" />
   `
 }
 

--- a/quartz/util/head.ts
+++ b/quartz/util/head.ts
@@ -48,12 +48,12 @@ export function maybeProduceVideoTag(videoPreview: string | undefined): string {
 }
 
 // skipcq: JS-D1001
-function renderImageTags(cardImage: string, altText: string | undefined): string {
+function renderImageTags(cardImage: string, altText: string): string {
   return `
     <meta property="og:image" content="${escapeHTML(cardImage)}" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="${escapeHTML(altText ?? "")}" />
+    <meta property="og:image:alt" content="${escapeHTML(altText)}" />
   `
 }
 


### PR DESCRIPTION
## Summary
- Fix a real bug in alias redirect generation where `ctx.cfg` (QuartzConfig) was passed instead of `ctx.cfg.configuration` (GlobalConfiguration), hidden by a double `as unknown as` cast
- Remove error-swallowing in favicon counting that violated the codebase's "fail loudly" principle, causing silent build corruption
- Add missing bot/branch filters to 3 CI workflows and harden unified status checks to handle skipped gate jobs

## Changes
- **aliases.ts**: Fix `ctx.cfg as unknown as GlobalConfiguration` → `ctx.cfg.configuration` (real bug — `cfg.baseUrl` resolved as `undefined`, masked by fallback)
- **countFavicons.ts**: Remove try/catch that swallowed write errors and per-file parse errors, letting them propagate and fail the build
- **head.ts**: Tighten `renderImageTags` parameter from `string | undefined` to `string` (callers always provide a defined value)
- **ContentMeta.tsx**: Add null check for missing `sequence-link` frontmatter to prevent rendering `<a href={undefined}>`
- **Authors.tsx**: Remove redundant `as GlobalConfiguration` cast and unused import
- **package.json**: Remove duplicate `ruff check --fix` from lint-staged Python pipeline
- **playwright-tests.yaml, visual-testing.yaml, lighthouse-layout-shift.yaml**: Add `!startsWith(github.head_ref, 'deepsource-')` filter to `should-run` gate (consistent with a11y, site-build-checks)
- **playwright-tests.yaml, visual-testing.yaml**: Handle `needs.should-run.result == 'skipped'` in unified status check so filtered branches don't fail the required check

## Testing
- All 3661 Jest tests pass with 100% coverage thresholds met
- `pnpm check` passes (TypeScript type checking, Prettier, Stylelint)
- All pre-push checks pass
- Added test for `renderSequenceTitleJsx` with sequence title but missing link

https://claude.ai/code/session_01CrisHqjQBcSHuGDvJntNxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrisHqjQBcSHuGDvJntNxF)_