### PR TITLE
Add collapse spaces option to punctilio demo

### DIFF
--- a/quartz/components/scripts/punctilio-demo.inline.ts
+++ b/quartz/components/scripts/punctilio-demo.inline.ts
@@ -42,6 +42,8 @@ function getConfig(): TransformOptions {
     superscript: document.querySelector<HTMLInputElement>("#opt-superscript")?.checked ?? false,
     ligatures: document.querySelector<HTMLInputElement>("#opt-ligatures")?.checked ?? false,
     nbsp: document.querySelector<HTMLInputElement>("#opt-nbsp")?.checked ?? true,
+    collapseSpaces:
+      document.querySelector<HTMLInputElement>("#opt-collapse-spaces")?.checked ?? true,
   }
 }
 

--- a/website_content/punctilio.md
+++ b/website_content/punctilio.md
@@ -66,4 +66,5 @@ While `punctilio` is easy to install, here's an online demo for fast access!
 > <li class="punctilio-option"><label><input type="checkbox" class="checkbox-toggle" id="opt-superscript" />Superscript</label></li>
 > <li class="punctilio-option"><label><input type="checkbox" class="checkbox-toggle" id="opt-ligatures" />Ligatures</label></li>
 > <li class="punctilio-option"><label><input type="checkbox" class="checkbox-toggle" id="opt-nbsp" checked />Non-breaking spaces</label></li>
+> <li class="punctilio-option"><label><input type="checkbox" class="checkbox-toggle" id="opt-collapse-spaces" checked />Collapse spaces</label></li>
 > </ul>


### PR DESCRIPTION
## Summary
Added support for the "collapse spaces" configuration option to the punctilio interactive demo, allowing users to toggle this text transformation feature.

## Changes
- **Demo script**: Added `collapseSpaces` configuration option to `getConfig()` function in the demo, defaulting to `true`
- **Demo UI**: Added a new checkbox input for the "Collapse spaces" option in the demo interface, checked by default

## Implementation Details
The new option follows the existing pattern used by other transformation options in the demo (superscript, ligatures, non-breaking spaces). It reads the state of a checkbox with id `opt-collapse-spaces` and passes it to the punctilio configuration, enabling users to test this feature interactively.

https://claude.ai/code/session_01XDjYjpLkovArHXL483CMc6