### PR TITLE
fix: code quality audit — deduplicate escapeHtml, fix shared refs, harden date validation

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -175,7 +175,7 @@ export default (() => {
         <link rel="stylesheet" href="/index.css" spa-preserve />
         {headJsx}
         {fileData.frontmatter?.avoidIndexing && (
-          <meta name="robots" content="noindex, noimageindex,nofollow" />
+          <meta name="robots" content="noindex, noimageindex, nofollow" />
         )}
         <link rel="stylesheet" href="/static/styles/katex.min.css" spa-preserve />
         {iconPreloads}

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -167,7 +167,7 @@ export function createPageListHast(
   allFiles: QuartzPluginData[],
   limit?: number,
 ): Element {
-  let list = allFiles.sort(byDateAndAlphabetical(cfg))
+  let list = [...allFiles].sort(byDateAndAlphabetical(cfg))
   if (limit) {
     list = list.slice(0, limit)
   }

--- a/quartz/components/scripts/component_script_utils.test.ts
+++ b/quartz/components/scripts/component_script_utils.test.ts
@@ -1,7 +1,6 @@
 import { jest, describe, it, beforeEach, afterEach, expect } from "@jest/globals"
 
 import {
-  escapeHtml,
   throttle,
   debounce,
   animate,
@@ -49,23 +48,6 @@ afterEach(() => {
   if (rafMap) {
     rafMap.clear()
   }
-})
-
-describe("escapeHtml", () => {
-  it.each([
-    ["&", "&amp;"],
-    ["<", "&lt;"],
-    [">", "&gt;"],
-    ['"', "&quot;"],
-    ["'", "&#39;"],
-    ['<script>alert("xss")</script>', "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"],
-    ["no special chars", "no special chars"],
-    ["", ""],
-    ["a & b < c > d", "a &amp; b &lt; c &gt; d"],
-    [`it's a "test"`, "it&#39;s a &quot;test&quot;"],
-  ])("escapes %j to %j", (input, expected) => {
-    expect(escapeHtml(input)).toBe(expected)
-  })
 })
 
 describe("throttle", () => {

--- a/quartz/components/scripts/component_script_utils.ts
+++ b/quartz/components/scripts/component_script_utils.ts
@@ -1,13 +1,3 @@
-/** Escape HTML special characters for safe insertion into innerHTML. */
-export function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-}
-
 /**
  * Limits how often a function can be called. Once called, subsequent calls within
  * the delay period will be ignored or queued for the next frame.

--- a/quartz/components/scripts/punctilio-demo-diff.ts
+++ b/quartz/components/scripts/punctilio-demo-diff.ts
@@ -1,6 +1,6 @@
 import { diffChars, diffLines, type Change } from "diff"
 
-import { escapeHtml } from "./component_script_utils"
+import { escapeHTML } from "../../util/escape"
 
 // Per-changed-line-pair cap for Myers char-diff. Beyond this combined length,
 // we fall back to a linear prefix+suffix diff — which highlights the divergent
@@ -10,7 +10,7 @@ import { escapeHtml } from "./component_script_utils"
 export const MAX_CHAR_DIFF_LENGTH = 4_000
 
 export function escapeForOutput(text: string): string {
-  return escapeHtml(text).replace(/\n/g, "<br>")
+  return escapeHTML(text).replace(/\n/g, "<br>")
 }
 
 /** Render char-level Myers changes, keeping only additions (green) and unchanged text. */

--- a/quartz/components/tests/Head.test.tsx
+++ b/quartz/components/tests/Head.test.tsx
@@ -271,7 +271,7 @@ describe("Head Component", () => {
       const html = render(h(Head, propsWithIndexing))
 
       expect(html).toContain('name="robots"')
-      expect(html).toContain("noindex, noimageindex,nofollow")
+      expect(html).toContain("noindex, noimageindex, nofollow")
     })
 
     it("should not include robots meta when avoidIndexing is false", () => {

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -7,7 +7,7 @@ import { toHtml } from "hast-util-to-html"
 import { h } from "hastscript"
 import { render } from "preact-render-to-string"
 import { quote } from "shell-quote"
-import { visit } from "unist-util-visit"
+import { EXIT, visit } from "unist-util-visit"
 
 import { simpleConstants, specialFaviconPaths, cdnBaseUrl } from "../../components/constants"
 import { renderPostStatistics } from "../../components/ContentMeta"
@@ -47,6 +47,7 @@ export const findElementById = (root: Root, id: string): Element | null => {
   visit(root, "element", (node) => {
     if (node.properties?.id === id) {
       found = node
+      return EXIT
     }
   })
   return found
@@ -380,7 +381,7 @@ export const populateElements = async (
       logger.debug(`Populating ${elements.length} element(s) with class .${config.className}`)
       const content = await config.generator()
       for (const element of elements) {
-        element.children = content
+        element.children = structuredClone(content)
         populatedElements.push(element)
       }
       logger.debug(`Added ${content.length} elements to each .${config.className}`)

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -404,7 +404,10 @@ export function identifyLinkNode(node: Element): Element | null {
   if (node.tagName === "a") {
     return node
   } else if (node.children && node.children.length > 0) {
-    return identifyLinkNode(node.children[node.children.length - 1] as Element)
+    const lastChild = node.children[node.children.length - 1]
+    if (lastChild.type === "element") {
+      return identifyLinkNode(lastChild)
+    }
   }
   return null
 }

--- a/quartz/plugins/transformers/lastmod.test.ts
+++ b/quartz/plugins/transformers/lastmod.test.ts
@@ -32,6 +32,15 @@ describe("coerceDate", () => {
     expect(() => coerceDate("test.md", input)).toThrow("Invalid date")
   })
 
+  it.each([
+    ["month 13", "2024-13-01"],
+    ["month 0", "2024-00-15"],
+    ["day 0", "2024-06-00"],
+    ["day 32", "2024-06-32"],
+  ])("throws for out-of-range date component: %s", (_, input) => {
+    expect(() => coerceDate("test.md", input)).toThrow("month must be 1-12 and day must be 1-31")
+  })
+
   it("includes file path and documentation link in error", () => {
     expect(() => coerceDate("my/custom/path.md", "invalid")).toThrow("my/custom/path.md")
     expect(() => coerceDate("test.md", "invalid")).toThrow(

--- a/quartz/plugins/transformers/lastmod.test.ts
+++ b/quartz/plugins/transformers/lastmod.test.ts
@@ -41,6 +41,15 @@ describe("coerceDate", () => {
     expect(() => coerceDate("test.md", input)).toThrow("month must be 1-12 and day must be 1-31")
   })
 
+  it.each([
+    ["Feb 30", "2024-02-30"],
+    ["Feb 31", "2024-02-31"],
+    ["Apr 31", "2024-04-31"],
+    ["Jun 31", "2024-06-31"],
+  ])("throws for day overflow: %s", (_, input) => {
+    expect(() => coerceDate("test.md", input)).toThrow("day is out of range for the given month")
+  })
+
   it("includes file path and documentation link in error", () => {
     expect(() => coerceDate("my/custom/path.md", "invalid")).toThrow("my/custom/path.md")
     expect(() => coerceDate("test.md", "invalid")).toThrow(

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -13,7 +13,12 @@ export function coerceDate(fp: string, d: MaybeDate): Date {
     const match = DAY_ONLY_DATE_RE.exec(d)
     if (match?.groups) {
       const { year, month, day } = match.groups
-      parsedDate = new Date(Number(year), Number(month) - 1, Number(day))
+      const monthNum = Number(month)
+      const dayNum = Number(day)
+      if (monthNum < 1 || monthNum > 12 || dayNum < 1 || dayNum > 31) {
+        throw new Error(`Invalid date "${d}" in \`${fp}\`: month must be 1-12 and day must be 1-31`)
+      }
+      parsedDate = new Date(Number(year), monthNum - 1, dayNum)
     } else {
       parsedDate = new Date(d)
     }

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -19,6 +19,9 @@ export function coerceDate(fp: string, d: MaybeDate): Date {
         throw new Error(`Invalid date "${d}" in \`${fp}\`: month must be 1-12 and day must be 1-31`)
       }
       parsedDate = new Date(Number(year), monthNum - 1, dayNum)
+      if (parsedDate.getMonth() !== monthNum - 1 || parsedDate.getDate() !== dayNum) {
+        throw new Error(`Invalid date "${d}" in \`${fp}\`: day is out of range for the given month`)
+      }
     } else {
       parsedDate = new Date(d)
     }

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1658,6 +1658,16 @@ describe("identifyLinkNode", () => {
     const node = createNode("div", [createNode("span"), createNode("em"), createNode("strong")])
     expect(identifyLinkNode(node)).toBeNull()
   })
+
+  it("should return null when last child is a text node", () => {
+    const node: Element = {
+      type: "element",
+      tagName: "div",
+      properties: {},
+      children: [createNode("a"), { type: "text", value: " trailing" }],
+    }
+    expect(identifyLinkNode(node)).toBeNull()
+  })
 })
 
 describe("moveQuotesBeforeLink", () => {


### PR DESCRIPTION
## Summary
- Thorough code audit across the TypeScript codebase found and fixed several correctness issues: a duplicate utility function, a shared mutable reference bug, an unsafe type cast, a mutating sort on caller data, silent date overflow, and inconsistent meta tag formatting.
- Adds 9 new tests covering the fixed edge cases.

## Changes

### Bug fixes
- **Remove duplicate `escapeHtml`**: `component_script_utils.ts` had its own `escapeHtml` duplicating `escapeHTML` from `util/escape.ts`. Removed the duplicate and updated `punctilio-demo-diff.ts` to import the canonical version.
- **Fix shared mutable reference in `populateContainers`**: When multiple elements share a CSS class, they were all assigned the *same* `content` array reference. Downstream mutation by `addFaviconsToLinks` would corrupt all elements. Now uses `structuredClone` to give each element its own copy.
- **Add early `EXIT` in `findElementById`**: Tree traversal now stops once the target element is found instead of walking the entire HAST tree.
- **Add type guard in `identifyLinkNode`**: Replaced unsafe `as Element` cast with a `type === "element"` check, preventing potential issues when the last child is a text node.
- **Prevent caller array mutation in `PageList`**: `allFiles.sort()` was mutating the passed-in array. Now copies with `[...allFiles].sort()`.
- **Harden date validation in `coerceDate`**: Validates month (1–12) and day (1–31) ranges, and catches silent JS Date rollover (e.g., Feb 31 → Mar 3) by verifying the constructed Date matches the input components.
- **Fix robots meta tag spacing**: `"noindex, noimageindex,nofollow"` → `"noindex, noimageindex, nofollow"` for spec-consistent comma-separated formatting.

### Tests added
- 4 tests for out-of-range month/day values (month 0, month 13, day 0, day 32)
- 4 tests for day-of-month overflow (Feb 30, Feb 31, Apr 31, Jun 31)
- 1 test for `identifyLinkNode` with a trailing text node

## Testing
- All 3,668 tests pass (9 new, 0 removed net — duplicate `escapeHtml` tests deleted since covered by `util/escape.test.ts`)
- `pnpm check` passes (type-check, Prettier, Stylelint)
- Pre-push checks all pass

https://claude.ai/code/session_01S3UToJmna1nb2BZyWfc8f1

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3UToJmna1nb2BZyWfc8f1)_