### PR TITLE
Improve rclone installation and retry resilience for R2 uploads

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -62,13 +62,16 @@ uv_install_if_missing alt-text-llm
 if is_root; then
 	# Map: command-to-probe -> apt package name. ffmpeg/imagemagick are
 	# needed by scripts/tests/test_compress.py et al. (the Stop hook runs
-	# pytest, and ~75 tests + 60 errors fall over without them).
+	# pytest, and ~75 tests + 60 errors fall over without them). rclone is
+	# needed by scripts/r2_upload.py and scripts/r2_baselines.py (and the
+	# pre-push hook's R2 asset uploads).
 	declare -A apt_needed=(
 		[shellcheck]=shellcheck
 		[fish]=fish
 		[ffmpeg]=ffmpeg
 		[convert]=imagemagick
 		[exiftool]=libimage-exiftool-perl
+		[rclone]=rclone
 	)
 	apt_pkgs=()
 	for cmd in "${!apt_needed[@]}"; do
@@ -114,16 +117,14 @@ fi
 
 #######################################
 # rclone (needed for R2 asset uploads in pre-push hook)
+#
+# Install via apt above (bundled with other system deps for atomicity).
+# Non-root sandboxes fall back to the official installer.
 #######################################
 
-if ! command -v rclone &>/dev/null; then
-	if is_root; then
-		{ apt-get update -qq && apt-get install -y -qq rclone; } 2>/dev/null ||
-			warn "Failed to install rclone via apt"
-	else
-		curl -fsSL https://rclone.org/install.sh | sudo bash 2>/dev/null ||
-			warn "Failed to install rclone"
-	fi
+if ! command -v rclone &>/dev/null && ! is_root; then
+	curl -fsSL https://rclone.org/install.sh | sudo bash 2>/dev/null ||
+		warn "Failed to install rclone"
 fi
 
 # Configure rclone R2 remote from environment variables

--- a/.github/actions/setup-visual-testing-env/action.yaml
+++ b/.github/actions/setup-visual-testing-env/action.yaml
@@ -48,3 +48,18 @@ runs:
         brew install ffmpeg
         ffprobe -version
       shell: bash
+
+    # rclone ships via apt as part of setup-site's install-system-deps on
+    # Linux, but macOS has no equivalent step — install it here so
+    # scripts/r2_baselines.py works on both platforms.
+    - name: Install rclone on macOS
+      if: runner.os == 'macOS'
+      run: |
+        if command -v rclone &>/dev/null; then
+          echo "rclone already available, skipping install"
+          rclone version
+          exit 0
+        fi
+        brew install rclone
+        rclone version
+      shell: bash

--- a/scripts/r2_baselines.py
+++ b/scripts/r2_baselines.py
@@ -23,6 +23,13 @@ R2_BUCKET = "turntrout"
 R2_PREFIX = "visual-baselines"
 LOCAL_DIR = Path("tests/visual-baselines")
 
+# Wider retry window than rclone's defaults (3 retries, 0s sleep). CI runners
+# occasionally hit transient DNS or network flaps reaching R2; with no sleep
+# between retries, all 3 attempts can fail inside the same flap. 5 retries
+# with 10s sleep gives ~50s of recovery time while still failing fast on a
+# real outage.
+RCLONE_RETRY_FLAGS = ("--retries=5", "--retries-sleep=10s")
+
 REQUIRED_ENV = (
     "ACCESS_KEY_ID_TURNTROUT_MEDIA",
     "SECRET_ACCESS_TURNTROUT_MEDIA",
@@ -85,6 +92,7 @@ def download(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *RCLONE_RETRY_FLAGS,
             ],
             config,
         )
@@ -114,6 +122,7 @@ def upload(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *RCLONE_RETRY_FLAGS,
             ],
             config,
         )

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -164,6 +164,25 @@ def mock_rclone() -> Iterator[MagicMock]:
         yield mock_run
 
 
+@pytest.fixture(autouse=True)
+def _stub_find_rclone(request: pytest.FixtureRequest) -> Iterator[None]:
+    """
+    Make ``requires_r2`` tests hermetic.
+
+    Tests marked ``requires_r2`` exercise the rclone-driven upload code paths
+    but mock ``subprocess.run``, so they don't need a real rclone binary. They
+    were still calling the real ``find_executable("rclone")`` probe, which
+    raised ``FileNotFoundError`` on machines without rclone installed (CI
+    sandboxes, fresh dev boxes). Stub the probe here so the marker actually
+    delivers on its "doesn't need real R2" promise.
+    """
+    if request.node.get_closest_marker("requires_r2") is None:
+        yield
+        return
+    with patch.object(script_utils, "find_executable", return_value="rclone"):
+        yield
+
+
 def _is_git_command(cmd: list | str) -> bool:
     """Check if command is a git executable."""
     if not isinstance(cmd, list) or not cmd:

--- a/scripts/tests/test_r2_baselines.py
+++ b/scripts/tests/test_r2_baselines.py
@@ -66,6 +66,8 @@ def test_download_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
     assert args[1] == r2_baselines._remote_path()
     assert args[2] == str(target)
     assert "--include=*.png" in args
+    for flag in r2_baselines.RCLONE_RETRY_FLAGS:
+        assert flag in args
 
 
 def test_upload_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
@@ -79,6 +81,8 @@ def test_upload_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
     assert args[0] == "copy"
     assert args[1] == str(src)
     assert args[2] == r2_baselines._remote_path()
+    for flag in r2_baselines.RCLONE_RETRY_FLAGS:
+        assert flag in args
 
 
 def test_upload_missing_dir(env_vars: None, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
This PR improves the reliability and consistency of rclone installation across different environments and adds retry resilience to R2 asset upload operations.

## Key Changes

- **Unified rclone installation**: Moved rclone into the apt package installation map in `session-setup.sh` so it's installed atomically with other system dependencies on Linux, rather than as a separate step. Non-root sandboxes fall back to the official installer.

- **macOS rclone support**: Added rclone installation to the visual testing environment setup on macOS via Homebrew, ensuring `scripts/r2_baselines.py` works consistently across CI platforms.

- **Enhanced retry logic**: Added configurable retry flags (`--retries=5`, `--retries-sleep=10s`) to rclone copy operations in `r2_baselines.py`. This provides ~50s of recovery time for transient DNS/network flaps in CI while still failing fast on real outages (vs. rclone's default 3 retries with 0s sleep).

- **Test hermiticity**: Added `_stub_find_rclone` fixture in `conftest.py` to stub the rclone binary probe for `requires_r2` marked tests, making them work on machines without rclone installed (CI sandboxes, fresh dev boxes) while still mocking subprocess calls.

- **Test coverage**: Updated `test_r2_baselines.py` to verify that retry flags are properly passed to rclone commands.

## Implementation Details

The retry configuration is centralized in `RCLONE_RETRY_FLAGS` and applied to both download and upload operations, ensuring consistent behavior across all R2 interactions. The fixture-based approach to stubbing `find_executable` keeps tests hermetic without requiring rclone to be present in the test environment.

https://claude.ai/code/session_01XH9QTenu5i3BLbsLXFvHW7