### PR TITLE
fix(fixtures): name fixture section headings uniquely so search auto-scrolls to them

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -496,10 +496,10 @@ test("Search URL updates as we select different results", async ({ page }) => {
 
 /* eslint-disable playwright/expect-expect */
 test("Checkbox search preview (screenshot)", async ({ page }, testInfo) => {
-  // Search the fixture's unique title so the preview deterministically shows
-  // the search fixture's checkboxes section instead of whichever live page
-  // wins a "Checkboxes" query.
-  await search(page, "Search preview fixture")
+  // The fixture's "Checkboxes fixture" heading is the only match for this
+  // phrase, so the preview deterministically lands on the fixture and the
+  // search component's auto-scroll centers the highlighted heading.
+  await search(page, "Checkboxes fixture")
 
   const previewContainer = await waitForArticlePreview(page)
   await takeRegressionScreenshot(page, testInfo, "Search-checkboxes", {
@@ -931,9 +931,11 @@ test("admonition background is transparent in focused mobile card preview (scree
 }, testInfo) => {
   test.skip(!isMobileViewport(page), "Card previews only render on mobile viewports")
 
-  // Source the admonition from the search fixture so the screenshot doesn't
-  // churn when test-page admonitions are added/removed.
-  await search(page, "Search preview fixture")
+  // The fixture's "Admonitions fixture" heading is the only match for this
+  // phrase, so the preview deterministically lands on the fixture and the
+  // search component's auto-scroll centers the highlighted heading just
+  // above the admonition we want to capture.
+  await search(page, "Admonitions fixture")
 
   const fixtureResult = page.locator('.result-card[id="search-fixture"]')
   await expect(fixtureResult).toBeVisible()

--- a/website_content/fixtures/Search-fixture.md
+++ b/website_content/fixtures/Search-fixture.md
@@ -14,7 +14,7 @@ This page is the search-preview target for the visual regression tests in `searc
 
 The fixture lives outside the live site (see `RemoveFixtures` filter), so no user-facing search references it.
 
-# Admonitions
+# Admonitions fixture
 
 > [!note]
 > A short note admonition for the focused mobile-card-preview screenshot.
@@ -22,7 +22,7 @@ The fixture lives outside the live site (see `RemoveFixtures` filter), so no use
 > [!quote]
 > A second admonition.
 
-# Checkboxes
+# Checkboxes fixture
 
 1. [ ] Fixture checkbox at `#checkbox-0`
 2. [ ] Second fixture checkbox


### PR DESCRIPTION
## Summary

- The `Checkbox search preview (screenshot)` and `admonition background is transparent in focused mobile card preview (screenshot)` tests were searching for the fixture page by its title (`"Search preview fixture"`). `PreviewManager.scrollToFirstmatch()` (`quartz/components/scripts/search.ts:428`) auto-scrolls the preview to the first `.search-match`, so the highlighted match landed on the fixture's title at the top of the page — framing the title block in the screenshot instead of the Checkboxes / Admonitions section the test wanted to capture.
- Rename the fixture's section headings to `# Admonitions fixture` and `# Checkboxes fixture`, and switch the two tests to query those phrases. The phrases are unique to the fixture (Test-page.md has only the single-word headings), so the fixture deterministically wins the search and the first `.search-match` is the heading itself — auto-scroll then centers it without any manual `scrollIntoViewIfNeeded` in the spec.

## Changes

- `website_content/fixtures/Search-fixture.md`: rename `# Admonitions` → `# Admonitions fixture` and `# Checkboxes` → `# Checkboxes fixture`.
- `quartz/components/tests/search.spec.ts`: change the Checkbox screenshot test's query to `"Checkboxes fixture"` and the mobile-card-preview-admonition test's query to `"Admonitions fixture"`; refresh the explanatory comments accordingly.

## Testing

- `pnpm check` (typecheck + prettier + stylelint) passes locally.
- Visual regression baselines for `Search-checkboxes` and `mobile-card-preview-admonition` will need re-approval after CI runs — they were previously framing the wrong section, so the new screenshots intentionally differ.

https://claude.ai/code/session_014nAKX9wbcYZB9oxuF4QBde

---
_Generated by [Claude Code](https://claude.ai/code/session_014nAKX9wbcYZB9oxuF4QBde)_