### PR TITLE
Redesign visual gallery: side-by-side diffs as landing page

### DIFF
--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -26,6 +26,7 @@ permissions:
   actions: read
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   # Gate: only run expensive tests on PRs when a CI label is actively added.
@@ -454,6 +455,27 @@ jobs:
           branch: ${{ steps.cf-branch.outputs.name }}
           public-dir: ./playwright-report
 
+      # Surface the Cloudflare URL as a commit status so the red X on
+      # PR/commit pages links straight to the diff gallery via "Details"
+      # — instead of dropping into the workflow run logs.
+      - name: Post visual-diff commit status
+        if: steps.deploy-report.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CLOUDFLARE_URL: https://${{ steps.cf-branch.outputs.name }}.turntrout.pages.dev
+        with:
+          script: |
+            const sha = context.payload.pull_request?.head.sha || context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'failure',
+              context: 'Visual diff report',
+              target_url: process.env.CLOUDFLARE_URL,
+              description: 'Open Details to view the screenshot diff gallery',
+            });
+
       # Always-on summary on the workflow run page. Works for PR and main
       # pushes so you can find the URLs from any failing visual-testing
       # run without hunting through the Artifacts section. Includes the
@@ -472,8 +494,8 @@ jobs:
             echo "## Visual diff report"
             echo ""
             if [ "$CLOUDFLARE_OK" = "true" ]; then
-              echo "- Playwright report (per-test detail): $CLOUDFLARE_URL"
-              echo "- Screenshot gallery (skim view): $CLOUDFLARE_URL/gallery.html"
+              echo "- Diff gallery (skim view, expected/actual/diff side-by-side): $CLOUDFLARE_URL"
+              echo "- Playwright report (per-test detail): $CLOUDFLARE_URL/report.html"
               echo ""
             fi
             echo "- Artifact: $ARTIFACT_URL"
@@ -513,8 +535,8 @@ jobs:
               '',
             ];
             if (cloudflareOk) {
-              lines.push(`- Playwright report (per-test detail): ${cloudflareUrl}`);
-              lines.push(`- Screenshot gallery (skim view): ${cloudflareUrl}/gallery.html`);
+              lines.push(`- Diff gallery (skim view, expected/actual/diff side-by-side): ${cloudflareUrl}`);
+              lines.push(`- Playwright report (per-test detail): ${cloudflareUrl}/report.html`);
               lines.push('');
             }
             lines.push(`Download: ${artifactUrl}`);

--- a/scripts/generate_visual_gallery.py
+++ b/scripts/generate_visual_gallery.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 """
-Generate a single-page screenshot gallery from Playwright trace artifacts.
+Build a single-page screenshot gallery from Playwright trace artifacts.
 
-The Playwright HTML report buries each shot behind a click-into-a-test panel,
-which is painful to skim for many failures. This emits a self-contained gallery:
-one row per failed screenshot with expected, actual, and diff side-by-side,
-click-to-enlarge lightbox.
+Usage: generate_visual_gallery.py <traces-dir> <report-dir>
 
-Usage: generate_visual_gallery.py <traces-dir> <report-dir>   traces-dir  Root
-of downloaded `playwright-traces-*` artifacts. Globbed               recursively
-for `*-actual.png` files, skipping `*-retry*`               dirs to avoid
-duplicates from Playwright's retry pass.   report-dir  Existing playwright-
-report directory. The script writes               `<report-dir>/index.html`
-(replacing Playwright's index, which               is preserved at
-`report.html`) and copies images to               `<report-dir>/gallery-
-images/`.
+Walks ``traces-dir`` for ``*-actual.png`` (skipping ``*-retry*`` dirs), pairs
+each with sibling ``*-expected.png`` / ``*-diff.png``, copies them into
+``<report-dir>/gallery-images/``, and writes the gallery to ``<report-
+dir>/index.html``. Any existing Playwright ``index.html`` is moved aside to
+``report.html`` and linked from the gallery header.
 """
 
 from __future__ import annotations
@@ -28,6 +22,52 @@ from pathlib import Path
 ACTUAL_SUFFIX = "-actual.png"
 EXPECTED_SUFFIX = "-expected.png"
 DIFF_SUFFIX = "-diff.png"
