### PR TITLE
Many code refactorings and util improvements

### DIFF
--- a/.github/actions/deploy-to-cloudflare/action.yaml
+++ b/.github/actions/deploy-to-cloudflare/action.yaml
@@ -1,15 +1,10 @@
 name: "Deploy to Cloudflare Pages"
-description: "Installs Wrangler and deploys to Cloudflare Pages"
+description: >-
+  Installs Wrangler and deploys to Cloudflare Pages. Reads
+  ``CLOUDFLARE_API_TOKEN``, ``CLOUDFLARE_ACCOUNT_ID`` and
+  ``CLOUDFLARE_ZONE_ID`` from the surrounding job/step environment (Wrangler
+  picks these up natively), so set them once at the job level.
 inputs:
-  cloudflare-api-token:
-    description: "Cloudflare API Token"
-    required: true
-  cloudflare-account-id:
-    description: "Cloudflare Account ID"
-    required: true
-  cloudflare-zone-id:
-    description: "Cloudflare Zone ID"
-    required: true
   project-name:
     description: "Cloudflare Pages project name"
     required: true
@@ -32,10 +27,6 @@ runs:
       shell: bash
 
     - name: Deploy to Cloudflare Pages
-      env:
-        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-token }}
-        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
-        CLOUDFLARE_ZONE_ID: ${{ inputs.cloudflare-zone-id }}
       run: |
         for attempt in 1 2 3; do
           if pnpm exec wrangler pages deploy ${{ inputs.public-dir }} --project-name=${{ inputs.project-name }} --branch ${{ inputs.branch }}; then

--- a/.github/actions/restore-site-build/action.yml
+++ b/.github/actions/restore-site-build/action.yml
@@ -1,0 +1,21 @@
+name: "Restore site build"
+description: >-
+  Restore the `public/` directory produced by the build-site workflow. Pins
+  the actions/cache/restore action SHA and the cache-key shape in one place
+  so callers stay in sync.
+
+inputs:
+  fail-on-cache-miss:
+    description: "Fail the step if the cache is missing."
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore built site from cache
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      with:
+        path: public/
+        key: site-build-${{ github.sha }}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/sanitize-shard-name/action.yml
+++ b/.github/actions/sanitize-shard-name/action.yml
@@ -1,0 +1,19 @@
+name: "Sanitize shard name"
+description: >-
+  Strips the trailing "/N" from a Playwright shard string (e.g. "3/8" → "3")
+  and exports the result as the ``SANITIZED_SHARD`` environment variable so
+  later steps can use it in artifact names (slashes are not allowed there).
+
+inputs:
+  shard:
+    description: "Raw shard label, e.g. \"3/8\""
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Sanitize shard name
+      shell: bash
+      env:
+        MATRIX_SHARD: ${{ inputs.shard }}
+      run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> "$GITHUB_ENV"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -64,11 +64,7 @@ jobs:
           install-python: "false"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Start server
         id: server

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,6 +39,12 @@ jobs:
     needs: deploy-build
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    # Wrangler reads these from the environment; setting them once at job
+    # level avoids re-declaring them on every deploy-to-cloudflare step.
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -54,20 +60,13 @@ jobs:
           install-system-deps: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       # --- PR preview: deploy immediately without subfont ---
       - name: Deploy PR preview to Cloudflare Pages
         if: github.event_name == 'pull_request'
         uses: ./.github/actions/deploy-to-cloudflare
         with:
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           project-name: turntrout
           branch: pr-${{ github.event.pull_request.number }}
 
@@ -123,15 +122,13 @@ jobs:
         if: github.event_name == 'push' && github.ref_name == 'dev'
         uses: ./.github/actions/deploy-to-cloudflare
         with:
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           project-name: turntrout
           branch: ${{ github.ref_name }}
 
       - name: Install subfont
         if: github.event_name == 'push'
-        run: pnpm add -g github:alexander-turner/subfont
+        # Pin to a commit SHA so `pnpm add -g` is reproducible.
+        run: pnpm add -g github:alexander-turner/subfont#f220fd1115ef2dd4512c24d4ec8ffe7248e196b2
       - name: Make script executable
         if: github.event_name == 'push'
         run: chmod +x ./scripts/subfont.sh
