### PR TITLE
Fix spoiler parsing in soft-wrapped blockquotes

### DIFF
--- a/quartz/plugins/transformers/spoiler.ts
+++ b/quartz/plugins/transformers/spoiler.ts
@@ -105,31 +105,70 @@ export function modifyNode(node: Element, index: number | undefined, parent: Par
   }
 }
 
+/**
+ * Split a text node's value on newlines into an alternating sequence of text
+ * nodes and <br> elements. A value with no newlines yields a single text node.
+ */
+function splitTextOnNewlines(value: string): (Text | Element)[] {
+  const lines = value.split("\n")
+  const result: (Text | Element)[] = []
+  lines.forEach((line, i) => {
+    if (i > 0) result.push(h("br"))
+    result.push({ type: "text", value: line })
+  })
+  return result
+}
+
+/**
+ * Flatten a paragraph's children so each logical line is a contiguous run of
+ * nodes separated by <br> elements. Markdown soft-wraps multiple `>` lines into
+ * a single paragraph whose text nodes contain embedded "\n" characters; this
+ * helper makes those line boundaries explicit.
+ */
+function flattenParagraphChildren(paragraph: Element): (Text | Element)[] {
+  const result: (Text | Element)[] = []
+  for (const child of paragraph.children) {
+    if (child.type === "text") {
+      result.push(...splitTextOnNewlines(child.value))
+      continue
+    }
+    /* istanbul ignore next -- paragraph children are always text or element nodes */
+    if (child.type === "element") {
+      result.push(child)
+    }
+  }
+  return result
+}
+
+function isLineBreak(node: Text | Element): boolean {
+  return node.type === "element" && node.tagName === "br"
+}
+
 export function processParagraph(paragraph: Element): Element | null {
   const newChildren: (Text | Element)[] = []
   let isSpoiler = false
+  let atLineStart = true
 
-  for (const child of paragraph.children) {
-    if (child.type === "text") {
-      const spoilerText = matchSpoilerText(child.value)
-      if (spoilerText !== null) {
-        isSpoiler = true
-        newChildren.push({ type: "text", value: spoilerText })
-        continue
-      }
-
-      if (!isSpoiler) {
-        return null
-      }
-
-      newChildren.push(child)
+  for (const node of flattenParagraphChildren(paragraph)) {
+    if (isLineBreak(node)) {
+      newChildren.push(node)
+      atLineStart = true
       continue
     }
 
-    /* istanbul ignore next -- paragraph children are always text or element nodes */
-    if (child.type === "element") {
-      newChildren.push(child)
+    if (atLineStart && node.type === "text") {
+      const spoilerText = matchSpoilerText(node.value)
+      if (spoilerText !== null) {
+        isSpoiler = true
+        newChildren.push({ type: "text", value: spoilerText })
+        atLineStart = false
+        continue
+      }
+      if (!isSpoiler) return null
     }
+
+    newChildren.push(node)
+    atLineStart = false
   }
 
   return isSpoiler ? { ...paragraph, children: newChildren } : null

--- a/quartz/plugins/transformers/spoiler.ts
+++ b/quartz/plugins/transformers/spoiler.ts
@@ -5,6 +5,8 @@ import { h } from "hastscript"
 
 import { createElementVisitorPlugin } from "./utils"
 
+type InlineNode = Text | Element
+
 const SPOILER_REGEX = /^!\s*(?<spoilerText>.*)/
 
 /**
@@ -109,9 +111,9 @@ export function modifyNode(node: Element, index: number | undefined, parent: Par
  * Split a text node's value on newlines into an alternating sequence of text
  * nodes and <br> elements. A value with no newlines yields a single text node.
  */
-function splitTextOnNewlines(value: string): (Text | Element)[] {
+function splitTextOnNewlines(value: string): InlineNode[] {
   const lines = value.split("\n")
-  const result: (Text | Element)[] = []
+  const result: InlineNode[] = []
   lines.forEach((line, i) => {
     if (i > 0) result.push(h("br"))
     result.push({ type: "text", value: line })
@@ -125,8 +127,8 @@ function splitTextOnNewlines(value: string): (Text | Element)[] {
  * a single paragraph whose text nodes contain embedded "\n" characters; this
  * helper makes those line boundaries explicit.
  */
-function flattenParagraphChildren(paragraph: Element): (Text | Element)[] {
-  const result: (Text | Element)[] = []
+function flattenParagraphChildren(paragraph: Element): InlineNode[] {
+  const result: InlineNode[] = []
   for (const child of paragraph.children) {
     if (child.type === "text") {
       result.push(...splitTextOnNewlines(child.value))
@@ -140,12 +142,12 @@ function flattenParagraphChildren(paragraph: Element): (Text | Element)[] {
   return result
 }
 
-function isLineBreak(node: Text | Element): boolean {
+function isLineBreak(node: InlineNode): boolean {
   return node.type === "element" && node.tagName === "br"
 }
 
 export function processParagraph(paragraph: Element): Element | null {
-  const newChildren: (Text | Element)[] = []
+  const newChildren: InlineNode[] = []
   let isSpoiler = false
   let atLineStart = true
 

--- a/quartz/plugins/transformers/tests/spoiler.test.ts
+++ b/quartz/plugins/transformers/tests/spoiler.test.ts
@@ -113,6 +113,16 @@ describe("rehype-custom-spoiler", () => {
         input: h("p", {}, "This is not a spoiler"),
         expected: null,
       },
+      {
+        name: "multi-line text within a single paragraph (soft-wrapped blockquote)",
+        input: h("p", {}, "! Line one\n! Line two\n! Line three"),
+        expected: h("p", {}, ["Line one", h("br"), "Line two", h("br"), "Line three"]),
+      },
+      {
+        name: "multi-line text with trailing non-spoiler line passes through",
+        input: h("p", {}, "! First\nsecond line"),
+        expected: h("p", {}, ["First", h("br"), "second line"]),
+      },
     ])("$name", ({ input, expected }) => {
       const result = processParagraph(input as Element)
       expect(removePositions(result)).toEqual(removePositions(expected))


### PR DESCRIPTION
## Summary

Fix spoiler detection to work correctly with soft-wrapped blockquotes, where multiple `>` lines are merged into a single paragraph with embedded newline characters. Previously, only the first line of such paragraphs was checked for spoiler markers.

## Changes

- **Added `InlineNode` type alias** for `Text | Element` to improve code clarity
- **Extracted `splitTextOnNewlines()`** helper to convert embedded `\n` characters in text nodes into explicit `<br>` elements, making line boundaries explicit
- **Extracted `flattenParagraphChildren()`** helper to normalize paragraph structure by splitting text nodes on newlines
- **Refactored `processParagraph()`** to track line boundaries with `atLineStart` flag, enabling spoiler detection on any line (not just the first), while preserving non-spoiler content on subsequent lines
- **Added test cases** for multi-line soft-wrapped blockquotes and mixed spoiler/non-spoiler content

## Implementation details

The core issue: Markdown soft-wraps multiple blockquote lines (`> ! Line one\n> ! Line two`) into a single `<p>` element with a text node containing `"! Line one\n! Line two"`. The old logic only checked the first line.

The fix normalizes paragraph children by splitting text nodes on `\n` and inserting `<br>` elements, then processes the flattened structure line-by-line. When a line starts with a spoiler marker, it's extracted; subsequent lines are preserved as-is (allowing mixed spoiler/non-spoiler content within a single paragraph).

https://claude.ai/code/session_01Ty4rPGS1ccwHSNt34PoAzy