### PR TITLE
Extract font-face regex patterns to module-level constants

### DIFF
--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -860,6 +860,20 @@ def compile_scss(scss_file_path: Path) -> str:
     return result.stdout
 
 
+_FONT_FACE_SRC_PATTERN = re.compile(
+    r"@font-face\s*\{[^}]*?"
+    r"src:\s*url\(\s*[\"']?(.*?)[\"']?\)\s*"
+    r"(?:format\([^\)]*\)\s*)?"
+    r"[^;]*;",
+    re.DOTALL,
+)
+
+_FONT_FACE_FAMILY_PATTERN = re.compile(
+    r"@font-face\s*\{[^}]*?font-family:\s*[\"']?(.*?)[\"']?[;,]",
+    re.DOTALL,
+)
+
+
 def check_font_files(css_content: str, base_dir: Path) -> list[str]:
     """
     Check if font files referenced in CSS exist.
@@ -872,16 +886,7 @@ def check_font_files(css_content: str, base_dir: Path) -> list[str]:
         List of missing font file paths
     """
     missing_fonts = []
-    font_pattern = re.compile(
-        r"""@font-face\s*\{[^}]*?
-        src:\s*url\(\s*["']?(.*?)["']?\)\s*
-        (?:format\([^\)]*\)\s*)?
-        [^;]*;"""
-                 ,
-        re.VERBOSE | re.DOTALL,
-    )
-
-    for match in font_pattern.finditer(css_content):
+    for match in _FONT_FACE_SRC_PATTERN.finditer(css_content):
         font_path = match.group(1)
         if font_path.startswith(("http:", "https:", "data:")):
             continue
@@ -930,15 +935,9 @@ def check_font_families(css_content: str) -> list[str]:
         return name.split(":")[0]
 
     # Find all @font-face declarations and their font families
-    font_face_pattern = re.compile(
-        r"""@font-face\s*\{[^}]*?
-        font-family:\s*["']?(.*?)["']?[;,]"""
-                                             ,
-        re.VERBOSE | re.DOTALL,
-    )
     declared_fonts = {
         clean_font_name(match.group(1))
-        for match in font_face_pattern.finditer(css_content)
+        for match in _FONT_FACE_FAMILY_PATTERN.finditer(css_content)
     }
 
     # Find all font-family references in CSS custom properties


### PR DESCRIPTION
## Summary

Refactored the `check_font_files` function in `scripts/source_file_checks.py` to extract two regex patterns used for parsing CSS `@font-face` declarations into module-level constants (`_FONT_FACE_SRC_PATTERN` and `_FONT_FACE_FAMILY_PATTERN`). This improves code maintainability and avoids redundant pattern compilation.

## Key changes

- Extracted `_FONT_FACE_SRC_PATTERN`: matches `@font-face` blocks and captures the `src: url(...)` font file path
- Extracted `_FONT_FACE_FAMILY_PATTERN`: matches `@font-face` blocks and captures the `font-family` declaration
- Removed inline pattern definitions from `check_font_files()` and the font-family extraction logic in the `get_declared_fonts()` helper
- Converted patterns from `re.VERBOSE` style (multiline strings) to raw strings with explicit whitespace, making them more compact and consistent

## Implementation details

- Both patterns use `re.DOTALL` flag to handle multiline `@font-face` blocks
- Patterns are compiled once at module load time rather than on each function call, improving performance for repeated invocations
- No functional changes to the regex logic or matching behavior

https://claude.ai/code/session_01B6JYQXusqpNzVEwvTEGfju