### PR TITLE
Simplify visual gallery layout to use responsive grid

### DIFF
--- a/scripts/generate_visual_gallery.py
+++ b/scripts/generate_visual_gallery.py
@@ -43,24 +43,18 @@ body { font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; ma
 h1 { margin: 0 0 .25rem; }
 .sub { color: #666; margin: 0 0 1.25rem; }
 .row { margin: 0 0 2.5rem; padding-bottom: 1.5rem;
-       border-bottom: 1px solid rgba(127,127,127,0.25);
-       overflow-x: auto; }
+       border-bottom: 1px solid rgba(127,127,127,0.25); }
 .row h3 { margin: 0 0 .75rem; font-size: 1rem;
           font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
           word-break: break-all; color: #333; }
 .row h3 a { color: inherit; text-decoration: none; }
 .row h3 a:hover { text-decoration: underline; }
-.cells { display: grid; grid-template-columns: repeat(3, auto);
-         gap: 1rem; align-items: start; width: max-content; }
-.cell { margin: 0; display: flex; flex-direction: column; gap: .35rem; }
+.cells { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+         gap: 1rem; align-items: start; }
+.cell { margin: 0; min-width: 0; display: flex; flex-direction: column; gap: .35rem; }
 .cell figcaption { font-size: .7rem; text-transform: uppercase;
                    letter-spacing: .05em; color: #888; }
-/* Width is set per-image at load time to naturalWidth / devicePixelRatio,
-   so each PNG pixel maps to one device pixel regardless of display DPR.
-   We deliberately don't stretch to fill the container — zooming the
-   browser then preserves the screenshot's native resolution. */
-.cell img { height: auto; display: block; cursor: zoom-in;
-            max-width: none;
+.cell img { width: 100%; height: auto; display: block; cursor: zoom-in;
             border: 1px solid rgba(127,127,127,0.3);
             background: rgba(127,127,127,0.06); }
 .cell.missing .placeholder { display: flex; align-items: center; justify-content: center;
@@ -87,7 +81,7 @@ h1 { margin: 0 0 .25rem; }
 .lb { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.92);
       z-index: 9999; cursor: zoom-out; padding: 1rem; overflow: auto; }
 .lb.show { display: block; }
-.lb img { display: block; margin: 0 auto; }
+.lb img { display: block; margin: 0 auto; max-width: 100%; }
 @media (prefers-color-scheme: dark) {
   .row h3 { color: #ddd; }
   .row { border-color: rgba(255,255,255,0.15); }
@@ -137,15 +131,6 @@ _JS = """
 // once every <img> in row N-1 has either finished loading or errored.
 // Keeps fetch parallelism predictable on multi-hundred-row diffs.
 (() => {
-  // Each screenshot is captured with deviceScaleFactor=1, so a PNG of
-  // W pixels represents W CSS pixels of the rendered page. Display it
-  // at W/DPR CSS px so 1 PNG pixel maps to 1 device pixel — crispest
-  // possible rendering, and stable under browser zoom-out.
-  const dpr = window.devicePixelRatio || 1;
-  function sizeToDPR(img) {
-    if (!img.naturalWidth) return;
-    img.style.width = (img.naturalWidth / dpr) + 'px';
-  }
   const rows = Array.from(document.querySelectorAll('.row'));
   function loadRow(idx) {
     if (idx >= rows.length) return;
@@ -154,7 +139,7 @@ _JS = """
     let pending = imgs.length;
     const done = () => { if (--pending === 0) loadRow(idx + 1); };
     imgs.forEach(img => {
-      img.addEventListener('load', () => { sizeToDPR(img); done(); }, { once: true });
+      img.addEventListener('load', done, { once: true });
       img.addEventListener('error', done, { once: true });
       img.src = img.dataset.src;
       img.removeAttribute('data-src');

--- a/scripts/tests/test_generate_visual_gallery.py
+++ b/scripts/tests/test_generate_visual_gallery.py
@@ -117,20 +117,6 @@ def test_render_html_uses_full_height_cells() -> None:
     assert "height: auto" in page
 
 
-def test_render_html_does_not_stretch_images_to_container() -> None:
-    """Images render at natural size scaled by DPR — never stretched to fit."""
-    page = gvg.render_html([])
-    # The old rule that stretched each image to its grid column is gone.
-    assert "width: 100%" not in page
-    # Lightbox no longer shrinks oversize images to viewport width either.
-    assert "max-width: 100%" not in page
-    # Rows can scroll horizontally when natural-sized images overflow.
-    assert "overflow-x: auto" in page
-    # Per-image width is computed client-side from naturalWidth / DPR.
-    assert "devicePixelRatio" in page
-    assert "naturalWidth" in page
-
-
 def test_render_html_escapes_label() -> None:
     tiles = [gvg.Tile(label="<script>x", expected=None, actual=None, diff=None)]
     page = gvg.render_html(tiles)

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1109,7 +1109,7 @@ I use [`linkchecker`](https://linkchecker.github.io/) to validate these links.
 >
 > **Dark-mode inversion:**
 >
-> 1. Raster `<img>` or inline looping `<video>` sources without an "invert in dark mode?" review which I completed;
+> 1. Raster `<img>` or inline looping `<video>` sources which don't have a confirmed judgment for "should this be inverted in dark mode?".
 > 2. `invert-in-dark-mode` class on a rendered element not matching the JSON's `invert` field (the source of truth);
 >
 > **CSS and styling:**

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1109,7 +1109,7 @@ I use [`linkchecker`](https://linkchecker.github.io/) to validate these links.
 >
 > **Dark-mode inversion:**
 >
-> 1. Eligible raster `<img>` and inline looping `<video>` sources which are missing from `.invert_labels.json` or which are not user-reviewed;
+> 1. Raster `<img>` or inline looping `<video>` sources without an "invert in dark mode?" review which I completed;
 > 2. `invert-in-dark-mode` class on a rendered element not matching the JSON's `invert` field (the source of truth);
 >
 > **CSS and styling:**


### PR DESCRIPTION
## Summary

Refactors the visual gallery HTML/CSS to use a responsive grid layout instead of a fixed-width horizontal-scroll approach. Images now scale responsively to fill their grid columns while maintaining aspect ratio, eliminating the need for client-side DPR-based sizing logic.

## Key changes

- **CSS grid layout**: Changed `.cells` from `grid-template-columns: repeat(3, auto)` with `width: max-content` to `repeat(3, minmax(0, 1fr))`, allowing columns to share available width responsively
- **Image sizing**: Replaced per-image width calculation (based on `naturalWidth / devicePixelRatio`) with `width: 100%` on `.cell img`, letting CSS handle responsive scaling
- **Removed horizontal scroll**: Deleted `overflow-x: auto` from `.row` since images no longer overflow their containers
- **Lightbox responsiveness**: Added `max-width: 100%` to `.lb img` to prevent oversized images from breaking the lightbox viewport
- **Removed client-side DPR logic**: Deleted the `sizeToDPR()` function and all `devicePixelRatio` calculations; simplified image load handler to just call `done()` without width manipulation
- **Added `min-width: 0`** to `.cell` to prevent flex children from overflowing their grid column (CSS best practice for flex inside grid)
- **Updated test**: Removed `test_render_html_does_not_stretch_images_to_container()` which validated the old DPR-based sizing behavior
- **Documentation**: Clarified dark-mode inversion criteria in `design.md` (minor wording improvement)

## Implementation notes

The old approach captured screenshots at `deviceScaleFactor=1` and then scaled them down by DPR client-side to achieve crisp 1:1 pixel mapping. This required horizontal scrolling when images exceeded viewport width. The new approach uses standard responsive CSS — images scale to fit their grid column, and the browser's native zoom behavior preserves clarity. This is simpler, more maintainable, and provides better UX on mobile/narrow viewports.

https://claude.ai/code/session_01UseWdos74Sapfb3MxhptbZ