### PR TITLE
Stabilize popover and search tests with fixture pages

### DIFF
--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -409,17 +409,19 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
   await expect(popover).toHaveCount(0)
 })
 
-test.describe("Footnote popovers", () => {
-  // Source footnote popovers from the popover fixture so footnote screenshots
-  // and DOM assertions don't churn when test-page footnotes are added or
-  // reordered. The file-level beforeEach already lands on test-page; this
-  // re-navigation overrides it for the describe.
-  test.beforeEach(async ({ page }) => {
+// Use base (not test) so footnote tests bypass the file-level beforeEach's
+// /test-page navigation — they navigate to the popover fixture instead, and
+// the double-nav on slow browsers (Safari) was causing 90s timeouts.
+base.describe("Footnote popovers", () => {
+  base.beforeEach(async ({ page }) => {
+    if (!isDesktopViewport(page)) {
+      base.skip()
+    }
     await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
     await page.mouse.move(1, 1)
   })
 
-  test("Footnote popover shows only footnote content, not full article", async ({ page }) => {
+  base("Footnote popover shows only footnote content, not full article", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
     await footnoteRef.click()
@@ -445,7 +447,7 @@ test.describe("Footnote popovers", () => {
     await expect(content).not.toBeEmpty()
   })
 
-  test("Footnote popover size reflects content size", async ({ page }) => {
+  base("Footnote popover size reflects content size", async ({ page }) => {
     // Find the footnote with a table (should be larger)
     const tableFootnoteRef = page.locator('a[href="#user-content-fn-table"]')
     await tableFootnoteRef.scrollIntoViewIfNeeded()
@@ -476,7 +478,7 @@ test.describe("Footnote popovers", () => {
     expect(tableHeight).toBeGreaterThan(simpleHeight * 1.5)
   })
 
-  test("Clicking footnote link opens pinned popover (screenshot)", async ({ page }, testInfo) => {
+  base("Clicking footnote link opens pinned popover (screenshot)", async ({ page }, testInfo) => {
     // Target the simple `[^pinned]` fixture footnote so the screenshot is a
     // stable representative rather than whatever footnote happens to come
     // first on the fixture (or test-page).
@@ -492,7 +494,7 @@ test.describe("Footnote popovers", () => {
     })
   })
 
-  test("Footnote popover with rich content (screenshot)", async ({ page }, testInfo) => {
+  base("Footnote popover with rich content (screenshot)", async ({ page }, testInfo) => {
     const footnoteRef = page.locator('a[href="#user-content-fn-rich"]')
     await footnoteRef.scrollIntoViewIfNeeded()
     await footnoteRef.click()
@@ -506,7 +508,7 @@ test.describe("Footnote popovers", () => {
     })
   })
 
-  test("Clicking footnote link opens pinned popover within viewport", async ({ page }) => {
+  base("Clicking footnote link opens pinned popover within viewport", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
 
@@ -520,25 +522,26 @@ test.describe("Footnote popovers", () => {
     await expect(popover).toBeInViewport({ ratio: 1 })
   })
 
-  test("Pressing Escape closes pinned footnote popover and returns focus to trigger", async ({
-    page,
-  }) => {
-    const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
-    await footnoteRef.scrollIntoViewIfNeeded()
+  base(
+    "Pressing Escape closes pinned footnote popover and returns focus to trigger",
+    async ({ page }) => {
+      const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
+      await footnoteRef.scrollIntoViewIfNeeded()
 
-    await footnoteRef.click()
-    const popover = page.locator(".popover")
-    await expect(popover).toBeVisible()
+      await footnoteRef.click()
+      const popover = page.locator(".popover")
+      await expect(popover).toBeVisible()
 
-    await page.keyboard.press("Escape")
-    await expect(popover).toBeHidden()
+      await page.keyboard.press("Escape")
+      await expect(popover).toBeHidden()
 
-    // Focus should return to the triggering footnote link
-    const focusedHref = await page.evaluate(() => document.activeElement?.getAttribute("href"))
-    expect(focusedHref).toMatch(/^#user-content-fn-/)
-  })
+      // Focus should return to the triggering footnote link
+      const focusedHref = await page.evaluate(() => document.activeElement?.getAttribute("href"))
+      expect(focusedHref).toMatch(/^#user-content-fn-/)
+    },
+  )
 
-  test("Focus moves into pinned footnote popover on open", async ({ page }) => {
+  base("Focus moves into pinned footnote popover on open", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
     await expect(footnoteRef).toBeInViewport()
@@ -552,11 +555,11 @@ test.describe("Footnote popovers", () => {
     await expect(activeElement).toHaveClass(/popover-close/)
   })
 
-  test("Tab key cycles focus within pinned footnote popover", async ({ page }) => {
+  base("Tab key cycles focus within pinned footnote popover", async ({ page }) => {
     // WebKit doesn't support Tab navigation by default — it requires the
     // "Press Tab to highlight each item on a webpage" Safari preference,
     // which Playwright cannot enable. See microsoft/playwright#2114.
-    test.skip(
+    base.skip(
       isSafariBrowser(page),
       "WebKit does not support Tab navigation without Safari preference",
     )
@@ -591,7 +594,7 @@ test.describe("Footnote popovers", () => {
     expect(focusIsInPopover).toBe(true)
   })
 
-  test("Hovering footnote link does NOT open popover", async ({ page }) => {
+  base("Hovering footnote link does NOT open popover", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
 
@@ -600,7 +603,7 @@ test.describe("Footnote popovers", () => {
     await expect(page.locator(".popover")).toHaveCount(0)
   })
 
-  test("Clicking outside closes footnote popover", async ({ page }) => {
+  base("Clicking outside closes footnote popover", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
 
@@ -613,7 +616,7 @@ test.describe("Footnote popovers", () => {
     await expect(popover).toBeHidden()
   })
 
-  test("Rapid clicks on different footnotes produce only one popover", async ({ page }) => {
+  base("Rapid clicks on different footnotes produce only one popover", async ({ page }) => {
     // Delay the same-page fetch that popover creation uses, widening the
     // race window so both clicks fire before either fetch resolves.
     await page.route("**/popover-fixture", async (route) => {
@@ -638,7 +641,7 @@ test.describe("Footnote popovers", () => {
     await expect(popover).toHaveCount(1)
   })
 
-  test("Clicking footnote link does not scroll to footnote section", async ({ page }) => {
+  base("Clicking footnote link does not scroll to footnote section", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
 
@@ -761,7 +764,11 @@ test.describe("Popover checkbox state preservation", () => {
   })
 })
 
-test("Popover with checked checkbox visual appearance (screenshot)", async ({ page }, testInfo) => {
+// Use base to bypass the file-level beforeEach's /test-page navigation —
+// this test loads the popover fixture directly.
+base("Popover with checked checkbox visual appearance (screenshot)", async ({ page }, testInfo) => {
+  base.skip(!isDesktopViewport(page), "Popovers are desktop-only")
+
   // Sourced from the popover fixture (rather than test-page) so the
   // screenshot doesn't churn when the test-page Checkboxes section moves.
   // Set state directly on the fixture page since checkbox state is keyed by

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -410,6 +410,15 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
 })
 
 test.describe("Footnote popovers", () => {
+  // Source footnote popovers from the popover fixture so footnote screenshots
+  // and DOM assertions don't churn when test-page footnotes are added or
+  // reordered. The file-level beforeEach already lands on test-page; this
+  // re-navigation overrides it for the describe.
+  test.beforeEach(async ({ page }) => {
+    await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
+    await page.mouse.move(1, 1)
+  })
+
   test("Footnote popover shows only footnote content, not full article", async ({ page }) => {
     const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
     await footnoteRef.scrollIntoViewIfNeeded()
@@ -453,7 +462,7 @@ test.describe("Footnote popovers", () => {
     await expect(tablePopover).toBeHidden()
 
     // Find a simple footnote (should be smaller)
-    const simpleFootnoteRef = page.locator('a[href="#user-content-fn-nested"]')
+    const simpleFootnoteRef = page.locator('a[href="#user-content-fn-pinned"]')
     await simpleFootnoteRef.scrollIntoViewIfNeeded()
     await simpleFootnoteRef.click()
 
@@ -468,7 +477,10 @@ test.describe("Footnote popovers", () => {
   })
 
   test("Clicking footnote link opens pinned popover (screenshot)", async ({ page }, testInfo) => {
-    const footnoteRef = page.locator('a[href^="#user-content-fn-"]').first()
+    // Target the simple `[^pinned]` fixture footnote so the screenshot is a
+    // stable representative rather than whatever footnote happens to come
+    // first on the fixture (or test-page).
+    const footnoteRef = page.locator('a[href="#user-content-fn-pinned"]')
     await footnoteRef.scrollIntoViewIfNeeded()
 
     await footnoteRef.click()
@@ -481,11 +493,6 @@ test.describe("Footnote popovers", () => {
   })
 
   test("Footnote popover with rich content (screenshot)", async ({ page }, testInfo) => {
-    // Source the rich-content footnote from the popover fixture so the
-    // screenshot doesn't churn when Test-page.md or its footnote list moves.
-    await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
-    await page.mouse.move(1, 1)
-
     const footnoteRef = page.locator('a[href="#user-content-fn-rich"]')
     await footnoteRef.scrollIntoViewIfNeeded()
     await footnoteRef.click()
@@ -609,13 +616,13 @@ test.describe("Footnote popovers", () => {
   test("Rapid clicks on different footnotes produce only one popover", async ({ page }) => {
     // Delay the same-page fetch that popover creation uses, widening the
     // race window so both clicks fire before either fetch resolves.
-    await page.route("**/test-page", async (route) => {
+    await page.route("**/popover-fixture", async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 500))
       await route.continue()
     })
 
-    const firstRef = page.locator('a[href="#user-content-fn-1"]')
-    const secondRef = page.locator('a[href="#user-content-fn-2"]')
+    const firstRef = page.locator('a[href="#user-content-fn-rich"]')
+    const secondRef = page.locator('a[href="#user-content-fn-pinned"]')
     await firstRef.scrollIntoViewIfNeeded()
 
     // Click both footnotes in quick succession (before either fetch completes)
@@ -652,8 +659,10 @@ test.describe("Footnote popovers", () => {
 // file-level test.beforeEach. These tests explicitly set a mobile viewport.
 base.describe("Footnote popover on mobile", () => {
   base.beforeEach(async ({ page }) => {
+    // Use the popover fixture so footnote interactions don't depend on
+    // test-page footnote ordering or content.
     await page.setViewportSize({ width: 375, height: 667 })
-    await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
+    await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
   })
 
   base("Tapping footnote opens pinned popover, close button dismisses it", async ({ page }) => {
@@ -750,18 +759,30 @@ test.describe("Popover checkbox state preservation", () => {
     const popoverChecked = await isElementChecked(popoverCheckbox)
     expect(popoverChecked).toBe(true)
   })
+})
 
-  test("Popover with checked checkbox visual appearance (screenshot)", async ({
-    page,
-  }, testInfo) => {
-    const linkToHover = page.locator("a#checkboxes-link").first()
-    await linkToHover.hover()
+test("Popover with checked checkbox visual appearance (screenshot)", async ({ page }, testInfo) => {
+  // Sourced from the popover fixture (rather than test-page) so the
+  // screenshot doesn't churn when the test-page Checkboxes section moves.
+  // Set state directly on the fixture page since checkbox state is keyed by
+  // page slug.
+  await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
+  await page.mouse.move(1, 1)
 
-    const popover = page.locator(".popover")
-    await expect(popover).toBeVisible()
-    await takeRegressionScreenshot(page, testInfo, "popover-checked-checkbox", {
-      elementToScreenshot: popover,
-      preserveSiblings: true, // Need this to take screenshot
-    })
+  const fixtureCheckbox = page.locator("h1 + ol #checkbox-0").first()
+  await fixtureCheckbox.scrollIntoViewIfNeeded()
+  expect(await isElementChecked(fixtureCheckbox)).toBe(false)
+  await fixtureCheckbox.click()
+  expect(await isElementChecked(fixtureCheckbox)).toBe(true)
+
+  const linkToHover = page.locator("a#checkboxes-link").first()
+  await linkToHover.scrollIntoViewIfNeeded()
+  await linkToHover.hover()
+
+  const popover = page.locator(".popover")
+  await expect(popover).toBeVisible()
+  await takeRegressionScreenshot(page, testInfo, "popover-checked-checkbox", {
+    elementToScreenshot: popover,
+    preserveSiblings: true,
   })
 })

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -496,7 +496,10 @@ test("Search URL updates as we select different results", async ({ page }) => {
 
 /* eslint-disable playwright/expect-expect */
 test("Checkbox search preview (screenshot)", async ({ page }, testInfo) => {
-  await search(page, "Checkboxes")
+  // Search a unique title token so the preview deterministically shows the
+  // search fixture's checkboxes section instead of whichever live page wins
+  // a "Checkboxes" query.
+  await search(page, "Searchpreviewfixture")
 
   const previewContainer = await waitForArticlePreview(page)
   await takeRegressionScreenshot(page, testInfo, "Search-checkboxes", {
@@ -542,7 +545,9 @@ test("Emoji search works and is converted to twemoji (screenshot)", async ({ pag
 })
 
 test("Footnote back arrow is properly replaced (screenshot)", async ({ page }, testInfo) => {
-  await search(page, "Testing site")
+  // Source the backref from the search fixture so the screenshot doesn't
+  // churn when test-page footnotes change.
+  await search(page, "Searchpreviewfixture")
   await page.waitForLoadState("load")
 
   const preview = await waitForArticlePreview(page)
@@ -822,7 +827,10 @@ test("should not select a search result on initial render, even if the mouse is 
 test("Footnote table displays within boundaries in search preview (screenshot)", async ({
   page,
 }, testInfo) => {
-  await search(page, "test page")
+  // Source the table footnote from the search fixture so the screenshot
+  // doesn't churn when test-page's footnote ordering or surrounding
+  // content changes.
+  await search(page, "Searchpreviewfixture")
 
   const previewContainer = await waitForArticlePreview(page)
   await expect(previewContainer).toBeVisible()
@@ -923,14 +931,15 @@ test("admonition background is transparent in focused mobile card preview (scree
 }, testInfo) => {
   test.skip(!isMobileViewport(page), "Card previews only render on mobile viewports")
 
-  // "Admonitions" matches the test page which has a section with various admonition types
-  await search(page, "Admonitions")
+  // Source the admonition from the search fixture so the screenshot doesn't
+  // churn when test-page admonitions are added/removed.
+  await search(page, "Searchpreviewfixture")
 
-  const testPageResult = page.locator('.result-card[id="test-page"]')
-  await expect(testPageResult).toBeVisible()
-  await testPageResult.focus()
+  const fixtureResult = page.locator('.result-card[id="search-fixture"]')
+  await expect(fixtureResult).toBeVisible()
+  await fixtureResult.focus()
 
-  const cardPreview = testPageResult.locator(".card-preview")
+  const cardPreview = fixtureResult.locator(".card-preview")
   const article = cardPreview.locator("article.search-preview")
   await expect(article).toBeAttached({ timeout: 10_000 })
 
@@ -938,14 +947,14 @@ test("admonition background is transparent in focused mobile card preview (scree
   // calls focusCard, which adds the .focus class. The focused card has a
   // non-transparent background (the hover/focus effect), while the
   // admonition inside is transparent — so the highlight shows through.
-  await expect(testPageResult).toHaveClass(/focus/)
+  await expect(fixtureResult).toHaveClass(/focus/)
 
   const admonition = cardPreview.locator(".admonition").first()
   await expect(admonition).toBeAttached()
   await expect(admonition).toHaveCSS("background-color", "rgba(0, 0, 0, 0)")
 
   await takeRegressionScreenshot(page, testInfo, "mobile-card-preview-admonition", {
-    elementToScreenshot: testPageResult,
+    elementToScreenshot: fixtureResult,
   })
 })
 

--- a/website_content/fixtures/Popover-fixture.md
+++ b/website_content/fixtures/Popover-fixture.md
@@ -22,6 +22,20 @@ A second paragraph gives the popover enough vertical content to exercise its fra
 
 This sentence anchors the rich-content footnote popover screenshot.[^rich]
 
+## Pinned footnote
+
+A short stable sentence anchors the footnote-popover-pinned screenshot.[^pinned]
+
+## Table footnote
+
+This sentence anchors the table-footnote popover size test.[^table]
+
+# Checkboxes
+
+1. [ ] Fixture checkbox at `#checkbox-0`
+
+The link <a id="checkboxes-link" href="#checkboxes">checkboxes link</a> targets the heading above so the popover-checked-checkbox screenshot has a deterministic anchor.
+
 [^rich]:
     Here's the detail, in a footnote. And here's a nested footnote.[^nested-fixture]
 
@@ -30,3 +44,12 @@ This sentence anchors the rich-content footnote popover screenshot.[^rich]
     > Here be an admonition in a footnote.
 
 [^nested-fixture]: I'm a nested footnote. I'm enjoying my nest! 🪺
+
+[^pinned]: A short stable footnote sentence used by the footnote-popover-pinned screenshot.
+
+[^table]:
+
+    | Col A | Col B | Col C |
+    | :---: | :---: | :---: |
+    |   1   |   2   |   3   |
+    |   4   |   5   |   6   |

--- a/website_content/fixtures/Search-fixture.md
+++ b/website_content/fixtures/Search-fixture.md
@@ -1,0 +1,43 @@
+---
+title: Searchpreviewfixture rendering surface
+permalink: search-fixture
+no_dropcap: "true"
+tags:
+  - website
+description: Stable fixture page used by search-preview visual regression tests in `search.spec.ts`. Modify only when intentionally updating a search-preview baseline.
+hideSubscriptionLinks: true
+date_published: 2024-12-04
+date_updated: 2024-12-04
+---
+
+# Searchpreviewfixture rendering surface
+
+This page is the search-preview target for the visual regression tests in `search.spec.ts`. The unique title token `searchpreviewfixture` deterministically returns this page for the test queries, so editing the body changes every search-preview screenshot that lands here.
+
+The fixture lives outside the live site (see `RemoveFixtures` filter), so no user-facing search references it.
+
+# Admonitions
+
+> [!note]
+> A short note admonition for the focused mobile-card-preview screenshot.
+
+> [!quote]
+> A second admonition.
+
+# Checkboxes
+
+1. [ ] Fixture checkbox at `#checkbox-0`
+2. [ ] Second fixture checkbox
+
+# Footnotes
+
+A simple sentence with a basic footnote.[^backref] A second sentence with a footnote that contains a table.[^table]
+
+[^backref]: A short footnote whose backref arrow anchors the back-arrow screenshot.
+
+[^table]:
+
+    | Col A | Col B | Col C |
+    | :---: | :---: | :---: |
+    |   1   |   2   |   3   |
+    |   4   |   5   |   6   |


### PR DESCRIPTION
## Summary

Refactored popover and search visual regression tests to use dedicated fixture pages instead of relying on live content pages. This eliminates test flakiness caused by content changes and improves test stability and maintainability.

## Key changes

**Popover tests (`popover.spec.ts`)**
- Migrated footnote popover tests from `test.describe` to `base.describe` with explicit `beforeEach` setup to bypass file-level navigation
- All footnote tests now navigate directly to `/popover-fixture` instead of `/test-page`, eliminating double-navigation timeouts on slow browsers (Safari)
- Updated footnote selectors to target stable fixture footnotes (`[^pinned]`, `[^table]`, `[^rich]`) instead of arbitrary first/numbered footnotes
- Moved "Popover with checked checkbox visual appearance" test to use `base` and source checkbox state from fixture
- Added desktop-only viewport check to footnote tests
- Updated route interception in "Rapid clicks" test to target `/popover-fixture` instead of `/test-page`

**Search tests (`search.spec.ts`)**
- Updated three visual regression tests to search for "Searchpreviewfixture" (unique title token) instead of generic queries:
  - "Checkbox search preview" — now targets fixture checkboxes
  - "Footnote back arrow is properly replaced" — now targets fixture backref footnote
  - "Footnote table displays within boundaries" — now targets fixture table footnote
- Updated "admonition background is transparent in focused mobile card preview" to search for fixture and target `search-fixture` result card

**Fixture pages**
- Enhanced `Popover-fixture.md` with new sections:
  - "Pinned footnote" section with `[^pinned]` footnote for stable screenshot anchoring
  - "Table footnote" section with `[^table]` containing a data table
  - "Checkboxes" section with fixture checkbox at `#checkbox-0` and deterministic `#checkboxes-link` anchor
- Created new `Search-fixture.md` with stable content for search preview tests:
  - Unique title token "Searchpreviewfixture" for deterministic search results
  - Admonitions section for mobile card preview test
  - Checkboxes section with fixture checkbox
  - Footnotes section with backref and table footnotes

## Implementation details

- Tests using fixtures now skip on mobile viewports where popovers aren't supported, rather than relying on implicit behavior
- Fixture footnotes are explicitly named (`[^pinned]`, `[^table]`, `[^rich]`) to avoid accidental reordering breaking selectors
- Search fixture includes a comment explaining its purpose and that it's excluded from live site via `RemoveFixtures` filter
- All fixture-based tests include inline comments explaining why they source from fixtures rather than live pages

https://claude.ai/code/session_01Qj7zDtbMFN58nDt4S2q1JQ