+
+_CSS = """
+:root { color-scheme: light dark; }
+body { font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; margin: 1.25rem; }
+h1 { margin: 0 0 .25rem; }
+.sub { color: #666; margin: 0 0 1.25rem; }
+.row { margin: 0 0 2rem; padding: .75rem; border-radius: 6px;
+       background: rgba(127,127,127,0.06); border: 1px solid rgba(127,127,127,0.2); }
+.row h3 { margin: 0 0 .5rem; font-size: .95rem; word-break: break-all; }
+.row h3 a { color: inherit; text-decoration: none; }
+.row h3 a:hover { text-decoration: underline; }
+.cells { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+         gap: .75rem; align-items: start; }
+.cell { margin: 0; max-height: 600px; overflow: auto;
+        border: 1px solid rgba(127,127,127,0.25); border-radius: 3px;
+        background: rgba(0,0,0,0.02); }
+.cell figcaption { position: sticky; top: 0; z-index: 1;
+                   font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
+                   color: #888; padding: .25rem .5rem;
+                   background: rgba(255,255,255,0.85);
+                   backdrop-filter: blur(4px);
+                   border-bottom: 1px solid rgba(127,127,127,0.15); }
+@media (prefers-color-scheme: dark) {
+  .cell figcaption { background: rgba(20,20,20,0.85); }
+}
+.cell img { width: 100%; height: auto; display: block; cursor: zoom-in; }
+.cell.missing { max-height: none; overflow: visible; border: none; background: none; }
+.cell.missing .placeholder { display: flex; align-items: center; justify-content: center;
+                             height: 6rem; color: #888; font-size: .8rem;
+                             border: 1px dashed rgba(127,127,127,0.4); border-radius: 3px; }
+.empty { color: #888; }
+.lb { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.92); z-index: 9999;
+      cursor: zoom-out; padding: 1rem; overflow: auto; }
+.lb.show { display: block; }
+.lb img { display: block; margin: 0 auto; max-width: 100%; }
+"""
+
+_JS = """
+const lb = document.getElementById('lb'), lbi = document.getElementById('lbi');
+document.querySelectorAll('.cell a').forEach(a => a.addEventListener('click', e => {
+  e.preventDefault(); lbi.src = a.querySelector('img').src;
+  lb.scrollTop = 0; lb.classList.add('show');
+}));
+lb.addEventListener('click', () => lb.classList.remove('show'));
+document.addEventListener('keydown', e => { if (e.key === 'Escape') lb.classList.remove('show'); });
+"""
 
 
 @dataclass(frozen=True)
@@ -55,31 +95,33 @@ def collect_tiles(traces_dir: Path, images_dir: Path) -> list[Tile]:
     tiles: list[Tile] = []
 
     for actual in sorted(traces_dir.rglob(f"*{ACTUAL_SUFFIX}")):
-        # Playwright re-runs failed tests in *-retry<N>/ subdirs; skip those
-        # so each test contributes one tile.
-        if "-retry" in actual.parent.name:
+        # Playwright re-runs failures under *-retry<N>/; skip so each test
+        # contributes one tile.
+        parent = actual.parent.name
+        if "-retry" in parent:
             continue
         stem = actual.name[: -len(ACTUAL_SUFFIX)]
-        key = f"{actual.parent.name}/{stem}"
+        key = f"{parent}/{stem}"
         if key in seen:
             continue
         seen.add(key)
 
-        prefix = f"{actual.parent.name}__{stem}"
-        expected_src = actual.with_name(f"{stem}{EXPECTED_SUFFIX}")
-        diff_src = actual.with_name(f"{stem}{DIFF_SUFFIX}")
-
+        prefix = f"{parent}__{stem}"
         tiles.append(
             Tile(
                 label=stem,
                 expected=_copy_if_exists(
-                    expected_src, images_dir, f"{prefix}-expected.png"
+                    actual.with_name(f"{stem}{EXPECTED_SUFFIX}"),
+                    images_dir,
+                    f"{prefix}-expected.png",
                 ),
                 actual=_copy_if_exists(
                     actual, images_dir, f"{prefix}-actual.png"
                 ),
                 diff=_copy_if_exists(
-                    diff_src, images_dir, f"{prefix}-diff.png"
+                    actual.with_name(f"{stem}{DIFF_SUFFIX}"),
+                    images_dir,
+                    f"{prefix}-diff.png",
                 ),
             )
         )
@@ -91,18 +133,33 @@ def collect_tiles(traces_dir: Path, images_dir: Path) -> list[Tile]:
 def _figure(images_subdir: str, kind: str, name: str | None) -> str:
     """Render one image cell, or a placeholder if the file is missing."""
     if name is None:
