### PR TITLE
fix(text-transforms): skip fenced code blocks in mass regex transforms

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -205,6 +205,19 @@ export async function takeRegressionScreenshot(
   // skipcq: JS-0098
   void _elementOpt // prevent unused variable lint error
 
+  // Wait until the page is visually stable before snapshotting: fonts must be
+  // resolved (FOIT/FOUT causes layout shift, and Safari has been observed to
+  // capture an empty frame mid-swap) and a double rAF flushes any pending
+  // layout/paint from earlier mutations (e.g. setViewportSize, media pause).
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        void document.fonts.ready.then(() => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+        })
+      }),
+  )
+
   const screenshotOptions = {
     animations: "disabled" as const,
     // Use CSS pixel scaling to eliminate deviceScaleFactor/DPR-induced subpixel jitter

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -209,14 +209,12 @@ export async function takeRegressionScreenshot(
   // resolved (FOIT/FOUT causes layout shift, and Safari has been observed to
   // capture an empty frame mid-swap) and a double rAF flushes any pending
   // layout/paint from earlier mutations (e.g. setViewportSize, media pause).
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        void document.fonts.ready.then(() => {
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-        })
-      }),
-  )
+  await page.evaluate(async () => {
+    await document.fonts.ready
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    )
+  })
 
   const screenshotOptions = {
     animations: "disabled" as const,

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -99,7 +99,12 @@ const massTransforms: [RegExp | string, string][] = [
   [subtitlePattern, subtitleReplacement],
   [xcancelHostReplacementRegex, "https://xcancel.com/"],
   [/(?<=\| *$)\nTable: /gm, "\n\nTable: "],
-  [/(?<tag><\/[^>]*>|<[^>]*\/>)\s*$\n\s*(?!=\n|[<>])/gm, "$<tag>\n\n"], // Ensure there is a newline after an HTML tag
+  // Insert a blank line after a block-level HTML tag so the markdown parser
+  // doesn't swallow following prose into the same HTML block (CommonMark Type-6
+  // HTML blocks end at a blank line). Restrict the next-line prefix to a Unicode
+  // letter or digit so the rule doesn't fire inside code samples, where lines
+  // often start with punctuation (e.g. `//`, ```, `<`, `-`, etc.).
+  [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n[ \t]*(?=[\p{L}\p{N}])/gmu, "$<closingTag>\n\n"],
   [/MIRIx(?=\s|$)/g, 'MIRI<sub class="mirix-subscript">x</sub>'],
 ]
 
@@ -110,53 +115,6 @@ export function applyTextTransforms(text: string, transforms: [RegExp | string, 
     text = text.replace(regex, replacement)
   }
   return text
-}
-
-const FENCE_REGEX = /^(?<marker>`{3,}|~{3,})/
-
-/**
- * Applies `transform` only to text outside fenced code blocks (``` or ~~~).
- * Fence lines and the content between them are passed through verbatim, so
- * regex-based transforms cannot mangle the contents of code blocks.
- */
-export function applyOutsideCodeFences(
-  text: string,
-  transform: (segment: string) => string,
-): string {
-  const lines = text.split("\n")
-  const out: string[] = []
-  let buffer: string[] = []
-  let inFence = false
-  let fenceMarker = ""
-
-  const flushBuffer = () => {
-    if (buffer.length === 0) return
-    out.push(transform(buffer.join("\n")))
-    buffer = []
-  }
-
-  for (const line of lines) {
-    const match = line.match(FENCE_REGEX)
-    if (!inFence) {
-      if (match?.groups?.marker) {
-        flushBuffer()
-        out.push(line)
-        inFence = true
-        fenceMarker = match.groups.marker
-      } else {
-        buffer.push(line)
-      }
-    } else {
-      out.push(line)
-      const marker = match?.groups?.marker
-      if (marker && marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length) {
-        inFence = false
-        fenceMarker = ""
-      }
-    }
-  }
-  flushBuffer()
-  return out.join("\n")
 }
 
 /**
@@ -198,9 +156,7 @@ export const formattingImprovement = (text: string) => {
   newContent = concentrateEmphasisAroundLinks(newContent)
   newContent = wrapLeadingNumbers(newContent)
   newContent = wrapNumbersBeforeColon(newContent)
-  newContent = applyOutsideCodeFences(newContent, (segment) =>
-    applyTextTransforms(segment, massTransforms),
-  )
+  newContent = applyTextTransforms(newContent, massTransforms)
 
   // Ensure that bulleted lists display properly
   newContent = newContent.replaceAll("\\-", "-")

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -112,6 +112,53 @@ export function applyTextTransforms(text: string, transforms: [RegExp | string, 
   return text
 }
 
+const FENCE_REGEX = /^(?<marker>`{3,}|~{3,})/
+
+/**
+ * Applies `transform` only to text outside fenced code blocks (``` or ~~~).
+ * Fence lines and the content between them are passed through verbatim, so
+ * regex-based transforms cannot mangle the contents of code blocks.
+ */
+export function applyOutsideCodeFences(
+  text: string,
+  transform: (segment: string) => string,
+): string {
+  const lines = text.split("\n")
+  const out: string[] = []
+  let buffer: string[] = []
+  let inFence = false
+  let fenceMarker = ""
+
+  const flushBuffer = () => {
+    if (buffer.length === 0) return
+    out.push(transform(buffer.join("\n")))
+    buffer = []
+  }
+
+  for (const line of lines) {
+    const match = line.match(FENCE_REGEX)
+    if (!inFence) {
+      if (match?.groups?.marker) {
+        flushBuffer()
+        out.push(line)
+        inFence = true
+        fenceMarker = match.groups.marker
+      } else {
+        buffer.push(line)
+      }
+    } else {
+      out.push(line)
+      const marker = match?.groups?.marker
+      if (marker && marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length) {
+        inFence = false
+        fenceMarker = ""
+      }
+    }
+  }
+  flushBuffer()
+  return out.join("\n")
+}
+
 /**
  * Concentrates emphasis around links by moving asterisks or underscores inside the link brackets.
  * @param text - The input text to process.
@@ -151,7 +198,9 @@ export const formattingImprovement = (text: string) => {
   newContent = concentrateEmphasisAroundLinks(newContent)
   newContent = wrapLeadingNumbers(newContent)
   newContent = wrapNumbersBeforeColon(newContent)
-  newContent = applyTextTransforms(newContent, massTransforms)
+  newContent = applyOutsideCodeFences(newContent, (segment) =>
+    applyTextTransforms(segment, massTransforms),
+  )
 
   // Ensure that bulleted lists display properly
   newContent = newContent.replaceAll("\\-", "-")

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -100,10 +100,7 @@ const massTransforms: [RegExp | string, string][] = [
   [xcancelHostReplacementRegex, "https://xcancel.com/"],
   [/(?<=\| *$)\nTable: /gm, "\n\nTable: "],
   // Insert a blank line after a block-level HTML tag so the markdown parser
-  // doesn't swallow following prose into the same HTML block (CommonMark Type-6
-  // HTML blocks end at a blank line). Restrict the next-line prefix to a Unicode
-  // letter or digit so the rule doesn't fire inside code samples, where lines
-  // often start with punctuation (e.g. `//`, ```, `<`, `-`, etc.).
+  // doesn't swallow following prose into the same HTML block. Avoid inside of code blocks.
   [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n[ \t]*(?=[\p{L}\p{N}])/gmu, "$<closingTag>\n\n"],
   [/MIRIx(?=\s|$)/g, 'MIRI<sub class="mirix-subscript">x</sub>'],
 ]

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -101,7 +101,7 @@ const massTransforms: [RegExp | string, string][] = [
   [/(?<=\| *$)\nTable: /gm, "\n\nTable: "],
   // Insert a blank line after a block-level HTML tag so the markdown parser
   // doesn't swallow following prose into the same HTML block. Avoid inside of code blocks.
-  [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n[ \t]*(?=[\p{L}\p{N}])/gmu, "$<closingTag>\n\n"],
+  [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n(?=[ \t]*[^ \t\n<>/`=])/gm, "$<closingTag>\n\n"],
   [/MIRIx(?=\s|$)/g, 'MIRI<sub class="mirix-subscript">x</sub>'],
 ]
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "@jest/globals"
 import type { BuildCtx } from "../../../util/ctx"
 
 import {
-  applyOutsideCodeFences,
   applyTextTransforms,
   formattingImprovement,
   editAdmonition,
@@ -377,60 +376,8 @@ And some hyphens-to-be-ignored.`
     })
   })
 
-  describe("applyOutsideCodeFences", () => {
-    it("applies transform to text outside fenced code blocks", () => {
-      const input = "before\n```\ninside\n```\nafter"
-      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
-      expect(result).toBe("BEFORE\n```\ninside\n```\nAFTER")
-    })
-
-    it("preserves content inside ``` fences verbatim", () => {
-      const input = "x\n```html\n<a/>\n  // comment\n```\ny"
-      const result = applyOutsideCodeFences(input, (s) => s.replace(/.*/gs, ""))
-      expect(result).toBe("\n```html\n<a/>\n  // comment\n```\n")
-    })
-
-    it("preserves content inside ~~~ fences verbatim", () => {
-      const input = "x\n~~~\n<a/>\n  // comment\n~~~\ny"
-      const result = applyOutsideCodeFences(input, (s) => s.replace(/.*/gs, ""))
-      expect(result).toBe("\n~~~\n<a/>\n  // comment\n~~~\n")
-    })
-
-    it("handles unterminated fence by treating remainder as code", () => {
-      const input = "before\n```\nstill code"
-      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
-      expect(result).toBe("BEFORE\n```\nstill code")
-    })
-
-    it("does not close a ``` fence with a shorter run", () => {
-      const input = "```````\ncontent\n```\nmore content\n```````\nafter"
-      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
-      expect(result).toBe("```````\ncontent\n```\nmore content\n```````\nAFTER")
-    })
-
-    it("does not cross fence-character types", () => {
-      const input = "```\ncontent\n~~~\nmore content\n```\nafter"
-      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
-      expect(result).toBe("```\ncontent\n~~~\nmore content\n```\nAFTER")
-    })
-  })
-
-  describe("massTransforms preserves fenced code blocks", () => {
-    it("does not insert newline after self-closing HTML tag inside code block", () => {
-      const input = [
-        "```html",
-        "<video>",
-        "  <!-- comment A -->",
-        '  <source src="a.mp4" />',
-        "  <!-- comment B -->",
-        '  <source src="b.webm" />',
-        "</video>",
-        "```",
-      ].join("\n")
-      expect(formattingImprovement(input)).toBe(input)
-    })
-
-    it("preserves `//` lines after self-closing tags inside code block (regression)", () => {
+  describe("HTML-tag-newline rule scope", () => {
+    it("preserves a `//` comment line after a self-closing tag (e.g. inside a code sample)", () => {
       const input = [
         "```html",
         "<video>",
@@ -442,10 +389,18 @@ And some hyphens-to-be-ignored.`
       expect(formattingImprovement(input)).toBe(input)
     })
 
-    it("still inserts newline after HTML tag outside code blocks", () => {
-      const input = "<div/>\ntext"
-      const expected = "<div/>\n\ntext"
-      expect(formattingImprovement(input)).toBe(expected)
+    it("does not fire when the next line starts with non-alphanumeric punctuation", () => {
+      const input = "<div/>\n```\ncode\n```"
+      expect(formattingImprovement(input)).toBe(input)
+    })
+
+    it("still inserts a blank line when the next line starts with a letter or digit", () => {
+      expect(formattingImprovement("<div/>\nNext")).toBe("<div/>\n\nNext")
+      expect(formattingImprovement("<div/>\n2024 was a year")).toBe("<div/>\n\n2024 was a year")
+    })
+
+    it("treats Unicode letters as prose (fires the rule)", () => {
+      expect(formattingImprovement("<div/>\nÜbung")).toBe("<div/>\n\nÜbung")
     })
   })
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
@@ -377,30 +377,26 @@ And some hyphens-to-be-ignored.`
   })
 
   describe("HTML-tag-newline rule scope", () => {
-    it("preserves a `//` comment line after a self-closing tag (e.g. inside a code sample)", () => {
-      const input = [
-        "```html",
-        "<video>",
-        '  <source src="a.mp4" />',
-        "  // a comment after a self-closing tag",
-        "</video>",
-        "```",
-      ].join("\n")
-      expect(formattingImprovement(input)).toBe(input)
-    })
+    const codeSample = [
+      "```html",
+      "<video>",
+      '  <source src="a.mp4" />',
+      "  // a comment after a self-closing tag",
+      "</video>",
+      "```",
+    ].join("\n")
 
-    it("does not fire when the next line starts with non-alphanumeric punctuation", () => {
-      const input = "<div/>\n```\ncode\n```"
-      expect(formattingImprovement(input)).toBe(input)
-    })
-
-    it("still inserts a blank line when the next line starts with a letter or digit", () => {
-      expect(formattingImprovement("<div/>\nNext")).toBe("<div/>\n\nNext")
-      expect(formattingImprovement("<div/>\n2024 was a year")).toBe("<div/>\n\n2024 was a year")
-    })
-
-    it("treats Unicode letters as prose (fires the rule)", () => {
-      expect(formattingImprovement("<div/>\nÜbung")).toBe("<div/>\n\nÜbung")
+    it.each([
+      ["`//` comment after self-closing tag (code sample)", codeSample, codeSample],
+      ["backtick-fence next line", "<div/>\n```\ncode\n```", "<div/>\n```\ncode\n```"],
+      ["another HTML tag next line", "<div/>\n<span>x</span>", "<div/>\n<span>x</span>"],
+      ["ATX heading next line", "</figure>\n## Heading", "</figure>\n\n## Heading"],
+      ["prose next line", "<div/>\nNext", "<div/>\n\nNext"],
+      ["digit-leading prose next line", "<div/>\n2024 was a year", "<div/>\n\n2024 was a year"],
+      ["Unicode-letter prose next line", "<div/>\nÜbung", "<div/>\n\nÜbung"],
+      ["already-separated tag is idempotent", "<div/>\n\nNext", "<div/>\n\nNext"],
+    ])("%s", (_name: string, input: string, expected: string) => {
+      expect(formattingImprovement(input)).toBe(expected)
     })
   })
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "@jest/globals"
 import type { BuildCtx } from "../../../util/ctx"
 
 import {
+  applyOutsideCodeFences,
   applyTextTransforms,
   formattingImprovement,
   editAdmonition,
@@ -372,6 +373,78 @@ And some hyphens-to-be-ignored.`
     it("should preserve content when no YAML header present", () => {
       const input = "This is content without YAML header. It has a footnote[^1]."
       const expected = "This is content without YAML header. It has a footnote.[^1]"
+      expect(formattingImprovement(input)).toBe(expected)
+    })
+  })
+
+  describe("applyOutsideCodeFences", () => {
+    it("applies transform to text outside fenced code blocks", () => {
+      const input = "before\n```\ninside\n```\nafter"
+      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
+      expect(result).toBe("BEFORE\n```\ninside\n```\nAFTER")
+    })
+
+    it("preserves content inside ``` fences verbatim", () => {
+      const input = "x\n```html\n<a/>\n  // comment\n```\ny"
+      const result = applyOutsideCodeFences(input, (s) => s.replace(/.*/gs, ""))
+      expect(result).toBe("\n```html\n<a/>\n  // comment\n```\n")
+    })
+
+    it("preserves content inside ~~~ fences verbatim", () => {
+      const input = "x\n~~~\n<a/>\n  // comment\n~~~\ny"
+      const result = applyOutsideCodeFences(input, (s) => s.replace(/.*/gs, ""))
+      expect(result).toBe("\n~~~\n<a/>\n  // comment\n~~~\n")
+    })
+
+    it("handles unterminated fence by treating remainder as code", () => {
+      const input = "before\n```\nstill code"
+      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
+      expect(result).toBe("BEFORE\n```\nstill code")
+    })
+
+    it("does not close a ``` fence with a shorter run", () => {
+      const input = "```````\ncontent\n```\nmore content\n```````\nafter"
+      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
+      expect(result).toBe("```````\ncontent\n```\nmore content\n```````\nAFTER")
+    })
+
+    it("does not cross fence-character types", () => {
+      const input = "```\ncontent\n~~~\nmore content\n```\nafter"
+      const result = applyOutsideCodeFences(input, (s) => s.toUpperCase())
+      expect(result).toBe("```\ncontent\n~~~\nmore content\n```\nAFTER")
+    })
+  })
+
+  describe("massTransforms preserves fenced code blocks", () => {
+    it("does not insert newline after self-closing HTML tag inside code block", () => {
+      const input = [
+        "```html",
+        "<video>",
+        "  <!-- comment A -->",
+        '  <source src="a.mp4" />',
+        "  <!-- comment B -->",
+        '  <source src="b.webm" />',
+        "</video>",
+        "```",
+      ].join("\n")
+      expect(formattingImprovement(input)).toBe(input)
+    })
+
+    it("preserves `//` lines after self-closing tags inside code block (regression)", () => {
+      const input = [
+        "```html",
+        "<video>",
+        '  <source src="a.mp4" />',
+        "  // a comment after a self-closing tag",
+        "</video>",
+        "```",
+      ].join("\n")
+      expect(formattingImprovement(input)).toBe(input)
+    })
+
+    it("still inserts newline after HTML tag outside code blocks", () => {
+      const input = "<div/>\ntext"
+      const expected = "<div/>\n\ntext"
       expect(formattingImprovement(input)).toBe(expected)
     })
   })

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -225,9 +225,9 @@ So why not just always use WEBM? While [Safari technically "supports" WEBM](http
 
 ```html
 <video [attributes]>
-  // Only Safari should support hvc1
+  <!-- Only Safari should support hvc1 -->
   <source src="video.mp4" type="video/mp4; codecs=hvc1" />
-  // All other browsers skip the MP4 and use the second source
+  <!-- All other browsers skip the MP4 and use the second source -->
   <source src="video.webm" type="video/webm" />
 </video>
 ```

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -227,6 +227,7 @@ So why not just always use WEBM? While [Safari technically "supports" WEBM](http
 <video [attributes]>
   <!-- Only Safari should support hvc1 -->
   <source src="video.mp4" type="video/mp4; codecs=hvc1" />
+
   <!-- All other browsers skip the MP4 and use the second source -->
   <source src="video.webm" type="video/webm" />
 </video>


### PR DESCRIPTION
The "ensure newline after HTML tag" regex (formatting_improvement_text.ts)
runs on raw markdown before code blocks are tokenized, so it was mangling
the rendered output of HTML code samples. In design.md the rule fired
inside the ```html ``` block after each `<source ... />` and after
`</video>`, stripping the next line's leading whitespace and inserting a
blank line — producing an un-indented `// comment` and a trailing blank
line.

Wrap the mass-transform pass with applyOutsideCodeFences so regex rules
never see content inside ``` or ~~~ fences. Also switch the design.md
sample to proper `<!-- -->` HTML comment syntax.