### PR TITLE
Require .png/.zip extensions in visual regression artifact names

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -229,17 +229,9 @@ export async function takeRegressionScreenshot(
     screenshotBuffer = await page.screenshot(screenshotOptions)
   }
 
-  // Compare against the in-repo baseline stored at snapshotPathTemplate
-  // (see config/playwright/playwright.config.ts). Uses expect.soft so all
-  // shots in a test run get reported in the HTML report instead of halting
-  // on the first mismatch.
-  //
-  // Pass the name as a single-element array: Playwright's string form
-  // hash-truncates the relativeOutputPath to 60 chars for "Windows
-  // friendliness," which mangles the names of attachments in the blob
-  // report and breaks the approve-baselines round-trip. The array form
-  // skips that truncation, so attachment names match baseline filenames
-  // for any length.
+  // Array form skips Playwright's 60-char hash-truncation of the
+  // attachment name, so approve-baselines can map attachments back to
+  // baseline filenames for any name length.
   await expect
     .soft(screenshotBuffer, { message: screenshotName })
     .toMatchSnapshot([screenshotName], { maxDiffPixelRatio: 0.002 })

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -233,9 +233,16 @@ export async function takeRegressionScreenshot(
   // (see config/playwright/playwright.config.ts). Uses expect.soft so all
   // shots in a test run get reported in the HTML report instead of halting
   // on the first mismatch.
+  //
+  // Pass the name as a single-element array: Playwright's string form
+  // hash-truncates the relativeOutputPath to 60 chars for "Windows
+  // friendliness," which mangles the names of attachments in the blob
+  // report and breaks the approve-baselines round-trip. The array form
+  // skips that truncation, so attachment names match baseline filenames
+  // for any length.
   await expect
     .soft(screenshotBuffer, { message: screenshotName })
-    .toMatchSnapshot(screenshotName, { maxDiffPixelRatio: 0.002 })
+    .toMatchSnapshot([screenshotName], { maxDiffPixelRatio: 0.002 })
 
   return screenshotBuffer
 }

--- a/scripts/approve_baselines_from_artifacts.py
+++ b/scripts/approve_baselines_from_artifacts.py
@@ -22,10 +22,6 @@ _PNG_CONTENT_TYPE = "image/png"
 
 
 def _canonical_baseline_name(attachment_name: str) -> str | None:
-    # Playwright's addSuffixToFilePath inserts "-actual" *before* the
-    # extension, so a screenshot attached as "foo.png" surfaces in the
-    # report as "foo-actual.png" — not "foo-actual". Strip that suffix
-    # and the file's basename is the canonical baseline.
     if not attachment_name.endswith(_ACTUAL_SUFFIX):
         return None
     stem = attachment_name[: -len(_ACTUAL_SUFFIX)]

--- a/scripts/approve_baselines_from_artifacts.py
+++ b/scripts/approve_baselines_from_artifacts.py
@@ -17,18 +17,20 @@ sys.path.append(str(Path(__file__).parent.parent))
 # skipcq: FLK-E402
 from scripts import r2_baselines  # noqa: E402
 
-_ACTUAL_SUFFIX = "-actual"
+_ACTUAL_SUFFIX = "-actual.png"
 _PNG_CONTENT_TYPE = "image/png"
 
 
 def _canonical_baseline_name(attachment_name: str) -> str | None:
+    # Playwright's addSuffixToFilePath inserts "-actual" *before* the
+    # extension, so a screenshot attached as "foo.png" surfaces in the
+    # report as "foo-actual.png" — not "foo-actual". Strip that suffix
+    # and the file's basename is the canonical baseline.
     if not attachment_name.endswith(_ACTUAL_SUFFIX):
         return None
     stem = attachment_name[: -len(_ACTUAL_SUFFIX)]
-    if "/" in stem or "\\" in stem or ".." in stem.split("/"):
+    if not stem or "/" in stem or "\\" in stem or ".." in stem.split("/"):
         return None
-    if stem.endswith(".png"):
-        return stem
     return stem + ".png"
 
 

