### PR TITLE
test(Test-page): cover slash between inline-code spans + refresh visual baselines

### DIFF
--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -742,6 +742,8 @@ function loseTheGame(numTimes: number): void {
 This is a plain code block without a language specified.
 ```
 
+Inline code adjacent to a slash: the sycophantic `A`/`B` token should render with breathing room on both sides of the slash, and the surrounding "sycophantic" and "token" should keep their spaces.
+
 # Formatting
 
 - Normal


### PR DESCRIPTION
## Summary

Adds a representative example of `` `A`/`B` `` (slash between two inline-code spans) to `Test-page.md` so the next visual-regression run captures the corrected rendering as a baseline (per the CLAUDE.md rule about new visual elements).

## Why a PR

R2 baselines have drifted from recent transformer changes:

- #1267 — slash-spacing fix between skipped inline-code siblings (rendering of `` `A`/`B` `` changed from `sycophanticA / Btoken` to `sycophantic A / B token`)
- #1268 — `TagAcronyms` → `TagSmallcaps` rename
- #1269 — font regexes

`tests/visual-baselines/` is gitignored — R2 is the source of truth. Refresh happens via the **"Approve these as baselines"** button on the visual-diff gallery for this PR's failing visual-testing run. The Test-page.md addition gives the run a meaningful diff to anchor the new baseline (rather than approving a no-op PR).

## Next step

1. Wait for `visual-testing` to fail on this PR.
2. Click "Approve these as baselines" on the gallery.
3. `update-visual-baselines.yaml` uploads the new actuals to R2 and pushes an empty commit to retrigger visual-testing.
4. Once green, merge.

https://claude.ai/code/session_014FMCUntxmPg6zhdaporYR7

---
_Generated by [Claude Code](https://claude.ai/code/session_014FMCUntxmPg6zhdaporYR7)_