### PR TITLE
refactor(content): share goose + emoji figures via PopulateExternalMarkdown

### DIFF
--- a/config/partials/emoji-comparison.md
+++ b/config/partials/emoji-comparison.md
@@ -1,0 +1,37 @@
+<!-- markdownlint-disable MD041 -->
+<figure id="emoji-comparison-figure">
+ <div role="img" aria-label="A collage comparing the 'Smiling Face with Hearts' emoji across eight different platforms.">
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/apple_hearts.avif" alt="">
+      <figcaption>Apple</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/google_hearts.avif" alt="">
+      <figcaption>Google</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/microsoft_hearts.avif" alt="">
+      <figcaption>Microsoft</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/facebook_hearts.avif" alt="">
+      <figcaption>Facebook</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/twemoji/1f970.svg" alt="">
+      <figcaption>Twitter</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/whatsapp_hearts.avif" alt="">
+      <figcaption>WhatsApp</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/samsung_hearts.avif" alt="">
+      <figcaption>Samsung</figcaption>
+    </div>
+    <div class="subfigure">
+      <img src="https://assets.turntrout.com/static/images/posts/LG_hearts.avif" alt="">
+      <figcaption>LG</figcaption>
+    </div>
+  </div>
+</figure>

--- a/config/partials/goose-terminal.md
+++ b/config/partials/goose-terminal.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD041 -->
+<figure data-rehype-pretty-code-figure="" id="goose-terminal"><pre tabindex="0" data-language="plaintext" data-theme="github-light github-dark"><button class="clipboard-button" type="button" aria-label="Copy source"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg></button><code data-language="plaintext" data-theme="github-light github-dark" style="display:grid;"><span data-line=""><span>  ______________________________________</span></span>
+<span data-line=""><span> / Find out just what any people will   \</span></span>
+<span data-line=""><span> | quietly submit to and you have the   |</span></span>
+<span data-line=""><span> | exact measure of the injustice and   |</span></span>
+<span data-line=""><span> | wrong which will be imposed on them. |</span></span>
+<span data-line=""><span> \ --- Frederick Douglass               /</span></span>
+<span data-line=""><span>  --------------------------------------</span></span>
+<span data-line=""><span>    \</span></span>
+<span data-line=""><span>     \</span></span>
+<span data-line=""><span>      \     ___</span></span>
+<span data-line=""><span>          .´   ""-⹁</span></span>
+<span data-line=""><span>      _.-´)  e  _  '⹁</span></span>
+<span data-line=""><span>     '-===.&lt;_.-´ '⹁  \</span></span>
+<span data-line=""><span>                   \  \</span></span>
+<span data-line=""><span>                    ;  \</span></span>
+<span data-line=""><span>                    ;   \          _</span></span>
+<span data-line=""><span>                    |    '⹁__..--"" ""-._    _.´)</span></span>
+<span data-line=""><span>                   /                     ""-´  _&gt;</span></span>
+<span data-line=""><span>                  :                          -´/</span></span>
+<span data-line=""><span>                  ;                  .__&lt;   __)</span></span>
+<span data-line=""><span>                   \    '._      .__.-'   .-´</span></span>
+<span data-line=""><span>                    '⹁_    '-⹁__.-´      /</span></span>
+<span data-line=""><span>                       '-⹁__/    ⹁    _.´</span></span>
+<span data-line=""><span>                      ____&lt; /'⹁__/_.""</span></span>
+<span data-line=""><span>                    .´.----´  | |</span></span>
+<span data-line=""><span>                  .´ /        | |</span></span>
+<span data-line=""><span>                 ´´-/      ___| ;</span></span>
+<span data-line=""><span>                          &lt;_    /</span></span>
+<span data-line=""><span>                            `.'´</span></span></code></pre></figure>

--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -77,6 +77,12 @@ const config: QuartzConfig = {
           "font-stats": {
             filePath: "config/font_stats.md",
           },
+          "goose-terminal": {
+            filePath: "config/partials/goose-terminal.md",
+          },
+          "emoji-comparison": {
+            filePath: "config/partials/emoji-comparison.md",
+          },
         },
       }),
       CreatedModifiedDate(),

--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -240,7 +240,7 @@ test.describe("Unique content around the site", () => {
   })
 
   test("Goose code block (screenshot)", async ({ page }, testInfo) => {
-    await gotoPage(page, "http://localhost:8080/open-source")
+    await gotoPage(page, "http://localhost:8080/goose-fixture")
     await page.locator("body").waitFor({ state: "visible" })
 
     const gooseCodeBlock = page.locator("#goose-terminal").first()

--- a/website_content/Test-page.md
+++ b/website_content/Test-page.md
@@ -609,42 +609,7 @@ He came in 1st but I came in 5,300,251st. :( _Emphasized "21st"._ October 5th, 1
 
 ## Emoji comparison
 
-<figure id="emoji-comparison-figure">
- <div role="img" aria-label="A collage comparing the 'Smiling Face with Hearts' emoji across eight different platforms.">
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/apple_hearts.avif" alt="">
-      <figcaption>Apple</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/google_hearts.avif" alt="">
-      <figcaption>Google</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/microsoft_hearts.avif" alt="">
-      <figcaption>Microsoft</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/facebook_hearts.avif" alt="">
-      <figcaption>Facebook</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/twemoji/1f970.svg" alt="">
-      <figcaption>Twitter</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/whatsapp_hearts.avif" alt="">
-      <figcaption>WhatsApp</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/samsung_hearts.avif" alt="">
-      <figcaption>Samsung</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/LG_hearts.avif" alt="">
-      <figcaption>LG</figcaption>
-    </div>
-  </div>
-</figure>
+<span class="populate-markdown-emoji-comparison"></span>
 
 # Color palette
 

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -654,42 +654,7 @@ Subtitle: This list is not exhaustive.
 
 Tasteful emoji usage helps brighten and vivify an article. However, it seems like there are over 9,000 emoji stylings:
 
-<figure id="emoji-comparison-figure">
- <div role="img" aria-label="A collage comparing the 'Smiling Face with Hearts' emoji across eight different platforms.">
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/apple_hearts.avif" alt="">
-      <figcaption>Apple</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/google_hearts.avif" alt="">
-      <figcaption>Google</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/microsoft_hearts.avif" alt="">
-      <figcaption>Microsoft</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/facebook_hearts.avif" alt="">
-      <figcaption>Facebook</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/twemoji/1f970.svg" alt="">
-      <figcaption>Twitter</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/whatsapp_hearts.avif" alt="">
-      <figcaption>WhatsApp</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/samsung_hearts.avif" alt="">
-      <figcaption>Samsung</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/LG_hearts.avif" alt="">
-      <figcaption>LG</figcaption>
-    </div>
-  </div>
-</figure>
+<span class="populate-markdown-emoji-comparison"></span>
 
 I want the user experience to be consistent, so my build process bakes in the Twitter emoji style: 🥰⭐️✨💘🐟😊🤡😏😮‍💨☺️🥰🎉🤷‍♂️🌊😠🏰❤️😞🙂‍↕️😌🥹🏝️🪂
 

--- a/website_content/fixtures/Emoji-fixture.md
+++ b/website_content/fixtures/Emoji-fixture.md
@@ -16,39 +16,4 @@ date_updated: 2024-12-04
 
 ## Emoji comparison
 
-<figure id="emoji-comparison-figure">
- <div role="img" aria-label="A collage comparing the 'Smiling Face with Hearts' emoji across eight different platforms.">
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/apple_hearts.avif" alt="">
-      <figcaption>Apple</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/google_hearts.avif" alt="">
-      <figcaption>Google</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/microsoft_hearts.avif" alt="">
-      <figcaption>Microsoft</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/facebook_hearts.avif" alt="">
-      <figcaption>Facebook</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/twemoji/1f970.svg" alt="">
-      <figcaption>Twitter</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/whatsapp_hearts.avif" alt="">
-      <figcaption>WhatsApp</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/samsung_hearts.avif" alt="">
-      <figcaption>Samsung</figcaption>
-    </div>
-    <div class="subfigure">
-      <img src="https://assets.turntrout.com/static/images/posts/LG_hearts.avif" alt="">
-      <figcaption>LG</figcaption>
-    </div>
-  </div>
-</figure>
+<span class="populate-markdown-emoji-comparison"></span>

--- a/website_content/fixtures/Goose-fixture.md
+++ b/website_content/fixtures/Goose-fixture.md
@@ -1,0 +1,13 @@
+---
+title: Goose terminal fixture
+permalink: goose-fixture
+no_dropcap: "true"
+tags:
+  - website
+description: Stable fixture page used by the goose-terminal visual regression test. The figure markup is shared with the open-source page so the screenshot stays in lockstep with the real article. Modify only when intentionally updating the goose baseline.
+hideSubscriptionLinks: true
+date_published: 2026-05-14
+date_updated: 2026-05-14
+---
+
+<span class="populate-markdown-goose-terminal"></span>

--- a/website_content/open-source.md
+++ b/website_content/open-source.md
@@ -85,35 +85,7 @@ My [`.dotfiles`](https://github.com/alexander-turner/.dotfiles) repository provi
 8. `git` aliases and other productivity shortcuts, and -- drum roll ---
 9. `goosesay`, because every terminal needs more geese.
 
-<figure data-rehype-pretty-code-figure="" id="goose-terminal"><pre tabindex="0" data-language="plaintext" data-theme="github-light github-dark"><button class="clipboard-button" type="button" aria-label="Copy source"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg></button><code data-language="plaintext" data-theme="github-light github-dark" style="display:grid;"><span data-line=""><span>  ______________________________________</span></span>
-<span data-line=""><span> / Find out just what any people will   \</span></span>
-<span data-line=""><span> | quietly submit to and you have the   |</span></span>
-<span data-line=""><span> | exact measure of the injustice and   |</span></span>
-<span data-line=""><span> | wrong which will be imposed on them. |</span></span>
-<span data-line=""><span> \ --- Frederick Douglass               /</span></span>
-<span data-line=""><span>  --------------------------------------</span></span>
-<span data-line=""><span>    \</span></span>
-<span data-line=""><span>     \</span></span>
-<span data-line=""><span>      \     ___</span></span>
-<span data-line=""><span>          .´   ""-⹁</span></span>
-<span data-line=""><span>      _.-´)  e  _  '⹁</span></span>
-<span data-line=""><span>     '-===.&lt;_.-´ '⹁  \</span></span>
-<span data-line=""><span>                   \  \</span></span>
-<span data-line=""><span>                    ;  \</span></span>
-<span data-line=""><span>                    ;   \          _</span></span>
-<span data-line=""><span>                    |    '⹁__..--"" ""-._    _.´)</span></span>
-<span data-line=""><span>                   /                     ""-´  _&gt;</span></span>
-<span data-line=""><span>                  :                          -´/</span></span>
-<span data-line=""><span>                  ;                  .__&lt;   __)</span></span>
-<span data-line=""><span>                   \    '._      .__.-'   .-´</span></span>
-<span data-line=""><span>                    '⹁_    '-⹁__.-´      /</span></span>
-<span data-line=""><span>                       '-⹁__/    ⹁    _.´</span></span>
-<span data-line=""><span>                      ____&lt; /'⹁__/_.""</span></span>
-<span data-line=""><span>                    .´.----´  | |</span></span>
-<span data-line=""><span>                  .´ /        | |</span></span>
-<span data-line=""><span>                 ´´-/      ___| ;</span></span>
-<span data-line=""><span>                          &lt;_    /</span></span>
-<span data-line=""><span>                            `.'´</span></span></code></pre></figure>
+<span class="populate-markdown-goose-terminal"></span>
 
 Each time I open the `fish` shell, a rainbow goose blurts out an interesting phrase. I spent several hours to achieve this modern luxury.
 


