### PR TITLE
refactor(contentIndex): require authors, default to [] upstream

### DIFF
--- a/quartz/components/scripts/randomPost.test.ts
+++ b/quartz/components/scripts/randomPost.test.ts
@@ -12,6 +12,7 @@ const cd = (content: string): ContentDetails => ({
   links: [],
   tags: [],
   content,
+  authors: [],
 })
 
 const mockContentIndex: Record<string, ContentDetails> = {

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -1190,9 +1190,9 @@ const formatForDisplay = (
   return {
     id,
     slug,
-    title: data[slug].title ?? "",
-    content: match(term, data[slug].content ?? "", true),
-    authors: data[slug].authors?.join(", ") ?? "",
+    title: data[slug].title,
+    content: match(term, data[slug].content, true),
+    authors: data[slug].authors.join(", "),
   }
 }
 
@@ -1327,7 +1327,7 @@ async function fillDocument(data: { [key: FullSlug]: ContentDetails }): Promise<
       slug: slug as FullSlug,
       title: fileData.title,
       content: fileData.content,
-      authors: fileData.authors?.join(", ") ?? "",
+      authors: fileData.authors.join(", "),
     }
     return index.addAsync(id, doc)
   })

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -180,7 +180,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<ContentIndexOptions>> = (
               : undefined,
             date,
             description: (file.data.description as string) ?? undefined,
-            authors: file.data.frontmatter?.authors,
+            authors: file.data.frontmatter?.authors ?? [],
           })
         }
       }

--- a/quartz/plugins/vfile.ts
+++ b/quartz/plugins/vfile.ts
@@ -79,7 +79,7 @@ export type ContentDetails = {
   tags: readonly string[]
   content: string
   richContent?: string
-  authors?: readonly string[]
+  authors: readonly string[]
 }
 export type ContentIndex = Map<FullSlug, ContentDetails>
 


### PR DESCRIPTION
## Summary

`ContentDetails.authors` was declared optional (`readonly string[] | undefined`), so every consumer had to write `details.authors?.join(...) ?? ""` — a silent fallback that hides a missing-authors invariant violation as an empty string.

Default `authors` to `[]` once at the emitter boundary (`contentIndex.ts`) and tighten the type to required `readonly string[]`. Consumers now call `.join(", ")` unconditionally.

## Files

- `quartz/plugins/vfile.ts`: `authors?: readonly string[]` → `authors: readonly string[]`
- `quartz/plugins/emitters/contentIndex.ts`: emit `authors: file.data.frontmatter?.authors ?? []`
- `quartz/components/scripts/search.ts`: drop `?.` and `?? ""` in `formatForDisplay` and `fillDocument`
- `quartz/components/scripts/randomPost.test.ts`: add `authors: []` to test fixture (required field)

## Audit context

This came out of @alexander-turner's review on #1294, where the same "typed-non-nullable field defensively coalesced" pattern surfaced for `title`/`content`. I ran a broader codebase audit; `authors` was the cleanest remaining case (the title/content `?? ""` in the emitter are reachable in the `includeEmptyFiles: true` path, so those *are* real fallbacks).

## Test plan

- [ ] `pnpm test` — search, randomPost, contentIndex suites all green locally.
- [ ] CI green on PR.
- [ ] No runtime regression on pages with no frontmatter authors (e.g. fixture pages, welcome page) — `[].join(", ")` returns `""`, same observable output as the old `?? ""`.

## Lessons learned

**When the same `?? defaultValue` fallback shows up at every call site of an optional field, the type is wrong.** Tighten the type to required and default once at the upstream boundary (the emitter/builder); consumers stop needing to defend against the absent case. This converts a silent-corruption mode (every consumer's `??` masks a missing value as empty) into either a type error (if the boundary forgets to default) or a normal empty-collection flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148EqFKtsJgDCGXnuQwomoK)_