### PR TITLE
docs(design): document invert-label validation; drop HTTP(S) check

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -864,25 +864,6 @@ def _invert_issue_string(
     )
 
 
-def _validate_eligible_src(
-    kind: str,
-    src: str,
-    has_class: bool,
-    invert_labels: Mapping[str, InvertLabel],
-) -> str | None:
-    """
-    Validate one src already past the extension + excluded-segment filters:
-
-    error on non-HTTP(S) (labeler can't reach it), otherwise delegate to
-    :func:`_invert_issue_string`.
-    """
-    if not src.startswith(("http://", "https://")):
-        return (
-            f"<{kind}> {src}: must be served over HTTP(S) to be invert-labeled"
-        )
-    return _invert_issue_string(kind, src, has_class, invert_labels.get(src))
-
-
 def check_invert_labels(
     soup: BeautifulSoup,
     invert_labels: Mapping[str, InvertLabel] | None,
@@ -891,11 +872,10 @@ def check_invert_labels(
     Validate every eligible ``<img>`` (raster ext) and inline looping
     ``<video>`` source against ``.invert_labels.json``: each must be present,
     reviewed, and have its ``invert-in-dark-mode`` class match the JSON
-    ``invert`` field (JSON is the source of truth).
+    ``invert`` field (the source of truth).
 
-    Also errors on non-HTTP(S) raster srcs the labeler can't reach. No-op when
-    ``invert_labels`` is None (loader-disabled in tests / when the labels file
-    is missing entirely).
+    No-op when ``invert_labels`` is ``None`` (loader-disabled in tests / when
+    the labels file is missing).
     """
     if invert_labels is None:
         return []
@@ -908,8 +888,8 @@ def check_invert_labels(
             continue
         if _is_excluded_segment(src):
             continue
-        issue = _validate_eligible_src(
-            "img", src, _has_invert_class(img), invert_labels
+        issue = _invert_issue_string(
+            "img", src, _has_invert_class(img), invert_labels.get(src)
         )
         if issue is not None:
             issues.append(issue)
@@ -918,8 +898,8 @@ def check_invert_labels(
         for src in _inline_looping_video_sources(video):
             if _is_excluded_segment(src):
                 continue
-            issue = _validate_eligible_src(
-                "video", src, has_class, invert_labels
+            issue = _invert_issue_string(
+                "video", src, has_class, invert_labels.get(src)
             )
             if issue is not None:
                 issues.append(issue)

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -6459,14 +6459,12 @@ def _class_mismatch_msg(
             {},
             [],
         ),
-        # Non-HTTP src on a raster <img> errors — labeler can't reach it.
+        # Non-HTTP src is reported as missing from labels like any other
+        # raster <img> — relative paths are an error mode for separate checks.
         (
             '<img src="/local/a.png">',
             {},
-            [
-                "<img> /local/a.png: must be served over HTTP(S) "
-                "to be invert-labeled"
-            ],
+            [_missing_msg("img", "/local/a.png")],
         ),
         # Mixed-case extension still matches.
         (

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1107,6 +1107,11 @@ I use [`linkchecker`](https://linkchecker.github.io/) to validate these links.
 > 4. `<video>` tags which do not provide multiple `<source>` options in the correct order (MP4 first, then WEBM);
 > 5. Required root files (`robots.txt`, `favicon.svg`, `favicon.ico`) missing;
 >
+> **Dark-mode inversion:**
+>
+> 1. Eligible raster `<img>` and inline looping `<video>` sources missing from `.invert_labels.json` or not user-reviewed;
+> 2. `invert-in-dark-mode` class on a rendered element disagreeing with the JSON's `invert` field (the source of truth);
+>
 > **CSS and styling:**
 >
 > 1. Inline styles which invoke nonexistent CSS variables;

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1109,7 +1109,7 @@ I use [`linkchecker`](https://linkchecker.github.io/) to validate these links.
 >
 > **Dark-mode inversion:**
 >
-> 1. Eligible raster `<img>` and inline looping `<video>` sources missing from `.invert_labels.json` or not user-reviewed;
+> 1. Eligible raster `<img>` and inline looping `<video>` sources which are missing from `.invert_labels.json` or which are not user-reviewed;
 > 2. `invert-in-dark-mode` class on a rendered element not matching the JSON's `invert` field (the source of truth);
 >
 > **CSS and styling:**

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1110,7 +1110,7 @@ I use [`linkchecker`](https://linkchecker.github.io/) to validate these links.
 > **Dark-mode inversion:**
 >
 > 1. Eligible raster `<img>` and inline looping `<video>` sources missing from `.invert_labels.json` or not user-reviewed;
-> 2. `invert-in-dark-mode` class on a rendered element disagreeing with the JSON's `invert` field (the source of truth);
+> 2. `invert-in-dark-mode` class on a rendered element not matching the JSON's `invert` field (the source of truth);
 >
 > **CSS and styling:**
 >


### PR DESCRIPTION
## Summary

- Document the dark-mode invert-label validator (added in #1254) in `design.md`'s "HTML validation checks" callout.
- Drop the HTTP(S) check from `check_invert_labels` — non-HTTP raster srcs flow through as ordinary "missing from .invert_labels.json" errors, matching the simpler framing. Separate checks (`check_local_media_files`, `check_asset_references`) already cover the local-path failure mode.
- Trivial `_validate_eligible_src` wrapper collapses back to direct `_invert_issue_string` calls.

## Test plan

- [x] `uv run pytest scripts/tests/test_built_site_checks.py -k invert` — 29 passed
- [x] `uv run pylint scripts/` — 10.00/10
- [x] `uv run mypy scripts/built_site_checks.py` — no issues
- [ ] CI

https://claude.ai/code/session_014AkErMwuFVLXebBhbzGzyr

---
_Generated by [Claude Code](https://claude.ai/code/session_014AkErMwuFVLXebBhbzGzyr)_