### PR TITLE
Add Python installation option to visual testing setup

### DIFF
--- a/.github/actions/setup-visual-testing-env/action.yaml
+++ b/.github/actions/setup-visual-testing-env/action.yaml
@@ -5,6 +5,10 @@ inputs:
     description: "Whether to install Playwright and its dependencies"
     required: false
     default: "false"
+  install-python:
+    description: "Whether to install Python and uv (needed for r2_baselines.py)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -20,7 +24,7 @@ runs:
         cache-playwright: "true"
         cache-puppeteer: "true"
         cache-apt: ${{ inputs.install-playwright }}
-        install-python: "false"
+        install-python: ${{ inputs.install-python }}
 
     - name: Install Playwright system dependencies (Linux)
       if: inputs.install-playwright == 'true' && runner.os == 'Linux'

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: ./.github/actions/setup-visual-testing-env
         with:
           install-playwright: "true"
+          install-python: "true"
 
       - name: Install browsers
         run: pnpm run install-browsers
@@ -91,6 +92,7 @@ jobs:
         uses: ./.github/actions/setup-visual-testing-env
         with:
           install-playwright: "false"
+          install-python: "true"
 
       - name: Install Playwright WebKit browser
         run: pnpm exec playwright install webkit

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -79,6 +79,7 @@ jobs:
         uses: ./.github/actions/setup-visual-testing-env
         with:
           install-playwright: "true"
+          install-python: "true"
 
       - name: Create Winston logs directory
         run: mkdir -p .logs
@@ -205,6 +206,7 @@ jobs:
         uses: ./.github/actions/setup-visual-testing-env
         with:
           install-playwright: "false"
+          install-python: "true"
 
       - name: Create Winston logs directory
         run: mkdir -p .logs

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -180,7 +180,7 @@ Quartz offers basic optimizations, such as [lazy loading](https://developer.mozi
 
 EB Garamond Regular 8pt takes 260KB as an `otf` file but compresses to 80KB under [the newer `woff2` format.](https://www.w3.org/TR/WOFF2/) In all, the font footprint shrinks from 1.5MB to about 609KB for most pages. I toyed around with manual [font subsetting](https://fonts.google.com/knowledge/glossary/subsetting) but it seemed too hard to predict which characters my site _never_ uses.
 
-Therefore, I use [my optimized fork of `subfont`](/open-source#faster-font-subsetting) to subset each font across my entire website, dropping unused OpenType tables and CSS-unreferenced features along the way.
+Therefore, I use [my optimized fork of `subfont`](/open-source#faster-font-subsetting) to subset each font across my entire website, dropping unused OpenType tables and font features the CSS never references.
 
 <span class="populate-markdown-font-stats"></span>
 


### PR DESCRIPTION
## Summary
This PR adds support for installing Python and `uv` in the visual testing environment setup action, enabling workflows that need to run Python-based tools like `r2_baselines.py`.

## Key Changes
- Added `install-python` input parameter to the `setup-visual-testing-env` action with a default value of `"false"`
- Updated the action to pass the `install-python` input to the underlying setup action instead of hardcoding it to `"false"`
- Enabled Python installation in three workflows that require it:
  - `update-visual-baselines.yaml`: Both the baseline update job and the comparison job
  - `visual-testing.yaml`: Both the main visual testing job and the comparison job
- Fixed a minor grammar issue in `design.md` for consistency

## Implementation Details
The change maintains backward compatibility by defaulting `install-python` to `"false"`. Workflows that need Python support explicitly opt-in by setting `install-python: "true"` when using the setup action.

https://claude.ai/code/session_01GQTWAD4pipcwQwfhDy9hF3