### PR TITLE
Add explicit Puppeteer Chrome installation for pa11y-ci and subfont

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: "Whether to cache Puppeteer browsers"
     required: false
     default: "false"
+  install-puppeteer-chrome:
+    description: "Whether to install Puppeteer's Chrome (needed by pa11y-ci, subfont, Mermaid). Implies cache-puppeteer."
+    required: false
+    default: "false"
   cache-apt:
     description: "Whether to cache apt packages across runs (redirects apt archive dir)"
     required: false
@@ -36,7 +40,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # ── Node.js ──────────────────────────────────────────────────────
+    # ── Node.js ─────────────────────────────────────────────────────────────────
     - name: Set up Node.js
       if: inputs.install-node-deps == 'true'
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -80,7 +84,7 @@ runs:
       run: pnpm install --os=linux --cpu=x64 sharp
       shell: bash
 
-    # ── Python ───────────────────────────────────────────────────────
+    # ── Python ────────────────────────────────────────────────────────────────
     - name: Set up uv
       if: inputs.install-python == 'true'
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7
@@ -98,7 +102,7 @@ runs:
       run: uv sync --frozen
       shell: bash
 
-    # ── Browsers ─────────────────────────────────────────────────────
+    # ── Browsers ──────────────────────────────────────────────────────────────
     - name: Cache Playwright browsers
       if: inputs.cache-playwright == 'true'
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -109,7 +113,7 @@ runs:
           playwright-${{ runner.os }}-
 
     - name: Cache Puppeteer browsers
-      if: inputs.cache-puppeteer == 'true'
+      if: inputs.cache-puppeteer == 'true' || inputs.install-puppeteer-chrome == 'true'
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: ~/.cache/puppeteer
@@ -117,7 +121,7 @@ runs:
         restore-keys: |
           puppeteer-${{ runner.os }}-
 
-    # ── Apt package cache ──────────────────────────────────────────
+    # ── Apt package cache ──────────────────────────────────────────────────────────
     # Redirect apt's archive dir to a cached location so ALL apt-get
     # install commands (here and in calling workflows) reuse cached .debs.
     - name: Restore apt package cache
@@ -141,7 +145,16 @@ runs:
       run: pnpm playwright install chromium && npx puppeteer browsers install chrome
       shell: bash
 
-    # ── System packages ──────────────────────────────────────────────
+    # Puppeteer ≥22 dropped the postinstall Chrome download — pa11y-ci,
+    # subfont, and any other Puppeteer caller will fail with "Could not
+    # find Chrome" unless we install it explicitly. Skipped when
+    # install-browsers already installed it above.
+    - name: Install Puppeteer Chrome
+      if: inputs.install-puppeteer-chrome == 'true' && inputs.install-browsers != 'true' && inputs.install-node-deps == 'true'
+      run: npx puppeteer browsers install chrome
+      shell: bash
+
+    # ── System packages ─────────────────────────────────────────────────────────────
     # All apt packages in one step so every workflow populates the same
     # cache. With cache-apt enabled, repeat installs unpack from disk in
     # seconds instead of downloading from slow mirrors.

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -60,6 +60,14 @@ jobs:
         uses: ./.github/actions/setup-site
         with:
           install-python: "false"
+          cache-puppeteer: "true"
+
+      # Puppeteer ≥22 dropped the postinstall Chrome download — pa11y-ci
+      # boots Chrome via Puppeteer and fails with "Could not find Chrome"
+      # unless we install it explicitly. Idempotent when the puppeteer
+      # cache restore above already populated `~/.cache/puppeteer`.
+      - name: Install Puppeteer Chrome for pa11y
+        run: npx puppeteer browsers install chrome
 
       - name: Restore built site from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -60,14 +60,7 @@ jobs:
         uses: ./.github/actions/setup-site
         with:
           install-python: "false"
-          cache-puppeteer: "true"
-
-      # Puppeteer ≥22 dropped the postinstall Chrome download — pa11y-ci
-      # boots Chrome via Puppeteer and fails with "Could not find Chrome"
-      # unless we install it explicitly. Idempotent when the puppeteer
-      # cache restore above already populated `~/.cache/puppeteer`.
-      - name: Install Puppeteer Chrome for pa11y
-        run: npx puppeteer browsers install chrome
+          install-puppeteer-chrome: "true"
 
       - name: Restore built site from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -62,14 +62,7 @@ jobs:
         uses: ./.github/actions/setup-site
         with:
           install-python: "false"
-          cache-puppeteer: "true"
-
-      # @turntrout/subfont uses Puppeteer to render fonts headless;
-      # Puppeteer ≥22 dropped the postinstall Chrome download, so we
-      # install Chrome explicitly. Idempotent when the puppeteer cache
-      # restore above already populated `~/.cache/puppeteer`.
-      - name: Install Puppeteer Chrome for subfont
-        run: npx puppeteer browsers install chrome
+          install-puppeteer-chrome: "true"
 
       - name: Restore built site from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -62,6 +62,14 @@ jobs:
         uses: ./.github/actions/setup-site
         with:
           install-python: "false"
+          cache-puppeteer: "true"
+
+      # @turntrout/subfont uses Puppeteer to render fonts headless;
+      # Puppeteer ≥22 dropped the postinstall Chrome download, so we
+      # install Chrome explicitly. Idempotent when the puppeteer cache
+      # restore above already populated `~/.cache/puppeteer`.
+      - name: Install Puppeteer Chrome for subfont
+        run: npx puppeteer browsers install chrome
 
       - name: Restore built site from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
## Summary
This PR adds support for explicitly installing Puppeteer's Chrome browser, which is required by tools like pa11y-ci, subfont, and Mermaid. Puppeteer ≥22 dropped the automatic postinstall Chrome download, causing these tools to fail with "Could not find Chrome" errors.

## Key Changes
- Added new `install-puppeteer-chrome` input to the `setup-site` GitHub Action that enables explicit Chrome installation
- Updated the Puppeteer browser cache step to activate when either `cache-puppeteer` or `install-puppeteer-chrome` is enabled
- Added a new step that installs Puppeteer Chrome only when explicitly requested and not already installed by the `install-browsers` step
- Updated `a11y.yml` and `lighthouse-layout-shift.yaml` workflows to use the new `install-puppeteer-chrome: "true"` input
- Aligned section comment formatting for consistency

## Implementation Details
- The new `install-puppeteer-chrome` input implies caching of Puppeteer browsers (as documented in the input description)
- The Chrome installation step includes a guard condition to skip installation if `install-browsers` already handled it, avoiding redundant work
- The step only runs when `install-node-deps` is enabled, ensuring the necessary Node.js environment is available

https://claude.ai/code/session_017RYqBA9U8ELTs5N1ec8Bbe