### PR TITLE
Refactor print theme comparison test to use direct screenshots

### DIFF
--- a/quartz/components/tests/print.spec.ts
+++ b/quartz/components/tests/print.spec.ts
@@ -30,10 +30,13 @@ test("Print media layout (screenshot)", async ({ page }, testInfo) => {
   await takeRegressionScreenshot(page, testInfo, "print-layout")
 })
 
-test("Print mode renders identically in light and dark themes", async ({ page }, testInfo) => {
+test("Print mode renders identically in light and dark themes", async ({ page }) => {
   await setTheme(page, "light")
   await page.emulateMedia({ media: "print" })
-  const lightScreenshot = await takeRegressionScreenshot(page, testInfo, "print-light-vs-dark")
+  const lightScreenshot = await page.screenshot({
+    animations: "disabled",
+    scale: "css",
+  })
 
   await page.emulateMedia({ media: "screen" })
   await setTheme(page, "dark")


### PR DESCRIPTION
## Summary
Refactored the print mode theme comparison test to use direct screenshot capture instead of the regression screenshot utility, allowing for more granular control over screenshot parameters.

## Key Changes
- Removed `testInfo` parameter from test function signature as it's no longer needed
- Replaced `takeRegressionScreenshot()` call with direct `page.screenshot()` call for the light theme capture
- Added explicit screenshot options: `animations: "disabled"` and `scale: "css"` to ensure consistent rendering

## Implementation Details
This change simplifies the test by removing the dependency on the regression screenshot utility for this particular comparison, giving the test more direct control over how screenshots are captured. The explicit animation and scale settings ensure consistent, deterministic screenshot output for the light vs. dark theme comparison.

https://claude.ai/code/session_01UL2YngCHzA77iQc5crMR3i