### PR DESCRIPTION
## Summary

- Move the "Goose code block (screenshot)" Playwright test off `/open-source` (which crashes WebKit reproducibly — separate root cause is queued for bisecting) onto a dedicated `/goose-fixture` page.
- Eliminate drift between the visual fixtures and the real-site pages by having both read each shared figure from a single common source via the existing `PopulateExternalMarkdown` mechanism.

## Changes

- `config/quartz/quartz.config.ts`: register two new local sources — `goose-terminal` → `config/partials/goose-terminal.md` and `emoji-comparison` → `config/partials/emoji-comparison.md`.
- `config/partials/goose-terminal.md` (new): byte-identical extraction of the goose figure HTML formerly inline in `open-source.md`.
- `config/partials/emoji-comparison.md` (new): byte-identical extraction of the emoji figure HTML formerly duplicated across `design.md`, `Test-page.md`, and `Emoji-fixture.md`.
- `website_content/open-source.md`: goose figure → `<span class="populate-markdown-goose-terminal"></span>` (29 lines → 1).
- `website_content/design.md`, `Test-page.md`, `fixtures/Emoji-fixture.md`: each emoji figure → `<span class="populate-markdown-emoji-comparison"></span>` (3 × 36 lines → 3 × 1).
- `website_content/fixtures/Goose-fixture.md` (new): minimal fixture page using the goose placeholder; frontmatter mirrors `Emoji-fixture.md`.
- `quartz/components/tests/test-page.spec.ts`: Goose test now navigates to `/goose-fixture` instead of `/open-source`. Selector (`#goose-terminal`) and screenshot baseline name (`open-source-goose-terminal`) preserved so existing baseline still matches.

