### PR TITLE
Add Jest --collect-only flag contribution to open source page

### DIFF
--- a/website_content/open-source.md
+++ b/website_content/open-source.md
@@ -160,6 +160,10 @@ When math content becomes scrollable (e.g. via CSS overflow), it cannot be focus
 
 KaTeX emits many CSS classes (`mord`, `mbin`, `mrel`, etc.) that appear in the final HTML output even though no CSS rules reference them. [PR #4164](https://github.com/KaTeX/KaTeX/pull/4164) strips these build-time-only classes from the rendered output, reducing the KaTeX DOM footprint by ~15%.
 
+## Jest `--collect-only` flag
+
+Jest lacked a way to enumerate test cases without running them, unlike `pytest --collect-only`. [PR #16006](https://github.com/jestjs/jest/pull/16006) adds a `--collect-only` flag that loads test files, registers all `describe`/`test`/`it` blocks, prints the discovered tests as a tree (or JSON), and exits without executing any test callbacks.
+
 ## SCSS linting rule
 
 I contributed a rule to [stylelint-scss](https://github.com/stylelint-scss/stylelint-scss). I ran into the following issue:

--- a/website_content/open-source.md
+++ b/website_content/open-source.md
@@ -162,7 +162,7 @@ KaTeX emits many CSS classes (`mord`, `mbin`, `mrel`, etc.) that appear in the f
 
 ## Jest `--collect-only` flag
 
-Jest lacked a way to enumerate test cases without running them, unlike `pytest --collect-only`. [PR #16006](https://github.com/jestjs/jest/pull/16006) adds a `--collect-only` flag that loads test files, registers all `describe`/`test`/`it` blocks, prints the discovered tests as a tree (or JSON), and exits without executing any test callbacks.
+Jest lacked a way to enumerate test cases without running them, unlike `pytest --collect-only`. [PR #16006](https://github.com/jestjs/jest/pull/16006) fixed that.
 
 ## SCSS linting rule
 


### PR DESCRIPTION
## Summary
Added documentation of a Jest contribution to the open source contributions page, highlighting the implementation of the `--collect-only` flag feature.

## Changes
- Added a new section documenting the Jest `--collect-only` flag contribution
- Explains that Jest previously lacked a way to enumerate test cases without running them, unlike pytest's `--collect-only` functionality
- References PR #16006 in the Jest repository where this feature was implemented
- Positioned between the KaTeX CSS classes optimization and SCSS linting rule sections

## Details
This addition documents a contribution that brings Jest's test discovery capabilities closer to feature parity with pytest, allowing developers to list test cases without executing them—a useful feature for test analysis and CI/CD workflows.

https://claude.ai/code/session_01QgMtCbZEBtxjzdUzYYLhc5