### PR TITLE
Strip whitespace inside inline elements and fix slash spacing

### DIFF
--- a/config/constants.json
+++ b/config/constants.json
@@ -168,5 +168,6 @@
     "leftGuillemet": "\u00AB",
     "rightGuillemet": "\u00BB",
     "germanOpenQuote": "\u201E"
-  }
+  },
+  "stripBoundaryWhitespaceTags": ["em", "strong", "i", "b", "a", "u", "ins", "mark", "del", "s"]
 }

--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -19,6 +19,7 @@ import {
   RemoveDrafts,
   Static,
   stripBadges,
+  StripInlineBoundaryWhitespace,
   SyntaxHighlighting,
   TableOfContents,
   TagPage,
@@ -105,6 +106,9 @@ const config: QuartzConfig = {
       TagSmallcaps(),
       AfterArticle(),
       AddFavicons(),
+      // After AddFavicons because favicon insertion can rewrite link
+      // content and reintroduce leading whitespace inside an <a>.
+      StripInlineBoundaryWhitespace(),
       ColorVariables(),
       TableOfContents({ minEntries: 3 }),
       addAssetDimensionsFromSrc(),

--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -2155,6 +2155,7 @@ homomorphisms
 homotopic
 homotopies
 homotopy
+hostname
 hotbar
 hotline
 hotspot

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "3.8.2",
+    "punctilio": "3.8.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "reading-time": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "3.5.0",
+    "punctilio": "3.8.2",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "reading-time": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 3.5.0
-        version: 3.5.0(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5)
+        specifier: 3.8.2
+        version: 3.8.2(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -7556,8 +7556,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@3.5.0:
-    resolution: {integrity: sha512-CxIN39iGwVRoe5NXpV3l1BllK3hUv8fgmxMU9VecPqJND/wYATACLC6MRZld9nh0b6pBz6DpvloUrU84+E5spQ==}
+  punctilio@3.8.2:
+    resolution: {integrity: sha512-CJcqbYVJfKMPrQiltC0DbegnaDHiCNRRsgOSMfQNQZul8gr9yJa2KtA/BjKFrLChS8bgC2UG3aMeLt4b/5Dj/w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rehype-parse: ^9.0.0
@@ -18238,7 +18238,7 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@3.5.0(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5):
+  punctilio@3.8.2(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5):
     dependencies:
       escape-string-regexp: 5.0.0
       quick-lru: 7.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 3.8.2
-        version: 3.8.2(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5)
+        specifier: 3.8.4
+        version: 3.8.4(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -7556,8 +7556,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@3.8.2:
-    resolution: {integrity: sha512-CJcqbYVJfKMPrQiltC0DbegnaDHiCNRRsgOSMfQNQZul8gr9yJa2KtA/BjKFrLChS8bgC2UG3aMeLt4b/5Dj/w==}
+  punctilio@3.8.4:
+    resolution: {integrity: sha512-NRLTfT3dqPOqto58sGKg/J5XrAVnb+JiPmqMjEP9iIr/IVVFDs2AB0Q78en7oh3CFAm8nxJpWx4dhWlk9w7epA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rehype-parse: ^9.0.0
@@ -18238,7 +18238,7 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@3.8.2(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5):
+  punctilio@3.8.4(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(unified@11.0.5):
     dependencies:
       escape-string-regexp: 5.0.0
       quick-lru: 7.3.0

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -67,6 +67,15 @@ export const {
   rightDoubleQuote: RIGHT_DOUBLE_QUOTE,
 } = constantsJson.unicodeTypography
 
+/**
+ * Inline tags whose first/last text-child should be trimmed of whitespace.
+ * Shared with `scripts/built_site_checks.py:_STRIP_BOUNDARY_TAGS`; keep in
+ * sync via `config/constants.json`.
+ */
+export const STRIP_BOUNDARY_TAGS: ReadonlySet<string> = new Set(
+  constantsJson.stripBoundaryWhitespaceTags,
+)
+
 /** Normalize non-breaking spaces to regular spaces */
 export function normalizeNbsp(s: string): string {
   return s.replace(new RegExp(NBSP, "g"), " ")

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -839,11 +839,6 @@ export const improveFormatting = (
     wrapUnicodeArrowsWithMonospaceStyle(tree)
     formatOrdinalSuffixes(tree)
     removeSpaceBeforeFootnotes(tree)
-    // Run after the main pipeline: the em-dash transform relies on the
-    // trailing space inside <em>/<strong> to fire (otherwise punctilio's
-    // hanging-hyphen rule treats "-<em>word" as suspended). Strip the
-    // residual boundary whitespace here, after em-dash has done its work.
-    stripInlineBoundaryWhitespace(tree)
   }
 }
 
@@ -856,6 +851,22 @@ export const HTMLFormattingImprovement: QuartzTransformerPlugin = () => {
     name: "htmlFormattingImprovement",
     htmlPlugins() {
       return [improveFormatting]
+    },
+  }
+}
+
+/**
+ * Quartz plugin running ``stripInlineBoundaryWhitespace`` as a late pass.
+ *
+ * Separated from ``HTMLFormattingImprovement`` so it can run *after*
+ * downstream plugins (``AddFavicons`` in particular) that rewrite link
+ * content and can reintroduce leading whitespace inside an ``<a>``.
+ */
+export const StripInlineBoundaryWhitespace: QuartzTransformerPlugin = () => {
+  return {
+    name: "stripInlineBoundaryWhitespace",
+    htmlPlugins() {
+      return [() => stripInlineBoundaryWhitespace]
     },
   }
 }

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -137,27 +137,39 @@ export function spacesAroundSlashes(text: string): string {
 }
 
 /**
- * Strip leading whitespace from text immediately inside `<em>`/`<strong>`.
+ * Strip whitespace adjacent to the inside boundary of an inline element.
  *
- * Markdown like `_ italics_` or `* bold*` produces `<em> italics</em>`/
- * `<strong> bold</strong>`. The leading space inside the emphasis renders
- * adjacent to whatever precedes the element (often an em-dash from `-`),
- * yielding "—  italics" — visually wrong for American typography. This
- * normalizer rewrites the emphasis as if the author had written `_italics_`.
+ * - `<em>` / `<strong>`: leading-only. Markdown like `_ italics_` produces
+ *   `<em> italics</em>`, and the leading space renders adjacent to whatever
+ *   precedes the element (often an em-dash from `-`), yielding "— italics".
+ *   Strip it so the rendering matches `_italics_`.
+ * - `<a>`: both ends. Link underlines that extend past the link text look
+ *   wrong; leading/trailing space inside the anchor visibly stretches the
+ *   underline beyond the actual content.
  */
-export function stripEmphasisLeadingSpace(tree: Root): void {
+export function stripInlineBoundaryWhitespace(tree: Root): void {
   visitParents(tree, "element", (node) => {
-    if (node.tagName !== "em" && node.tagName !== "strong") return
-    const firstChild = node.children[0]
-    if (firstChild?.type !== "text") return
-    const trimmed = firstChild.value.replace(/^\s+/, "")
-    if (trimmed === firstChild.value) return
-    if (trimmed === "") {
-      node.children.shift()
-      return
+    if (node.tagName === "em" || node.tagName === "strong") {
+      trimTextChild(node, "leading")
+    } else if (node.tagName === "a") {
+      trimTextChild(node, "leading")
+      trimTextChild(node, "trailing")
     }
-    firstChild.value = trimmed
   })
+}
+
+function trimTextChild(node: Element, side: "leading" | "trailing"): void {
+  const idx = side === "leading" ? 0 : node.children.length - 1
+  const child = node.children[idx]
+  if (child?.type !== "text") return
+  const trimmed =
+    side === "leading" ? child.value.replace(/^\s+/, "") : child.value.replace(/\s+$/, "")
+  if (trimmed === child.value) return
+  if (trimmed === "") {
+    node.children.splice(idx, 1)
+    return
+  }
+  child.value = trimmed
 }
 
 export function removeSpaceBeforeFootnotes(tree: Root): void {
@@ -829,8 +841,8 @@ export const improveFormatting = (
     // Run after the main pipeline: the em-dash transform relies on the
     // trailing space inside <em>/<strong> to fire (otherwise punctilio's
     // hanging-hyphen rule treats "-<em>word" as suspended). Strip the
-    // residual leading space here, after em-dash has done its work.
-    stripEmphasisLeadingSpace(tree)
+    // residual boundary whitespace here, after em-dash has done its work.
+    stripInlineBoundaryWhitespace(tree)
   }
 }
 

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -22,6 +22,7 @@ import {
   LEFT_SINGLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
   HEADING_TAGS,
+  STRIP_BOUNDARY_TAGS,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
 import { replaceRegex, fractionRegex, hasClass, hasAncestor, urlRegex, isCode } from "./utils"
@@ -139,22 +140,22 @@ export function spacesAroundSlashes(text: string): string {
 /**
  * Strip whitespace adjacent to the inside boundary of an inline element.
  *
- * - `<em>` / `<strong>`: leading-only. Markdown like `_ italics_` produces
- *   `<em> italics</em>`, and the leading space renders adjacent to whatever
- *   precedes the element (often an em-dash from `-`), yielding "— italics".
- *   Strip it so the rendering matches `_italics_`.
- * - `<a>`: both ends. Link underlines that extend past the link text look
- *   wrong; leading/trailing space inside the anchor visibly stretches the
- *   underline beyond the actual content.
+ * Covers two visual categories — text styling (`<em>`, `<strong>`, `<i>`,
+ * `<b>`) and visually-bound rendering where an underline / strikethrough /
+ * background extends across the whole element (`<a>`, `<u>`, `<ins>`,
+ * `<mark>`, `<del>`, `<s>`). Both get both sides stripped: markdown won't
+ * normally produce trailing whitespace inside emphasis (the closing delimiter
+ * rejects it), so any trailing whitespace we see is either raw HTML or a
+ * transformer accident and is safe to clean.
+ *
+ * The tag list is shared with the built-site check via
+ * `config/constants.json:stripBoundaryWhitespaceTags`.
  */
 export function stripInlineBoundaryWhitespace(tree: Root): void {
   visitParents(tree, "element", (node) => {
-    if (node.tagName === "em" || node.tagName === "strong") {
-      trimTextChild(node, "leading")
-    } else if (node.tagName === "a") {
-      trimTextChild(node, "leading")
-      trimTextChild(node, "trailing")
-    }
+    if (!STRIP_BOUNDARY_TAGS.has(node.tagName)) return
+    trimTextChild(node, "leading")
+    trimTextChild(node, "trailing")
   })
 }
 

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -116,15 +116,17 @@ export function spacesAroundSlashes(text: string): string {
     const { spaceBefore: leftSpace, spaceAfter: rightSpace } = groups
     const leftMarker = groups.markerBefore ?? ""
     const rightMarker = groups.markerAfter ?? ""
-    if (leftMarker && rightMarker) {
-      // "/" alone between two markers: the captured spaces live in sibling
-      // text nodes (e.g. <code>A</code>/<code>B</code>). Keep them outside
-      // the markers so siblings retain their boundary spaces; pad "/" with
-      // NBSPs so the cluster stays unbreakable.
-      return `${leftSpace}${leftMarker}${NBSP}/${NBSP}${rightMarker}${rightSpace}`
-    }
-    // Otherwise absorb the captured space into the slash's own text node.
-    return `${leftMarker}${leftSpace || NBSP}/${rightSpace || NBSP}${rightMarker}`
+    // Decide each side independently. A captured space sitting OUTSIDE a
+    // marker (e.g. " <SEP>/" or "/<SEP> ") lives in a sibling text node, not
+    // the slash's own node — keep it outside and glue an NBSP to "/" instead.
+    // With no marker on a side, the space is in the same text node as the
+    // slash, so absorb it (preserves marker invariance with empty inline
+    // elements there).
+    const outerLeft = leftMarker ? leftSpace : ""
+    const padLeft = leftMarker ? NBSP : leftSpace || NBSP
+    const outerRight = rightMarker ? rightSpace : ""
+    const padRight = rightMarker ? NBSP : rightSpace || NBSP
+    return `${outerLeft}${leftMarker}${padLeft}/${padRight}${rightMarker}${outerRight}`
   })
 
   const numberSlashThenNonNumber = /(?<=\d)\/(?=\D)/g
@@ -132,6 +134,30 @@ export function spacesAroundSlashes(text: string): string {
 
   // Restore the h/t occurrences
   return text.replace(new RegExp(hatTipPlaceholder, "g"), "h/t")
+}
+
+/**
+ * Strip leading whitespace from text immediately inside `<em>`/`<strong>`.
+ *
+ * Markdown like `_ italics_` or `* bold*` produces `<em> italics</em>`/
+ * `<strong> bold</strong>`. The leading space inside the emphasis renders
+ * adjacent to whatever precedes the element (often an em-dash from `-`),
+ * yielding "—  italics" — visually wrong for American typography. This
+ * normalizer rewrites the emphasis as if the author had written `_italics_`.
+ */
+export function stripEmphasisLeadingSpace(tree: Root): void {
+  visitParents(tree, "element", (node) => {
+    if (node.tagName !== "em" && node.tagName !== "strong") return
+    const firstChild = node.children[0]
+    if (firstChild?.type !== "text") return
+    const trimmed = firstChild.value.replace(/^\s+/, "")
+    if (trimmed === firstChild.value) return
+    if (trimmed === "") {
+      node.children.shift()
+      return
+    }
+    firstChild.value = trimmed
+  })
 }
 
 export function removeSpaceBeforeFootnotes(tree: Root): void {
@@ -800,6 +826,11 @@ export const improveFormatting = (
     wrapUnicodeArrowsWithMonospaceStyle(tree)
     formatOrdinalSuffixes(tree)
     removeSpaceBeforeFootnotes(tree)
+    // Run after the main pipeline: the em-dash transform relies on the
+    // trailing space inside <em>/<strong> to fire (otherwise punctilio's
+    // hanging-hyphen rule treats "-<em>word" as suspended). Strip the
+    // residual leading space here, after em-dash has done its work.
+    stripEmphasisLeadingSpace(tree)
   }
 }
 

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -14,7 +14,10 @@ export { HardLineBreaks } from "./linebreaks"
 export { TagSmallcaps } from "./tagSmallcaps"
 export { TroutOrnamentHr } from "./trout_hr"
 export { TextFormattingImprovement } from "./formatting_improvement_text"
-export { HTMLFormattingImprovement } from "./formatting_improvement_html"
+export {
+  HTMLFormattingImprovement,
+  StripInlineBoundaryWhitespace,
+} from "./formatting_improvement_html"
 export { Twemoji } from "./twemoji"
 export { TableCaption } from "./tablecaption"
 export { ColorVariables } from "./color_variables"

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -748,24 +748,25 @@ describe("HTMLFormattingImprovement", () => {
     }
 
     it.each([
-      // Emphasis: leading only (the user-facing rendering uses surrounding text)
-      ["<p><em> despite</em></p>", "<p><em>despite</em></p>"],
-      ["<p><strong> bold</strong></p>", "<p><strong>bold</strong></p>"],
-      ["<p><em>  many   leading</em></p>", "<p><em>many   leading</em></p>"],
-      // Trailing space inside emphasis is left alone (scoped to leading).
-      ["<p><em>kept </em></p>", "<p><em>kept </em></p>"],
-      // No leading whitespace: pass through unchanged.
+      // Every supported tag: both leading and trailing whitespace stripped.
+      ["<p><em> despite </em></p>", "<p><em>despite</em></p>"],
+      ["<p><strong> bold </strong></p>", "<p><strong>bold</strong></p>"],
+      ["<p><i> italics </i></p>", "<p><i>italics</i></p>"],
+      ["<p><b> bold </b></p>", "<p><b>bold</b></p>"],
+      ['<p>a <a href="x"> link </a> b</p>', '<p>a <a href="x">link</a> b</p>'],
+      ["<p><u> emph </u></p>", "<p><u>emph</u></p>"],
+      ["<p><ins> added </ins></p>", "<p><ins>added</ins></p>"],
+      ["<p><mark> note </mark></p>", "<p><mark>note</mark></p>"],
+      ["<p><del> wrong </del></p>", "<p><del>wrong</del></p>"],
+      ["<p><s> wrong </s></p>", "<p><s>wrong</s></p>"],
+      // Multiple leading / trailing spaces are all stripped.
+      ["<p><em>  many   </em></p>", "<p><em>many</em></p>"],
+      // No boundary whitespace: pass through unchanged.
       ["<p><em>fine</em></p>", "<p><em>fine</em></p>"],
       // Whitespace-only text node is removed entirely.
       ["<p><em> <strong>nested</strong></em></p>", "<p><em><strong>nested</strong></em></p>"],
-      // First child is an element (not text) — leading-text strip doesn't apply.
+      // First/last child is an element (not text) — leading/trailing-text strip doesn't apply.
       ["<p><em><span> inner</span></em></p>", "<p><em><span> inner</span></em></p>"],
-      // Anchors: BOTH leading and trailing are stripped (underline would
-      // otherwise extend past the link's content).
-      ['<p>a <a href="x"> link</a> b</p>', '<p>a <a href="x">link</a> b</p>'],
-      ['<p>a <a href="x">link </a> b</p>', '<p>a <a href="x">link</a> b</p>'],
-      ['<p>a <a href="x"> link </a> b</p>', '<p>a <a href="x">link</a> b</p>'],
-      ['<p>a <a href="x">fine</a> b</p>', '<p>a <a href="x">fine</a> b</p>'],
     ])("normalizes %s", (input, expected) => {
       expect(runOnHtml(input)).toBe(expected)
     })

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -60,6 +60,10 @@ function testHtmlFormattingImprovement(
   } else {
     processor.use(improveFormatting, options)
   }
+  // Match the production pipeline: stripInlineBoundaryWhitespace runs as a
+  // separate late pass (after AddFavicons in `quartz.config.ts`). Include it
+  // here so tests see the same end-state.
+  processor.use(() => stripInlineBoundaryWhitespace)
 
   return processor.processSync(inputHTML).toString()
 }

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -38,6 +38,7 @@ import {
   rearrangeLinkPunctuation,
   arrowsToWrap,
   stripInlineBoundaryWhitespace,
+  StripInlineBoundaryWhitespace,
 } from "../formatting_improvement_html"
 import { toSkip, SKIP_TAGS, FRACTION_SKIP_TAGS, SKIP_CLASSES } from "../formatting_improvement_html"
 
@@ -2154,6 +2155,23 @@ describe("HTMLFormattingImprovement plugin", () => {
       )
     }
     expect(valueToCheck).toEqual([improveFormatting])
+  })
+
+  it("StripInlineBoundaryWhitespace plugin trims boundary whitespace via rehype", () => {
+    const plugin = StripInlineBoundaryWhitespace()
+    expect(plugin.name).toBe("stripInlineBoundaryWhitespace")
+    expect(plugin.htmlPlugins).toBeDefined()
+
+    const mockCtx = {} as unknown
+    const htmlPlugins = plugin.htmlPlugins!(
+      mockCtx as Parameters<NonNullable<typeof plugin.htmlPlugins>>[0],
+    )
+    const processor = rehype().data("settings", { fragment: true })
+    for (const p of htmlPlugins) {
+      processor.use(p as never)
+    }
+    const result = processor.processSync("<p><em> word </em></p>").toString()
+    expect(result).toBe("<p><em>word</em></p>")
   })
 
   describe("Unicode Arrow Wrapping", () => {

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2262,8 +2262,10 @@ describe("HTMLFormattingImprovement plugin", () => {
 
 describe("Non-breaking space insertion", () => {
   it.each([
-    // After short words (1-2 letters) and before last word (widow prevention)
-    ["<p>I love this</p>", `<p>I${NBSP}love${NBSP}this</p>`],
+    // After short words (1-2 letters) and before last word (widow prevention).
+    // punctilio 3.8.4 skips the widow NBSP when an earlier NBSP is already in
+    // the same paragraph.
+    ["<p>I love this</p>", `<p>I${NBSP}love this</p>`],
     ["<p>A cat sat on a mat</p>", `<p>A${NBSP}cat sat on${NBSP}a${NBSP}mat</p>`],
     // Before last word (widow prevention)
     ["<p>Hello world</p>", `<p>Hello${NBSP}world</p>`],

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -37,7 +37,7 @@ import {
   HTMLFormattingImprovement,
   rearrangeLinkPunctuation,
   arrowsToWrap,
-  stripEmphasisLeadingSpace,
+  stripInlineBoundaryWhitespace,
 } from "../formatting_improvement_html"
 import { toSkip, SKIP_TAGS, FRACTION_SKIP_TAGS, SKIP_CLASSES } from "../formatting_improvement_html"
 
@@ -224,7 +224,7 @@ describe("HTMLFormattingImprovement", () => {
       ],
       [
         '<p>(<strong>NAFTA</strong> <a href="x">/ˈnæftə/</a> <a href="y"><em>NAF-tə</em></a>; Spanish)</p>',
-        '<p>(<strong>NAFTA</strong> <a href="x"> / ˈnæftə / </a> <a href="y"><em>NAF-tə</em>;</a> Spanish)</p>',
+        '<p>(<strong>NAFTA</strong> <a href="x">/ ˈnæftə /</a> <a href="y"><em>NAF-tə</em>;</a> Spanish)</p>',
       ],
       [
         "<p>upweight the sycophantic <code>A</code>/<code>B</code> token</p>",
@@ -738,20 +738,21 @@ describe("HTMLFormattingImprovement", () => {
     })
   })
 
-  describe("stripEmphasisLeadingSpace", () => {
+  describe("stripInlineBoundaryWhitespace", () => {
     function runOnHtml(html: string): string {
       const processor = rehype().data("settings", { fragment: true })
       processor.use(() => (tree: Root) => {
-        stripEmphasisLeadingSpace(tree)
+        stripInlineBoundaryWhitespace(tree)
       })
       return processor.processSync(html).toString()
     }
 
     it.each([
+      // Emphasis: leading only (the user-facing rendering uses surrounding text)
       ["<p><em> despite</em></p>", "<p><em>despite</em></p>"],
       ["<p><strong> bold</strong></p>", "<p><strong>bold</strong></p>"],
       ["<p><em>  many   leading</em></p>", "<p><em>many   leading</em></p>"],
-      // Trailing space is left alone (intentionally scoped to leading only).
+      // Trailing space inside emphasis is left alone (scoped to leading).
       ["<p><em>kept </em></p>", "<p><em>kept </em></p>"],
       // No leading whitespace: pass through unchanged.
       ["<p><em>fine</em></p>", "<p><em>fine</em></p>"],
@@ -759,6 +760,12 @@ describe("HTMLFormattingImprovement", () => {
       ["<p><em> <strong>nested</strong></em></p>", "<p><em><strong>nested</strong></em></p>"],
       // First child is an element (not text) — leading-text strip doesn't apply.
       ["<p><em><span> inner</span></em></p>", "<p><em><span> inner</span></em></p>"],
+      // Anchors: BOTH leading and trailing are stripped (underline would
+      // otherwise extend past the link's content).
+      ['<p>a <a href="x"> link</a> b</p>', '<p>a <a href="x">link</a> b</p>'],
+      ['<p>a <a href="x">link </a> b</p>', '<p>a <a href="x">link</a> b</p>'],
+      ['<p>a <a href="x"> link </a> b</p>', '<p>a <a href="x">link</a> b</p>'],
+      ['<p>a <a href="x">fine</a> b</p>', '<p>a <a href="x">fine</a> b</p>'],
     ])("normalizes %s", (input, expected) => {
       expect(runOnHtml(input)).toBe(expected)
     })
@@ -766,7 +773,7 @@ describe("HTMLFormattingImprovement", () => {
     it("makes em-dash conversion produce Chicago-style output for `-_ word_`", () => {
       // Before: "I think that—<em> despite</em>" (em-dash preserves boundary
       // space inside <em>, since punctilio 3.8.2 respects marker boundaries).
-      // After stripEmphasisLeadingSpace runs first, the <em> has no leading
+      // After stripInlineBoundaryWhitespace runs first, the <em> has no leading
       // space, so em-dash conversion produces the unspaced "—despite" form.
       const out = testHtmlFormattingImprovement("<p>I think that -<em> despite</em></p>")
       expect(normalizeNbsp(out)).toBe("<p>I think that—<em>despite</em></p>")

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals"
-import { type Element, type ElementContent, type Parent, type Text } from "hast"
+import { type Element, type ElementContent, type Parent, type Root, type Text } from "hast"
 import { toHtml as hastToHtml } from "hast-util-to-html"
 import { h } from "hastscript"
 import { symbolTransform } from "punctilio"
@@ -37,6 +37,7 @@ import {
   HTMLFormattingImprovement,
   rearrangeLinkPunctuation,
   arrowsToWrap,
+  stripEmphasisLeadingSpace,
 } from "../formatting_improvement_html"
 import { toSkip, SKIP_TAGS, FRACTION_SKIP_TAGS, SKIP_CLASSES } from "../formatting_improvement_html"
 
@@ -223,7 +224,7 @@ describe("HTMLFormattingImprovement", () => {
       ],
       [
         '<p>(<strong>NAFTA</strong> <a href="x">/ˈnæftə/</a> <a href="y"><em>NAF-tə</em></a>; Spanish)</p>',
-        '<p>(<strong>NAFTA</strong><a href="x"> / ˈnæftə / </a><a href="y"><em>NAF-tə</em>;</a> Spanish)</p>',
+        '<p>(<strong>NAFTA</strong> <a href="x"> / ˈnæftə / </a> <a href="y"><em>NAF-tə</em>;</a> Spanish)</p>',
       ],
       [
         "<p>upweight the sycophantic <code>A</code>/<code>B</code> token</p>",
@@ -232,6 +233,14 @@ describe("HTMLFormattingImprovement", () => {
       [
         "<p>the <code>A</code>/<code>B</code> token</p>",
         "<p>the <code>A</code> / <code>B</code> token</p>",
+      ],
+      // Asymmetric: only the left side is a skipped-element boundary. The
+      // captured leftSpace must stay outside the marker (i.e. the trailing
+      // space of "of the ") instead of being absorbed into the slash's text
+      // node — otherwise the rendered output reads "of the<code>unknown</code>".
+      [
+        "<p>volumetric properties of the <code>unknown</code>/non-<code>unknown</code> portions.</p>",
+        "<p>volumetric properties of the <code>unknown</code> / non-<code>unknown</code> portions.</p>",
       ],
     ])(
       "should add spaces around '/' even near other HTML tags: %s",
@@ -307,26 +316,19 @@ describe("HTMLFormattingImprovement", () => {
       expect(strippedResult).toBe(transformedWithoutMarker)
     })
 
-    it("spacesAroundSlashes should be invariant with marker before slash (after space)", () => {
+    it("spacesAroundSlashes keeps captured space outside the marker when one is present", () => {
+      // The captured space sits on the outside of the marker, so it belongs
+      // to a sibling text node. The transform preserves its position and
+      // glues an NBSP to "/" instead of moving the space across the boundary.
       const textWithMarker = `: ${markerChar}/ ,`
-      const textWithoutMarker = ": / ,"
-
-      const transformedWithMarker = spacesAroundSlashes(textWithMarker)
-      const transformedWithoutMarker = spacesAroundSlashes(textWithoutMarker)
-      const strippedResult = transformedWithMarker.replaceAll(markerChar, "")
-
-      expect(strippedResult).toBe(transformedWithoutMarker)
+      const transformed = spacesAroundSlashes(textWithMarker)
+      expect(transformed).toBe(`: ${markerChar}${NBSP}/ ,`)
     })
 
-    it("spacesAroundSlashes should be invariant with marker before slash followed by comma (no space after)", () => {
+    it("spacesAroundSlashes preserves outer space with marker before slash and no space after", () => {
       const textWithMarker = `at : ${markerChar}/,`
-      const textWithoutMarker = "at : /,"
-
-      const transformedWithMarker = spacesAroundSlashes(textWithMarker)
-      const transformedWithoutMarker = spacesAroundSlashes(textWithoutMarker)
-      const strippedResult = transformedWithMarker.replaceAll(markerChar, "")
-
-      expect(strippedResult).toBe(transformedWithoutMarker)
+      const transformed = spacesAroundSlashes(textWithMarker)
+      expect(transformed).toBe(`at : ${markerChar}${NBSP}/${NBSP},`)
     })
 
     it("symbolTransform is invariant with colon-slash pattern", () => {
@@ -714,7 +716,6 @@ describe("HTMLFormattingImprovement", () => {
   describe("Hyphens", () => {
     it.each([
       ["<code>This is a - hyphen.</code>", "<code>This is a - hyphen.</code>"],
-      ["<p>I think that -<em> despite</em></p>", "<p>I think that—<em>despite</em></p>"],
       [
         "<blockquote><p>Perhaps one did not want to be loved so much as to be understood.</p><p>-- Orwell, <em>1984</em></p></blockquote>",
         "<blockquote><p>Perhaps one did not want to be loved so much as to be understood.</p><p>— Orwell, <em>1984</em></p></blockquote>",
@@ -736,6 +737,42 @@ describe("HTMLFormattingImprovement", () => {
       expect(normalizeNbsp(processedHtml)).toBe(expected)
     })
   })
+
+  describe("stripEmphasisLeadingSpace", () => {
+    function runOnHtml(html: string): string {
+      const processor = rehype().data("settings", { fragment: true })
+      processor.use(() => (tree: Root) => {
+        stripEmphasisLeadingSpace(tree)
+      })
+      return processor.processSync(html).toString()
+    }
+
+    it.each([
+      ["<p><em> despite</em></p>", "<p><em>despite</em></p>"],
+      ["<p><strong> bold</strong></p>", "<p><strong>bold</strong></p>"],
+      ["<p><em>  many   leading</em></p>", "<p><em>many   leading</em></p>"],
+      // Trailing space is left alone (intentionally scoped to leading only).
+      ["<p><em>kept </em></p>", "<p><em>kept </em></p>"],
+      // No leading whitespace: pass through unchanged.
+      ["<p><em>fine</em></p>", "<p><em>fine</em></p>"],
+      // Whitespace-only text node is removed entirely.
+      ["<p><em> <strong>nested</strong></em></p>", "<p><em><strong>nested</strong></em></p>"],
+      // First child is an element (not text) — leading-text strip doesn't apply.
+      ["<p><em><span> inner</span></em></p>", "<p><em><span> inner</span></em></p>"],
+    ])("normalizes %s", (input, expected) => {
+      expect(runOnHtml(input)).toBe(expected)
+    })
+
+    it("makes em-dash conversion produce Chicago-style output for `-_ word_`", () => {
+      // Before: "I think that—<em> despite</em>" (em-dash preserves boundary
+      // space inside <em>, since punctilio 3.8.2 respects marker boundaries).
+      // After stripEmphasisLeadingSpace runs first, the <em> has no leading
+      // space, so em-dash conversion produces the unspaced "—despite" form.
+      const out = testHtmlFormattingImprovement("<p>I think that -<em> despite</em></p>")
+      expect(normalizeNbsp(out)).toBe("<p>I think that—<em>despite</em></p>")
+    })
+  })
+
   describe("transformParagraph", () => {
     function _getParagraphNode(numChildren: number, value = "Hello, world!"): Element {
       return h(

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1960,6 +1960,7 @@ def check_file_for_issues(
         "emphasis_spacing": check_emphasis_spacing(soup),
         "link_spacing": check_link_spacing(soup),
         "inline_formatting_spacing": check_inline_formatting_spacing(soup),
+        "inline_boundary_whitespace": check_inline_boundary_whitespace(soup),
         "long_description": check_description_length(soup),
         "late_header_tags": meta_tags_early(file_path),
         "problematic_iframes": check_iframe_sources(soup),
@@ -2278,6 +2279,50 @@ def _abbr_starts_with_digit(element: Tag) -> bool:
     """Check if an abbreviation element's text starts with a digit."""
     text = element.get_text()
     return bool(text) and text[0].isdigit()
+
+
+# Tags mirroring ``stripInlineBoundaryWhitespace`` in
+# ``quartz/plugins/transformers/formatting_improvement_html.ts``. Shared with
+# the transform via ``config/constants.json:stripBoundaryWhitespaceTags`` —
+# this check verifies the transform's invariant held end-to-end.
+_STRIP_BOUNDARY_TAGS: tuple[str, ...] = tuple(
+    script_utils.load_shared_constants()["stripBoundaryWhitespaceTags"]
+)
+
+
+def _flag_boundary_whitespace(
+    element: Tag, side: Literal["leading", "trailing"], issues: list[str]
+) -> None:
+    """Flag boundary whitespace on one side of an inline element."""
+    if not element.contents:
+        return
+    child = element.contents[0] if side == "leading" else element.contents[-1]
+    if not isinstance(child, NavigableString):
+        return
+    stripped = child.lstrip() if side == "leading" else child.rstrip()
+    if child == stripped:
+        return
+    _append_to_list(
+        issues,
+        f"<{element.name}>{element.get_text()[:40]}",
+        prefix=f"{side.capitalize()} whitespace inside element: ",
+    )
+
+
+def check_inline_boundary_whitespace(soup: BeautifulSoup) -> list[str]:
+    """
+    Verify inline elements have no inside-boundary whitespace on either side.
+
+    Elements inside ``no-formatting`` / ``<pre>`` zones are skipped.
+    """
+    issues: list[str] = []
+    for tag_name in _STRIP_BOUNDARY_TAGS:
+        for element in _tags_only(soup.find_all(tag_name)):
+            if should_skip(element):
+                continue
+            _flag_boundary_whitespace(element, "leading", issues)
+            _flag_boundary_whitespace(element, "trailing", issues)
+    return issues
 
 
 def check_inline_formatting_spacing(soup: BeautifulSoup) -> list[str]:

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2679,6 +2679,37 @@ def test_check_inline_formatting_spacing(html, expected):
     assert sorted(result) == sorted(expected)
 
 
+@pytest.mark.parametrize(
+    "html, expected_count",
+    [
+        # Single-side flagged for every supported tag (leading or trailing).
+        ("<p><em> bad</em></p>", 1),
+        ("<p><em>bad </em></p>", 1),
+        ("<p><strong> bad </strong></p>", 2),
+        ("<p><i> bad</i></p>", 1),
+        ("<p><b>bad </b></p>", 1),
+        ('<p><a href="x"> bad </a></p>', 2),
+        ("<p><u> bad </u></p>", 2),
+        ("<p><ins> bad </ins></p>", 2),
+        ("<p><mark> bad </mark></p>", 2),
+        ("<p><del> bad </del></p>", 2),
+        ("<p><s> bad </s></p>", 2),
+        # Clean cases: no boundary whitespace at all.
+        ("<p><em>fine</em></p>", 0),
+        ('<p><a href="x">fine</a></p>', 0),
+        # First/last child is an element (not text) — no text-side to inspect.
+        ("<p><em><span> inside</span></em></p>", 0),
+        # Elements inside no-formatting zones are skipped.
+        ('<p class="no-formatting"><em> raw</em></p>', 0),
+    ],
+)
+def test_check_inline_boundary_whitespace(html, expected_count):
+    """Boundary-whitespace check fires once per side that has whitespace."""
+    soup = BeautifulSoup(html, "html.parser")
+    result = built_site_checks.check_inline_boundary_whitespace(soup)
+    assert len(result) == expected_count
+
+
 def test_extract_flat_paragraph_texts():
     """Test flattened paragraph text extraction with data-original-text."""
     html = """<article>

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -614,6 +614,9 @@ Detecting multipliers
 Spaced slashes
 : Used for separators like "cat" / "dog" in place of "cat"<span class="no-formatting">/</span>"dog".
 
+Trim space inside emphasis and links
+: Inline elements shouldn't carry stray whitespace at their boundary. Markdown like `_ italics_` parses oddly, but upstream transformers occasionally produce `<em> text </em>`. I trim the leading and trailing whitespace from the first and last text-child of tags like `<em>`.
+
 Mathematical definitions
 : In the past, I used the $:=$ symbol to denote definitions (as opposed to normal equations). I now convert these symbols to the self-explanatory $ :=$.
 


### PR DESCRIPTION
## Summary

Adds a new `stripInlineBoundaryWhitespace` transform to remove stray whitespace at the inside boundaries of inline elements (emphasis, links, etc.), and refines the `spacesAroundSlashes` logic to correctly preserve captured spaces outside marker boundaries.

## Changes

- **New transform: `stripInlineBoundaryWhitespace`**
  - Strips leading/trailing whitespace from text children of inline elements (`<em>`, `<strong>`, `<i>`, `<b>`, `<a>`, `<u>`, `<ins>`, `<mark>`, `<del>`, `<s>`)
  - Runs after the main formatting pipeline so em-dash conversion can rely on boundary spaces before they're trimmed
  - Fixes Chicago-style em-dash output for patterns like `-<em> word</em>` → `—<em>word</em>`
  - Tag list shared with built-site checks via `config/constants.json:stripBoundaryWhitespaceTags`

- **Refined `spacesAroundSlashes` logic**
  - Changed from binary "both markers present" logic to per-side decision
  - Captured spaces sitting outside a marker (in sibling text nodes) now stay outside; NBSP is glued to "/" instead
  - Preserves marker invariance while correctly handling asymmetric cases like `<code>unknown</code> / non-<code>unknown</code>`
  - Updated test expectations to reflect the new behavior

- **Built-site checks**
  - Added `check_inline_boundary_whitespace` to verify the transform's invariant end-to-end
  - Flags boundary whitespace on any supported tag, skipping elements in `no-formatting` zones

- **Documentation**
  - Updated `website_content/design.md` with new "Trim space inside emphasis and links" section
  - Added comprehensive test coverage for both transforms

- **Dependencies**
  - Upgraded `punctilio` from 3.5.0 to 3.8.2 (respects marker boundaries in em-dash conversion)

- **Test cleanup**
  - Removed duplicate "REGEX_VERSION_NUMBER tests" describe block in `tagSmallcaps.test.ts`
  - Removed test case that relied on old boundary-space behavior; now covered by new `stripInlineBoundaryWhitespace` tests

## Implementation details

The `spacesAroundSlashes` refactor treats each side of "/" independently:
- If a marker is present on a side, any captured space lives in a sibling text node → keep it outside, pad "/" with NBSP
- If no marker, the space is in the same text node as "/" → absorb it (preserves invariance with empty inline elements)

This ensures correct rendering in cases like `of the <code>unknown</code> / non-<code>unknown</code>` where only the left side has a marker boundary.

The `stripInlineBoundaryWhitespace` transform runs last in the pipeline so earlier transforms (em-dash, etc.) can rely on boundary spaces for their logic before cleanup.

https://claude.ai/code/session_014FMCUntxmPg6zhdaporYR7