### PR TITLE
fix(ci): unblock publish-visual-report (blob name collision + testDir merge)

### DIFF
--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -161,6 +161,17 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+      # Playwright's blob reporter writes report-<run-id>-<shard-num>.zip,
+      # so Linux and macOS shards with the same shard number produce the
+      # same filename. publish-visual-report downloads with merge-multiple,
+      # which silently overwrites the colliding files. Tag with platform
+      # before upload so every blob report has a unique name.
+      - name: Tag blob report with platform
+        if: always() && hashFiles('blob-report/*.zip') != ''
+        run: |
+          cd blob-report
+          for f in *.zip; do mv "$f" "linux-$f"; done
+
       # Blob report is consumed by the publish-visual-report job to
       # generate a merged HTML diff report with side-by-side comparisons.
       - name: Upload blob report shard
@@ -290,6 +301,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+      # See Linux job for the rationale — without a platform tag, Linux
+      # and macOS shards with the same shard number collide on download.
+      - name: Tag blob report with platform
+        if: always() && hashFiles('blob-report/*.zip') != ''
+        run: |
+          cd blob-report
+          for f in *.zip; do mv "$f" "macos-$f"; done
+
       - name: Upload blob report shard
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -373,8 +392,14 @@ jobs:
           path: ./all-blob-reports
           merge-multiple: true
 
+      # Pass -c so merge-reports tolerates the Linux/macOS testDir
+      # difference (/home/runner vs /Users/runner) — without it the merge
+      # aborts with "different test directories, merging cannot proceed".
       - name: Merge blob reports into HTML
-        run: pnpm exec playwright merge-reports --reporter html ./all-blob-reports
+        run: |
+          pnpm exec playwright merge-reports \
+            -c config/playwright/playwright.config.ts \
+            --reporter html ./all-blob-reports
 
       # Pull every shard's test-results/ for the screenshot gallery generator.
       - name: Download trace artifacts (for gallery)


### PR DESCRIPTION
## Diagnosis

Every `publish-visual-report` run on `main` since #1224 has died at the **Merge blob reports into HTML** step with exit code 1, leaving the Cloudflare Pages diff URL ("nothing is here yet") and no `visual-diff-report` artifact. I downloaded the actual blob report artifacts from run [25417433516](https://github.com/alexander-turner/TurnTrout.com/actions/runs/25417433516) and reproduced both bugs locally.

**Bug 1 — name collision on download.** Playwright's blob reporter writes `blob-report/report-<run-id>-<shard-num>.zip`. Linux shards `1/3, 2/3, 3/3` and macOS shards `1/2, 2/2` produce overlapping names (`report-…-1.zip`, `report-…-2.zip`). The download step uses `merge-multiple: true`, which silently overwrites collisions — only one platform's blob report for each shard number survives. With 3 of 5 reports retained, the merge proceeds against an incomplete set.

**Bug 2 — `testDir` mismatch on merge.** Even with the dedup fix in place, `playwright merge-reports` aborts:

```
Error: Blob reports being merged were recorded with different test directories, and
merging cannot proceed.
…
Found directories:
/Users/runner/work/TurnTrout.com/TurnTrout.com/quartz
/home/runner/work/TurnTrout.com/TurnTrout.com/quartz
```

The error message itself recommends the fix: pass `-c <config>` so the merger ignores the recorded testDirs and uses the local one.

## Changes

- **`.github/workflows/visual-testing.yaml`** — added a `Tag blob report with platform` shell step in both the Linux and macOS test jobs, prefixing each blob zip with `linux-` / `macos-` before upload. Each blob filename is now unique across the matrix.
- **`.github/workflows/visual-testing.yaml`** — `Merge blob reports into HTML` now passes `-c config/playwright/playwright.config.ts` so the merger tolerates the Linux/macOS path difference.

## Verification

Locally reproduced the original failure with the actual artifacts from run 25417433516, then re-ran with the fixes:

```
$ pnpm exec playwright merge-reports -c config/playwright/playwright.config.ts \
    --reporter html /tmp/merge-debug/all-blob-reports-flat
merging reports from /tmp/merge-debug/all-blob-reports-flat
extracting: …/6823070913.zip
extracting: …/6823133681.zip
extracting: …/6823135636.zip
extracting: …/6823153912.zip
extracting: …/6823238745.zip
merging events
processing test events
building final report
finished building report
```

Once this lands, `publish-visual-report` will produce both the Playwright HTML report (`https://visual-main-<run-id>.turntrout.pages.dev/`) and the screenshot gallery (`/gallery.html`), and the `visual-diff-report` GHA artifact will populate as well.

https://claude.ai/code/session_01MbEdT7KG4uMPyJWLskZ8QM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbEdT7KG4uMPyJWLskZ8QM)_