### PR TITLE
ci: switch macOS runners from macos-26 to macos-15

### DIFF
--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -136,7 +136,7 @@ jobs:
   # WebKit flake check on macOS
   flake-check-macos:
     needs: [setup, build]
-    runs-on: macos-26
+    runs-on: macos-15
     timeout-minutes: 90
     strategy:
       fail-fast: false

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -151,7 +151,7 @@ jobs:
   playwright-tests-macos:
     needs: [build, should-run]
     if: needs.should-run.outputs.run-macos == 'true'
-    runs-on: macos-26
+    runs-on: macos-15
     # macOS WebKit runs at 1 worker (see playwright.config.ts) — tripling
     # per-shard wall time. Generous job budget keeps shards from being
     # killed without log output.

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -187,7 +187,7 @@ jobs:
   visual-testing-macos:
     needs: [build, should-run]
     if: needs.should-run.outputs.run-macos == 'true'
-    runs-on: macos-26
+    runs-on: macos-15
     # macOS WebKit runs at 1 worker (see playwright.config.ts) — tripling
     # per-shard wall time. Generous job budget keeps shards from being
     # killed without log output.


### PR DESCRIPTION
## Summary

The `macos-26` (Tahoe) image has very limited capacity in GitHub's shared
runner pool, so jobs queue indefinitely with the message
`All GitHub-hosted runners with label [macos-26] are busy`, even when none
of the account's own macOS jobs are running.

Switches all three macOS workflows to `macos-15`, which has substantially
more capacity and identical WebKit fidelity for these tests:

- `.github/workflows/playwright-tests.yaml`
- `.github/workflows/visual-testing.yaml`
- `.github/workflows/playwright-flake-check.yaml`

## Test plan

- [ ] Confirm macOS Playwright shards pick up a runner promptly on this PR
- [ ] Confirm visual-testing macOS shards complete successfully
- [ ] No change to WebKit test results vs. previous `macos-26` baselines

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVvgPsuwvnKatzX7sLYGZv)_