### PR TITLE
fix(visual-testing): poll deploy.yaml before rerunning verify-test-results

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   approve:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30 # 5 min R2 upload + up to 15 min polling deploy.yaml
     steps:
       - name: Resolve PR ref (if any)
         id: resolve
@@ -154,30 +154,81 @@ jobs:
             });
             core.info(`Posted passing visual-testing check-run for ${headSha}`);
 
-            const deployRuns = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'deploy.yaml',
-              head_sha: headSha,
-              per_page: 5,
-            });
-            const deploy = deployRuns.data.workflow_runs.find(
-              (r) => r.status === 'completed' && r.conclusion !== 'success'
-            );
+            // Find the deploy.yaml run for this commit, then poll until it
+            // reaches a terminal state — `rerun-failed-jobs` only works on
+            // completed runs. Typical wait is just `prepare-deploy`
+            // finishing (≈3–5 min); cap at 15 min so a stuck pipeline
+            // doesn't burn the workflow's 20-min timeout.
+            const listDeployRuns = () =>
+              github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'deploy.yaml',
+                head_sha: headSha,
+                per_page: 5,
+              });
+            const POLL_INTERVAL_MS = 30_000;
+            const MAX_ATTEMPTS = 30; // 30 × 30s = 15 min
+            let deploy;
+            for (let i = 0; i < MAX_ATTEMPTS; i++) {
+              const { data } = await listDeployRuns();
+              const run = data.workflow_runs[0]; // most recent for this SHA
+              if (!run) {
+                core.info(`No deploy.yaml run for ${headSha} yet; waiting…`);
+              } else if (run.status === 'completed') {
+                deploy = run;
+                break;
+              } else {
+                core.info(
+                  `deploy.yaml run ${run.id} still ${run.status}; waiting…`
+                );
+              }
+              await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+            }
             if (!deploy) {
-              core.info(
-                `No failed deploy.yaml run for ${headSha}; if one is ` +
-                `still in progress its verify-test-results poll will see ` +
-                `the new success on its next iteration.`
+              core.warning(
+                `deploy.yaml run for ${headSha} didn't finish within 15 min; ` +
+                `re-run its failed jobs manually from the Actions UI to ` +
+                `unblock the deploy.`
               );
               return;
             }
-            await github.rest.actions.reRunWorkflowFailedJobs({
+            if (deploy.conclusion === 'success') {
+              core.info(
+                `deploy.yaml ${deploy.id} already succeeded; nothing to do`
+              );
+              return;
+            }
+            // Rerun just the `verify-test-results` job — `rerun-job`
+            // also reruns dependents, so `deploy` re-evaluates against
+            // the now-passing visual-testing check-run. More targeted
+            // than `rerun-failed-jobs`, which would also rerun anything
+            // else that happened to fail in this run.
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: deploy.id,
+              per_page: 50,
             });
-            core.info(`Re-running deploy run ${deploy.id} failed jobs`);
+            const verifyJob = jobs.data.jobs.find(
+              (j) => j.name === 'verify-test-results'
+            );
+            if (!verifyJob) {
+              core.warning(
+                `deploy.yaml ${deploy.id} has no verify-test-results job; ` +
+                `nothing to rerun`
+              );
+              return;
+            }
+            await github.rest.actions.reRunJobForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              job_id: verifyJob.id,
+            });
+            core.info(
+              `Re-running verify-test-results job ${verifyJob.id} ` +
+              `(part of deploy run ${deploy.id})`
+            );
 
       - name: Comment success on PR
         if: success() && steps.resolve.outputs.pr_number != ''


### PR DESCRIPTION
## Summary
Fixes the main-run approve-baselines flow: even though R2 upload + synthetic `visual-testing` success check-run worked correctly, `verify-test-results` had already exited with `failure` on the original visual-testing failure and nothing re-ran it. The `deploy.yaml` run for the head SHA was still `in_progress` (waiting on `prepare-deploy`), so the prior `rerun-failed-jobs` call's "filter for completed runs" never matched and silently no-op'd.

## What changed
- Poll for the deploy.yaml run on the head SHA to reach a terminal state (30s × up to 30 attempts = 15 min cap).
- Once completed (and not already successful), `rerun-job` on the specific `verify-test-results` job. GitHub also reruns its dependents, so `deploy` re-evaluates against the now-passing `verify-test-results` (which on its retry sees the synthetic visual-testing success via `sort_by(.started_at) | last`).
- Switched from `rerun-failed-jobs` (run-wide) to `rerun-job` (targeted): only one job needs rerunning, no point bouncing anything unrelated.
- Bumped the workflow's `timeout-minutes` from 20 → 30 to fit the poll budget on top of R2 upload time.

## Verification
On the affected commit (`08bc8c8d2`), confirmed via `gh api`:
- Synthetic `visual-testing` check-run posted with `conclusion=success` at `2026-05-11T18:18:50Z` (later than the original `failure` at `18:11:09Z`).
- `verify-test-results`'s poll uses `select(.name == "visual-testing") | sort_by(.started_at) | last`, which would correctly return `success` on rerun.

So the synthetic-check approach is sound; the only fix needed is making sure we actually run the verify-test-results retry once the deploy run is rerunnable.

## Manual unblock for current stuck run
The deploy run on `08bc8c8d2` is still `in_progress` (`prepare-deploy` running). Once it completes, fire this once:
```
gh api -X POST repos/alexander-turner/TurnTrout.com/actions/jobs/75414969453/rerun
```

https://claude.ai/code/session_01MVtfvDEiKjsATCb18HDYzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVtfvDEiKjsATCb18HDYzE)_