### PR TITLE
fix(search): bound mobile results panel height

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -82,6 +82,13 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
   display: none;
   backdrop-filter: blur(4px);
 
+  // On mobile the results panel is height-bounded and scrolls internally, so
+  // the outer container never needs to scroll — disabling outer scroll
+  // prevents the modal from sliding past the end of the results.
+  @media all and (max-width: $tablet-breakpoint) {
+    overflow: hidden;
+  }
+
   &.active {
     display: inline-block;
   }

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -166,6 +166,10 @@
         &[data-preview] > #results-container {
           width: 100%;
           height: auto;
+
+          // Bound the results panel so the outer search-container can't scroll
+          // past the end of results; long lists scroll inside the panel.
+          max-height: calc(75vh - 12vh);
           flex: 0 0 100%;
         }
       }

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -1,5 +1,12 @@
 @use "../../styles/variables.scss" as *;
 
+// Search modal vertical layout: #search-space sits below a top offset and
+// the results/preview panels are capped so the modal fits within the
+// viewport (the remainder is bottom buffer).
+$search-space-top-offset: 12vh;
+$search-modal-bottom-buffer: 25vh;
+$search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-bottom-buffer;
+
 #navbar-right {
   @media all and (max-width: $max-mobile-width) {
     display: flex;
@@ -81,7 +88,7 @@
 
   & > #search-space {
     width: 65%;
-    margin-top: 12vh;
+    margin-top: $search-space-top-offset;
     margin-left: auto;
     margin-right: auto;
 
@@ -154,7 +161,7 @@
       }
 
       & > div {
-        height: calc(75vh - 12vh);
+        height: $search-panel-max-height;
         border-radius: $border-radius;
       }
 
@@ -169,7 +176,7 @@
 
           // Bound the results panel so the outer search-container can't scroll
           // past the end of results; long lists scroll inside the panel.
