### PR TITLE
fix: regex injection, XSS hardening, and type safety audit

### DIFF
--- a/quartz/components/scripts/randomPost.ts
+++ b/quartz/components/scripts/randomPost.ts
@@ -17,20 +17,20 @@ export function isPost(slug: string): boolean {
 
 /** Generate the inline script from the canonical exclusion lists. */
 export const randomPostScript = `document.addEventListener("click", async function(e) {
-  var btn = e.target.closest("#random-post-link");
+  const btn = e.target.closest("#random-post-link");
   if (!btn) return;
   e.preventDefault();
-  var data = await getContentIndex();
+  const data = await getContentIndex();
   if (!data) return;
-  var excluded = new Set(${JSON.stringify([...EXCLUDED_SLUGS])});
-  var prefixes = ${JSON.stringify(EXCLUDED_SLUG_PREFIXES)};
-  var posts = Object.keys(data).filter(function(s) {
+  const excluded = new Set(${JSON.stringify([...EXCLUDED_SLUGS])});
+  const prefixes = ${JSON.stringify(EXCLUDED_SLUG_PREFIXES)};
+  const posts = Object.keys(data).filter(function(s) {
     return !excluded.has(s) && !prefixes.some(function(p) { return s.startsWith(p) });
   });
   if (posts.length <= 1) { console.error("[randomPost] Not enough posts:", posts.length); return; }
-  var current = document.body.dataset.slug;
-  var candidates = posts.filter(function(s) { return s !== current });
-  var slug = candidates[Math.floor(Math.random() * candidates.length)];
-  var url = new URL("/" + slug, location.origin);
+  const current = document.body.dataset.slug;
+  const candidates = posts.filter(function(s) { return s !== current });
+  const slug = candidates[Math.floor(Math.random() * candidates.length)];
+  const url = new URL("/" + slug, location.origin);
   window.spaNavigate ? window.spaNavigate(url) : location.assign(url);
 })`

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -7,6 +7,7 @@ import FlexSearch, {
 import { replaceEmojiConvertArrows } from "../../plugins/transformers/twemoji"
 import { type ContentDetails } from "../../plugins/vfile"
 import { tabletBreakpoint } from "../../styles/variables"
+import { escapeHTML } from "../../util/escape"
 import { type FullSlug, resolveRelative } from "../../util/path"
 import { NBSP, simpleConstants, SEARCH_MATCH_CLASS } from "../constants"
 import { registerEscapeHandler, removeAllChildren, debounce } from "./component_script_utils"
@@ -196,15 +197,15 @@ export function match(searchTerm: string, text: string, trim?: boolean) {
 
   const slice = tokenizedText
     .map((tok: string): string => {
-      // see if this tok is prefixed by any search terms
+      const escaped = escapeHTML(tok)
       for (const searchTok of tokenizedTerms) {
         if (tok.toLowerCase().includes(searchTok.toLowerCase())) {
-          const sanitizedSearchTok = RegExp.escape(searchTok)
-          const regex = new RegExp(sanitizedSearchTok.toLowerCase(), "gi")
-          return tok.replace(regex, `<span class="${SEARCH_MATCH_CLASS}">$&</span>`)
+          const sanitizedSearchTok = RegExp.escape(escapeHTML(searchTok))
+          const regex = new RegExp(sanitizedSearchTok, "gi")
+          return escaped.replace(regex, `<span class="${SEARCH_MATCH_CLASS}">$&</span>`)
         }
       }
-      return tok
+      return escaped
     })
     .join(" ")
 

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -133,6 +133,34 @@ describe("match", () => {
     )
   })
 
+  it.each([
+    {
+      name: "angle brackets",
+      term: "script",
+      text: "Try <script>alert(1)</script> here",
+      shouldContain: ["&lt;", "&gt;", '<span class="search-match">script</span>'],
+      shouldNotContain: ["<script>"],
+    },
+    {
+      name: "ampersands",
+      term: "R",
+      text: "R&D department",
+      shouldContain: ["&amp;D", '<span class="search-match">R</span>'],
+      shouldNotContain: [],
+    },
+    {
+      name: "quotes",
+      term: "hello",
+      text: 'She said "hello" today',
+      shouldContain: ["&quot;", '<span class="search-match">hello</span>'],
+      shouldNotContain: [],
+    },
+  ])("should HTML-escape $name in content tokens", ({ term, text, shouldContain, shouldNotContain }) => {
+    const matched = match(term, text)
+    for (const s of shouldContain) expect(matched).toContain(s)
+    for (const s of shouldNotContain) expect(matched).not.toContain(s)
+  })
+
   describe("Trimming and ellipsis", () => {
     const generateText = (numWords: number, suffix = "") =>
       Array.from({ length: numWords }, (_, i) => `word${i}${suffix}`).join(" ")

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -155,11 +155,14 @@ describe("match", () => {
       shouldContain: ["&quot;", '<span class="search-match">hello</span>'],
       shouldNotContain: [],
     },
-  ])("should HTML-escape $name in content tokens", ({ term, text, shouldContain, shouldNotContain }) => {
-    const matched = match(term, text)
-    for (const s of shouldContain) expect(matched).toContain(s)
-    for (const s of shouldNotContain) expect(matched).not.toContain(s)
-  })
+  ])(
+    "should HTML-escape $name in content tokens",
+    ({ term, text, shouldContain, shouldNotContain }) => {
+      const matched = match(term, text)
+      for (const s of shouldContain) expect(matched).toContain(s)
+      for (const s of shouldNotContain) expect(matched).not.toContain(s)
+    },
+  )
 
   describe("Trimming and ellipsis", () => {
     const generateText = (numWords: number, suffix = "") =>

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -2014,7 +2014,7 @@ describe("normalizeUrl", () => {
   it.each([
     ["./page?query=value#section", "https://www.turntrout.com/page?query=value#section"],
     ["./", "https://www.turntrout.com/"],
-    ["../../deep/path", "https://www.turntrout.com/../deep/path"],
+    ["../../deep/path", "https://www.turntrout.com/deep/path"],
   ])("should handle edge cases: %s", (input, expected) => {
     const result = favicons.normalizeUrl(input)
     expect(result).toBe(expected)

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -763,11 +763,7 @@ export function shouldIncludeFavicon(
  */
 export function normalizeUrl(href: string): string {
   if (!href.startsWith("http")) {
-    if (href.startsWith("./")) {
-      href = href.slice(2)
-    } else if (href.startsWith("../")) {
-      href = href.slice(3)
-    }
+    href = href.replace(/^(?:\.\.?\/)+/, "")
     href = `https://www.turntrout.com/${href}`
   }
   return href

--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -342,7 +342,8 @@ export function removeUnreferencedMarkers(svg: Element): void {
     for (const value of Object.values(child.properties)) {
       if (typeof value !== "string") continue
       for (const match of value.matchAll(/url\(#(?<id>[^)]+)\)/g)) {
-        referencedIds.add(match.groups!.id)
+        const id = match.groups?.id
+        if (id) referencedIds.add(id)
       }
     }
   })

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -88,7 +88,7 @@ function sluggify(s: string): string {
 export function slugifyFilePath(fp: FilePath, excludeExt?: boolean): FullSlug {
   fp = stripSlashes(fp) as FilePath
   let ext = _getFileExtension(fp)
-  const withoutFileExt = fp.replace(new RegExp(`${ext}$`), "")
+  const withoutFileExt = ext ? fp.slice(0, -ext.length) : fp
   if (excludeExt || [".md", ".html", undefined].includes(ext)) {
     ext = ""
   }


### PR DESCRIPTION
## Summary

- Fix several latent bugs and harden security found via a thorough codebase audit across TypeScript, Python, CI, and test coverage
- Focused on high-impact, minimal changes: regex injection, incomplete URL normalization, XSS defense-in-depth, type safety, and modern JS

## Changes

1. **Fix regex injection in `slugifyFilePath`** (`quartz/util/path.ts`): File extensions like `.md` contain `.` which is a regex wildcard. The old code `new RegExp(\`${ext}$\`)` could match unintended characters. Replaced with `fp.slice(0, -ext.length)` — no regex needed.

2. **Fix incomplete `../` stripping in `normalizeUrl`** (`quartz/plugins/transformers/favicons.ts`): The old code only stripped a single `./` or `../` prefix. Input like `../../deep/path` would incorrectly become `https://www.turntrout.com/../deep/path`. Now uses `href.replace(/^(?:\.\.?\/)+/, "")` to strip all leading relative segments.

3. **HTML-escape search content tokens** (`quartz/components/scripts/search.ts`): The `match()` function builds HTML strings with `<span>` tags via string interpolation, then the result is set via `innerHTML`. Content tokens from the content index were not HTML-escaped before interpolation. Now uses `escapeHTML()` on both tokens and search terms before building the highlight HTML. Defense-in-depth (content is author-controlled), but prevents any future injection vector.

4. **Replace `!` non-null assertion** (`quartz/plugins/transformers/gfm.ts`): `match.groups!.id` replaced with `match.groups?.id` + null guard in `removeUnreferencedMarkers`.

5. **Replace `var` with `const`** (`quartz/components/scripts/randomPost.ts`): Inline script template used `var` for all declarations. Modernized to `const`.

6. **Add test coverage for HTML escaping** (`quartz/components/scripts/tests/search.test.ts`): 3 new parametrized test cases verifying angle brackets, ampersands, and quotes are escaped in search match output.

## Testing

- `pnpm check` — type checking passes
- `pnpm test` — all 3671 tests pass, 100% coverage maintained
- Pre-push hooks pass (linting, formatting, SCSS, asset checks)

https://claude.ai/code/session_014Jp6E7G5F4PmEy7DeLG4Qe

---
_Generated by [Claude Code](https://claude.ai/code/session_014Jp6E7G5F4PmEy7DeLG4Qe)_