## Why this works

`PopulateExternalMarkdown` runs at `textTransform`, the earliest pipeline stage — placeholder spans are replaced with file contents *before* markdown parsing. The substitution is a verbatim string replace, so the rendered HTML is byte-identical to the previous inline form. Editing the partial updates real article + fixture + visual baseline together; drift becomes structurally impossible.

## Testing

- `pnpm check` clean (typecheck, prettier, stylelint).
- `git diff` shows only removals (138 lines) plus the small placeholder/partial additions (91 lines).
- The visual baseline does not need rebuilding — same HTML out, same screenshot in.
- Pre-existing Jest ESM-import failure (`escape-string-regexp`) reproduces on `main`; unrelated to this PR. CI environment runs the same suite cleanly.

## Lessons learned

- **What**: When multiple files carry byte-identical HTML chunks (typically copy/pasted figure markup that needs to stay in sync between fixtures and real pages), reach for the existing `PopulateExternalMarkdown` mechanism with a `LocalMarkdownSource` rather than markdown transclusion. Transclusion only works for content that survives the filter phase (so a `fixtures/`-housed source can't be transcluded by a non-fixture page in a production build), whereas `textTransform` runs before filters and works regardless.
- **Where**: Future "share content between fixture and real page" tasks. Add a brief note to `.claude/dev-notes.md`.
- **Why**: Initial instinct was Obsidian-style `[[file#section]]` transclusion; tracing `processors/filter.ts` showed `filterContent` removes filtered items from the array passed to `emitContent`, so transclusion targets that live under `fixtures/` would be invisible to non-fixture pages in production builds.

https://claude.ai/code/session_39759ffb-0961-4dde-a049-838695111901

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzDXqxmSRv6M6C4noznvPV)_