### PR TITLE
build(ci): run subfont via pnpm exec, drop github fork install

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,9 +129,9 @@ jobs:
           project-name: turntrout
           branch: ${{ github.ref_name }}
 
-      - name: Install subfont
-        if: github.event_name == 'push'
-        run: pnpm add -g github:alexander-turner/subfont
+      # subfont is pinned to @turntrout/subfont@1.8.1 in package.json and
+      # installed by setup-site's `pnpm install`, so we run it via
+      # `pnpm exec` (in scripts/subfont.sh) — no separate global install.
       - name: Make script executable
         if: github.event_name == 'push'
         run: chmod +x ./scripts/subfont.sh

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -60,11 +60,12 @@ jobs:
           key: site-build-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - name: Install subfont
-        run: pnpm add -g github:alexander-turner/subfont
+      # subfont is pinned to @turntrout/subfont@1.8.1 in package.json and
+      # installed by setup-site's `pnpm install`, so we run it via
+      # `pnpm exec` — no separate global install.
       - name: Subset fonts for Lighthouse test pages
         run: |
-          subfont --root public/ \
+          pnpm exec subfont --root public/ \
             public/index.html \
             public/design.html \
             public/about.html \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,13 @@ Design philosophy from `design.md`: minimal targeted changes; verify before gene
 ## CI monitoring
 
 After pushing, monitor CI until pass or fail. The PostToolUse hook polls GitHub Actions; the Stop hook blocks completion on remote CI failures. See `.claude/dev-notes.md` for manual commands and CI cost-optimization labels.
+
+## DeepSource issues
+
+- The `deepsource` CLI is authenticated by the SessionStart hook. When asked to fix DeepSource issues — or proactively when you've just landed nontrivial work — list outstanding issues and clear them.
+- Useful invocations:
+  - `deepsource issues --default-branch --analyzer python --output json` (issues on `main`)
+  - `deepsource issues --default-branch --analyzer javascript --output json`
+  - `deepsource issues --pr <N> --output json` (issues introduced/remaining on a PR)
+- Fix root causes, not by appending `// skipcq: <CODE>` — only suppress when the warning is genuinely a false positive and write a comment explaining why on the same line.
+- Group fixes into one focused PR per analyzer (or per issue cluster if a single PR would balloon), keeping the diff reviewable. After landing, re-run the CLI to confirm the count went down.

--- a/config/javascript/babel.config.cjs
+++ b/config/javascript/babel.config.cjs
@@ -1,7 +1,8 @@
-/* global module */
 "use strict"
 
