### PR TITLE
ci(playwright): bump macOS workers to 3, reduce shards

### DIFF
--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -152,20 +152,14 @@ jobs:
     needs: [build, should-run]
     if: needs.should-run.outputs.run-macos == 'true'
     runs-on: macos-15
-    # macOS WebKit runs at 1 worker (see playwright.config.ts) — tripling
-    # per-shard wall time. Generous job budget keeps shards from being
-    # killed without log output.
-    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         shard:
           [
-            "1/5",
-            "2/5",
-            "3/5",
-            "4/5",
-            "5/5",
+            "1/3",
+            "2/3",
+            "3/3",
           ]
     env:
       PLAYWRIGHT_BROWSERS: webkit
@@ -173,9 +167,6 @@ jobs:
       # which crashes WebKit on macOS ARM64 (microsoft/playwright#40009).
       # Reverted upstream but no 1.59.2 release yet. Remove when upgrading Playwright.
       PLAYWRIGHT_NO_UA_PLATFORM: "1"
-      # Cap Playwright ~5 min under timeout-minutes so failures surface as
-      # logs/artifacts before GitHub Actions kills the runner.
-      PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "6900000"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -188,10 +188,6 @@ jobs:
     needs: [build, should-run]
     if: needs.should-run.outputs.run-macos == 'true'
     runs-on: macos-15
-    # macOS WebKit runs at 1 worker (see playwright.config.ts) — tripling
-    # per-shard wall time. Generous job budget keeps shards from being
-    # killed without log output.
-    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -206,9 +202,6 @@ jobs:
       # which crashes WebKit on macOS ARM64 (microsoft/playwright#40009).
       # Reverted upstream but no 1.59.2 release yet. Remove when upgrading Playwright.
       PLAYWRIGHT_NO_UA_PLATFORM: "1"
-      # Cap Playwright ~5 min under timeout-minutes so failures surface as
-      # logs/artifacts before GitHub Actions kills the runner.
-      PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "6900000"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -94,11 +94,9 @@ export default defineConfig({
       ? 45 * 60 * 1000
       : undefined,
   fullyParallel: true,
-  // Serialize WebKit on macOS: concurrent WebKit renderers on the macOS
-  // runner exhaust memory and trigger "page.goto: Page crashed" (same
-  // Playwright 1.58+ regression that forces the Desktop-only filter
-  // above). One worker fits inside the 45-minute globalTimeout.
-  workers: process.env.PLAYWRIGHT_BROWSERS === "webkit" ? 1 : undefined,
+  // macOS ARM runners have 3 cores but Playwright defaults to 1 worker for
+  // WebKit, causing shards to hit their job timeout. Force 3 workers on macOS.
+  workers: process.env.PLAYWRIGHT_BROWSERS === "webkit" ? 3 : undefined,
   retries: process.env.CI ? 1 : 0,
   testDir: "../../quartz/",
   testMatch: /.*\.spec\.ts/,


### PR DESCRIPTION
Restore 3 workers per macOS runner (reverting the 1-worker
serialization) and shrink shard counts to match the recovered
parallelism: playwright shards 5→3, visual shards stay at 2.
Drop the timeout-minutes and PLAYWRIGHT_GLOBAL_TIMEOUT_MS overrides
that were only needed under 1-worker mode.