-          max-height: calc(75vh - 12vh);
+          max-height: $search-panel-max-height;
           flex: 0 0 100%;
         }
       }

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -222,18 +222,25 @@ test("Mobile search results scroll inside the panel, not past it", async ({ page
   await search(page, "the")
   await expect(page.locator(".result-card").nth(3)).toBeVisible({ timeout: 10_000 })
 
-  const { outerOverflow, resultsOverflow } = await page.evaluate(() => {
+  const { outerOverflow, resultsOverflow, allowedOuterOverflow } = await page.evaluate(() => {
     const outer = document.getElementById("search-container") as HTMLElement
     const results = document.getElementById("results-container") as HTMLElement
+    const space = document.getElementById("search-space") as HTMLElement
+    // `#search-space > *` has `margin-bottom: calc(4 * $base-margin)`. Two such
+    // children (input + layout) can leak that margin past the viewport even
+    // when the results panel is bounded — that's the only legitimate slack.
+    const inputMargin = parseFloat(getComputedStyle(space.children[0]).marginBottom)
+    const layoutMargin = parseFloat(getComputedStyle(space.children[1]).marginBottom)
     return {
       outerOverflow: outer.scrollHeight - outer.clientHeight,
       resultsOverflow: results.scrollHeight - results.clientHeight,
+      allowedOuterOverflow: inputMargin + layoutMargin,
     }
   })
 
   // Long result lists must scroll inside #results-container, not push
   // #search-space past the viewport so the outer container becomes scrollable.
-  expect(outerOverflow).toBeLessThan(100)
+  expect(outerOverflow).toBeLessThanOrEqual(allowedOuterOverflow)
   expect(resultsOverflow).toBeGreaterThan(0)
 })
 

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -222,21 +222,19 @@ test("Mobile search results scroll inside the panel, not past it", async ({ page
   await search(page, "the")
   await expect(page.locator(".result-card").nth(3)).toBeVisible({ timeout: 10_000 })
 
-  const { outerScrollTop, resultsScrollDelta } = await page.evaluate(() => {
+  const { outerOverflowY, resultsScrollDelta } = await page.evaluate(() => {
     const outer = document.getElementById("search-container") as HTMLElement
     const results = document.getElementById("results-container") as HTMLElement
-    // Ask the outer container to scroll as far as it can — the browser clamps
-    // to its scrollable range.
-    outer.scrollTop = Number.MAX_SAFE_INTEGER
     return {
-      outerScrollTop: outer.scrollTop,
+      outerOverflowY: getComputedStyle(outer).overflowY,
       resultsScrollDelta: results.scrollHeight - results.clientHeight,
     }
   })
 
-  // The outer container must not scroll — long result lists overflow inside
-  // #results-container instead of sliding the modal past the end of results.
-  expect(outerScrollTop).toBe(0)
+  // The outer container must not be a touch-scrollable region — long result
+  // lists must overflow inside #results-container, not slide the whole modal
+  // past the end of results.
+  expect(outerOverflowY).toBe("hidden")
   expect(resultsScrollDelta).toBeGreaterThan(0)
 })
 

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -214,6 +214,29 @@ test("Preview panel shows on desktop and hides on mobile", async ({ page }) => {
   await expect(previewContainer).toBeVisible({ visible: isDesktop })
 })
 
+test("Mobile search results scroll inside the panel, not past it", async ({ page }) => {
+  test.skip(!isMobileViewport(page), "Mobile-only behavior")
+
+  // "the" is a common term that reliably fills the result limit so the panel
+  // would overflow the viewport without a bounded height.
+  await search(page, "the")
+  await expect(page.locator(".result-card").nth(3)).toBeVisible({ timeout: 10_000 })
+
+  const { outerOverflow, resultsOverflow } = await page.evaluate(() => {
+    const outer = document.getElementById("search-container") as HTMLElement
+    const results = document.getElementById("results-container") as HTMLElement
+    return {
+      outerOverflow: outer.scrollHeight - outer.clientHeight,
+      resultsOverflow: results.scrollHeight - results.clientHeight,
+    }
+  })
+
+  // Long result lists must scroll inside #results-container, not push
+  // #search-space past the viewport so the outer container becomes scrollable.
+  expect(outerOverflow).toBeLessThan(100)
+  expect(resultsOverflow).toBeGreaterThan(0)
+})
+
 test("Search placeholder changes based on viewport", async ({ page }) => {
   const searchBar = page.locator("#search-bar")
   const pageWidth = page.viewportSize()?.width

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -222,26 +222,22 @@ test("Mobile search results scroll inside the panel, not past it", async ({ page
   await search(page, "the")
   await expect(page.locator(".result-card").nth(3)).toBeVisible({ timeout: 10_000 })
 
-  const { outerOverflow, resultsOverflow, allowedOuterOverflow } = await page.evaluate(() => {
+  const { outerScrollTop, resultsScrollDelta } = await page.evaluate(() => {
     const outer = document.getElementById("search-container") as HTMLElement
     const results = document.getElementById("results-container") as HTMLElement
-    const space = document.getElementById("search-space") as HTMLElement
-    // `#search-space > *` has `margin-bottom: calc(4 * $base-margin)`. Two such
-    // children (input + layout) can leak that margin past the viewport even
-    // when the results panel is bounded — that's the only legitimate slack.
-    const inputMargin = parseFloat(getComputedStyle(space.children[0]).marginBottom)
-    const layoutMargin = parseFloat(getComputedStyle(space.children[1]).marginBottom)
+    // Ask the outer container to scroll as far as it can — the browser clamps
+    // to its scrollable range.
+    outer.scrollTop = Number.MAX_SAFE_INTEGER
     return {
-      outerOverflow: outer.scrollHeight - outer.clientHeight,
-      resultsOverflow: results.scrollHeight - results.clientHeight,
-      allowedOuterOverflow: inputMargin + layoutMargin,
+      outerScrollTop: outer.scrollTop,
+      resultsScrollDelta: results.scrollHeight - results.clientHeight,
     }
   })
 
-  // Long result lists must scroll inside #results-container, not push
-  // #search-space past the viewport so the outer container becomes scrollable.
-  expect(outerOverflow).toBeLessThanOrEqual(allowedOuterOverflow)
-  expect(resultsOverflow).toBeGreaterThan(0)
+  // The outer container must not scroll — long result lists overflow inside
+  // #results-container instead of sliding the modal past the end of results.
+  expect(outerScrollTop).toBe(0)
+  expect(resultsScrollDelta).toBeGreaterThan(0)
 })
 
 test("Search placeholder changes based on viewport", async ({ page }) => {


### PR DESCRIPTION
On mobile, `#results-container` had `height: auto`, so a full result list
made `#search-space` taller than the viewport and the outer
`#search-container` (which has `overflow-y: auto`) could be scrolled far
past the end of results into empty space. Cap it at the same `calc(75vh
- 12vh)` used on desktop so overflow scrolls inside `#results-container`
instead.