### PR TITLE
fix(content): repair broken video block in gpt2-steering article

### DIFF
--- a/website_content/steering-gpt-2-xl-by-adding-an-activation-vector.md
+++ b/website_content/steering-gpt-2-xl-by-adding-an-activation-vector.md
@@ -865,8 +865,7 @@ Activation additions have _already_ helped us find representations in a model. A
 
 > [!quote] [Understanding and Controlling a Maze-Solving Policy Network](./understanding-and-controlling-a-maze-solving-policy-network)
 > <video autoplay loop muted playsinline style="width:60%;"><source src="https://assets.turntrout.com/static/images/posts/vyflftmbwgl7jmbaeimm.mp4" type="video/mp4; codecs=hvc1">
-
-<source src="https://assets.turntrout.com/static/images/posts/vyflftmbwgl7jmbaeimm.webm" type="video/webm"></video>
+> <source src="https://assets.turntrout.com/static/images/posts/vyflftmbwgl7jmbaeimm.webm" type="video/webm"></video>
 >
 > Figure: **Locally retargeting the search by modifying a single activation.** We found a residual channel halfway through a maze-solving network. When we set one of the channel activations to +5.5, the agent often navigates to the maze location (shown above in red) implied by that positive activation. This allows limited on-the-fly redirection of the net's goals.
 


### PR DESCRIPTION
## Summary

Stacked on **PR #1259**. Fixes the broken `<video>` block in `steering-gpt-2-xl-by-adding-an-activation-vector.md`, line 867, which was the only real failure left in `built-site-checks` once the timeouts and missing invert labels were resolved.

## What was wrong

```md
> [!quote] [Understanding and Controlling a Maze-Solving Policy Network](./...)
> <video autoplay loop muted playsinline style="width:60%;"><source src="...mp4" type="...">

<source src="...webm" type="video/webm"></video>
>
> Figure: **Locally retargeting the search by modifying a single activation.** ...
```

The blank line between the two `<source>` tags ends the markdown HTML block. The rendered result:

- `<video>` element has only **one** `<source>` child (the `.mp4`) → trips `video_source_order_and_match` ("`<video>` tag has < 2 `<source>` children").
- The orphaned `.webm` `<source>` and the dangling `</video>` end up outside the `<video>` entirely.
- The "Figure:" caption beneath is parsed as a loose paragraph, not as part of a figure block → trips `problematic_paragraphs` ("Problematic paragraph: Figure: Locally retargeting...").

## The fix

Drop the blank line, add the `> ` callout prefix on the second `<source>` so the whole video stays in one HTML block inside the quote callout. Matches the canonical pattern already used throughout `My-research.md`.

https://claude.ai/code/session_013mZB1SsRpGooUc2dPgNSMW

---
_Generated by [Claude Code](https://claude.ai/code/session_013mZB1SsRpGooUc2dPgNSMW)_