### PR TITLE
feat(hooks): catch counterfactual past-code phrasings

### DIFF
--- a/.claude/hooks/check-narrative-comments.sh
+++ b/.claude/hooks/check-narrative-comments.sh
@@ -7,7 +7,7 @@ file=$(jq -r '.tool_input.file_path // empty' <<<"$input")
 case "$file" in *.md | *.mdx | *.json | *.yaml | *.yml | *.toml | *.html | *.svg | *.xml) exit 0 ;; esac
 new=$(jq -r '.tool_input.new_string // .tool_input.content // empty' <<<"$input")
 hits=$(grep -inE '^[[:space:]]*(//|/\*|#|\*[^/=]|<!--)' <<<"$new" |
-	grep -iE '\b(previously|formerly|used to (be|do|use|have)|the old [[:alnum:]_-]+|prior (version|impl(ementation)?|behavior)|earlier (version|iteration|attempt)|regression(:| test for)|legacy (code|impl(ementation)?)|short-lived [[:alnum:]_-]+( [[:alnum:]_-]+)? fork|in the previous (version|iteration|attempt|impl(ementation)?))\b' || true)
+	grep -iE '\b(previously|formerly|used to (be|do|use|have)|the old [[:alnum:]_-]+|prior (version|impl(ementation)?|behavior)|earlier (version|iteration|attempt)|regression(:| test for)|legacy (code|impl(ementation)?)|short-lived [[:alnum:]_-]+( [[:alnum:]_-]+)? fork|in the previous (version|iteration|attempt|impl(ementation)?)|would (also|otherwise|still|instead|have|incorrectly|wrongly) (highlight|match|pull|drag|land|trigger|fire|return|emit|cause|pick|select|hit|scroll)|naive (approach|impl(ementation)?|version)|without this (check|fix|guard|change|code)|the alternative (would|impl)|if we (had|did) not)\b' || true)
 [ -z "$hits" ] && exit 0
 {
 	echo "Narrative comments in $file (CLAUDE.md: comments describe current code, not history):"


### PR DESCRIPTION
## Summary

Extend `check-narrative-comments.sh` to flag a few more anti-patterns the literal-past-tense regex missed:

- counterfactual subjunctives (`"would also highlight..."`, `"would otherwise trigger..."`)
- naive/alternative-approach narration (`"naive approach..."`, `"the alternative would..."`)
- without-this-X narration (`"without this guard..."`, `"without this check..."`)
- if-we-had-not narration (`"if we had not..."`, `"if we did not..."`)

All describe a prior or hypothetical implementation rather than the current code; CLAUDE.md treats those as archaeology that belongs in git history, not in comments.

## Motivation

While working on #1294 I wrote this in a code comment:

```
// A multi-word phrase like "Checkboxes fixture" would also highlight the
// bare "fixture" token in the page title, pulling the auto-scroll to
// the top of the page.
```

It's the same anti-pattern the hook is meant to catch (describing what *another* implementation would do rather than what the current code does), but the regex only checked literal past-tense keywords ("previously", "formerly", "used to", etc.). Counterfactual subjunctives slipped through.

## Test plan

- [ ] Edit a TS/JS/Py file with a comment containing `// X would also trigger...` — hook fires, blocks edit.
- [ ] Edit a TS/JS/Py file with a comment containing `// naive approach...` — hook fires.
- [ ] Edit a TS/JS/Py file with a comment containing `// X is currently the case` (legitimate "current code" comment, not past/counterfactual) — hook is silent.
- [ ] Edit a markdown file containing `would also` in prose — hook is silent (markdown skipped via case statement).

## Lessons learned

Past-code/anti-archaeology hooks need to cover counterfactual phrasings, not just literal past-tense keywords. The dead-giveaway pattern is *any* description of code that doesn't exist — past, hypothetical, or alternative.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148EqFKtsJgDCGXnuQwomoK)_