### PR TITLE
fix(playwright): drop redundant `__routerInitialized` wait in gotoPage

### DIFF
--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -128,8 +128,7 @@ test.beforeEach(async ({ page }) => {
   // Log any console errors to help diagnose issues
   page.on("pageerror", (error) => console.error("Page Error:", error))
 
-  // Navigate to a page that uses the SPA inline logic
-  await gotoPage(page, `http://localhost:8080/${testingPageSlug}`, "domcontentloaded")
+  await gotoPage(page, `http://localhost:8080/${testingPageSlug}`)
 
   // Dispatch the 'nav' event to ensure the router is properly initialized
   await page.evaluate(() => {

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -438,8 +438,6 @@ async function handlePopstate(event: PopStateEvent): Promise<void> {
  */
 function createRouter() {
   if (typeof window !== "undefined" && !window.__routerInitialized) {
-    window.__routerInitialized = true
-
     window.addEventListener(
       "scroll",
       () => {
@@ -482,6 +480,8 @@ function createRouter() {
 
     // Listener for back/forward navigation
     window.addEventListener("popstate", handlePopstate)
+
+    window.__routerInitialized = true
   }
 }
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -1,9 +1,12 @@
 import type { Page, Request } from "playwright"
 
 import { type Locator, type TestInfo, expect } from "@playwright/test"
+import { appendFileSync, mkdirSync } from "fs"
+import { join } from "path"
 import sanitize from "sanitize-filename"
 
 import { minDesktopWidth } from "../../styles/variables"
+import { findGitRoot } from "../../util/log"
 import { savedThemeKey } from "../constants"
 import { type Theme } from "../scripts/darkmode"
 
@@ -590,15 +593,12 @@ export async function gotoPage(
   // separate waitForLoadState(), but WebKit/Safari can destroy the execution
   // context between those two steps, causing "Execution context was destroyed"
   // errors on page.evaluate / page.waitForFunction calls.
-  // Collect failed sub-resource fetches during this navigation and warn
-  // after goto resolves, so CI logs name the failing URL.  Filter out
-  // net::ERR_ABORTED — these are the browser cancelling in-flight requests
-  // at teardown/redirect, not real fetch failures.
+  // Collect failed sub-resource fetches during this navigation and append
+  // them to .logs/gotoPage-failed-requests.log so the CI logs artifact
+  // names the failing URL without flooding stdout.
   const failedRequests: Array<{ url: string; reason: string }> = []
   const onRequestFailed = (req: Request): void => {
-    const reason = req.failure()?.errorText ?? "unknown"
-    if (reason.includes("ERR_ABORTED")) return
-    failedRequests.push({ url: req.url(), reason })
+    failedRequests.push({ url: req.url(), reason: req.failure()?.errorText ?? "unknown" })
   }
   page.on("requestfailed", onRequestFailed)
 
@@ -618,13 +618,24 @@ export async function gotoPage(
   }
 
   if (failedRequests.length > 0) {
-    console.warn(
-      `[gotoPage] ${failedRequests.length} failed request(s) during navigation to ${url}:`,
-    )
-    for (const { url: failedUrl, reason } of failedRequests) {
-      console.warn(`  - ${reason}: ${failedUrl}`)
-    }
+    logFailedRequests(url, failedRequests)
   }
+}
+
+const failedRequestsLogPath = join(findGitRoot(), ".logs", "gotoPage-failed-requests.log")
+let failedRequestsLogDirEnsured = false
+
+function logFailedRequests(url: string, failures: Array<{ url: string; reason: string }>): void {
+  if (!failedRequestsLogDirEnsured) {
+    mkdirSync(join(findGitRoot(), ".logs"), { recursive: true })
+    failedRequestsLogDirEnsured = true
+  }
+  const lines = [
+    `[${new Date().toISOString()}] ${failures.length} failed request(s) during navigation to ${url}:`,
+    ...failures.map(({ url: failedUrl, reason }) => `  - ${reason}: ${failedUrl}`),
+    "",
+  ]
+  appendFileSync(failedRequestsLogPath, lines.join("\n"))
 }
 
 /** Reload the current page by navigating away and back to the original URL.

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -591,10 +591,14 @@ export async function gotoPage(
   // context between those two steps, causing "Execution context was destroyed"
   // errors on page.evaluate / page.waitForFunction calls.
   // Collect failed sub-resource fetches during this navigation and warn
-  // after goto resolves, so CI logs name the failing URL.
+  // after goto resolves, so CI logs name the failing URL.  Filter out
+  // net::ERR_ABORTED — these are the browser cancelling in-flight requests
+  // at teardown/redirect, not real fetch failures.
   const failedRequests: Array<{ url: string; reason: string }> = []
   const onRequestFailed = (req: Request): void => {
-    failedRequests.push({ url: req.url(), reason: req.failure()?.errorText ?? "unknown" })
+    const reason = req.failure()?.errorText ?? "unknown"
+    if (reason.includes("ERR_ABORTED")) return
+    failedRequests.push({ url: req.url(), reason })
   }
   page.on("requestfailed", onRequestFailed)
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -1,5 +1,6 @@
+import type { Page, Request } from "playwright"
+
 import { type Locator, type TestInfo, expect } from "@playwright/test"
-import { type Page } from "playwright"
 import sanitize from "sanitize-filename"
 
 import { minDesktopWidth } from "../../styles/variables"
@@ -589,6 +590,14 @@ export async function gotoPage(
   // separate waitForLoadState(), but WebKit/Safari can destroy the execution
   // context between those two steps, causing "Execution context was destroyed"
   // errors on page.evaluate / page.waitForFunction calls.
+  // Collect failed sub-resource fetches during this navigation and warn
+  // after goto resolves, so CI logs name the failing URL.
+  const failedRequests: Array<{ url: string; reason: string }> = []
+  const onRequestFailed = (req: Request): void => {
+    failedRequests.push({ url: req.url(), reason: req.failure()?.errorText ?? "unknown" })
+  }
+  page.on("requestfailed", onRequestFailed)
+
   try {
     await page.goto(url, { waitUntil: loadState })
   } catch (error: unknown) {
@@ -600,12 +609,18 @@ export async function gotoPage(
     } else {
       throw error
     }
+  } finally {
+    page.off("requestfailed", onRequestFailed)
   }
 
-  // Wait for the SPA router to finish initializing so a late client-side
-  // navigation doesn't destroy the execution context before callers can
-  // run page.evaluate() (Safari/WebKit is especially prone to this).
-  await page.waitForFunction(() => window.__routerInitialized === true)
+  if (failedRequests.length > 0) {
+    console.warn(
+      `[gotoPage] ${failedRequests.length} failed request(s) during navigation to ${url}:`,
+    )
+    for (const { url: failedUrl, reason } of failedRequests) {
+      console.warn(`  - ${reason}: ${failedUrl}`)
+    }
+  }
 }
 
 /** Reload the current page by navigating away and back to the original URL.


### PR DESCRIPTION
## Summary

`gotoPage` polled `window.__routerInitialized === true` with no explicit timeout. When `postscript.js`'s load was disrupted on macOS WebKit, that wait burned the full 90 s per-test budget for every test in the file — the dominant failure on run [25898695397](https://github.com/alexander-turner/TurnTrout.com/actions/runs/25898695397). Investigation found three problems stacked:

1. **The wait was redundant.** `gotoPage`'s default `loadState` is already `"load"`, and the `load` event fires only after deferred/module scripts have executed. The SPA router (in `postscript.js`, loaded as `<script type="module" defer>`) is guaranteed to have run by `load`. The `waitForFunction` added nothing on top.
2. **The flag was set in the wrong place.** `window.__routerInitialized = true` was the **first line** of `createRouter` — set before the scroll/click/popstate listeners attached. So a test resolving on the flag had no guarantee the router was actually functional, just that `createRouter` had been entered.
3. **The comment told a story the code didn't back up.** "Wait for the SPA router to finish initializing so a late client-side navigation doesn't destroy the execution context" — but the flag flipped before the `nav` event handler that might cause such a navigation was even attached.

This PR:

- **Removes the `waitForFunction(__routerInitialized)` from `gotoPage`.** `loadState: "load"` is a strictly stronger guarantee.
- **Moves `window.__routerInitialized = true` to *after* listeners attach** in `createRouter`. The flag now matches its name — true iff the router is functional. The flag is still read by `quartz/static/scripts/instantScrollRestoration.js:269` to decide whether to skip its own scroll-restoration logic, so this placement change improves that consumer's contract too.
- **Drops the `"domcontentloaded"` override in `spa.inline.spec.ts` beforeEach** so it uses the default `"load"`.
- **Adds a per-call `requestfailed` listener in `gotoPage`.** If a future intermittent sub-resource fetch failure happens, CI logs will name the failing URL instead of presenting as an opaque hang.

## Known risk

18 other `gotoPage(..., "domcontentloaded")` callsites across `spa.inline.spec.ts`, `darkmode.spec.ts`, `navbar.spec.ts`, `popover.spec.ts`, `print.spec.ts`, `test-page.spec.ts`, `smallcaps-copy.spec.ts`, `visual_utils.spec.ts` are unchanged in this PR. Per HTML spec, deferred/module scripts execute before `DOMContentLoaded` fires, so DCL should already gate module-script execution — but if any of those tests were quietly relying on the implicit `__routerInitialized` wait beyond what DCL guarantees, they could regress. CI will tell us; followup is to flip those to `"load"` as well if needed.

## Test plan

- [ ] All Playwright suites green (Linux + macOS, all browsers)
- [ ] No regression in tests that pass `"domcontentloaded"` to `gotoPage`
- [ ] If a future run hangs, the new `requestfailed` log surfaces the failing URL

## Lessons learned

- **A flag named `__routerInitialized` should be set when the router is initialized, not when initialization starts.** Setting the guard at the top of `createRouter` made the flag mean "createRouter has been entered," not "createRouter has finished." That made the polling wait, the comment, and the consumer in `instantScrollRestoration.js` all subtly wrong in the same way. The fix: place the assignment after all the setup it claims to gate.
- **`waitForFunction` without an explicit timeout silently scopes to the test budget.** A single unbounded wait can consume the entire per-test timeout and leave every subsequent assertion in the same test with no useful error context. Always pass `{ timeout }` so failures are "predicate didn't hold" (with a useful stack), not "test ran out of time" (with no signal).
- **Before adding a polling-based readiness wait, check whether Playwright's existing `waitUntil` mechanic already covers it.** `loadState: "load"` already waits for deferred/module scripts to execute; a polling wait on top is belt-over-belt and tends to encode mistaken assumptions about what the underlying state means.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsMKA2GP4ccuK1N2MezvGi)_