### PR TITLE
test(popover): source rich footnote screenshot from fixture

### DIFF
--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -481,8 +481,12 @@ test.describe("Footnote popovers", () => {
   })
 
   test("Footnote popover with rich content (screenshot)", async ({ page }, testInfo) => {
-    // Target the footnote with paragraphs and an admonition for maximum content
-    const footnoteRef = page.locator('a[href="#user-content-fn-footnote"]')
+    // Source the rich-content footnote from the popover fixture so the
+    // screenshot doesn't churn when Test-page.md or its footnote list moves.
+    await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
+    await page.mouse.move(1, 1)
+
+    const footnoteRef = page.locator('a[href="#user-content-fn-rich"]')
     await footnoteRef.scrollIntoViewIfNeeded()
     await footnoteRef.click()
 

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -517,7 +517,7 @@ Links ending [with code tags should still wrap OK: `code.`](#external-links-with
 
 <div id="populate-favicon-container" class="no-favicon-span"></div>
 
-### Favicon kerning iteration
+## Favicon kerning iteration
 
 <!--spellchecker-disable-->
 

--- a/website_content/fixtures/Popover-fixture.md
+++ b/website_content/fixtures/Popover-fixture.md
@@ -17,3 +17,16 @@ This page is the hover target for the link-popover visual regression test in `po
 ## Anchor target
 
 A second paragraph gives the popover enough vertical content to exercise its frame proportions without depending on any other page's churn. The dummy link in `Test-page.md` points to the heading above so the popover-scroll-to-hash test has a deterministic target.
+
+## Rich-content footnote
+
+This sentence anchors the rich-content footnote popover screenshot.[^rich]
+
+[^rich]:
+    Here's the detail, in a footnote. And here's a nested footnote.[^nested-fixture]
+
+    > [!note] Admonition in a footnote
+    >
+    > Here be an admonition in a footnote.
+
+[^nested-fixture]: I'm a nested footnote. I'm enjoying my nest! 🪺


### PR DESCRIPTION
The "Footnote popover with rich content" screenshot was clicking a
footnote in Test-page.md, so unrelated edits to that page (or its
footnote ordering) churned the baseline. Move the rich-content
footnote into Popover-fixture.md and have the test navigate there
before clicking, so the popover content is stable.

Also promote "Favicon kerning iteration" in Test-page.md to its own
top-level section.