### PR TITLE
refactor: trim dead SSR guard and obvious WHAT comments

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -262,7 +262,6 @@ async function partialRebuildFromEntrypoint(
         // only content files can have added/removed dependencies because of transclusions
         if (path.extname(fp) === ".md") {
           for (const emitter of cfg.plugins.emitters) {
-            // get new dependencies from all emitters for this file
             const emitterGraph =
               (await emitter.getDependencyGraph?.(ctx, processedFiles, staticResources)) ?? null
 
@@ -331,9 +330,8 @@ async function partialRebuildFromEntrypoint(
         const upstreams = [...depGraph.getLeafNodeAncestors(fp)] as FilePath[]
 
         const upstreamContent = upstreams
-          // filter out non-markdown files
           .filter((file) => contentMap.has(file))
-          // if file was deleted, don't give it to the emitter
+          // skip deleted files so the emitter doesn't see stale paths
           .filter((file) => !toRemove.has(file))
           .map((file) => contentMap.get(file) || [])
           .filter((content) => content.length > 0)

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -386,7 +386,6 @@ export function renderPage(
     }
   })
 
-  // set componentData.tree to the edited html that has transclusions rendered
   componentData.tree = root
 
   const { head: Head, beforeBody, pageBody: Content, left, right } = components

--- a/quartz/components/scripts/spa_utils.ts
+++ b/quartz/components/scripts/spa_utils.ts
@@ -6,16 +6,10 @@
  */
 export function isLocalUrl(href: string): boolean {
   try {
-    // Provide the current location as the base URL for resolving protocol-relative URLs
+    // Base URL resolves protocol-relative and relative inputs against the current page
     const url = new URL(href, window.location.href)
-    /* istanbul ignore next -- SSR guard: typeof window is always defined in jsdom */
-    if (typeof window !== "undefined" && window.location) {
-      if (window.location.origin === url.origin) {
-        return true
-      }
-    }
+    return window.location.origin === url.origin
   } catch {
-    // Malformed URLs or environments without window.location will return false
+    return false
   }
-  return false
 }

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -24,8 +24,8 @@ import {
 import { type QuartzEmitterPlugin } from "../types"
 import { write } from "./helpers"
 
-// get all the dependencies for the markdown file
-// eg. images, scripts, stylesheets, transclusions
+// Walks the rendered tree to collect referenced local assets (images, scripts,
+// stylesheets, transclusions) so the dep graph can re-emit on changes.
 const parseDependencies = (argv: Argv, hast: Root, file: VFile): string[] => {
   const dependencies: FilePath[] = []
 

--- a/quartz/plugins/index.ts
+++ b/quartz/plugins/index.ts
@@ -18,7 +18,6 @@ export function getStaticResourcesFromPlugins(ctx: BuildCtx) {
     }
   }
 
-  // if serving locally, listen for rebuilds and reload the page
   if (ctx.argv.serve) {
     const wsUrl = ctx.argv.remoteDevHost
       ? `wss://${ctx.argv.remoteDevHost}:${ctx.argv.wsPort}`


### PR DESCRIPTION
- spa_utils.isLocalUrl: remove unreachable typeof window guard (the
  function only runs in the browser; the istanbul ignore confirmed it
  was dead code) and collapse the early-return-via-if into a direct
  return for clarity.
- Drop a handful of comments that just restated the next line of code
  (build.ts, renderPage.tsx, plugins/index.ts) and rewrite contentPage's
  parseDependencies header to explain WHY rather than WHAT.

https://claude.ai/code/session_01Wxu8PmmSd2UyS7AfLKEcoK