### PR TITLE
Cancel in-progress workflow runs when PR closes

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yaml
+++ b/.github/workflows/cancel-stale-pr-runs.yaml
@@ -1,0 +1,31 @@
+name: Cancel Stale PR Runs
+
+# `cancel-in-progress` only handles the same-branch supersede case, so
+# in-flight visual-testing / playwright-tests shards keep chewing the
+# macOS minute pool after a PR merges. Cancel them when the PR closes.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - run: |
+          set -euo pipefail
+          for wf in visual-testing.yaml playwright-tests.yaml; do
+            gh run list --workflow "$wf" --branch "$BRANCH" \
+              --json databaseId,status \
+              --jq '.[] | select(.status=="in_progress" or .status=="queued") | .databaseId' \
+              | xargs -r -n1 gh run cancel
+          done


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that cancels stale in-progress and queued runs for visual-testing and playwright-tests when a pull request closes. This prevents these long-running workflows from consuming macOS minutes after a PR has already been merged.

## Changes

- **New workflow**: `.github/workflows/cancel-stale-pr-runs.yaml`
  - Triggers on `pull_request` closed events
  - Queries GitHub API for in-progress or queued runs on the PR's branch for `visual-testing.yaml` and `playwright-tests.yaml`
  - Cancels all matching runs to free up CI resources

## Implementation details

The workflow uses `gh run list` with jq filtering to identify runs in `in_progress` or `queued` status, then pipes their database IDs to `gh run cancel`. This complements the existing `cancel-in-progress` mechanism, which only handles same-branch supersede cases (e.g., pushing a new commit to the same PR). By canceling on PR close, we avoid the scenario where visual-testing and playwright-tests shards continue consuming the macOS minute pool after the PR merges.

Requires `actions: write` permission to cancel runs.

https://claude.ai/code/session_01ARPirLuCWQLMK3X2XzUaHL