### PR TITLE
Improve link rendering with special characters and favicon spacing

### DIFF
--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -623,7 +623,7 @@ export function insertFavicon(imgPath: string | null, node: Element): void {
 // Glyphs where top-right corner is occupied (ascenders with rightward
 // hooks/crossbars, tall punctuation) and which therefore visually crowd the
 // favicon without extra spacing.
-export const charsToSpace = ["!", "?", "|", "]", '"', "”", "’", "'", "f", "t", "r"]
+export const charsToSpace = ["!", "?", "|", "]", '"', "”", "’", "'", "f", "t", "q"]
 export const tagsToZoomInto = ["code", "em", "strong", "i", "b", "del", "s", "ins", "abbr"]
 
 /**

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -623,21 +623,7 @@ export function insertFavicon(imgPath: string | null, node: Element): void {
 // Glyphs where top-right corner is occupied (ascenders with rightward
 // hooks/crossbars, tall punctuation) and which therefore visually crowd the
 // favicon without extra spacing.
-export const charsToSpace = [
-  "!",
-  "?",
-  "|",
-  "]",
-  '"',
-  "”",
-  "’",
-  "'",
-  "f",
-  "q",
-  ":",
-  ";",
-  "/",
-]
+export const charsToSpace = ["!", "?", "|", "]", '"', "”", "’", "'", "f", "q", ":", ";", "/"]
 export const tagsToZoomInto = ["code", "em", "strong", "i", "b", "del", "s", "ins", "abbr"]
 
 /**

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -623,7 +623,21 @@ export function insertFavicon(imgPath: string | null, node: Element): void {
 // Glyphs where top-right corner is occupied (ascenders with rightward
 // hooks/crossbars, tall punctuation) and which therefore visually crowd the
 // favicon without extra spacing.
-export const charsToSpace = ["!", "?", "|", "]", '"', "”", "’", "'", "f", "t", "q"]
+export const charsToSpace = [
+  "!",
+  "?",
+  "|",
+  "]",
+  '"',
+  "”",
+  "’",
+  "'",
+  "f",
+  "q",
+  ":",
+  ";",
+  "/",
+]
 export const tagsToZoomInto = ["code", "em", "strong", "i", "b", "del", "s", "ins", "abbr"]
 
 /**

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -543,6 +543,8 @@ Links ending [with code tags should still wrap OK: `code.`](#external-links-with
 | [ab-](https://npmjs.com)   | [ab/](https://npmjs.com)   | [ab\\](https://npmjs.com)  | [ab\|](https://npmjs.com)  | [ab&](https://npmjs.com)   | [ab\*](https://npmjs.com)  |
 | [ab@](https://npmjs.com)   | [ab#](https://npmjs.com)   | [ab%](https://npmjs.com)   | [ab$](https://npmjs.com)   | [ab+](https://npmjs.com)   | [ab=](https://npmjs.com)   |
 | [ab\<](https://npmjs.com)  | [ab\>](https://npmjs.com)  | [ab~](https://npmjs.com)   | [ab^](https://npmjs.com)   | [ab\_](https://npmjs.com)  | <a href="https://npmjs.com">ab&#96;</a> |
+| [ab…](https://npmjs.com)   | [ab—](https://npmjs.com)   | [ab–](https://npmjs.com)   | [ab′](https://npmjs.com)   | [ab″](https://npmjs.com)   | [ab°](https://npmjs.com)   |
+| [ab→](https://npmjs.com)   | [ab×](https://npmjs.com)   | [ab™](https://npmjs.com)   | [ab©](https://npmjs.com)   | [ab®](https://npmjs.com)   | [ab⁉](https://npmjs.com)   |
 
 # Typography
 

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -544,7 +544,7 @@ Links ending [with code tags should still wrap OK: `code.`](#external-links-with
 | [ab@](https://npmjs.com)   | [ab#](https://npmjs.com)   | [ab%](https://npmjs.com)   | [ab$](https://npmjs.com)   | [ab+](https://npmjs.com)   | [ab=](https://npmjs.com)   |
 | [ab\<](https://npmjs.com)  | [ab\>](https://npmjs.com)  | [ab~](https://npmjs.com)   | [ab^](https://npmjs.com)   | [ab\_](https://npmjs.com)  | <a href="https://npmjs.com">ab&#96;</a> |
 | [ab…](https://npmjs.com)   | [ab—](https://npmjs.com)   | [ab–](https://npmjs.com)   | [ab′](https://npmjs.com)   | [ab″](https://npmjs.com)   | [ab°](https://npmjs.com)   |
-| [ab→](https://npmjs.com)   | [ab×](https://npmjs.com)   | [ab™](https://npmjs.com)   | [ab©](https://npmjs.com)   | [ab®](https://npmjs.com)   | [ab⁉](https://npmjs.com)   |
+| [ab→](https://npmjs.com)   | [ab×](https://npmjs.com)   | [ab™](https://npmjs.com)   | [ab©](https://npmjs.com)   | [ab®](https://npmjs.com)   | [ab⁇](https://npmjs.com)   |
 
 # Typography
 

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -542,7 +542,7 @@ Links ending [with code tags should still wrap OK: `code.`](#external-links-with
 | [ab(](https://npmjs.com)   | [ab)](https://npmjs.com)   | [ab\[](https://npmjs.com)  | [ab\]](https://npmjs.com)  | [ab\{](https://npmjs.com)  | [ab\}](https://npmjs.com)  |
 | [ab-](https://npmjs.com)   | [ab/](https://npmjs.com)   | [ab\\](https://npmjs.com)  | [ab\|](https://npmjs.com)  | [ab&](https://npmjs.com)   | [ab\*](https://npmjs.com)  |
 | [ab@](https://npmjs.com)   | [ab#](https://npmjs.com)   | [ab%](https://npmjs.com)   | [ab$](https://npmjs.com)   | [ab+](https://npmjs.com)   | [ab=](https://npmjs.com)   |
-| [ab\<](https://npmjs.com)  | [ab\>](https://npmjs.com)  | [ab~](https://npmjs.com)   | [ab^](https://npmjs.com)   | [ab\_](https://npmjs.com)  | [ab\`](https://npmjs.com)  |
+| [ab\<](https://npmjs.com)  | [ab\>](https://npmjs.com)  | [ab~](https://npmjs.com)   | [ab^](https://npmjs.com)   | [ab\_](https://npmjs.com)  | <a href="https://npmjs.com">ab&#96;</a> |
 
 # Typography
 


### PR DESCRIPTION
## Summary
This PR improves the handling of special characters in links and refines favicon spacing logic by updating test cases and character configuration.

## Key Changes
- **Test page updates**: Added comprehensive test cases for links containing special Unicode characters (ellipsis, dashes, primes, arrows, multiplication, trademark, copyright, registered trademark symbols) and fixed the backtick link rendering to use HTML entity syntax
- **Favicon spacing refinement**: Updated the `charsToSpace` character list to better identify glyphs that visually crowd favicons, replacing "t" and "r" with "q", ":", ";", and "/" for more accurate spacing calculations

## Implementation Details
- The backtick character in the test table is now rendered using `&#96;` HTML entity within an anchor tag instead of markdown link syntax, likely to avoid parsing conflicts
- The favicon spacing character list was adjusted based on visual analysis of which characters have top-right corner occupation that requires extra spacing to prevent crowding

https://claude.ai/code/session_0134jnrsVqyhH77KW4MdFa65