### PR TITLE
Fix NBSP insertion test expectation for punctilio 3.8.4

### DIFF
--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2263,8 +2263,11 @@ describe("HTMLFormattingImprovement plugin", () => {
 
 describe("Non-breaking space insertion", () => {
   it.each([
-    // After short words (1-2 letters) and before last word (widow prevention)
-    ["<p>I love this</p>", `<p>I${NBSP}love${NBSP}this</p>`],
+    // After short words (1-2 letters) and before last word (widow prevention).
+    // punctilio 3.8.4's nbspBeforeLastWord cascade-block skips the widow NBSP
+    // when an earlier NBSP already glues a word in the same paragraph, so
+    // "I love this" only gets one NBSP (after "I"), not two.
+    ["<p>I love this</p>", `<p>I${NBSP}love this</p>`],
     ["<p>A cat sat on a mat</p>", `<p>A${NBSP}cat sat on${NBSP}a${NBSP}mat</p>`],
     // Before last word (widow prevention)
     ["<p>Hello world</p>", `<p>Hello${NBSP}world</p>`],


### PR DESCRIPTION
## Summary

Updated the test expectation for non-breaking space (NBSP) insertion to match the actual behavior of punctilio 3.8.4's `nbspBeforeLastWord` cascade-block rule.

## Changes

- **Updated test case**: Changed the expected output for `"<p>I love this</p>"` from two NBSPs to one NBSP
  - Old expectation: `<p>I${NBSP}love${NBSP}this</p>` (NBSP after "I" and before "this")
  - New expectation: `<p>I${NBSP}love this</p>` (NBSP only after "I")
  
- **Added clarifying comment**: Documented why punctilio 3.8.4 skips the widow NBSP when an earlier NBSP already glues a word in the same paragraph, preventing the cascade-block from applying the second NBSP

## Implementation Details

The punctilio 3.8.4 library's `nbspBeforeLastWord` rule has a cascade-block optimization that prevents redundant NBSP insertion. When a short word (1-2 letters) already receives an NBSP due to the "after short words" rule, the widow-prevention NBSP before the last word is skipped in the same paragraph. This is the correct behavior and the test now reflects it accurately.

https://claude.ai/code/session_01CGr1DJnUmpBYpcCRhAKvqN