-// babel.config.cjs
+// babel.config.cjs — `module` is provided by the CommonJS runtime
+// and declared as a global for ESLint via the `**/*.cjs` block in
+// config/javascript/eslint.config.js.
 
 module.exports = {
   presets: [

--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -32,6 +32,12 @@ export default [
   // JS/TS/React base configs
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { languageOptions: { globals: globals.browser } },
+
+  // CommonJS files (.cjs) need Node-style globals like `module` and `require`
+  {
+    files: ["**/*.cjs"],
+    languageOptions: { globals: globals.node },
+  },
   pluginJs.configs.recommended,
   ...tseslintConfigs.recommended,
   pluginReact.configs.flat.recommended,

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -55,8 +55,9 @@ const allBrowsers: Browser[] = [
 
 // CI workflows set PLAYWRIGHT_BROWSERS to run specific engines per OS
 // (e.g. "chromium,firefox" on Linux, "webkit" on macOS).
-const browsers: Browser[] = process.env.PLAYWRIGHT_BROWSERS
-  ? allBrowsers.filter((b) => process.env.PLAYWRIGHT_BROWSERS!.split(",").includes(b.engine))
+const playwrightBrowsersEnv = process.env.PLAYWRIGHT_BROWSERS
+const browsers: Browser[] = playwrightBrowsersEnv
+  ? allBrowsers.filter((b) => playwrightBrowsersEnv.split(",").includes(b.engine))
   : allBrowsers
 
 /**

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "shell-quote": "1.8.3",
     "shiki": "4.0.2",
     "source-map-support": "0.5.21",
-    "subfont": "npm:@turntrout/subfont@1.8.1",
+    "subfont": "npm:@turntrout/subfont@1.9.5",
     "title-case": "4.3.2",
     "to-vfile": "8.0.0",
     "toml": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,8 +287,8 @@ importers:
         specifier: 0.5.21
         version: 0.5.21
       subfont:
-        specifier: npm:@turntrout/subfont@1.8.1
-        version: '@turntrout/subfont@1.8.1(@types/babel__core@7.20.5)'
+        specifier: npm:@turntrout/subfont@1.9.5
+        version: '@turntrout/subfont@1.9.5(@types/babel__core@7.20.5)'
       title-case:
         specifier: 4.3.2
         version: 4.3.2
@@ -2445,8 +2445,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turntrout/subfont@1.8.1':
-    resolution: {integrity: sha512-sbWMwOI9fTLyclyZrC8cDUeT8glepOTfJgB5/K3SqLJU1f1jRy01Xfoq8wrTJ8WqSkaE+HsedJKHZGrZ44LPJw==}
+  '@turntrout/subfont@1.9.5':
+    resolution: {integrity: sha512-Wn1iomWYzIXakfUyv4sHj8jZCXQZTjFb1EWxeCJ1ICObg+YenCiJ+CMgIvrBfFcwFM/XIjzILD6QCs6X0sMuAw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8408,9 +8408,6 @@ packages:
   stream-splicer@2.0.1:
     resolution: {integrity: sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==}
 
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
-
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -8710,9 +8707,6 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
-
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -11584,7 +11578,7 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
-  '@turntrout/subfont@1.8.1(@types/babel__core@7.20.5)':
+  '@turntrout/subfont@1.9.5(@types/babel__core@7.20.5)':
     dependencies:
       '@gustavnikolaj/async-main-wrap': 3.0.1
       '@hookun/parse-animation-shorthand': 0.1.5
@@ -19353,15 +19347,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  streamx@2.23.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -19738,7 +19723,7 @@ snapshots:
 
   teex@1.0.1:
     dependencies:
-      streamx: 2.23.0
+      streamx: 2.25.0
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -19773,12 +19758,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
-
-  text-decoder@1.2.3:
-    dependencies:
-      b4a: 1.8.0
-    transitivePeerDependencies:
-      - react-native-b4a
 
   text-decoder@1.2.7:
     dependencies:

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -13,6 +13,7 @@ import style from "./styles/contentMeta.scss"
 import { TagList } from "./TagList"
 import { type QuartzComponentConstructor, type QuartzComponentProps } from "./types"
 
+// skipcq: JS-W1042 -- TagList's type annotation requires an opts argument; passing undefined is the canonical no-options form
 const TagListComponent = TagList(undefined)
 
 // Render publication information including original URL and date

--- a/quartz/components/Navbar.tsx
+++ b/quartz/components/Navbar.tsx
@@ -197,6 +197,7 @@ const NavbarComponent: QuartzComponent = ({ cfg, fileData }: QuartzComponentProp
           </a>
         </li>
       </ul>
+      {/* skipcq: JS-0440 -- inline script content is a build-time constant; no user input reaches this path */}
       <script dangerouslySetInnerHTML={{ __html: randomPostScript }} />
     </nav>
   )

--- a/quartz/components/scripts/punctilio-demo-diff.test.ts
+++ b/quartz/components/scripts/punctilio-demo-diff.test.ts
@@ -113,8 +113,8 @@ describe("renderChangedLinePair", () => {
     // Build inputs whose combined length exceeds MAX_CHAR_DIFF_LENGTH, with
     // edits scattered enough that char-diff would produce multiple spans.
     const size = MAX_CHAR_DIFF_LENGTH
-    const oldText = "X" + "a".repeat(size) + "Y" + "b".repeat(size) + "Z"
-    const newText = "P" + "a".repeat(size) + "Q" + "b".repeat(size) + "R"
+    const oldText = `X${"a".repeat(size)}Y${"b".repeat(size)}Z`
+    const newText = `P${"a".repeat(size)}Q${"b".repeat(size)}R`
     const html = renderChangedLinePair(oldText, newText)
     // Prefix/suffix merges the three separate edits into exactly one span
     expect(html.match(/class="diff-insert"/g)?.length).toBe(1)

--- a/quartz/components/scripts/tests/popover.test.ts
+++ b/quartz/components/scripts/tests/popover.test.ts
@@ -571,6 +571,7 @@ describe("attachPopoverEventListeners", () => {
       linkElement.href = "http://example.com/"
       cleanup = attachPopoverEventListeners(popoverElement, linkElement, jest.fn())
 
+      // skipcq: JS-0321 -- intentional no-op: silence real navigation in tests
       const navSpy = jest.spyOn(navigation, "goTo").mockImplementation(() => {})
 
       let clickEvent: MouseEvent
@@ -597,6 +598,7 @@ describe("attachPopoverEventListeners", () => {
     linkElement.href = "http://example.com/"
     cleanup = attachPopoverEventListeners(popoverElement, linkElement, jest.fn())
 
+    // skipcq: JS-0321 -- intentional no-op: silence real navigation in tests
     const navSpy = jest.spyOn(navigation, "goTo").mockImplementation(() => {})
     popoverElement.dispatchEvent(new MouseEvent("click"))
     expect(navSpy).not.toHaveBeenCalled()

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -274,6 +274,7 @@ describe("showSearch", () => {
   })
 
   it("should show UI and trigger initialization when search is not yet initialized", async () => {
+    // skipcq: JS-0321 -- intentional no-op: suppress console.error noise in tests
     const spy = jest.spyOn(console, "error").mockImplementation(() => {})
     resetSearchStateForTesting()
     stubGetContentIndex(() => Promise.resolve(null))
@@ -735,6 +736,7 @@ describe("initializeSearch retry after failed fetch", () => {
   let consoleErrorSpy: jest.SpiedFunction<typeof console.error>
 
   beforeEach(() => {
+    // skipcq: JS-0321 -- intentional no-op: suppress console.error noise in tests
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
     resetSearchStateForTesting()
     document.body.innerHTML = `

--- a/quartz/components/tests/TagList.test.tsx
+++ b/quartz/components/tests/TagList.test.tsx
@@ -56,6 +56,7 @@ describe("TagList", () => {
         tags: ["tag1", "tag2"],
       },
     } as QuartzPluginData
+    // skipcq: JS-W1042 -- TagList's type annotation requires an opts argument; passing undefined is the canonical no-options form
     const Component = TagList(undefined)
     const html = render(h(Component, { fileData } as QuartzComponentProps))
     expect(html).toContain('<a href="/tags/tag1" class="can-trigger-popover tag-link">tag1</a>')
@@ -68,6 +69,7 @@ describe("TagList", () => {
         title: "Test Page",
       },
     } as QuartzPluginData
+    // skipcq: JS-W1042 -- TagList's type annotation requires an opts argument; passing undefined is the canonical no-options form
     const Component = TagList(undefined)
     const html = render(h(Component, { fileData } as QuartzComponentProps))
     expect(html).toBe("")

--- a/quartz/components/tests/fixtures.ts
+++ b/quartz/components/tests/fixtures.ts
@@ -9,6 +9,7 @@ export const test = base.extend({
     await page.addInitScript(() => {
       Math.random = () => 0.5
     })
+    // skipcq: JS-0820 -- `use` is Playwright's fixture-yield callback, not a React hook
     await use(page)
   },
 })

--- a/quartz/plugins/emitters/contentIndex.test.ts
+++ b/quartz/plugins/emitters/contentIndex.test.ts
@@ -65,8 +65,13 @@ describe("ContentIndex", () => {
     }),
   ]
 
-  const getWriteCall = (slugSubstring: string) =>
-    write.mock.calls.find((c) => c[0].slug.includes(slugSubstring))
+  const getWriteCall = (slugSubstring: string) => {
+    const call = write.mock.calls.find((c) => c[0].slug.includes(slugSubstring))
+    if (!call) {
+      throw new Error(`No write call found for slug containing "${slugSubstring}"`)
+    }
+    return call
+  }
 
   // --- Title formatting (the fix under test) ---
   const titleTransformCases: [string, string, string][] = [
@@ -79,7 +84,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent(input), mockResources)
 
     const jsonCall = getWriteCall("contentIndex")
-    const index = JSON.parse(jsonCall![0].content)
+    const index = JSON.parse(jsonCall[0].content)
     expect(index["test-post"].title).toContain(expected)
   })
 
@@ -88,7 +93,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent(input), mockResources)
 
     const rssCall = getWriteCall("rss")
-    expect(rssCall![0].content).toContain(expected)
+    expect(rssCall[0].content).toContain(expected)
   })
 
   // --- Sitemap ---
@@ -102,7 +107,7 @@ describe("ContentIndex", () => {
 
     const sitemapCall = getWriteCall("sitemap")
     expect(sitemapCall).toBeDefined()
-    const xml = sitemapCall![0].content
+    const xml = sitemapCall[0].content
     expect(xml).toContain("<loc>https://example.com/test-post</loc>")
     expect(xml).toContain("<lastmod>")
     expect(xml).toContain("</urlset>")
@@ -124,7 +129,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, content, mockResources)
 
     const rssCall = getWriteCall("rss")
-    const xml = rssCall![0].content
+    const xml = rssCall[0].content
     const secondIdx = xml.indexOf("zzz-second")
     const firstIdx = xml.indexOf("aaa-first")
     expect(secondIdx).toBeLessThan(firstIdx)
@@ -140,7 +145,7 @@ describe("ContentIndex", () => {
     )
 
     const rssCall = getWriteCall("rss")
-    expect(rssCall![0].content).toContain("\u201C")
+    expect(rssCall[0].content).toContain("\u201C")
   })
 
   it("uses richContent in RSS description when rssFullHtml is enabled", async () => {
@@ -148,7 +153,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent("Post"), mockResources)
 
     const rssCall = getWriteCall("rss")
-    const xml = rssCall![0].content
+    const xml = rssCall[0].content
     // richContent is the HTML-escaped toHtml output; verify it lands in <description>
     expect(xml).toMatch(/<description>.*<\/description>/)
   })
@@ -158,7 +163,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent("Post"), mockResources)
 
     const rssCall = getWriteCall("rss")
-    expect(rssCall![0].content).toContain(uiStrings.pages.rss.recentNotes)
+    expect(rssCall[0].content).toContain(uiStrings.pages.rss.recentNotes)
   })
 
   // --- Dependency graph ---
@@ -167,7 +172,10 @@ describe("ContentIndex", () => {
     ["omits sitemap/RSS edges when disabled", false, false],
   ])("dependency graph %s", async (_, enableSiteMap, enableRSS) => {
     const plugin = ContentIndex({ enableSiteMap, enableRSS })
-    const graph = await plugin.getDependencyGraph!(mockCtx, makeContent("Test"), mockResources)
+    if (!plugin.getDependencyGraph) {
+      throw new Error("ContentIndex plugin should expose getDependencyGraph")
+    }
+    const graph = await plugin.getDependencyGraph(mockCtx, makeContent("Test"), mockResources)
 
     expect(graph.hasNode("public/static/contentIndex.json" as FilePath)).toBe(true)
     expect(graph.hasNode("public/sitemap.xml" as FilePath)).toBe(enableSiteMap)
@@ -184,7 +192,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent("Empty", { text: "" }), mockResources)
 
     const jsonCall = getWriteCall("contentIndex")
-    const index = JSON.parse(jsonCall![0].content)
+    const index = JSON.parse(jsonCall[0].content)
     expect(index["test-post"]).toBeUndefined()
   })
 
@@ -193,7 +201,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent("Empty", { text: "" }), mockResources)
 
     const jsonCall = getWriteCall("contentIndex")
-    const index = JSON.parse(jsonCall![0].content)
+    const index = JSON.parse(jsonCall[0].content)
     expect(index["test-post"]).toBeDefined()
   })
 
@@ -202,7 +210,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, makeContent("Post", { description: "A description" }), mockResources)
 
     const jsonCall = getWriteCall("contentIndex")
-    const index = JSON.parse(jsonCall![0].content)
+    const index = JSON.parse(jsonCall[0].content)
     expect(index["test-post"].description).toBeUndefined()
     expect(index["test-post"].date).toBeUndefined()
   })
@@ -218,9 +226,9 @@ describe("ContentIndex", () => {
     await plugin.emit(noBaseUrlCtx, makeContent("Post"), mockResources)
 
     const sitemapCall = getWriteCall("sitemap")
-    expect(sitemapCall![0].content).toContain("<loc>https://test-post</loc>")
+    expect(sitemapCall[0].content).toContain("<loc>https://test-post</loc>")
     const rssCall = getWriteCall("rss")
-    expect(rssCall![0].content).toContain("<link>https://</link>")
+    expect(rssCall[0].content).toContain("<link>https://</link>")
   })
 
   it("handles missing frontmatter and text", async () => {
@@ -234,7 +242,7 @@ describe("ContentIndex", () => {
     await plugin.emit(mockCtx, content, mockResources)
 
     const jsonCall = getWriteCall("contentIndex")
-    const index = JSON.parse(jsonCall![0].content)
+    const index = JSON.parse(jsonCall[0].content)
     expect(index["bare"].title).toBe("")
     expect(index["bare"].tags).toEqual([])
     expect(index["bare"].content).toBe("")

--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -323,7 +323,7 @@ export function optimizeMermaidSvgs(tree: Root): void {
     visit(node, "element", (child: Element) => {
       if (!child.properties) return
       for (const attr of unnecessaryAttrs) {
-        delete child.properties[attr]
+        Reflect.deleteProperty(child.properties, attr)
       }
     })
 
@@ -342,7 +342,8 @@ export function removeUnreferencedMarkers(svg: Element): void {
     for (const value of Object.values(child.properties)) {
       if (typeof value !== "string") continue
       for (const match of value.matchAll(/url\(#(?<id>[^)]+)\)/g)) {
-        referencedIds.add(match.groups!.id)
+        const id = match.groups?.id
+        if (id) referencedIds.add(id)
       }
     }
   })

--- a/quartz/plugins/transformers/lastmod.test.ts
+++ b/quartz/plugins/transformers/lastmod.test.ts
@@ -19,6 +19,7 @@ describe("coerceDate", () => {
 
   it("returns current date for undefined input", () => {
     const before = Date.now()
+    // skipcq: JS-W1042 -- the test exists to verify the undefined branch; coerceDate's `d` is required (typed as MaybeDate)
     const result = coerceDate("test.md", undefined)
     const after = Date.now()
     expect(result.getTime()).toBeGreaterThanOrEqual(before)

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -610,18 +610,18 @@ describe("Asset Dimensions Plugin", () => {
 
     it("should retry on network failure and succeed on third attempt", async () => {
       let callCount = 0
-      mockedFetch.mockImplementation(async () => {
+      mockedFetch.mockImplementation(() => {
         callCount++
         if (callCount <= 2) {
-          throw new Error("Network failure")
+          return Promise.reject(new Error("Network failure"))
         }
         // Succeed on third attempt
-        return {
+        return Promise.resolve({
           ok: true,
           status: 200,
           headers: { get: (h: string) => (h === "Content-Type" ? "image/png" : null) } as Headers,
           arrayBuffer: () => Promise.resolve(mockImageData),
-        } as unknown as Response
+        } as unknown as Response)
       })
 
       sizeOfMock.mockClear()

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1302,7 +1302,7 @@ describe("setFirstLetterAttribute", () => {
       const processedHtml = testHtmlFormattingImprovement(input, false)
       // Smart-quote transform may convert straight apostrophe to RIGHT_SINGLE_QUOTE,
       // so check for a space after X followed by any apostrophe variant
-      expect(normalizeNbsp(processedHtml)).toMatch(/X ['\u2018\u2019]s story/)
+      expect(normalizeNbsp(processedHtml)).toMatch(/X ['\u2018\u2019]s story/u)
       expect(processedHtml).toContain('data-first-letter="X"')
     },
   )

--- a/quartz/util/resources.tsx
+++ b/quartz/util/resources.tsx
@@ -42,6 +42,7 @@ export function JSResourceToScriptElement(resource: JSResource): JSX.Element {
         type={scriptType}
         spa-preserve
         defer={toDefer}
+        // skipcq: JS-0440 -- inline script content is build-time only; no user input reaches this path
         dangerouslySetInnerHTML={{ __html: content }}
       ></script>
     )

--- a/quartz/util/tests/head.test.ts
+++ b/quartz/util/tests/head.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../components/constants"
 import { type ProcessedContent } from "../../plugins/vfile"
 import { backgroundDark, backgroundLight } from "../../styles/variables"
-import { type GlobalConfiguration } from "../../util/config"
+import { type GlobalConfiguration } from "../config"
 import { escapeHTML } from "../escape"
 import { renderHead, maybeProduceVideoTag } from "../head"
 import { type FullSlug } from "../path"

--- a/scripts/subfont.sh
+++ b/scripts/subfont.sh
@@ -17,7 +17,7 @@ echo "Subsetting fonts in $num_files files"
 # --formats and --instance are unused and intentionally omitted.
 start_time=$(date +%s)
 # shellcheck disable=SC2086
-NODE_OPTIONS="--max-old-space-size=12288" subfont --root public/ $html_files --in-place --inline-css --no-recursive --debug
+NODE_OPTIONS="--max-old-space-size=12288" pnpm exec subfont --root public/ $html_files --in-place --inline-css --no-recursive --debug
 end_time=$(date +%s)
 elapsed=$((end_time - start_time))
 echo "Subfont completed in ${elapsed}s"

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -13,6 +13,22 @@ from rich.style import Style
 from scripts import run_push_checks
 
 
+def _step_by_name(
+    steps: list[run_push_checks.CheckStep], name: str
+) -> run_push_checks.CheckStep:
+    """
+    Look up a step by name.
+
+    Asserts existence (StopIteration would mask a missing step as a RuntimeError
+    in Python 3.7+; this surfaces it as a clear AssertionError in test output
+    instead).
+    """
+    for step in steps:
+        if step.name == name:
+            return step
+    raise AssertionError(f"Step not found: {name!r}")
+
+
 @pytest.fixture
 def temp_state_dir() -> Iterator[str]:
     """Create a temporary directory for state files."""
@@ -610,14 +626,14 @@ def test_get_formatter_steps():
     # Ruff check has --fix so the step is an autofixer, not a blocking
     # check. We deliberately do NOT run `ruff format` here — black runs
     # via lint-staged in the pre-commit hook and the two formatters fight.
-    ruff_lint = next(s for s in steps if s.name == "Linting Python")
+    ruff_lint = _step_by_name(steps, "Linting Python")
     assert "--fix" in ruff_lint.command
     assert "format" not in ruff_lint.command
     assert not any(
         s.command[:4] == ["uv", "run", "ruff", "format"] for s in steps
     )
 
-    eslint_step = next(s for s in steps if s.name == "Linting TypeScript")
+    eslint_step = _step_by_name(steps, "Linting TypeScript")
     assert "--fix" in eslint_step.command
     assert str(test_root / "config" / "javascript" / "eslint.config.js") in str(
         eslint_step.command
@@ -628,101 +644,111 @@ def test_get_formatter_steps():
         assert step.requires is None
 
     # Prettier step globs should reach expected trees
-    prettier_markdown = next(
-        s for s in steps if s.name == "Formatting markdown"
-    )
+    prettier_markdown = _step_by_name(steps, "Formatting markdown")
     assert any("website_content" in arg for arg in prettier_markdown.command)
 
 
-def test_get_check_steps():
-    """Test that check steps are properly configured."""
-    test_root = Path("/test/root")
-    steps = run_push_checks.get_check_steps(test_root)
+_TEST_ROOT = Path("/test/root")
+_VERIFY_NAMES = frozenset(
+    {"Pylint", "Mypy", "Source file checks", "Spellcheck and Vale"}
+)
+_EXPECTED_STEP_NAMES = (
+    "Linting Python",
+    "Linting TypeScript",
+    "Formatting Python docstrings",
+    "Cleaning up SCSS",
+    "Generate SCSS variables",
+    "Pylint",
+    "Mypy",
+    "Source file checks",
+    "Spellcheck and Vale",
+    "Compressing and uploading local assets",
+    "Scanning for images without alt text",
+)
 
-    # Formatter steps + 4 parallel verifiers + 2 local-only tail steps
-    formatter_count = len(run_push_checks.get_formatter_steps(test_root))
-    # Formatter steps + SCSS-vars prep + 4 parallel verifiers + 2 tail steps
+
+def test_get_check_steps_has_expected_step_count():
+    """Formatter steps + SCSS-vars prep + 4 parallel verifiers + 2 tail
+    steps."""
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    formatter_count = len(run_push_checks.get_formatter_steps(_TEST_ROOT))
     assert len(steps) == formatter_count + 7
 
-    step_names = [s.name for s in steps]
-    assert "Linting Python" in step_names
-    assert "Linting TypeScript" in step_names
-    assert "Formatting Python docstrings" in step_names
-    assert "Cleaning up SCSS" in step_names
-    assert "Generate SCSS variables" in step_names
-    assert "Pylint" in step_names
-    assert "Mypy" in step_names
-    assert "Source file checks" in step_names
-    assert "Spellcheck and Vale" in step_names
-    assert "Compressing and uploading local assets" in step_names
-    assert "Scanning for images without alt text" in step_names
 
-    # SCSS variables must be generated before the verify group so
-    # source_file_checks can resolve `@use "./variables.scss"`. Keep it
-    # sequential (parallel_group=None).
-    scss_step = next(s for s in steps if s.name == "Generate SCSS variables")
+@pytest.mark.parametrize("name", _EXPECTED_STEP_NAMES)
+def test_get_check_steps_includes_named_step(name):
+    """Each expected step shows up in the configured pipeline."""
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    assert name in [s.name for s in steps]
+
+
+def test_scss_variables_runs_before_source_file_checks():
+    """
+    SCSS variables must be generated before the verify group so
+    source_file_checks can resolve `@use "./variables.scss"`.
+
+    Keep it sequential (parallel_group=None).
+    """
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    scss_step = _step_by_name(steps, "Generate SCSS variables")
     assert scss_step.parallel_group is None
-    scss_idx = next(
-        i for i, s in enumerate(steps) if s.name == "Generate SCSS variables"
-    )
-    source_idx = next(
-        i for i, s in enumerate(steps) if s.name == "Source file checks"
-    )
-    assert scss_idx < source_idx
-
-    pylint_step = next(s for s in steps if s.name == "Pylint")
-    assert pylint_step.command[:5] == [
-        "uv",
-        "run",
-        "python",
-        "-m",
-        "pylint",
-    ]
+    step_index = {s.name: i for i, s in enumerate(steps)}
     assert (
-        str(test_root / "config" / "python" / ".pylintrc")
+        step_index["Generate SCSS variables"] < step_index["Source file checks"]
+    )
+
+
+def test_pylint_step_invocation():
+    """Pylint is invoked via `uv run python -m pylint` with the project's
+    pylintrc and runs in the verify parallel group."""
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    pylint_step = _step_by_name(steps, "Pylint")
+    assert pylint_step.command[:5] == ["uv", "run", "python", "-m", "pylint"]
+    assert (
+        str(_TEST_ROOT / "config" / "python" / ".pylintrc")
         in pylint_step.command
     )
     assert pylint_step.command[-1] == "."
-    assert pylint_step.cwd == str(test_root)
+    assert pylint_step.cwd == str(_TEST_ROOT)
     assert pylint_step.parallel_group == "verify"
 
-    # All four read-only verifiers share the same parallel group so they
-    # run concurrently rather than serially.
-    verify_names = {
-        "Pylint",
-        "Mypy",
-        "Source file checks",
-        "Spellcheck and Vale",
+
+def test_verify_steps_share_parallel_group():
+    """All four read-only verifiers share the verify parallel group; every other
+    step is sequential (parallel_group=None)."""
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    expected = {
+        s.name: ("verify" if s.name in _VERIFY_NAMES else None) for s in steps
     }
-    for step in steps:
-        if step.name in verify_names:
-            assert step.parallel_group == "verify"
-        else:
-            assert step.parallel_group is None
+    actual = {s.name: s.parallel_group for s in steps}
+    assert actual == expected
 
-    spellcheck_step = next(s for s in steps if s.name == "Spellcheck and Vale")
-    assert spellcheck_step.requires == "vale"
 
-    # Verify ESLint is configured with --fix and correct config path
-    # skipcq: PTC-W0063 (step existence already asserted via step_names above)
-    eslint_step = next(s for s in steps if s.name == "Linting TypeScript")
+def test_spellcheck_step_requires_vale():
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    assert _step_by_name(steps, "Spellcheck and Vale").requires == "vale"
+
+
+def test_eslint_step_invocation():
+    """ESLint runs with --fix and the project's eslint.config.js."""
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    eslint_step = _step_by_name(steps, "Linting TypeScript")
     assert "--fix" in eslint_step.command
-    assert str(test_root / "config" / "javascript" / "eslint.config.js") in str(
-        eslint_step.command
-    )
+    assert str(
+        _TEST_ROOT / "config" / "javascript" / "eslint.config.js"
+    ) in str(eslint_step.command)
 
-    # Verify asset step uses bash shell and requires rclone
-    # skipcq: PTC-W0063 (step existence already asserted via step_names above)
-    asset_step = next(
-        s for s in steps if s.name == "Compressing and uploading local assets"
-    )
+
+def test_asset_step_uses_bash_and_requires_rclone():
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    asset_step = _step_by_name(steps, "Compressing and uploading local assets")
     assert asset_step.shell is True
     assert asset_step.requires == "rclone"
 
-    # skipcq: PTC-W0063 (step existence already asserted via step_names above)
-    alt_step = next(
-        s for s in steps if s.name == "Scanning for images without alt text"
-    )
+
+def test_alt_text_step_requires_alt_text_llm():
+    steps = run_push_checks.get_check_steps(_TEST_ROOT)
+    alt_step = _step_by_name(steps, "Scanning for images without alt text")
     assert alt_step.requires == "alt-text-llm"
 
 


### PR DESCRIPTION
PR #1213 switched the local subfont devDependency to the pinned npm
package @turntrout/subfont@1.8.1, but deploy.yaml and
lighthouse-layout-shift.yaml were still installing from the github
fork (`pnpm add -g github:alexander-turner/subfont`) before each run.
The global install pulled an unpinned tip-of-branch version, defeating
the deterministic-installs goal of #1213 and silently masking version
drift between local and CI.

Drop the global install entirely and call subfont through `pnpm exec`,
which resolves to the version pinned in package.json and pnpm-lock.yaml
(installed by setup-site's `pnpm install --frozen-lockfile`).

- scripts/subfont.sh: `subfont` -> `pnpm exec subfont`.
- deploy.yaml prepare-deploy: drop the install step; comment notes
  the new resolution path.
- lighthouse-layout-shift.yaml: drop the install step; the inline
  invocation now uses `pnpm exec subfont`.
- subfont-bisect.yaml is intentionally left alone; it bisects fork
  refs and is supposed to install the github fork at a chosen ref.