### PR TITLE
Refactor InvertInDarkMode: remove caching, simplify label loading

### DIFF
--- a/quartz/plugins/transformers/invertInDarkMode.ts
+++ b/quartz/plugins/transformers/invertInDarkMode.ts
@@ -18,62 +18,53 @@ export const labelsPath = path.join(
   ".invert_labels.json",
 )
 
-export const INVERT_CLASS = invertInDarkModeClass
-
 export type InvertLabelMap = ReadonlyMap<string, boolean>
 
-let cache: InvertLabelMap | null = null
-
-export function resetCacheForTesting(): void {
-  cache = null
+function parseLabels(raw: string, source: string): InvertLabelMap {
+  const parsed: unknown = JSON.parse(raw)
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${source} must contain a JSON object`)
+  }
+  const labels = new Map<string, boolean>()
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (value === null || typeof value !== "object" || !("invert" in value)) {
+      throw new Error(`${source} entry for ${key} must be {invert, reviewed}`)
+    }
+    labels.set(key, Boolean((value as { invert: unknown }).invert))
+  }
+  return labels
 }
 
+/** Missing file → empty map; other I/O errors propagate. */
 export async function loadInvertLabels(filePath: string = labelsPath): Promise<InvertLabelMap> {
-  const isDefault = filePath === labelsPath
-  if (isDefault && cache !== null) return cache
-
   let raw: string
   try {
     raw = await fs.readFile(filePath, "utf-8")
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      const empty: InvertLabelMap = new Map()
-      if (isDefault) cache = empty
-      return empty
-    }
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map()
     throw error
   }
+  return parseLabels(raw, filePath)
+}
 
-  const parsed = JSON.parse(raw) as unknown
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`${filePath} must contain a JSON object`)
-  }
-  const labels = new Map<string, boolean>()
-  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-    if (v === null || typeof v !== "object" || !("invert" in v)) {
-      throw new Error(`${filePath} entry for ${k} must be {invert, reviewed}`)
-    }
-    labels.set(k, Boolean((v as { invert: unknown }).invert))
-  }
-  if (isDefault) cache = labels
-  return labels
+function classTokens(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String)
+  if (typeof value === "string") return value.split(/\s+/).filter(Boolean)
+  return []
 }
 
 export function addInvertClass(node: Element): void {
   const props = (node.properties ??= {})
-  const existing = props.className
-  const tokens = Array.isArray(existing)
-    ? existing.map(String)
-    : typeof existing === "string"
-      ? existing.split(/\s+/).filter(Boolean)
-      : []
-  if (!tokens.includes(INVERT_CLASS)) tokens.push(INVERT_CLASS)
+  const tokens = classTokens(props.className)
+  if (!tokens.includes(invertInDarkModeClass)) tokens.push(invertInDarkModeClass)
   props.className = tokens
 }
 
-/** True iff this is an inline GIF-replacement video — autoplay+loop+muted —
+/**
+ * True iff this is an inline GIF-replacement video — autoplay+loop+muted —
  * but not the persistent `#pond-video` background. (Hast normalizes the
- * `autoplay` HTML attr to the camelCased property `autoPlay`.) */
+ * `autoplay` HTML attr to the camelCased property `autoPlay`.)
+ */
 export function isInlineLoopingVideo(node: Element): boolean {
   if (node.tagName !== "video") return false
   const props = node.properties ?? {}
@@ -81,11 +72,11 @@ export function isInlineLoopingVideo(node: Element): boolean {
   return Boolean(props.autoPlay) && Boolean(props.loop) && Boolean(props.muted)
 }
 
-/** Returns every `src` referenced by this video — direct `src` if present
- * plus every `<source src>` child. */
+/** Direct `src` plus every `<source src>` child of a video element. */
 export function collectVideoSources(node: Element): string[] {
+  const sources: string[] = []
   const direct = node.properties?.src
-  const sources: string[] = typeof direct === "string" ? [direct] : []
+  if (typeof direct === "string") sources.push(direct)
   for (const child of node.children) {
     if (child.type !== "element" || child.tagName !== "source") continue
     const childSrc = child.properties?.src
@@ -94,9 +85,8 @@ export function collectVideoSources(node: Element): string[] {
   return sources
 }
 
-/** Returns the URLs that, if labeled `true`, mean we should tag this node
- * with the invert class. `[]` for elements we don't care about. */
-function eligibleSources(node: Element): string[] {
+/** URLs whose label decides whether to tag this element. */
+function eligibleSources(node: Element): readonly string[] {
   if (node.tagName === "img") {
     const src = node.properties?.src
     return typeof src === "string" ? [src] : []
@@ -118,12 +108,15 @@ export function applyLabelsToTree(tree: Root, labels: InvertLabelMap): void {
  * class. Dark-mode CSS applies the inversion filter only to tagged
  * elements. The persistent `#pond-video` is excluded by
  * `isInlineLoopingVideo`.
+ *
+ * Labels are read once per plugin instance and shared across every page in
+ * the build.
  */
-export const InvertInDarkMode = () => ({
-  name: "InvertInDarkMode" as const,
-  htmlPlugins: () => [
-    () => async (tree: Root) => {
-      applyLabelsToTree(tree, await loadInvertLabels())
-    },
-  ],
-})
+export const InvertInDarkMode = () => {
+  let labelsPromise: Promise<InvertLabelMap> | null = null
+  const labels = () => (labelsPromise ??= loadInvertLabels())
+  return {
+    name: "InvertInDarkMode" as const,
+    htmlPlugins: () => [() => async (tree: Root) => applyLabelsToTree(tree, await labels())],
+  }
+}

--- a/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
+++ b/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
@@ -6,28 +6,26 @@ import type { Element, Root } from "hast"
 import { jest, expect, it, describe, beforeEach, afterEach } from "@jest/globals"
 import fs from "fs/promises"
 import { h } from "hastscript"
-import os from "os"
-import path from "path"
 
+import { invertInDarkModeClass } from "../../../components/constants"
 import {
   addInvertClass,
   applyLabelsToTree,
   collectVideoSources,
-  INVERT_CLASS,
   InvertInDarkMode,
   isInlineLoopingVideo,
   labelsPath,
   loadInvertLabels,
-  resetCacheForTesting,
 } from "../invertInDarkMode"
+
+const errno = (code: string): NodeJS.ErrnoException => Object.assign(new Error(code), { code })
+
+const tree = (...nodes: Element[]): Root => ({ type: "root", children: nodes })
 
 let readFileSpy: ReturnType<typeof jest.spyOn>
 
-const enoent = (): NodeJS.ErrnoException => Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-
 describe("InvertInDarkMode", () => {
   beforeEach(() => {
-    resetCacheForTesting()
     readFileSpy = jest.spyOn(fs, "readFile")
   })
   afterEach(() => {
@@ -36,7 +34,7 @@ describe("InvertInDarkMode", () => {
 
   describe("loadInvertLabels", () => {
     it("returns empty map when file is missing", async () => {
-      readFileSpy.mockRejectedValue(enoent() as never)
+      readFileSpy.mockRejectedValue(errno("ENOENT") as never)
       expect(await loadInvertLabels()).toEqual(new Map())
     })
 
@@ -62,24 +60,16 @@ describe("InvertInDarkMode", () => {
       await expect(loadInvertLabels()).rejects.toThrow(/invert, reviewed/)
     })
 
-    it("caches by default path", async () => {
-      readFileSpy.mockResolvedValue(JSON.stringify({}) as never)
-      await loadInvertLabels()
-      await loadInvertLabels()
-      expect(readFileSpy).toHaveBeenCalledTimes(1)
-    })
-
-    it("does not cache for non-default paths", async () => {
-      const tempPath = path.join(os.tmpdir(), "labels-test.json")
-      readFileSpy.mockResolvedValue(JSON.stringify({}) as never)
-      await loadInvertLabels(tempPath)
-      await loadInvertLabels(tempPath)
-      expect(readFileSpy).toHaveBeenCalledTimes(2)
-    })
-
     it("propagates non-ENOENT read errors", async () => {
-      readFileSpy.mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }) as never)
+      readFileSpy.mockRejectedValue(errno("EACCES") as never)
       await expect(loadInvertLabels()).rejects.toThrow("EACCES")
+    })
+
+    it("does not cache across calls", async () => {
+      readFileSpy.mockResolvedValue(JSON.stringify({}) as never)
+      await loadInvertLabels()
+      await loadInvertLabels()
+      expect(readFileSpy).toHaveBeenCalledTimes(2)
     })
 
     it("default path points at the project sidecar", () => {
@@ -89,8 +79,16 @@ describe("InvertInDarkMode", () => {
 
   describe("addInvertClass", () => {
     it.each<[string, Element, string[]]>([
-      ["array", h("img", { className: ["existing"] }) as Element, ["existing", INVERT_CLASS]],
-      ["array w/ duplicate", h("img", { className: [INVERT_CLASS] }) as Element, [INVERT_CLASS]],
+      [
+        "array",
+        h("img", { className: ["existing"] }) as Element,
+        ["existing", invertInDarkModeClass],
+      ],
+      [
+        "array w/ duplicate",
+        h("img", { className: [invertInDarkModeClass] }) as Element,
+        [invertInDarkModeClass],
+      ],
       [
         "string",
         {
@@ -99,7 +97,7 @@ describe("InvertInDarkMode", () => {
           properties: { className: "foo bar" },
           children: [],
         } as Element,
-        ["foo", "bar", INVERT_CLASS],
+        ["foo", "bar", invertInDarkModeClass],
       ],
       [
         "empty string",
@@ -109,12 +107,12 @@ describe("InvertInDarkMode", () => {
           properties: { className: "" },
           children: [],
         } as Element,
-        [INVERT_CLASS],
+        [invertInDarkModeClass],
       ],
       [
         "missing properties",
         { type: "element", tagName: "img", children: [] } as unknown as Element,
-        [INVERT_CLASS],
+        [invertInDarkModeClass],
       ],
     ])("normalizes className for %s", (_label, node, expected) => {
       addInvertClass(node)
@@ -123,8 +121,6 @@ describe("InvertInDarkMode", () => {
   })
 
   describe("applyLabelsToTree", () => {
-    const tree = (...nodes: Element[]): Root => ({ type: "root", children: nodes })
-
     it("adds class only when label is true", () => {
       const yes = h("img", { src: "https://x/a.avif" }) as Element
       const no = h("img", { src: "https://x/b.avif" }) as Element
@@ -136,7 +132,7 @@ describe("InvertInDarkMode", () => {
           ["https://x/b.avif", false],
         ]),
       )
-      expect(yes.properties?.className).toEqual([INVERT_CLASS])
+      expect(yes.properties?.className).toEqual([invertInDarkModeClass])
       expect(no.properties?.className).toBeUndefined()
       expect(unlabeled.properties?.className).toBeUndefined()
     })
@@ -155,7 +151,7 @@ describe("InvertInDarkMode", () => {
         h("source", { src: "https://x/a.webm" }),
       ]) as Element
       applyLabelsToTree(tree(video), new Map([["https://x/a.webm", true]]))
-      expect(video.properties?.className).toEqual([INVERT_CLASS])
+      expect(video.properties?.className).toEqual([invertInDarkModeClass])
     })
 
     it("does not tag the persistent #pond-video", () => {
@@ -229,18 +225,34 @@ describe("InvertInDarkMode", () => {
   })
 
   describe("InvertInDarkMode plugin", () => {
+    const transformOf = (plugin: ReturnType<typeof InvertInDarkMode>) => {
+      const factories = plugin.htmlPlugins() as Array<() => (tree: Root) => Promise<void>>
+      return factories[0]()
+    }
+
     it("applies labels to a tree at build time", async () => {
       readFileSpy.mockResolvedValue(
         JSON.stringify({ "https://x/a.avif": { invert: true, reviewed: true } }) as never,
       )
       const plugin = InvertInDarkMode()
       expect(plugin.name).toBe("InvertInDarkMode")
-      const factories = plugin.htmlPlugins() as Array<() => (tree: Root) => Promise<void>>
-      const transform = factories[0]()
+      const transform = transformOf(plugin)
       const img = h("img", { src: "https://x/a.avif" }) as Element
-      const tree: Root = { type: "root", children: [img] }
-      await transform(tree)
-      expect(img.properties?.className).toEqual([INVERT_CLASS])
+      await transform(tree(img))
+      expect(img.properties?.className).toEqual([invertInDarkModeClass])
+    })
+
+    it("reads labels once per plugin instance and re-reads for a new instance", async () => {
+      readFileSpy.mockResolvedValue(JSON.stringify({}) as never)
+      const plugin = InvertInDarkMode()
+      const transform = transformOf(plugin)
+      await transform(tree())
+      await transform(tree())
+      expect(readFileSpy).toHaveBeenCalledTimes(1)
+
+      const other = InvertInDarkMode()
+      await transformOf(other)(tree())
+      expect(readFileSpy).toHaveBeenCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
## Summary

Simplifies the `InvertInDarkMode` plugin by removing the global cache mechanism and restructuring label loading to be instance-scoped. This makes the plugin more predictable and easier to test while maintaining the same external behavior.

## Key changes

- **Removed global cache**: Deleted `cache` variable and `resetCacheForTesting()` function. Labels are no longer cached across function calls, simplifying state management.
- **Extracted `parseLabels()` helper**: Separated JSON parsing and validation logic into a dedicated function for clarity and reusability.
- **Extracted `classTokens()` helper**: Consolidated className normalization logic (handles array, string, or missing values) into a single utility function.
- **Instance-scoped caching**: Moved caching into the plugin factory function itself via a closure (`labelsPromise`). Each plugin instance now caches labels once and reuses them across all pages in that build, while separate instances get fresh reads.
- **Simplified `collectVideoSources()`**: Refactored to initialize the array first, then conditionally push the direct `src`, improving readability.
- **Updated JSDoc comments**: Clarified documentation for `isInlineLoopingVideo()`, `collectVideoSources()`, and `eligibleSources()`. Added note to `InvertInDarkMode` explaining per-instance caching behavior.
- **Test updates**: Removed `resetCacheForTesting()` calls; replaced global `INVERT_CLASS` constant with imported `invertInDarkModeClass`; added test verifying per-instance caching behavior; simplified test helpers and error construction.

## Implementation details

The key architectural shift is moving from a module-level cache (which required manual reset in tests) to a closure-based cache within the plugin factory. This ensures:
- Labels are read exactly once per plugin instance
- No global state to manage or reset
- Tests no longer need `beforeEach` cache resets
- The behavior is more intuitive: each build gets its own plugin instance with its own label cache

The extracted helpers (`parseLabels`, `classTokens`) improve code organization without changing behavior, making the module easier to maintain and test.

https://claude.ai/code/session_01UfyRJ2xdVXUfQ6debWXpuR