-        return (
-            f'<figure class="cell missing">'
-            f"<figcaption>{kind}</figcaption>"
-            f'<div class="placeholder">not captured</div>'
-            f"</figure>"
+        inner = '<div class="placeholder">not captured</div>'
+        cls = "cell missing"
+    else:
+        src = f"{images_subdir}/{html.escape(name)}"
+        inner = (
+            f'<a href="{src}"><img src="{src}" loading="lazy" alt="{kind}"></a>'
         )
-    src = f"{images_subdir}/{html.escape(name)}"
+        cls = "cell"
     return (
-        f'<figure class="cell">'
-        f"<figcaption>{kind}</figcaption>"
-        f'<a href="{src}"><img src="{src}" loading="lazy" alt="{kind}"></a>'
-        f"</figure>"
+        f'<figure class="{cls}"><figcaption>{kind}</figcaption>{inner}</figure>'
+    )
+
+
+def _row(t: Tile, images_subdir: str) -> str:
+    label = html.escape(t.label)
+    cells = "".join(
+        _figure(images_subdir, kind, name)
+        for kind, name in (
+            ("expected", t.expected),
+            ("actual", t.actual),
+            ("diff", t.diff),
+        )
+    )
+    return (
+        f'<section class="row" id="{label}">'
+        f'<h3><a href="#{label}">{label}</a></h3>'
+        f'<div class="cells">{cells}</div></section>'
     )
 
 
@@ -118,19 +175,9 @@ def render_html(
     If ``has_playwright_report`` is False, the header link to the full
     Playwright report is omitted to avoid a dead link.
     """
-    rows = "\n".join(
-        f'<section class="row" id="{html.escape(t.label)}">'
-        f'<h3><a href="#{html.escape(t.label)}">{html.escape(t.label)}</a></h3>'
-        f'<div class="cells">'
-        f'{_figure(images_subdir, "expected", t.expected)}'
-        f'{_figure(images_subdir, "actual", t.actual)}'
-        f'{_figure(images_subdir, "diff", t.diff)}'
-        f"</div>"
-        f"</section>"
-        for t in tiles
+    body = "\n".join(_row(t, images_subdir) for t in tiles) or (
+        '<p class="empty">No failing screenshots found.</p>'
     )
-
-    body = rows or '<p class="empty">No failing screenshots found.</p>'
     count = len(tiles)
     plural = "" if count == 1 else "s"
     report_link = (
@@ -138,64 +185,20 @@ def render_html(
         if has_playwright_report
         else ""
     )
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Visual diff gallery</title>
-<style>
-:root {{ color-scheme: light dark; }}
-body {{ font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; margin: 1.25rem; }}
-h1 {{ margin: 0 0 .25rem; }}
-.sub {{ color: #666; margin: 0 0 1.25rem; }}
-.row {{ margin: 0 0 2rem; padding: .75rem; border-radius: 6px;
-       background: rgba(127,127,127,0.06); border: 1px solid rgba(127,127,127,0.2); }}
-.row h3 {{ margin: 0 0 .5rem; font-size: .95rem; word-break: break-all; }}
-.row h3 a {{ color: inherit; text-decoration: none; }}
-.row h3 a:hover {{ text-decoration: underline; }}
-.cells {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
-          gap: .75rem; align-items: start; }}
-.cell {{ margin: 0; max-height: 600px; overflow: auto;
-         border: 1px solid rgba(127,127,127,0.25); border-radius: 3px;
-         background: rgba(0,0,0,0.02); }}
-.cell figcaption {{ position: sticky; top: 0; z-index: 1;
-                    font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
-                    color: #888; padding: .25rem .5rem;
-                    background: rgba(255,255,255,0.85);
-                    backdrop-filter: blur(4px);
-                    border-bottom: 1px solid rgba(127,127,127,0.15); }}
-@media (prefers-color-scheme: dark) {{
-  .cell figcaption {{ background: rgba(20,20,20,0.85); }}
-}}
-.cell img {{ width: 100%; height: auto; display: block; cursor: zoom-in; }}
-.cell.missing {{ max-height: none; overflow: visible; border: none; background: none; }}
-.cell.missing .placeholder {{ display: flex; align-items: center; justify-content: center;
-                              height: 6rem; color: #888; font-size: .8rem;
-                              border: 1px dashed rgba(127,127,127,0.4); border-radius: 3px; }}
-.empty {{ color: #888; }}
-.lb {{ display: none; position: fixed; inset: 0; background: rgba(0,0,0,.92); z-index: 9999;
-       cursor: zoom-out; padding: 1rem; overflow: auto; }}
-.lb.show {{ display: block; }}
-.lb img {{ display: block; margin: 0 auto; max-width: 100%; }}
-</style>
-</head>
-<body>
-<h1>Visual diff gallery</h1>
-<p class="sub">{count} failing screenshot{plural} · click any image to enlarge · scroll within a cell to see tall screenshots{report_link}</p>
-{body}
-<div class="lb" id="lb"><img id="lbi" alt=""></div>
-<script>
-const lb = document.getElementById('lb'); const lbi = document.getElementById('lbi');
-document.querySelectorAll('.cell a').forEach(a => a.addEventListener('click', e => {{
-  e.preventDefault(); lbi.src = a.querySelector('img').src;
-  lb.scrollTop = 0; lb.classList.add('show');
-}}));
-lb.addEventListener('click', () => lb.classList.remove('show'));
-document.addEventListener('keydown', e => {{ if (e.key === 'Escape') lb.classList.remove('show'); }});
-</script>
-</body>
-</html>
-"""
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        "<title>Visual diff gallery</title>\n"
+        f"<style>{_CSS}</style>\n</head>\n<body>\n"
+        "<h1>Visual diff gallery</h1>\n"
+        f'<p class="sub">{count} failing screenshot{plural} · click any image '
+        f"to enlarge · scroll within a cell to see tall screenshots"
+        f"{report_link}</p>\n"
+        f"{body}\n"
+        '<div class="lb" id="lb"><img id="lbi" alt=""></div>\n'
+        f"<script>{_JS}</script>\n"
+        "</body>\n</html>\n"
+    )
 
 
 def install_as_index(report_dir: Path, gallery_html: str) -> None:
@@ -208,10 +211,10 @@ def install_as_index(report_dir: Path, gallery_html: str) -> None:
 
 def main(traces_dir: Path, report_dir: Path) -> None:
     """Build the gallery and install it as index.html."""
-    images_dir = report_dir / "gallery-images"
-    tiles = collect_tiles(traces_dir, images_dir)
-    has_report = (report_dir / "index.html").exists()
-    page = render_html(tiles, has_playwright_report=has_report)
+    tiles = collect_tiles(traces_dir, report_dir / "gallery-images")
+    page = render_html(
+        tiles, has_playwright_report=(report_dir / "index.html").exists()
+    )
     # Keep gallery.html for backward-compatible deep links.
     (report_dir / "gallery.html").write_text(page, encoding="utf-8")
     install_as_index(report_dir, page)

--- a/scripts/generate_visual_gallery.py
+++ b/scripts/generate_visual_gallery.py
@@ -3,16 +3,18 @@
 Generate a single-page screenshot gallery from Playwright trace artifacts.
 
 The Playwright HTML report buries each shot behind a click-into-a-test panel,
-which is painful to skim for ~100 bootstrap shots. This emits a self-contained
-`gallery.html` next to it: one tile per failed-comparison screenshot, click-to-
-enlarge lightbox, sorted by test label.
+which is painful to skim for many failures. This emits a self-contained gallery:
+one row per failed screenshot with expected, actual, and diff side-by-side,
+click-to-enlarge lightbox.
 
-Usage: generate-visual-gallery.py <traces-dir> <report-dir>   traces-dir  Root
+Usage: generate_visual_gallery.py <traces-dir> <report-dir>   traces-dir  Root
 of downloaded `playwright-traces-*` artifacts. Globbed               recursively
 for `*-actual.png` files, skipping `*-retry*`               dirs to avoid
 duplicates from Playwright's retry pass.   report-dir  Existing playwright-
-report directory. The script writes               `<report-dir>/gallery.html`
-and copies images to               `<report-dir>/gallery-images/`.
+report directory. The script writes               `<report-dir>/index.html`
+(replacing Playwright's index, which               is preserved at
+`report.html`) and copies images to               `<report-dir>/gallery-
+images/`.
 """
 
 from __future__ import annotations
@@ -20,78 +22,150 @@ from __future__ import annotations
 import html
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
+ACTUAL_SUFFIX = "-actual.png"
+EXPECTED_SUFFIX = "-expected.png"
+DIFF_SUFFIX = "-diff.png"
 
-def main(traces_dir: Path, report_dir: Path) -> None:
-    """Build a static HTML gallery of Playwright `*-actual.png` screenshots."""
-    images_dir = report_dir / "gallery-images"
+
+@dataclass(frozen=True)
+class Tile:
+    """One failing screenshot: expected vs actual vs diff."""
+
+    label: str
+    expected: str | None
+    actual: str | None
+    diff: str | None
+
+
+def _copy_if_exists(src: Path, dest_dir: Path, dest_name: str) -> str | None:
+    """Copy src into dest_dir as dest_name; return the copied filename."""
+    if not src.exists():
+        return None
+    shutil.copy(src, dest_dir / dest_name)
+    return dest_name
+
+
+def collect_tiles(traces_dir: Path, images_dir: Path) -> list[Tile]:
+    """Walk traces_dir for failing screenshots and copy them into images_dir."""
     images_dir.mkdir(parents=True, exist_ok=True)
-
     seen: set[str] = set()
-    tiles: list[tuple[str, str]] = []  # (label, copied filename)
+    tiles: list[Tile] = []
 
-    for actual in sorted(traces_dir.rglob("*-actual.png")):
-        parent = actual.parent.name
+    for actual in sorted(traces_dir.rglob(f"*{ACTUAL_SUFFIX}")):
         # Playwright re-runs failed tests in *-retry<N>/ subdirs; skip those
         # so each test contributes one tile.
-        if "-retry" in parent:
+        if "-retry" in actual.parent.name:
             continue
-        # Use parent dir as the test label — Playwright already sanitizes
-        # it to a (somewhat) human-readable form.
-        if parent in seen:
+        stem = actual.name[: -len(ACTUAL_SUFFIX)]
+        key = f"{actual.parent.name}/{stem}"
+        if key in seen:
             continue
-        seen.add(parent)
+        seen.add(key)
 
-        dest_name = f"{parent}__{actual.name}"
-        shutil.copy(actual, images_dir / dest_name)
-        tiles.append((parent, dest_name))
+        prefix = f"{actual.parent.name}__{stem}"
+        expected_src = actual.with_name(f"{stem}{EXPECTED_SUFFIX}")
+        diff_src = actual.with_name(f"{stem}{DIFF_SUFFIX}")
 
-    tiles.sort(key=lambda t: t[0])
+        tiles.append(
+            Tile(
+                label=stem,
+                expected=_copy_if_exists(
+                    expected_src, images_dir, f"{prefix}-expected.png"
+                ),
+                actual=_copy_if_exists(
+                    actual, images_dir, f"{prefix}-actual.png"
+                ),
+                diff=_copy_if_exists(
+                    diff_src, images_dir, f"{prefix}-diff.png"
+                ),
+            )
+        )
 
-    tile_html = "\n".join(
-        f'<a class="tile" href="gallery-images/{html.escape(name)}" '
-        f'data-label="{html.escape(label)}">'
-        f'<img src="gallery-images/{html.escape(name)}" loading="lazy" '
-        f'alt="{html.escape(label)}">'
-        f"<p>{html.escape(label)}</p>"
-        f"</a>"
-        for label, name in tiles
+    tiles.sort(key=lambda t: t.label)
+    return tiles
+
+
+def _figure(images_subdir: str, kind: str, name: str | None) -> str:
+    """Render one image cell, or a placeholder if the file is missing."""
+    if name is None:
+        return (
+            f'<figure class="cell missing">'
+            f"<figcaption>{kind}</figcaption>"
+            f'<div class="placeholder">not captured</div>'
+            f"</figure>"
+        )
+    src = f"{images_subdir}/{html.escape(name)}"
+    return (
+        f'<figure class="cell">'
+        f"<figcaption>{kind}</figcaption>"
+        f'<a href="{src}"><img src="{src}" loading="lazy" alt="{kind}"></a>'
+        f"</figure>"
     )
 
-    page = f"""<!DOCTYPE html>
+
+def render_html(
+    tiles: list[Tile], images_subdir: str = "gallery-images"
+) -> str:
+    """Build the gallery HTML page."""
+    rows = "\n".join(
+        f'<section class="row" id="{html.escape(t.label)}">'
+        f'<h3><a href="#{html.escape(t.label)}">{html.escape(t.label)}</a></h3>'
+        f'<div class="cells">'
+        f'{_figure(images_subdir, "expected", t.expected)}'
+        f'{_figure(images_subdir, "actual", t.actual)}'
+        f'{_figure(images_subdir, "diff", t.diff)}'
+        f"</div>"
+        f"</section>"
+        for t in tiles
+    )
+
+    body = rows or '<p class="empty">No failing screenshots found.</p>'
+    count = len(tiles)
+    plural = "" if count == 1 else "s"
+    return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Visual screenshot gallery</title>
+<title>Visual diff gallery</title>
 <style>
 :root {{ color-scheme: light dark; }}
 body {{ font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; margin: 1.25rem; }}
 h1 {{ margin: 0 0 .25rem; }}
 .sub {{ color: #666; margin: 0 0 1.25rem; }}
-.grid {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }}
-.tile {{ display: block; text-decoration: none; color: inherit; padding: .5rem; border-radius: 4px;
-        background: rgba(127,127,127,0.06); border: 1px solid rgba(127,127,127,0.2); }}
-.tile:hover {{ background: rgba(127,127,127,0.12); }}
-.tile img {{ width: 100%; height: auto; display: block; border: 1px solid rgba(127,127,127,0.2); cursor: zoom-in; }}
-.tile p {{ font-size: .8rem; word-break: break-all; margin: .35rem 0 0; }}
-.lb {{ display: none; position: fixed; inset: 0; background: rgba(0,0,0,.9); z-index: 9999;
+.row {{ margin: 0 0 2rem; padding: .75rem; border-radius: 6px;
+       background: rgba(127,127,127,0.06); border: 1px solid rgba(127,127,127,0.2); }}
+.row h3 {{ margin: 0 0 .5rem; font-size: .95rem; word-break: break-all; }}
+.row h3 a {{ color: inherit; text-decoration: none; }}
+.row h3 a:hover {{ text-decoration: underline; }}
+.cells {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: .75rem; align-items: start; }}
+.cell {{ margin: 0; }}
+.cell figcaption {{ font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
+                    color: #888; margin: 0 0 .25rem; }}
+.cell img {{ width: 100%; height: auto; display: block; cursor: zoom-in;
+             border: 1px solid rgba(127,127,127,0.25); border-radius: 3px; }}
+.cell.missing .placeholder {{ display: flex; align-items: center; justify-content: center;
+                              height: 6rem; color: #888; font-size: .8rem;
+                              border: 1px dashed rgba(127,127,127,0.4); border-radius: 3px; }}
+.empty {{ color: #888; }}
+.lb {{ display: none; position: fixed; inset: 0; background: rgba(0,0,0,.92); z-index: 9999;
        align-items: center; justify-content: center; cursor: zoom-out; padding: 1rem; }}
 .lb.show {{ display: flex; }}
 .lb img {{ max-width: 100%; max-height: 100%; }}
 </style>
 </head>
 <body>
-<h1>Visual screenshot gallery</h1>
-<p class="sub">{len(tiles)} screenshot{'s' if len(tiles) != 1 else ''} · click any tile to enlarge · <a href="index.html">back to Playwright report</a></p>
-<div class="grid">
-{tile_html}
-</div>
+<h1>Visual diff gallery</h1>
+<p class="sub">{count} failing screenshot{plural} · click any image to enlarge · <a href="report.html">open full Playwright report</a></p>
+{body}
 <div class="lb" id="lb"><img id="lbi" alt=""></div>
 <script>
 const lb = document.getElementById('lb'); const lbi = document.getElementById('lbi');
-document.querySelectorAll('.tile').forEach(t => t.addEventListener('click', e => {{
-  e.preventDefault(); lbi.src = t.querySelector('img').src; lb.classList.add('show');
+document.querySelectorAll('.cell a').forEach(a => a.addEventListener('click', e => {{
+  e.preventDefault(); lbi.src = a.querySelector('img').src; lb.classList.add('show');
 }}));
 lb.addEventListener('click', () => lb.classList.remove('show'));
 document.addEventListener('keydown', e => {{ if (e.key === 'Escape') lb.classList.remove('show'); }});
@@ -100,8 +174,24 @@ document.addEventListener('keydown', e => {{ if (e.key === 'Escape') lb.classLis
 </html>
 """
 
+
+def install_as_index(report_dir: Path, gallery_html: str) -> None:
+    """Make the gallery the landing page; preserve Playwright at report.html."""
+    playwright_index = report_dir / "index.html"
+    if playwright_index.exists():
+        playwright_index.replace(report_dir / "report.html")
+    (report_dir / "index.html").write_text(gallery_html, encoding="utf-8")
+
+
+def main(traces_dir: Path, report_dir: Path) -> None:
+    """Build the gallery and install it as index.html."""
+    images_dir = report_dir / "gallery-images"
+    tiles = collect_tiles(traces_dir, images_dir)
+    page = render_html(tiles)
+    # Keep gallery.html for backward-compatible deep links.
     (report_dir / "gallery.html").write_text(page, encoding="utf-8")
-    print(f"Wrote {report_dir / 'gallery.html'} with {len(tiles)} tiles")
+    install_as_index(report_dir, page)
+    print(f"Wrote {report_dir / 'index.html'} with {len(tiles)} tiles")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_visual_gallery.py
+++ b/scripts/generate_visual_gallery.py
@@ -107,9 +107,17 @@ def _figure(images_subdir: str, kind: str, name: str | None) -> str:
 
 
 def render_html(
-    tiles: list[Tile], images_subdir: str = "gallery-images"
+    tiles: list[Tile],
+    images_subdir: str = "gallery-images",
+    *,
+    has_playwright_report: bool = True,
 ) -> str:
-    """Build the gallery HTML page."""
+    """
+    Build the gallery HTML page.
+
+    If ``has_playwright_report`` is False, the header link to the full
+    Playwright report is omitted to avoid a dead link.
+    """
     rows = "\n".join(
         f'<section class="row" id="{html.escape(t.label)}">'
         f'<h3><a href="#{html.escape(t.label)}">{html.escape(t.label)}</a></h3>'
@@ -125,6 +133,11 @@ def render_html(
     body = rows or '<p class="empty">No failing screenshots found.</p>'
     count = len(tiles)
     plural = "" if count == 1 else "s"
+    report_link = (
+        ' · <a href="report.html">open full Playwright report</a>'
+        if has_playwright_report
+        else ""
+    )
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -142,30 +155,40 @@ h1 {{ margin: 0 0 .25rem; }}
 .row h3 a:hover {{ text-decoration: underline; }}
 .cells {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
           gap: .75rem; align-items: start; }}
-.cell {{ margin: 0; }}
-.cell figcaption {{ font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
-                    color: #888; margin: 0 0 .25rem; }}
-.cell img {{ width: 100%; height: auto; display: block; cursor: zoom-in;
-             border: 1px solid rgba(127,127,127,0.25); border-radius: 3px; }}
+.cell {{ margin: 0; max-height: 600px; overflow: auto;
+         border: 1px solid rgba(127,127,127,0.25); border-radius: 3px;
+         background: rgba(0,0,0,0.02); }}
+.cell figcaption {{ position: sticky; top: 0; z-index: 1;
+                    font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
+                    color: #888; padding: .25rem .5rem;
+                    background: rgba(255,255,255,0.85);
+                    backdrop-filter: blur(4px);
+                    border-bottom: 1px solid rgba(127,127,127,0.15); }}
+@media (prefers-color-scheme: dark) {{
+  .cell figcaption {{ background: rgba(20,20,20,0.85); }}
+}}
+.cell img {{ width: 100%; height: auto; display: block; cursor: zoom-in; }}
+.cell.missing {{ max-height: none; overflow: visible; border: none; background: none; }}
 .cell.missing .placeholder {{ display: flex; align-items: center; justify-content: center;
                               height: 6rem; color: #888; font-size: .8rem;
                               border: 1px dashed rgba(127,127,127,0.4); border-radius: 3px; }}
 .empty {{ color: #888; }}
 .lb {{ display: none; position: fixed; inset: 0; background: rgba(0,0,0,.92); z-index: 9999;
-       align-items: center; justify-content: center; cursor: zoom-out; padding: 1rem; }}
-.lb.show {{ display: flex; }}
-.lb img {{ max-width: 100%; max-height: 100%; }}
+       cursor: zoom-out; padding: 1rem; overflow: auto; }}
+.lb.show {{ display: block; }}
+.lb img {{ display: block; margin: 0 auto; max-width: 100%; }}
 </style>
 </head>
 <body>
 <h1>Visual diff gallery</h1>
-<p class="sub">{count} failing screenshot{plural} · click any image to enlarge · <a href="report.html">open full Playwright report</a></p>
+<p class="sub">{count} failing screenshot{plural} · click any image to enlarge · scroll within a cell to see tall screenshots{report_link}</p>
 {body}
 <div class="lb" id="lb"><img id="lbi" alt=""></div>
 <script>
 const lb = document.getElementById('lb'); const lbi = document.getElementById('lbi');
 document.querySelectorAll('.cell a').forEach(a => a.addEventListener('click', e => {{
-  e.preventDefault(); lbi.src = a.querySelector('img').src; lb.classList.add('show');
+  e.preventDefault(); lbi.src = a.querySelector('img').src;
+  lb.scrollTop = 0; lb.classList.add('show');
 }}));
 lb.addEventListener('click', () => lb.classList.remove('show'));
 document.addEventListener('keydown', e => {{ if (e.key === 'Escape') lb.classList.remove('show'); }});
@@ -187,7 +210,8 @@ def main(traces_dir: Path, report_dir: Path) -> None:
     """Build the gallery and install it as index.html."""
     images_dir = report_dir / "gallery-images"
     tiles = collect_tiles(traces_dir, images_dir)
-    page = render_html(tiles)
+    has_report = (report_dir / "index.html").exists()
+    page = render_html(tiles, has_playwright_report=has_report)
     # Keep gallery.html for backward-compatible deep links.
     (report_dir / "gallery.html").write_text(page, encoding="utf-8")
     install_as_index(report_dir, page)

--- a/scripts/tests/test_generate_visual_gallery.py
+++ b/scripts/tests/test_generate_visual_gallery.py
@@ -1,0 +1,179 @@
+"""Tests for scripts/generate_visual_gallery.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import generate_visual_gallery as gvg
+
+
+def _png(path: Path, payload: bytes = b"\x89PNG\r\n\x1a\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def test_collect_tiles_pairs_expected_actual_diff(tmp_path: Path) -> None:
+    test_dir = tmp_path / "traces" / "spec-foo-Desktop-Chrome"
+    _png(test_dir / "shot-actual.png")
+    _png(test_dir / "shot-expected.png")
+    _png(test_dir / "shot-diff.png")
+
+    images = tmp_path / "out" / "gallery-images"
+    tiles = gvg.collect_tiles(tmp_path / "traces", images)
+
+    assert len(tiles) == 1
+    tile = tiles[0]
+    assert tile.label == "shot"
+    assert tile.expected and (images / tile.expected).exists()
+    assert tile.actual and (images / tile.actual).exists()
+    assert tile.diff and (images / tile.diff).exists()
+
+
+def test_collect_tiles_handles_missing_siblings(tmp_path: Path) -> None:
+    test_dir = tmp_path / "traces" / "spec"
+    _png(test_dir / "shot-actual.png")
+    # No -expected.png, no -diff.png
+    tiles = gvg.collect_tiles(tmp_path / "traces", tmp_path / "out")
+
+    assert len(tiles) == 1
+    assert tiles[0].expected is None
+    assert tiles[0].diff is None
+    assert tiles[0].actual is not None
+
+
+def test_collect_tiles_skips_retry_dirs(tmp_path: Path) -> None:
+    _png(tmp_path / "traces" / "spec" / "shot-actual.png")
+    _png(tmp_path / "traces" / "spec-retry1" / "shot-actual.png")
+    tiles = gvg.collect_tiles(tmp_path / "traces", tmp_path / "out")
+
+    assert len(tiles) == 1
+    # Retry duplicate of the same parent name still gets deduped via `seen`.
+    assert "retry" not in tiles[0].label
+
+
+def test_collect_tiles_dedupes_same_parent_and_stem(tmp_path: Path) -> None:
+    """Two artifact dirs with the same trailing test dir collapse to one
+    tile."""
+    a = tmp_path / "traces" / "shard1" / "spec"
+    b = tmp_path / "traces" / "shard2" / "spec"
+    _png(a / "shot-actual.png")
+    _png(b / "shot-actual.png")
+
+    tiles = gvg.collect_tiles(tmp_path / "traces", tmp_path / "out")
+
+    # Same parent name ('spec') + same stem ('shot') → one tile.
+    assert len(tiles) == 1
+
+
+def test_collect_tiles_keeps_distinct_parents(tmp_path: Path) -> None:
+    """Different test dirs produce distinct tiles even with the same stem."""
+    _png(tmp_path / "traces" / "spec-Chrome" / "shot-actual.png")
+    _png(tmp_path / "traces" / "spec-Firefox" / "shot-actual.png")
+
+    tiles = gvg.collect_tiles(tmp_path / "traces", tmp_path / "out")
+    assert len(tiles) == 2
+
+
+def test_render_html_includes_all_tiles(tmp_path: Path) -> None:
+    tiles = [
+        gvg.Tile(
+            label="alpha", expected="a-e.png", actual="a-a.png", diff="a-d.png"
+        ),
+        gvg.Tile(label="beta", expected=None, actual="b-a.png", diff=None),
+    ]
+    page = gvg.render_html(tiles)
+
+    assert "2 failing screenshots" in page
+    assert "alpha" in page and "beta" in page
+    assert "gallery-images/a-e.png" in page
+    assert "not captured" in page  # placeholder for missing files
+    assert 'href="report.html"' in page  # link to Playwright report
+
+
+def test_render_html_singular_count() -> None:
+    page = gvg.render_html([gvg.Tile("only", None, "x.png", None)])
+    assert "1 failing screenshot " in page  # no plural "s"
+
+
+def test_render_html_empty() -> None:
+    page = gvg.render_html([])
+    assert "No failing screenshots found" in page
+    assert "0 failing screenshots" in page
+
+
+def test_render_html_escapes_label() -> None:
+    tiles = [gvg.Tile(label="<script>x", expected=None, actual=None, diff=None)]
+    page = gvg.render_html(tiles)
+    # The label is escaped wherever rendered.
+    assert "&lt;script&gt;x" in page
+    # The raw tag does not leak into the page (the inline script block uses
+    # a literal <script>, so check for our payload-marker form).
+    assert "<script>x" not in page
+
+
+def test_install_as_index_preserves_playwright(tmp_path: Path) -> None:
+    (tmp_path / "index.html").write_text("PLAYWRIGHT_HTML", encoding="utf-8")
+    gvg.install_as_index(tmp_path, "GALLERY_HTML")
+
+    assert (tmp_path / "report.html").read_text(
+        encoding="utf-8"
+    ) == "PLAYWRIGHT_HTML"
+    assert (tmp_path / "index.html").read_text(
+        encoding="utf-8"
+    ) == "GALLERY_HTML"
+
+
+def test_install_as_index_when_no_playwright(tmp_path: Path) -> None:
+    gvg.install_as_index(tmp_path, "GALLERY_HTML")
+    assert (tmp_path / "index.html").read_text(
+        encoding="utf-8"
+    ) == "GALLERY_HTML"
+    assert not (tmp_path / "report.html").exists()
+
+
+def test_main_writes_index_and_gallery(tmp_path: Path) -> None:
+    traces = tmp_path / "traces"
+    report = tmp_path / "report"
+    report.mkdir()
+    (report / "index.html").write_text("ORIGINAL", encoding="utf-8")
+    _png(traces / "spec" / "shot-actual.png")
+    _png(traces / "spec" / "shot-diff.png")
+
+    gvg.main(traces, report)
+
+    assert (report / "index.html").exists()
+    assert (report / "gallery.html").exists()
+    assert (report / "report.html").read_text(encoding="utf-8") == "ORIGINAL"
+    assert (report / "gallery-images" / "spec__shot-actual.png").exists()
+
+
+def test_cli_argument_parsing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Run the script via runpy so the __main__ branch is covered."""
+    import runpy
+    import sys
+
+    traces = tmp_path / "traces"
+    report = tmp_path / "report"
+    report.mkdir()
+    traces.mkdir()
+
+    monkeypatch.setattr(
+        sys, "argv", ["generate_visual_gallery.py", str(traces), str(report)]
+    )
+    runpy.run_module("scripts.generate_visual_gallery", run_name="__main__")
+
+    assert (report / "index.html").exists()
+
+
+def test_cli_wrong_arg_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    import runpy
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["generate_visual_gallery.py"])
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("scripts.generate_visual_gallery", run_name="__main__")
+    assert exc.value.code == 2

--- a/scripts/tests/test_generate_visual_gallery.py
+++ b/scripts/tests/test_generate_visual_gallery.py
@@ -103,6 +103,18 @@ def test_render_html_empty() -> None:
     assert "0 failing screenshots" in page
 
 
+def test_render_html_omits_report_link_when_absent() -> None:
+    page = gvg.render_html([], has_playwright_report=False)
+    assert 'href="report.html"' not in page
+
+
+def test_render_html_caps_cell_height() -> None:
+    """Tall screenshots must scroll within their cell, not blow out the page."""
+    page = gvg.render_html([])
+    assert "max-height: 600px" in page
+    assert "overflow: auto" in page
+
+
 def test_render_html_escapes_label() -> None:
     tiles = [gvg.Tile(label="<script>x", expected=None, actual=None, diff=None)]
     page = gvg.render_html(tiles)
@@ -147,6 +159,24 @@ def test_main_writes_index_and_gallery(tmp_path: Path) -> None:
     assert (report / "gallery.html").exists()
     assert (report / "report.html").read_text(encoding="utf-8") == "ORIGINAL"
     assert (report / "gallery-images" / "spec__shot-actual.png").exists()
+    # Playwright report existed → header link to it is rendered.
+    assert 'href="report.html"' in (report / "index.html").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_main_omits_report_link_when_no_playwright_index(
+    tmp_path: Path,
+) -> None:
+    traces = tmp_path / "traces"
+    report = tmp_path / "report"
+    report.mkdir()  # no index.html
+    _png(traces / "spec" / "shot-actual.png")
+
+    gvg.main(traces, report)
+
+    page = (report / "index.html").read_text(encoding="utf-8")
+    assert 'href="report.html"' not in page
 
 
 def test_cli_argument_parsing(


### PR DESCRIPTION
## Summary

Redesigns the visual screenshot gallery from a grid of thumbnails to a side-by-side comparison layout (expected/actual/diff), and makes it the landing page of the Playwright report instead of a secondary view.

## Key Changes

- **Gallery layout**: Changed from a grid of clickable tiles to a row-per-screenshot layout with three columns (expected, actual, diff) displayed side-by-side
- **Landing page**: Gallery now replaces `index.html` as the primary entry point; original Playwright report is preserved at `report.html`
- **Image handling**: Refactored to independently handle expected, actual, and diff images—each is optional and shows a placeholder if missing
- **Code structure**: 
  - Extracted `Tile` dataclass to represent a screenshot comparison
  - Separated concerns: `collect_tiles()`, `render_html()`, and `install_as_index()` functions
  - Added `_copy_if_exists()` helper for optional image files
- **Styling**: Updated CSS for row-based layout with sticky captions, scrollable cells for tall images, and improved dark mode support
- **Deduplication**: Improved logic to deduplicate by both parent directory and stem, preventing duplicates across shards
- **Workflow integration**: 
  - Added commit status reporting that links directly to the gallery via "Details"
  - Updated workflow summaries to highlight the gallery as the primary view
- **Testing**: Added comprehensive test suite (209 lines) covering tile collection, HTML rendering, file handling, and CLI argument parsing

## Notable Details

- Tall screenshots can now scroll within their cell (max-height: 600px) without breaking page layout
- Labels are properly HTML-escaped to prevent injection
- Lightbox zoom functionality preserved for detailed inspection
- Backward compatibility: `gallery.html` is still written for existing deep links
- Report link in header is conditionally rendered based on whether Playwright report exists

https://claude.ai/code/session_01Jj9C9zTapM8xutxoQurgZZ