### PR TITLE
docs: fix broken /test-page#emoji anchor

### DIFF
--- a/website_content/playwright-tips.md
+++ b/website_content/playwright-tips.md
@@ -108,7 +108,7 @@ Mock the content
 : When I take screenshots of site styling, they're almost all of the test page content. The test page decouples site styling from updates to content around my site, ruling out alerts from "changed" screenshots which only show updated content.
 
 Use isolated fixture pages for visual regression testing
-: I used to take screenshot of searching for [the emoji section of the test page](/test-page#emoji). However, test page modifications would jitter the screenshot, churning against baselines. I fixed this by writing fixture pages to decouple e.g. the search appearance from the specific (changing) content of the test page.
+: I used to take screenshot of searching for [the emoji section of the test page](/test-page#emoji-examples). However, test page modifications would jitter the screenshot, churning against baselines. I fixed this by writing fixture pages to decouple e.g. the search appearance from the specific (changing) content of the test page.
 
 Run WebKit tests on macOS, not Linux
 : Playwright's Linux WebKit engine (WPE) is _not_ the same as real Safari. WPE is flaky. The Playwright team [recommends running WebKit on macOS](https://playwright.dev/docs/browsers#webkit) for Safari fidelity. I split my CI into Linux jobs (Chromium & Firefox) and macOS jobs (WebKit only).


### PR DESCRIPTION
## Summary

- Update `playwright-tips.md` link from `/test-page#emoji` to `/test-page#emoji-examples` to match the actual heading on `Test-page.md` (`# Emoji examples`, line 606). The old anchor was broken — no `# Emoji` heading exists on that page.

## Test plan

- [x] Verified the target slug `#emoji-examples` corresponds to an existing heading in `website_content/Test-page.md`.
- [x] Confirmed no other references to `/test-page#emoji` exist outside `public/` (build output).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGr1DJnUmpBYpcCRhAKvqN)_