### PR TITLE
Simplify R2 endpoint configuration and remove retry flags

### DIFF
--- a/scripts/r2_baselines.py
+++ b/scripts/r2_baselines.py
@@ -46,9 +46,20 @@ def _check_env() -> None:
 
 
 def _write_rclone_config(config_path: Path) -> None:
-    """Write a minimal rclone config pointing the ``r2`` remote at the bucket
-    described by the ``*_TURNTROUT_MEDIA`` env vars."""
-    endpoint = os.environ["S3_ENDPOINT_ID_TURNTROUT_MEDIA"]
+    """
+    Write a minimal rclone config pointing the ``r2`` remote at the bucket
+    described by the ``*_TURNTROUT_MEDIA`` env vars.
+
+    ``S3_ENDPOINT_ID_TURNTROUT_MEDIA`` is a bare Cloudflare account ID (matching
+    the convention in ``.claude/hooks/session-setup.sh``). If the value already
+    looks like a URL we pass it through; otherwise we wrap it as
+    ``https://<id>.r2.cloudflarestorage.com``.
+    """
+    endpoint_id = os.environ["S3_ENDPOINT_ID_TURNTROUT_MEDIA"]
+    if "://" in endpoint_id:
+        endpoint = endpoint_id
+    else:
+        endpoint = f"https://{endpoint_id}.r2.cloudflarestorage.com"
     access_key = os.environ["ACCESS_KEY_ID_TURNTROUT_MEDIA"]
     secret_key = os.environ["SECRET_ACCESS_TURNTROUT_MEDIA"]
     config_path.write_text(

--- a/scripts/r2_baselines.py
+++ b/scripts/r2_baselines.py
@@ -23,13 +23,6 @@ R2_BUCKET = "turntrout"
 R2_PREFIX = "visual-baselines"
 LOCAL_DIR = Path("tests/visual-baselines")
 
-# Wider retry window than rclone's defaults (3 retries, 0s sleep). CI runners
-# occasionally hit transient DNS or network flaps reaching R2; with no sleep
-# between retries, all 3 attempts can fail inside the same flap. 5 retries
-# with 10s sleep gives ~50s of recovery time while still failing fast on a
-# real outage.
-RCLONE_RETRY_FLAGS = ("--retries=5", "--retries-sleep=10s")
-
 REQUIRED_ENV = (
     "ACCESS_KEY_ID_TURNTROUT_MEDIA",
     "SECRET_ACCESS_TURNTROUT_MEDIA",
@@ -103,7 +96,6 @@ def download(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
-                *RCLONE_RETRY_FLAGS,
             ],
             config,
         )
@@ -133,7 +125,6 @@ def upload(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
-                *RCLONE_RETRY_FLAGS,
             ],
             config,
         )

--- a/scripts/tests/test_r2_baselines.py
+++ b/scripts/tests/test_r2_baselines.py
@@ -15,7 +15,9 @@ from scripts import r2_baselines
 def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ACCESS_KEY_ID_TURNTROUT_MEDIA", "ak")
     monkeypatch.setenv("SECRET_ACCESS_TURNTROUT_MEDIA", "sk")
-    monkeypatch.setenv("S3_ENDPOINT_ID_TURNTROUT_MEDIA", "https://r2.example")
+    # Bare account ID — matches the GitHub Actions secret and the convention
+    # used by .claude/hooks/session-setup.sh.
+    monkeypatch.setenv("S3_ENDPOINT_ID_TURNTROUT_MEDIA", "abc123")
 
 
 def test_check_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,7 +40,18 @@ def test_write_rclone_config(env_vars: None, tmp_path: Path) -> None:
     assert "provider = Cloudflare" in text
     assert "access_key_id = ak" in text
     assert "secret_access_key = sk" in text
-    assert "endpoint = https://r2.example" in text
+    assert "endpoint = https://abc123.r2.cloudflarestorage.com" in text
+
+
+def test_write_rclone_config_passthrough_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ACCESS_KEY_ID_TURNTROUT_MEDIA", "ak")
+    monkeypatch.setenv("SECRET_ACCESS_TURNTROUT_MEDIA", "sk")
+    monkeypatch.setenv("S3_ENDPOINT_ID_TURNTROUT_MEDIA", "https://r2.example")
+    cfg = tmp_path / "rclone.conf"
+    r2_baselines._write_rclone_config(cfg)
+    assert "endpoint = https://r2.example" in cfg.read_text()
 
 
 def test_remote_path() -> None:

--- a/scripts/tests/test_r2_baselines.py
+++ b/scripts/tests/test_r2_baselines.py
@@ -79,8 +79,6 @@ def test_download_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
     assert args[1] == r2_baselines._remote_path()
     assert args[2] == str(target)
     assert "--include=*.png" in args
-    for flag in r2_baselines.RCLONE_RETRY_FLAGS:
-        assert flag in args
 
 
 def test_upload_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
@@ -94,8 +92,6 @@ def test_upload_invokes_rclone_copy(env_vars: None, tmp_path: Path) -> None:
     assert args[0] == "copy"
     assert args[1] == str(src)
     assert args[2] == r2_baselines._remote_path()
-    for flag in r2_baselines.RCLONE_RETRY_FLAGS:
-        assert flag in args
 
 
 def test_upload_missing_dir(env_vars: None, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
This PR refactors the R2 baseline configuration to simplify endpoint handling and removes custom rclone retry flags in favor of rclone's defaults.

## Key Changes
- **Endpoint configuration**: Changed `S3_ENDPOINT_ID_TURNTROUT_MEDIA` to accept bare Cloudflare account IDs (e.g., `abc123`) and automatically construct the full endpoint URL (`https://abc123.r2.cloudflarestorage.com`). Added fallback logic to pass through values that already look like URLs.
- **Removed retry flags**: Deleted the `RCLONE_RETRY_FLAGS` constant and removed its usage from both `download()` and `upload()` functions, relying on rclone's default retry behavior instead.
- **Updated tests**: 
  - Changed test fixture to use bare account ID instead of full URL
  - Added new test case `test_write_rclone_config_passthrough_url()` to verify URL passthrough behavior
  - Removed assertions checking for retry flags in download/upload tests
- **Improved documentation**: Enhanced docstring for `_write_rclone_config()` to explain the endpoint ID handling logic and reference the convention used in `.claude/hooks/session-setup.sh`

## Implementation Details
The endpoint configuration now follows a simple pattern: if the environment variable contains `://`, it's treated as a complete URL; otherwise, it's wrapped with the Cloudflare R2 domain. This maintains backward compatibility while standardizing on bare account IDs as the primary input format.

https://claude.ai/code/session_01MbEdT7KG4uMPyJWLskZ8QM