@@ -351,6 +348,10 @@ jobs:
     if: ${{ github.event_name == 'push' && ((always() && github.ref_name == 'dev') || (needs.verify-test-results.result == 'success' && (needs.verify-lp-approval.result == 'success' || needs.verify-lp-approval.result == 'skipped'))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -363,8 +364,5 @@ jobs:
       - name: Deploy to Cloudflare Pages
         uses: ./.github/actions/deploy-to-cloudflare
         with:
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           project-name: turntrout
           branch: ${{ github.ref_name }}

--- a/.github/workflows/lighthouse-layout-shift.yaml
+++ b/.github/workflows/lighthouse-layout-shift.yaml
@@ -54,14 +54,11 @@ jobs:
           install-python: "false"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Install subfont
-        run: pnpm add -g github:alexander-turner/subfont
+        # Pin to a commit SHA so `pnpm add -g` is reproducible.
+        run: pnpm add -g github:alexander-turner/subfont#f220fd1115ef2dd4512c24d4ec8ffe7248e196b2
       - name: Subset fonts for Lighthouse test pages
         run: |
           subfont --root public/ \
@@ -74,7 +71,8 @@ jobs:
             --formats woff2 --in-place --instance --inline-css --no-recursive --debug
 
       - name: Install Wrangler
-        run: pnpm add -g wrangler
+        # Match the version pinned in .github/actions/deploy-to-cloudflare/action.yaml.
+        run: pnpm add -g wrangler@3.99.0
 
       - name: Publish to Cloudflare Pages for Lighthouse testing
         id: deploy_cf_pages

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -82,10 +82,10 @@ jobs:
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
 
       - name: Sanitize shard name
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
         if: always()
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload flake check logs
         if: always()
@@ -181,10 +181,10 @@ jobs:
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
 
       - name: Sanitize shard name
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
         if: always()
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload flake check logs
         if: always()

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -64,11 +64,7 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests (repeat-each=${{ needs.setup.outputs.repeat }})
         id: playwright
@@ -167,11 +163,7 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests (repeat-each=${{ needs.setup.outputs.repeat }})
         id: playwright

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -103,10 +103,10 @@ jobs:
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2100000"
 
       - name: Sanitize shard name
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
         if: always()
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
         if: always()
@@ -207,10 +207,10 @@ jobs:
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2700000"
 
       - name: Sanitize shard name
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
         if: always()
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
         if: always()

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -90,11 +90,7 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests
         id: playwright
@@ -198,11 +194,7 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests
         id: playwright

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -85,11 +85,7 @@ jobs:
           cache-apt: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Check CSS variables
         run: |
@@ -120,11 +116,7 @@ jobs:
         uses: ./.github/actions/setup-site
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Start server
         id: server

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -102,11 +102,11 @@ jobs:
           # 40 min job timeout → 35 min Playwright global timeout
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2100000"
 
-      - name: Create sanitized shard
+      - name: Sanitize shard name
         if: always()
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
         if: always()
@@ -214,11 +214,11 @@ jobs:
           # 40 min job timeout → 35 min Playwright global timeout
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "2100000"
 
-      - name: Create sanitized shard
+      - name: Sanitize shard name
         if: always()
-        run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> $GITHUB_ENV
-        env:
-          MATRIX_SHARD: ${{ matrix.shard }}
+        uses: ./.github/actions/sanitize-shard-name
+        with:
+          shard: ${{ matrix.shard }}
 
       - name: Upload Playwright logs
         if: always()

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -88,11 +88,7 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests
         id: playwright
@@ -204,11 +200,7 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: public/
-          key: site-build-${{ github.sha }}
-          fail-on-cache-miss: true
+        uses: ./.github/actions/restore-site-build
 
       - name: Run Playwright tests
         id: playwright

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -110,20 +110,8 @@ export const specialDomainMappings: ReadonlyArray<{ pattern: RegExp; to: string 
 export const EXTERNAL_LINK_REL = "noopener noreferrer"
 
 // HTML tag groups reused across transformers/components
-export const HEADING_TAGS: ReadonlySet<string> = new Set([
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-])
-export const MEDIA_TAGS: ReadonlySet<string> = new Set([
-  "img",
-  "video",
-  "audio",
-  "iframe",
-])
+export const HEADING_TAGS: ReadonlySet<string> = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
+export const MEDIA_TAGS: ReadonlySet<string> = new Set(["img", "video", "audio", "iframe"])
 
 // Shared CSS class names (used across multiple components/scripts)
 export const PREVIEWABLE_CLASS = "previewable"

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -109,6 +109,22 @@ export const specialDomainMappings: ReadonlyArray<{ pattern: RegExp; to: string 
 // External link attributes
 export const EXTERNAL_LINK_REL = "noopener noreferrer"
 
+// HTML tag groups reused across transformers/components
+export const HEADING_TAGS: ReadonlySet<string> = new Set([
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+])
+export const MEDIA_TAGS: ReadonlySet<string> = new Set([
+  "img",
+  "video",
+  "audio",
+  "iframe",
+])
+
 // Shared CSS class names (used across multiple components/scripts)
 export const PREVIEWABLE_CLASS = "previewable"
 export const CAN_TRIGGER_POPOVER_CLASS = "can-trigger-popover"

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -16,6 +16,7 @@ import {
   NBSP,
   LEFT_SINGLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
+  HEADING_TAGS,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
 import { replaceRegex, fractionRegex, hasClass, hasAncestor, urlRegex, isCode } from "./utils"
@@ -25,7 +26,6 @@ import { replaceRegex, fractionRegex, hasClass, hasAncestor, urlRegex, isCode } 
  * Content inside these elements won't have formatting improvements applied.
  */
 export const SKIP_TAGS = ["code", "script", "style", "pre"] as const
-export const HEADING_TAGS: ReadonlySet<string> = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
 
 /**
  * Tags that should be skipped during fraction replacement.

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -7,7 +7,12 @@ import { visit } from "unist-util-visit"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-import { EXTERNAL_LINK_REL, CAN_TRIGGER_POPOVER_CLASS } from "../../components/constants"
+import {
+  EXTERNAL_LINK_REL,
+  CAN_TRIGGER_POPOVER_CLASS,
+  HEADING_TAGS,
+  MEDIA_TAGS,
+} from "../../components/constants"
 import {
   type FullSlug,
   type RelativeURL,
@@ -34,9 +39,6 @@ const defaultOptions: Options = {
   openLinksInNewTab: true,
   lazyLoad: true,
 }
-
-const HEADER_TAGS: ReadonlySet<string> = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
-const MEDIA_TAGS: ReadonlySet<string> = new Set(["img", "video", "audio", "iframe"])
 
 /**
  * Whether a URL should be left as-is (not rewritten by `transformLink`).
@@ -128,7 +130,7 @@ function processAnchor(
     classes.push("internal")
 
     // Header links (e.g. clickable section titles) shouldn't trigger popovers
-    const isLinkInsideHeader = parent?.type === "element" && HEADER_TAGS.has(parent.tagName)
+    const isLinkInsideHeader = parent?.type === "element" && HEADING_TAGS.has(parent.tagName)
     if (!isLinkInsideHeader) {
       classes.push(CAN_TRIGGER_POPOVER_CLASS)
     }

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -4,6 +4,7 @@
  */
 
 import { execFileSync } from "child_process"
+import escapeStringRegexp from "escape-string-regexp"
 import { readFileSync } from "fs"
 
 import type { QuartzTransformerPlugin } from "../types"
@@ -171,7 +172,7 @@ function getContent(name: string, source: MarkdownSource): string {
 // skipcq: JS-D1001
 export function buildPlaceholderRegex(sourceNames: string[]): RegExp {
   if (sourceNames.length === 0) return /(?!)/g // never matches
-  const escaped = sourceNames.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  const escaped = sourceNames.map(escapeStringRegexp)
   return new RegExp(
     `<span\\s+class="populate-markdown-(${escaped.join("|")})"\\s*>(?:<\\/span>)?`,
     "g",

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -48,9 +48,7 @@ export const allowAcronyms: readonly string[] = [
 export const ignoreList: readonly string[] = ["th", "hz", "st", "nd", "rd"]
 
 // Escaped and joined allowAcronyms as an intermediate variable
-const escapedAllowAcronyms = allowAcronyms.map((acronym) =>
-  escapeStringRegexp(acronym),
-)
+const escapedAllowAcronyms = allowAcronyms.map((acronym) => escapeStringRegexp(acronym))
 
 const boundaryAllowAcronyms = escapedAllowAcronyms
   .map((acronym) => `\\b${acronym}(?!-)\\b`)

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -1,6 +1,7 @@
 import type { Element, Node, Parent, Text } from "hast"
 import type { Plugin } from "unified"
 
+import escapeStringRegexp from "escape-string-regexp"
 import { h } from "hastscript"
 // skipcq: JS-0257
 import { visitParents } from "unist-util-visit-parents"
@@ -48,7 +49,7 @@ export const ignoreList: readonly string[] = ["th", "hz", "st", "nd", "rd"]
 
 // Escaped and joined allowAcronyms as an intermediate variable
 const escapedAllowAcronyms = allowAcronyms.map((acronym) =>
-  acronym.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"),
+  escapeStringRegexp(acronym),
 )
 
 const boundaryAllowAcronyms = escapedAllowAcronyms

--- a/quartz/util/log.test.ts
+++ b/quartz/util/log.test.ts
@@ -37,9 +37,12 @@ jest.mock("winston", () => ({
   },
 }))
 
-// Mock child_process and fs used by log root detection
-jest.mock("child_process", () => ({
-  execSync: jest.fn(() => "/repo\n"),
+// Mock find-git-root and fs used by log root detection.
+// find-git-root returns the path to the `.git` directory; log.ts wraps it
+// with path.dirname() so the working-tree root is what callers see.
+jest.unstable_mockModule("find-git-root", () => ({
+  __esModule: true,
+  default: jest.fn(() => "/repo/.git"),
 }))
 
 jest.mock("fs", () => ({

--- a/quartz/util/log.test.ts
+++ b/quartz/util/log.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals"
 
-// Mocks for winston + rotate transport
+// All mocks use `jest.unstable_mockModule` because log.ts loads its
+// dependencies via ESM-style default imports inside `await import("./log")`.
+// `jest.mock` is unreliable in that combination on Node 22 CI runners
+// (the `fs` mock silently slips through and the real `mkdirSync('/repo/.logs')`
+// fires with EACCES).
+
+// Constructor mock for winston-daily-rotate-file (the imported default).
+// Captured at module scope so tests can inspect `.mock.calls` directly,
+// without going through `jest.requireMock` (which is CJS-only).
+const mockDailyRotateFileCtor: jest.Mock<
+  (opts: Record<string, unknown>) => Record<string, unknown>
+> = jest.fn(() => ({}))
 const mockDailyRotateFile = jest.fn()
 const mockConsoleTransport = jest.fn()
 const mockLoggerInstance = {
@@ -14,11 +25,13 @@ const mockCreateLogger = jest.fn(() => mockLoggerInstance)
 
 let capturedPrintfFormatter: ((info: { level: string; message: string }) => string) | null = null
 
-jest.mock("winston-daily-rotate-file", () => {
-  return jest.fn(() => ({}))
-})
+jest.unstable_mockModule("winston-daily-rotate-file", () => ({
+  __esModule: true,
+  default: mockDailyRotateFileCtor,
+}))
 
-jest.mock("winston", () => ({
+jest.unstable_mockModule("winston", () => ({
+  __esModule: true,
   transports: {
     DailyRotateFile: mockDailyRotateFile,
     Console: mockConsoleTransport,
@@ -39,11 +52,21 @@ jest.mock("winston", () => ({
 
 // find-git-root returns the path to the `.git` directory; log.ts wraps it
 // with path.dirname() so the working-tree root is what callers see.
-// Using `unstable_mockModule` because find-git-root is loaded via ESM-style
-// default import; `jest.mock` does not consistently apply to those.
 jest.unstable_mockModule("find-git-root", () => ({
   __esModule: true,
   default: jest.fn(() => "/repo/.git"),
+}))
+
+// fs is mocked so the per-call `mkdirSync` inside createWinstonLogger does
+// not try to write under the mocked git root.
+const fsMock = {
+  existsSync: jest.fn(() => true),
+  mkdirSync: jest.fn(),
+}
+jest.unstable_mockModule("fs", () => ({
+  __esModule: true,
+  default: fsMock,
+  ...fsMock,
 }))
 
 // Import after mocks are set up
@@ -70,11 +93,7 @@ describe("util/log", () => {
     // The rotate-file transport is instantiated via `new transports.DailyRotateFile(...)`.
     // In our module, we assign that transport constructor to the imported DailyRotateFile,
     // so we assert on the DailyRotateFile mock.
-    const callArgs = (
-      jest.requireMock("winston-daily-rotate-file") as unknown as {
-        mock: { calls: unknown[][] }
-      }
-    ).mock.calls[0][0] as Record<string, unknown>
+    const callArgs = mockDailyRotateFileCtor.mock.calls[0][0] as Record<string, unknown>
     expect(callArgs).toMatchObject({
       datePattern: "YYYY-MM-DD",
       zippedArchive: true,
@@ -121,11 +140,7 @@ describe("util/log", () => {
     createWinstonLogger("logger1")
     createWinstonLogger("logger2")
 
-    const calls = (
-      jest.requireMock("winston-daily-rotate-file") as unknown as {
-        mock: { calls: unknown[][] }
-      }
-    ).mock.calls
+    const calls = mockDailyRotateFileCtor.mock.calls
     expect((calls[0][0] as Record<string, unknown>).filename).toContain("logger1.log")
     expect((calls[1][0] as Record<string, unknown>).filename).toContain("logger2.log")
   })

--- a/quartz/util/log.test.ts
+++ b/quartz/util/log.test.ts
@@ -37,17 +37,13 @@ jest.mock("winston", () => ({
   },
 }))
 
-// Mock find-git-root and fs used by log root detection.
 // find-git-root returns the path to the `.git` directory; log.ts wraps it
 // with path.dirname() so the working-tree root is what callers see.
+// Using `unstable_mockModule` because find-git-root is loaded via ESM-style
+// default import; `jest.mock` does not consistently apply to those.
 jest.unstable_mockModule("find-git-root", () => ({
   __esModule: true,
   default: jest.fn(() => "/repo/.git"),
-}))
-
-jest.mock("fs", () => ({
-  existsSync: jest.fn(() => true),
-  mkdirSync: jest.fn(),
 }))
 
 // Import after mocks are set up

--- a/quartz/util/log.ts
+++ b/quartz/util/log.ts
@@ -41,10 +41,10 @@ export const findGitRoot = (): string => {
 
 const logDir = path.join(findGitRoot(), ".logs")
 
-// Create the log directory if it doesn't exist
-if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir, { recursive: true })
-}
+// `createWinstonLogger` ensures `logDir` exists before instantiating a
+// transport. We deliberately do NOT create it at module load: that turns
+// every `import` into a filesystem write and breaks tests in sandboxes that
+// mock the git-root to a non-writable path.
 
 const timezoneFormat = new Date().toLocaleString("en-US", {
   timeZone: "America/Los_Angeles",

--- a/quartz/util/log.ts
+++ b/quartz/util/log.ts
@@ -1,8 +1,9 @@
 import type Transport from "winston-transport"
 
-import { execSync } from "child_process"
+import gitRoot from "find-git-root"
 import fs from "fs"
 import path from "path"
+import { fileURLToPath } from "url"
 import { transports, format, createLogger } from "winston"
 import DailyRotateFile from "winston-daily-rotate-file"
 
@@ -30,18 +31,15 @@ export function setLogLevelFromArgv(argv: Partial<Argv> | undefined): void {
 
 /**
  * Finds the root directory of the current Git repository.
+ *
+ * Wraps the `find-git-root` package, which returns the `.git` directory; we
+ * return its parent so callers receive the working-tree root.
  */
-export const findGitRoot = (): string | null => {
-  return execSync("git rev-parse --show-toplevel").toString().trim()
+export const findGitRoot = (): string => {
+  return path.dirname(gitRoot(fileURLToPath(import.meta.url)))
 }
 
-const gitRoot = findGitRoot()
-
-if (!gitRoot) {
-  throw new Error("Git root not found.")
-}
-
-const logDir = path.join(gitRoot, ".logs")
+const logDir = path.join(findGitRoot(), ".logs")
 
 // Create the log directory if it doesn't exist
 if (!fs.existsSync(logDir)) {

--- a/scripts/convert_assets.py
+++ b/scripts/convert_assets.py
@@ -276,15 +276,12 @@ def convert_asset(
     for md_file in script_utils.get_files(
         dir_to_search=md_references_dir, filetypes_to_match=(".md",)
     ):
-        with open(md_file, encoding="utf-8") as file:
-            content = file.read()
-
-        replaced_content = _replace_content(
-            content, original_pattern, replacement_pattern
+        script_utils.update_markdown_file(
+            md_file,
+            lambda content: _replace_content(
+                content, original_pattern, replacement_pattern
+            ),
         )
-
-        with open(md_file, "w", encoding="utf-8") as file:
-            file.write(replaced_content)
 
     if remove_originals and input_file.suffix not in (".mp4", ".avif"):
         input_file.unlink()

--- a/scripts/convert_markdown_yaml.py
+++ b/scripts/convert_markdown_yaml.py
@@ -9,22 +9,13 @@ ImageMagick, and uploads them to R2 storage.
 
 #!/usr/bin/env python3
 import argparse
-import io
-import os
 import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from urllib import parse
 
-import requests
 from frozendict import frozendict
-from ruamel.yaml import YAML  # type: ignore
-
-yaml_parser = YAML(typ="rt")  # Use Round-Trip to preserve formatting
-yaml_parser.preserve_quotes = True  # Preserve existing quotes
-yaml_parser.indent(mapping=2, sequence=2, offset=2)  # Set desired indentation
 
 try:
     from . import r2_upload, source_file_checks
@@ -33,6 +24,9 @@ except ImportError:
     import r2_upload  # type: ignore
     import source_file_checks  # type: ignore
     import utils as script_utils  # type: ignore
+
+yaml_parser = script_utils.get_yaml_parser()
+_http_session = script_utils.http_session()
 
 
 _CAN_CONVERT_EXTENSIONS: set[str] = {
@@ -87,7 +81,7 @@ def _download_image(url: str, output_path: Path) -> None:
     Raises:
         ValueError: If download fails
     """
-    response = requests.get(
+    response = _http_session.get(
         url, stream=True, timeout=10, headers=_DOWNLOAD_HEADERS
     )
     if response.status_code == 200:
@@ -174,8 +168,7 @@ def _process_image(card_image_url: str, temp_dir: Path) -> tuple[Path, str]:
     Returns:
         Tuple of (converted JPEG path, JPEG filename)
     """
-    parsed_url = parse.urlparse(card_image_url)
-    card_image_filename = os.path.basename(parsed_url.path)
+    card_image_filename = script_utils.extract_filename_from_url(card_image_url)
     downloaded_path = temp_dir / card_image_filename
     jpeg_filename = downloaded_path.with_suffix(".jpg").name
     jpeg_path = downloaded_path.with_suffix(".jpg")
@@ -259,15 +252,9 @@ def process_card_image_in_markdown(md_file: Path) -> None:
     # Update the YAML frontmatter
     data["card_image"] = _get_r2_image_url(local_jpeg_path)
 
-    # Write back to file
-    stream = io.StringIO()
-    yaml_parser.dump(data, stream)
-    updated_yaml = stream.getvalue()
-    updated_content = f"---\n{updated_yaml}---\n{md_body}"
-
-    with open(md_file, "w", encoding="utf-8") as file:
-        file.write(updated_content)
-
+    script_utils.write_yaml_frontmatter(
+        md_file, data, md_body, parser=yaml_parser
+    )
     print(f"Updated 'card_image' in {md_file}")
 
 

--- a/scripts/download_external_media.py
+++ b/scripts/download_external_media.py
@@ -13,13 +13,15 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Sequence
-from urllib.parse import urlparse
+
+import requests
 
 try:
     from . import utils as script_utils
 except ImportError:
     import utils as script_utils  # type: ignore
+
+_http_session = script_utils.http_session()
 
 
 MEDIA_EXTENSIONS = (
@@ -56,36 +58,25 @@ def download_media(url: str, target_dir: Path) -> bool:
     Returns:
         True if download succeeded, False otherwise
     """
-    filename = os.path.basename(urlparse(url).path)
-    if not filename:
+    try:
+        filename = script_utils.extract_filename_from_url(url)
+    except ValueError:
         print(f"Skipping URL with no filename: {url}", file=sys.stderr)
         return False
     target_path = target_dir / filename
 
     print(f"Downloading: {url} to {target_path}")
 
-    curl_command: Sequence[str] = [
-        "curl",
-        "-L",  # Follow redirects
-        "-o",
-        str(target_path),  # Output file
-        "--retry",
-        "5",  # Retry up to 5 times
-        "--retry-delay",
-        "1",  # Start with a 1 second delay, doubles for each retry
-        "--retry-max-time",
-        "60",  # Maximum time for retries
-        "-s",  # Silent mode
-        "-S",  # Show error messages
-        url,
-    ]
-
     try:
-        subprocess.run(curl_command, check=True, stderr=subprocess.PIPE)
+        with _http_session.get(
+            url, stream=True, timeout=60, allow_redirects=True
+        ) as response:
+            response.raise_for_status()
+            with open(target_path, "wb") as out_file:
+                shutil.copyfileobj(response.raw, out_file)
         return True
-    except subprocess.CalledProcessError as e:
-        error_output = e.stderr.decode() if e.stderr else str(e)
-        print(f"Error downloading {url}: {error_output}", file=sys.stderr)
+    except requests.RequestException as e:
+        print(f"Error downloading {url}: {e}", file=sys.stderr)
         return False
 
 
@@ -98,13 +89,9 @@ def replace_url_in_file(file_path: Path, old_url: str, new_url: str) -> None:
             f"File path {file_path} is not in the website_content directory."
         )
 
-    with open(file_path, encoding="utf-8") as f:
-        content = f.read()
-
-    new_content = content.replace(old_url, new_url)
-
-    with open(file_path, "w", encoding="utf-8") as f:
-        f.write(new_content)
+    script_utils.update_markdown_file(
+        file_path, lambda content: content.replace(old_url, new_url)
+    )
 
 
 def find_external_media_urls(markdown_files: list[Path]) -> set[str]:
@@ -165,7 +152,7 @@ def main() -> None:
         if not download_media(url, asset_staging_dir):
             continue
 
-        filename = os.path.basename(urlparse(url).path)
+        filename = script_utils.extract_filename_from_url(url)
         new_url = f"asset_staging/{filename}"
         print(f"Downloaded to {new_url}")
 

--- a/scripts/r2_upload.py
+++ b/scripts/r2_upload.py
@@ -89,7 +89,9 @@ def update_markdown_references(
         references_dir: Dir to search for files to update references.
         verbose: Whether to print verbose output.
     """
-    relative_original_path = script_utils.path_relative_to_quartz_parent(file_path)
+    relative_original_path = script_utils.path_relative_to_quartz_parent(
+        file_path
+    )
     static_index = relative_original_path.parts.index("static")
     relative_subpath = Path(*relative_original_path.parts[static_index:])
 
@@ -104,16 +106,15 @@ def update_markdown_references(
     for text_file_path in script_utils.get_files(
         references_dir, (".md",), use_git_ignore=False
     ):
-        with open(text_file_path, encoding="utf-8") as f:
-            file_content: str = f.read()
-
-        new_content: str = re.sub(source_regex, r2_address, file_content)
-
-        with open(text_file_path, "w", encoding="utf-8") as f:
-            f.write(new_content)
+        script_utils.update_markdown_file(
+            text_file_path,
+            lambda content: re.sub(source_regex, r2_address, content),
+        )
 
 
-def _download_from_r2(upload_target: str, target: Path) -> None:  # pragma: no cover
+def _download_from_r2(
+    upload_target: str, target: Path
+) -> None:  # pragma: no cover
     rclone_args = ["rclone", "copyto", upload_target, str(target)]
     subprocess.run(rclone_args, check=True)
 
@@ -248,7 +249,9 @@ def upload_and_move(
         if not move_to_dir.exists():
             print(f"Warning: Directory does not exist: {move_to_dir}")
         else:
-            move_uploaded_file(file_path, move_to_dir=move_to_dir, verbose=verbose)
+            move_uploaded_file(
+                file_path, move_to_dir=move_to_dir, verbose=verbose
+            )
 
 
 def main() -> None:
@@ -266,7 +269,9 @@ def main() -> None:
         default=None,
         help="Move file to directory after upload",
     )
-    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+    parser.add_argument(
+        "--verbose", action="store_true", help="Enable verbose output"
+    )
     parser.add_argument(
         "--upload-from-directory",
         type=Path,
@@ -302,7 +307,9 @@ def main() -> None:
             use_git_ignore=False,  # several image dirs are git ignored
         )
         # Filter out ignored files
-        files_to_upload = [f for f in all_files if f.name not in args.ignore_files]
+        files_to_upload = [
+            f for f in all_files if f.name not in args.ignore_files
+        ]
     elif args.file:
         files_to_upload = [args.file]
     else:

--- a/scripts/replace_asset_staging_refs.py
+++ b/scripts/replace_asset_staging_refs.py
@@ -63,11 +63,9 @@ def _process_markdown_file(
 
     ``markdown_root`` is used only for pretty printing the relative path.
     """
-    original = md_path.read_text(encoding="utf-8")
-    updated = _replace_content(original, filename)
-
-    if updated != original:
-        md_path.write_text(updated, encoding="utf-8")
+    if script_utils.update_markdown_file(
+        md_path, lambda content: _replace_content(content, filename)
+    ):
         print(f"  Updated: {md_path.relative_to(markdown_root)}")
 
 

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -863,6 +863,15 @@ def compile_scss(scss_file_path: Path) -> str:
     return result.stdout
 
 
+_FONT_FACE_PATTERN = re.compile(
+    r"""@font-face\s*\{[^}]*?
+    src:\s*url\(\s*["']?(.*?)["']?\)\s*
+    (?:format\([^\)]*\)\s*)?
+    [^;]*;""",
+    re.VERBOSE | re.DOTALL,
+)
+
+
 def check_font_files(css_content: str, base_dir: Path) -> List[str]:
     """
     Check if font files referenced in CSS exist.
@@ -875,15 +884,7 @@ def check_font_files(css_content: str, base_dir: Path) -> List[str]:
         List of missing font file paths
     """
     missing_fonts = []
-    font_pattern = re.compile(
-        r"""@font-face\s*\{[^}]*?
-        src:\s*url\(\s*["']?(.*?)["']?\)\s*
-        (?:format\([^\)]*\)\s*)?
-        [^;]*;""",
-        re.VERBOSE | re.DOTALL,
-    )
-
-    for match in font_pattern.finditer(css_content):
+    for match in _FONT_FACE_PATTERN.finditer(css_content):
         font_path = match.group(1)
         if font_path.startswith(("http:", "https:", "data:")):
             continue

--- a/scripts/tests/test_convert_markdown.py
+++ b/scripts/tests/test_convert_markdown.py
@@ -255,7 +255,9 @@ def test_download_image(tmp_path):
     mock_response.status_code = 200
     mock_response.raw = io.BytesIO(b"fake image data")
 
-    with mock.patch("requests.get", return_value=mock_response) as mock_get:
+    with mock.patch.object(
+        convert_markdown_yaml._http_session, "get", return_value=mock_response
+    ) as mock_get:
         convert_markdown_yaml._download_image(url, output_path)
 
         mock_get.assert_called_once()
@@ -272,7 +274,11 @@ def test_download_image_failure(tmp_path):
     mock_response.status_code = 404
 
     with (
-        mock.patch("requests.get", return_value=mock_response),
+        mock.patch.object(
+            convert_markdown_yaml._http_session,
+            "get",
+            return_value=mock_response,
+        ),
         pytest.raises(ValueError, match="Failed to download image"),
     ):
         convert_markdown_yaml._download_image(url, output_path)

--- a/scripts/tests/test_download_external_media.py
+++ b/scripts/tests/test_download_external_media.py
@@ -1,6 +1,6 @@
 """Tests for download_external_media.py."""
 
-import subprocess
+import io
 from unittest import mock
 
 import pytest
@@ -109,23 +109,33 @@ def test_find_external_media_urls_case_insensitive(mock_git_root):
     assert "https://example.com/video.MP4" in urls
 
 
+def _mock_response(payload: bytes = b"") -> mock.MagicMock:
+    """Build a MagicMock that mimics a streaming requests Response."""
+    response = mock.MagicMock()
+    response.raw = io.BytesIO(payload)
+    response.__enter__.return_value = response
+    response.raise_for_status = mock.MagicMock()
+    return response
+
+
 def test_download_media_success(mock_git_root, tmp_path):
     """Test successful media download."""
     target_dir = tmp_path / "downloads"
     target_dir.mkdir()
 
-    with mock.patch("subprocess.run") as mock_run:
-        mock_run.return_value = mock.Mock(returncode=0)
-
+    response = _mock_response(b"image-bytes")
+    with mock.patch.object(
+        download_external_media._http_session, "get", return_value=response
+    ) as mock_get:
         result = download_external_media.download_media(
             "https://example.com/image.png", target_dir
         )
 
         assert result is True
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args[0][0]
-        assert "curl" in call_args
-        assert "https://example.com/image.png" in call_args
+        mock_get.assert_called_once()
+        url = mock_get.call_args[0][0]
+        assert url == "https://example.com/image.png"
+        assert (target_dir / "image.png").read_bytes() == b"image-bytes"
 
 
 def test_download_media_failure(mock_git_root, tmp_path):
@@ -133,11 +143,13 @@ def test_download_media_failure(mock_git_root, tmp_path):
     target_dir = tmp_path / "downloads"
     target_dir.mkdir()
 
-    with mock.patch("subprocess.run") as mock_run:
-        mock_run.side_effect = subprocess.CalledProcessError(
-            1, "curl", stderr=b"Error message"
-        )
-
+    with mock.patch.object(
+        download_external_media._http_session,
+        "get",
+        side_effect=download_external_media.requests.RequestException(
+            "Error message"
+        ),
+    ):
         result = download_external_media.download_media(
             "https://example.com/image.png", target_dir
         )
@@ -205,20 +217,25 @@ def test_main_downloads_and_updates(mock_git_root, capsys):
     md_file = mock_git_root / "website_content" / "test.md"
     md_file.write_text("![Image](https://example.com/image.png)")
 
-    with mock.patch("subprocess.run") as mock_run:
+    response = _mock_response(b"image-bytes")
+    with (
+        mock.patch("subprocess.run") as mock_run,
+        mock.patch.object(
+            download_external_media._http_session,
+            "get",
+            return_value=response,
+        ) as mock_get,
+    ):
         mock_run.return_value = mock.Mock(returncode=0)
 
         download_external_media.main()
 
-        # Check that subprocess.run was called multiple times (pkill, curl, open)
-        assert mock_run.call_count >= 3
+        # pkill and open were invoked via subprocess.run
+        assert mock_run.call_count >= 2
 
-        # Check that curl download was attempted
-        curl_calls = [
-            call for call in mock_run.call_args_list if "curl" in str(call)
-        ]
-        assert len(curl_calls) == 1
-        assert "https://example.com/image.png" in str(curl_calls[0])
+        # Download was attempted via the http session
+        mock_get.assert_called_once()
+        assert mock_get.call_args[0][0] == "https://example.com/image.png"
 
         # Check that URL was updated in markdown
         updated_content = md_file.read_text()
@@ -235,15 +252,17 @@ def test_main_handles_download_failures(mock_git_root, capsys):
     md_file = mock_git_root / "website_content" / "test.md"
     md_file.write_text("![Image](https://example.com/image.png)")
 
-    with mock.patch("subprocess.run") as mock_run:
-        # First call (pkill) succeeds, second call (curl) fails, third call (open) succeeds
-        mock_run.side_effect = [
-            mock.Mock(returncode=0),  # pkill
-            subprocess.CalledProcessError(
-                1, "curl", stderr=b"Error"
-            ),  # curl fails
-            mock.Mock(returncode=0),  # open
-        ]
+    with (
+        mock.patch("subprocess.run") as mock_run,
+        mock.patch.object(
+            download_external_media._http_session,
+            "get",
+            side_effect=download_external_media.requests.RequestException(
+                "Error"
+            ),
+        ),
+    ):
+        mock_run.return_value = mock.Mock(returncode=0)
 
         download_external_media.main()
 

--- a/scripts/tests/test_download_external_media.py
+++ b/scripts/tests/test_download_external_media.py
@@ -118,6 +118,22 @@ def _mock_response(payload: bytes = b"") -> mock.MagicMock:
     return response
 
 
+def test_download_media_skips_url_with_no_filename(
+    mock_git_root, tmp_path, capsys
+):
+    """URLs whose path has no filename component are skipped without raising."""
+    target_dir = tmp_path / "downloads"
+    target_dir.mkdir()
+
+    result = download_external_media.download_media(
+        "https://example.com/", target_dir
+    )
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert "Skipping URL with no filename" in captured.err
+
+
 def test_download_media_success(mock_git_root, tmp_path):
     """Test successful media download."""
     target_dir = tmp_path / "downloads"

--- a/scripts/tests/test_script_utils.py
+++ b/scripts/tests/test_script_utils.py
@@ -1,5 +1,6 @@
 """Test the utilities used for running the tests :)"""
 
+import io
 import shutil
 import subprocess
 from collections.abc import Iterator
@@ -1206,3 +1207,75 @@ def test_get_imagemagick_command_im6_operation_not_found(
         FileNotFoundError, match="ImageMagick 'identify' not found"
     ):
         script_utils.get_imagemagick_command("identify")
+
+
+# ---------------------------------------------------------------------------
+# Newer shared helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_yaml_parser_round_trips_and_preserves_quotes(tmp_path: Path):
+    parser = script_utils.get_yaml_parser()
+    source = 'name: "quoted"\nlist:\n  - a\n  - b\n'
+    loaded = parser.load(source)
+    assert loaded["name"] == "quoted"
+    stream = io.StringIO()
+    parser.dump(loaded, stream)
+    # Quotes preserved by the round-trip parser
+    assert '"quoted"' in stream.getvalue()
+
+
+def test_write_yaml_frontmatter_writes_full_file(tmp_path: Path):
+    file_path = tmp_path / "post.md"
+    script_utils.write_yaml_frontmatter(
+        file_path, {"title": "Hi"}, "body line\n"
+    )
+    contents = file_path.read_text(encoding="utf-8")
+    assert contents.startswith("---\n")
+    assert "title: Hi" in contents
+    assert contents.endswith("body line\n")
+
+
+def test_write_yaml_frontmatter_accepts_explicit_parser(tmp_path: Path):
+    file_path = tmp_path / "post.md"
+    parser = script_utils.get_yaml_parser()
+    script_utils.write_yaml_frontmatter(
+        file_path, {"a": 1}, "body\n", parser=parser
+    )
+    assert "a: 1" in file_path.read_text(encoding="utf-8")
+
+
+def test_update_markdown_file_writes_only_on_change(tmp_path: Path):
+    file_path = tmp_path / "post.md"
+    file_path.write_text("original", encoding="utf-8")
+
+    changed = script_utils.update_markdown_file(file_path, lambda s: s)
+    assert changed is False
+
+    changed = script_utils.update_markdown_file(
+        file_path, lambda s: s + " updated"
+    )
+    assert changed is True
+    assert file_path.read_text(encoding="utf-8") == "original updated"
+
+
+def test_extract_filename_from_url_returns_basename():
+    assert (
+        script_utils.extract_filename_from_url(
+            "https://example.com/path/to/file.png"
+        )
+        == "file.png"
+    )
+
+
+def test_extract_filename_from_url_raises_when_empty():
+    with pytest.raises(ValueError, match="no filename component"):
+        script_utils.extract_filename_from_url("https://example.com/")
+
+
+def test_error_exit_prints_to_stderr_and_exits(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        script_utils.error_exit("boom", code=2)
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "boom" in captured.err

--- a/scripts/update_date_on_publish.py
+++ b/scripts/update_date_on_publish.py
@@ -1,13 +1,11 @@
 """Update the publish and update dates in markdown files."""
 
-import io
 import re  # Import the re module
 import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 
-from ruamel.yaml import YAML
 from ruamel.yaml.timestamp import TimeStamp
 
 # Ensure the parent directory is in the sys path so we can import utils
@@ -15,10 +13,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 # pylint: disable=wrong-import-position
 import scripts.utils as script_utils
 
-yaml_parser = YAML(typ="rt")  # Use Round-Trip to preserve formatting
-yaml_parser.preserve_quotes = True  # Preserve existing quotes
-yaml_parser.indent(mapping=2, sequence=2, offset=2)
-yaml_parser.width = 4096  # Prevent line wrapping for long URLs
+yaml_parser = script_utils.get_yaml_parser()
 
 now = datetime.now()
 current_date = TimeStamp(
@@ -143,17 +138,9 @@ def maybe_update_publish_date(yaml_metadata: dict) -> None:
 
 def write_to_yaml(file_path: Path, metadata: dict, content: str) -> None:
     """Write updated metadata to a markdown file."""
-    # Use StringIO to capture the YAML dump with preserved formatting
-    stream = io.StringIO()
-    yaml_parser.dump(metadata, stream)
-    updated_yaml = stream.getvalue()
-
-    # Write back to file if changes were made
-    with file_path.open("w", encoding="utf-8") as f:
-        f.write("---\n")
-        f.write(updated_yaml)
-        f.write("---\n")
-        f.write(content)
+    script_utils.write_yaml_frontmatter(
+        file_path, metadata, content, parser=yaml_parser
+    )
 
 
 _README_PATH = Path("README.md")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,12 +1,16 @@
 """Utility functions for scripts/ directory."""
 
 import functools
+import io
 import json
 import logging
+import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
-from typing import Collection, Dict, Optional, Set
+from typing import Callable, Collection, Dict, NoReturn, Optional, Set
+from urllib.parse import urlparse
 
 import git
 import requests
@@ -227,6 +231,78 @@ def path_relative_to_quartz_parent(input_file: Path) -> Path:
         raise ValueError("The path must be within a 'quartz' directory.") from e
 
 
+def get_yaml_parser() -> YAML:
+    """
+    Return a round-trip ruamel.yaml parser configured for markdown frontmatter.
+
+    Preserves quotes and comments; sets the indentation used across this
+    project. ``width`` is large so long URLs do not get wrapped onto multiple
+    lines.
+    """
+    parser = YAML(typ="rt")
+    parser.preserve_quotes = True
+    parser.indent(mapping=2, sequence=2, offset=2)
+    parser.width = 4096
+    return parser
+
+
+def write_yaml_frontmatter(
+    file_path: Path,
+    metadata: dict,
+    content: str,
+    parser: Optional[YAML] = None,
+) -> None:
+    """
+    Write *metadata* as YAML frontmatter followed by *content* to *file_path*.
+
+    A new :func:`get_yaml_parser` instance is used if *parser* is not given.
+    """
+    yaml_parser = parser if parser is not None else get_yaml_parser()
+    stream = io.StringIO()
+    yaml_parser.dump(metadata, stream)
+    with file_path.open("w", encoding="utf-8") as f:
+        f.write("---\n")
+        f.write(stream.getvalue())
+        f.write("---\n")
+        f.write(content)
+
+
+def update_markdown_file(
+    file_path: Path, transform_fn: Callable[[str], str]
+) -> bool:
+    """
+    Read *file_path*, apply *transform_fn* to its contents, write back if
+    changed.
+
+    Returns True when the file was modified.
+    """
+    original = file_path.read_text(encoding="utf-8")
+    updated = transform_fn(original)
+    if updated == original:
+        return False
+    file_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def extract_filename_from_url(url: str) -> str:
+    """
+    Return the trailing filename of *url* (everything after the final ``/``).
+
+    Raises:
+        ValueError: When the URL has no filename component.
+    """
+    filename = os.path.basename(urlparse(url).path)
+    if not filename:
+        raise ValueError(f"URL has no filename component: {url}")
+    return filename
+
+
+def error_exit(message: str, code: int = 1) -> NoReturn:
+    """Print *message* to stderr and exit with *code*."""
+    print(message, file=sys.stderr)
+    sys.exit(code)
+
+
 def split_yaml(file_path: Path, verbose: bool = False) -> tuple[dict, str]:
     """
     Split a markdown file into its YAML frontmatter and content.
@@ -238,10 +314,7 @@ def split_yaml(file_path: Path, verbose: bool = False) -> tuple[dict, str]:
     Returns:
         Tuple of (metadata dict, content string)
     """
-    yaml = YAML(
-        typ="rt"
-    )  # 'rt' means round-trip, preserving comments and formatting
-    yaml.preserve_quotes = True  # Preserve quote style
+    yaml = get_yaml_parser()
 
     with file_path.open("r", encoding="utf-8") as f:
         content = f.read()


### PR DESCRIPTION
## Summary

Replace subprocess-based curl calls with the `requests` library for downloading external media, improving code maintainability and testability. Extract common utility functions for YAML handling and markdown file operations into `scripts/utils.py`.

## Key Changes

**Media Download Refactoring:**
- Replace `subprocess.run("curl", ...)` with `requests.get()` in `download_external_media.py`
- Use streaming response with `shutil.copyfileobj()` for efficient file writing
- Catch `requests.RequestException` instead of `subprocess.CalledProcessError`
- Add test for URLs with no filename component (e.g., `https://example.com/`)

**Shared Utilities (scripts/utils.py):**
- `get_yaml_parser()`: Factory for round-trip YAML parser with project-standard formatting
- `write_yaml_frontmatter()`: Write metadata + content to markdown files with proper frontmatter
- `update_markdown_file()`: Read, transform, and write markdown files only if changed
- `extract_filename_from_url()`: Extract trailing filename from URL path; raises `ValueError` if empty
- `error_exit()`: Print to stderr and exit with code

**Downstream Refactoring:**
- `convert_markdown_yaml.py`: Use `get_yaml_parser()` and `_http_session` for consistency
- `update_date_on_publish.py`: Use `get_yaml_parser()` and `write_yaml_frontmatter()`
- `r2_upload.py`: Use `update_markdown_file()` for file transformations
- `convert_assets.py`: Use `update_markdown_file()` for content replacement
- `replace_asset_staging_refs.py`: Use `update_markdown_file()`

**GitHub Actions Improvements:**
- Extract `restore-site-build` action to centralize cache-restore logic across workflows
- Extract `sanitize-shard-name` action to deduplicate shard name sanitization
- Move Cloudflare credentials to job-level `env` in `deploy.yaml` (Wrangler reads them natively)
- Update `deploy-to-cloudflare` action to remove credential inputs (now read from environment)

**TypeScript/JavaScript:**
- `quartz/util/log.ts`: Replace `execSync("git rev-parse --show-toplevel")` with `find-git-root` package for better testability
- `quartz/util/log.test.ts`: Mock `find-git-root` instead of `child_process`
- `quartz/components/constants.ts`: Export `HEADING_TAGS` and `MEDIA_TAGS` for reuse across transformers
- `quartz/plugins/transformers/links.ts`: Import tag constants from `constants.ts` instead of defining locally
- `quartz/plugins/transformers/formatting_improvement_html.ts`: Import `HEADING_TAGS` from constants
- `quartz/plugins/transformers/populateExternalMarkdown.ts`: Add `escape-string-regexp` import
- `quartz/plugins/transformers/tagSmallcaps.ts`: Add `escape-string-regexp` import

**Python Tests:**
- Update `test_download_external_media.py` to mock `_http_session.get()` instead of `subprocess.run()`
- Add `_mock_response()` helper for building streaming response mocks
- Add test for skipping URLs with no filename
- Update `test_convert_markdown.py` to mock `_http_session.get()`
- Add comprehensive tests for new utility functions in `test_script_utils.py`

## Notable Implementation Details

- HTTP session uses `stream=True` and `shutil.copyfileobj()` for memory-efficient downloads
- YAML parser configured with `width=4096` to prevent URL wrapping
- `update_markdown_file()` returns boolean to indicate whether file was modified
- GitHub Actions refactoring centralizes configuration in one place, reducing duplication across 5+ workflows
- TypeScript log root detection now uses a proper package instead of shell invocation, improving testability

https://claude.ai/code/session_01NKzLHFZurJpheAjXuWpma2