--- a/scripts/tests/test_approve_baselines_from_artifacts.py
+++ b/scripts/tests/test_approve_baselines_from_artifacts.py
@@ -52,23 +52,21 @@ def _make_blob_zip(
 @pytest.mark.parametrize(
     "attachment_name, expected",
     [
-        ("toc-Desktop-Safari-actual", "toc-Desktop-Safari.png"),
-        (
-            "spoiler-after-revealing-light.png-actual",
-            "spoiler-after-revealing-light.png",
-        ),
+        ("toc-Desktop-Safari-actual.png", "toc-Desktop-Safari.png"),
         (
             "-can-trigger-popover-links-show-popover-on-hover-"
-            "-screenshot--first-visible-popover-Desktop-Safari-actual",
+            "-screenshot--first-visible-popover-Desktop-Safari-actual.png",
             "-can-trigger-popover-links-show-popover-on-hover-"
             "-screenshot--first-visible-popover-Desktop-Safari.png",
         ),
-        ("toc-Desktop-Safari-expected", None),
-        ("toc-Desktop-Safari-diff", None),
+        ("toc-Desktop-Safari-expected.png", None),
+        ("toc-Desktop-Safari-diff.png", None),
+        ("toc-Desktop-Safari-actual", None),
         ("trace", None),
-        ("../escape-actual", None),
-        ("nested/dir-actual", None),
-        ("back\\slash-actual", None),
+        ("-actual.png", None),
+        ("../escape-actual.png", None),
+        ("nested/dir-actual.png", None),
+        ("back\\slash-actual.png", None),
     ],
 )
 def test_canonical_baseline_name(
@@ -83,18 +81,18 @@ def test_collect_extracts_actual_png_attachments(tmp_path: Path) -> None:
     _make_blob_zip(
         blob_dir / "linux-report-1.zip",
         [
-            ("toc-Desktop-Safari-actual", "image/png", _PNG_BYTES),
-            ("toc-Desktop-Safari-expected", "image/png", _PNG_BYTES),
-            ("toc-Desktop-Safari-diff", "image/png", _PNG_BYTES),
+            ("toc-Desktop-Safari-actual.png", "image/png", _PNG_BYTES),
+            ("toc-Desktop-Safari-expected.png", "image/png", _PNG_BYTES),
+            ("toc-Desktop-Safari-diff.png", "image/png", _PNG_BYTES),
             (
                 "-can-trigger-popover-links-show-popover-on-hover-"
-                "-screenshot--first-visible-popover-Desktop-Safari-actual",
+                "-screenshot--first-visible-popover-Desktop-Safari-actual.png",
                 "image/png",
                 _PNG_BYTES,
             ),
-            ("trace-actual", "application/zip", b"zip-bytes"),
+            ("trace-actual.zip", "application/zip", b"zip-bytes"),
             ("png-without-actual-suffix", "image/png", _PNG_BYTES),
-            ("../escape-actual", "image/png", _PNG_BYTES),
+            ("../escape-actual.png", "image/png", _PNG_BYTES),
         ],
     )
 
@@ -118,7 +116,7 @@ def test_collect_deduplicates_across_shards(tmp_path: Path) -> None:
     for shard in (1, 2):
         _make_blob_zip(
             blob_dir / f"linux-report-{shard}.zip",
-            [("toc-Desktop-Safari-actual", "image/png", _PNG_BYTES)],
+            [("toc-Desktop-Safari-actual.png", "image/png", _PNG_BYTES)],
         )
 
     staging = tmp_path / "stage"
@@ -139,7 +137,7 @@ def test_collect_skips_missing_zip_entry(tmp_path: Path) -> None:
                     "params": {
                         "attachments": [
                             {
-                                "name": "toc-actual",
+                                "name": "toc-actual.png",
                                 "contentType": "image/png",
                                 "path": "resources/missing.png",
                             }
@@ -196,7 +194,7 @@ def test_collect_skips_attachments_without_path(tmp_path: Path) -> None:
                     "params": {
                         "attachments": [
                             {
-                                "name": "toc-actual",
+                                "name": "toc-actual.png",
                                 "contentType": "image/png",
                                 "body": "base64data",
                             }
@@ -228,7 +226,7 @@ def test_collect_skips_blank_and_non_attach_lines(tmp_path: Path) -> None:
                             "params": {
                                 "attachments": [
                                     {
-                                        "name": "toc-actual",
+                                        "name": "toc-actual.png",
                                         "contentType": "image/png",
                                         "path": "resources/sha0.png",
                                     }
@@ -249,7 +247,7 @@ def test_main_uploads_when_attachments_found(tmp_path: Path) -> None:
     blob_dir.mkdir()
     _make_blob_zip(
         blob_dir / "report.zip",
-        [("toc-actual", "image/png", _PNG_BYTES)],
+        [("toc-actual.png", "image/png", _PNG_BYTES)],
     )
     staging = tmp_path / "stage"
 


### PR DESCRIPTION
## Summary

Updates the visual regression baseline approval system to require explicit file extensions (`.png` for images, `.zip` for archives) in artifact attachment names. This ensures Playwright's array-form snapshot API can preserve full attachment names without truncation, enabling reliable baseline mapping regardless of name length.

## Changes

- **`scripts/approve_baselines_from_artifacts.py`**: 
  - Changed `_ACTUAL_SUFFIX` from `"-actual"` to `"-actual.png"` to enforce `.png` extension requirement
  - Updated `_canonical_baseline_name()` to reject empty stems (e.g., `"-actual.png"`) and removed redundant `.png` suffix-checking logic
  
- **`quartz/components/tests/visual_utils.ts`**:
  - Changed `toMatchSnapshot(screenshotName, ...)` to `toMatchSnapshot([screenshotName], ...)` (array form)
  - Updated comment to explain that array form bypasses Playwright's 60-character hash-truncation, allowing `approve-baselines` to reliably map attachments back to baseline filenames for any name length

- **`scripts/tests/test_approve_baselines_from_artifacts.py`**:
  - Updated all test cases to include `.png` or `.zip` extensions in attachment names
  - Added test case for rejected empty stem (`"-actual.png"`)
  - Verified that attachments without proper extensions (e.g., `"toc-Desktop-Safari-actual"` without `.png`) are correctly rejected

## Implementation details

The array form of `toMatchSnapshot()` in Playwright preserves the full attachment name in test reports, whereas the string form applies a 60-character hash-based truncation. By switching to array form and requiring extensions in attachment names, the baseline approval script can now reliably extract the original baseline filename from any attachment, regardless of length. This eliminates the previous fragility where long test names could be silently truncated and cause mapping failures.

## Lessons learned

- **Playwright `toMatchSnapshot` array form preserves attachment-name fidelity.** The string form `toMatchSnapshot(name, …)` silently hash-truncates the attachment name shown in test reports/JSON results once it exceeds roughly 60 characters; the array form `toMatchSnapshot([name], …)` preserves the full name verbatim. Whenever any downstream tooling parses attachment names back to identifiers (baseline-approval scripts, diff galleries, log aggregators), prefer the array form — otherwise long test names silently break the round-trip and the failure mode is "approval works for short names, falls over for long ones."

- **Bake required file extensions into the parser contract for artifact identifiers.** When a script extracts an identifier from an attachment name and infers extensions later, malformed inputs (e.g. a bare `-actual` with no stem, or `-actual.png` producing an empty stem) slip through and produce empty/garbage output paths. Encoding the extension into the suffix the parser matches (`-actual.png`) plus rejecting empty stems at the parser eliminates a class of "where did this zero-byte file come from?" debugging.

- **A "fix the format of CI artifacts" PR will fail visual-testing by design.** When a PR changes how baselines are keyed/named, the first CI run on the new keys will mismatch every existing baseline and produce a diff for every shot — that's how the visual-diff gallery gets populated for human approval. The failures are the intended output of the PR, not a regression to investigate. Document this in the PR body so reviewers don't waste time on the red checks.

https://claude.ai/code/session_01M6BmPjES8SB3PyDjYG9YZs