### PR TITLE
fix(typography): skip nbsp in subtitles and admonition titles

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -105,11 +105,13 @@ const config: QuartzConfig = {
       GitHubFlavoredMarkdown({ enableSmartyPants: false }),
       FixFootnotes(),
       WrapNakedElements(),
+      // Before HTMLFormattingImprovement so the "subtitle" class is set when
+      // nbsp transforms run, letting them skip subtitles like they skip headings.
+      rehypeCustomSubtitle(),
       HTMLFormattingImprovement(),
       Latex(),
       CrawlLinks({ lazyLoad: true, markdownLinkResolution: "shortest" }),
       rehypeCustomSpoiler(),
-      rehypeCustomSubtitle(),
       TagSmallcaps(),
       AfterArticle(),
       AddFavicons(),

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -342,6 +342,14 @@ function isHeading(node: Element): boolean {
   return HEADING_TAGS.has(node.tagName)
 }
 
+// Display-heading elements: text that's styled like a heading and wraps
+// in a tight, balanced way. NBSP widow-prevention here creates brittle
+// titles (especially paper titles in subtitles, which often contain
+// short conjunctions like "by"/"an"/"of").
+function isDisplayHeading(node: Element): boolean {
+  return isHeading(node) || (node.tagName === "p" && hasClass(node, "subtitle"))
+}
+
 // skipcq: JS-0098
 function isKatex(node: Element): boolean {
   return hasClass(node, "katex")
@@ -794,10 +802,12 @@ export const improveFormatting = (
         return
       }
 
-      // Skip nbsp in headings — it prevents natural line-breaking and looks bad
-      const inHeading =
-        isHeading(node as Element) || hasAncestor(node as Element, isHeading, ancestors)
-      const activeUncheckedTransformers = inHeading
+      // Skip nbsp in headings and subtitles — it prevents natural line-breaking
+      // and looks bad
+      const inDisplayHeading =
+        isDisplayHeading(node as Element) ||
+        hasAncestor(node as Element, isDisplayHeading, ancestors)
+      const activeUncheckedTransformers = inDisplayHeading
         ? uncheckedTextTransformers.filter((t) => t !== nbspTransformWrapper)
         : uncheckedTextTransformers
 

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -347,7 +347,11 @@ function isHeading(node: Element): boolean {
 // titles (especially paper titles in subtitles, which often contain
 // short conjunctions like "by"/"an"/"of").
 function isDisplayHeading(node: Element): boolean {
-  return isHeading(node) || (node.tagName === "p" && hasClass(node, "subtitle"))
+  return (
+    isHeading(node) ||
+    (node.tagName === "p" && hasClass(node, "subtitle")) ||
+    hasClass(node, "admonition-title")
+  )
 }
 
 // skipcq: JS-0098
@@ -802,8 +806,8 @@ export const improveFormatting = (
         return
       }
 
-      // Skip nbsp in headings and subtitles — it prevents natural line-breaking
-      // and looks bad
+      // Skip nbsp in headings, subtitles, and admonition titles — it prevents
+      // natural line-breaking and looks bad
       const inDisplayHeading =
         isDisplayHeading(node as Element) ||
         hasAncestor(node as Element, isDisplayHeading, ancestors)

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2307,6 +2307,14 @@ describe("Non-breaking space insertion", () => {
     expect(testHtmlFormattingImprovement(input)).toBe(input)
   })
 
+  it.each([
+    '<div class="admonition-title">I love this</div>',
+    '<div class="admonition-title"><a href="/">Lisa Thiergart</a></div>',
+    '<div class="admonition-title"><div class="admonition-title-inner">A cat sat on a mat</div></div>',
+  ])("does not insert nbsp in admonition titles: %s", (input) => {
+    expect(testHtmlFormattingImprovement(input)).toBe(input)
+  })
+
   it("also applies via applyTextTransforms (titles, TOC, etc.)", () => {
     const result = applyTextTransforms("I love this thing")
     expect(result).toContain(NBSP)

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2297,6 +2297,16 @@ describe("Non-breaking space insertion", () => {
     expect(testHtmlFormattingImprovement(input)).toBe(input)
   })
 
+  it.each([
+    '<p class="subtitle">I love this</p>',
+    '<p class="subtitle">A cat sat on a mat</p>',
+    '<p class="subtitle">MATS 3.0, Steering GPT-2-XL by Adding an Activation Vector</p>',
+    '<p class="subtitle"><a href="/gpt2-steering-vectors">Steering GPT-2-XL by Adding an Activation Vector</a></p>',
+    '<p class="subtitle"><em>I love this</em></p>',
+  ])("does not insert nbsp in subtitles: %s", (input) => {
+    expect(testHtmlFormattingImprovement(input)).toBe(input)
+  })
+
   it("also applies via applyTextTransforms (titles, TOC, etc.)", () => {
     const result = applyTextTransforms("I love this thing")
     expect(result).toContain(NBSP)


### PR DESCRIPTION
## Summary

- Subtitles and admonition titles are display headings: tight, balanced wrap, often with paper titles or links.
- Punctilio's nbsp transforms (widow prevention + short-word glue) accumulate inside them and make them brittle on narrow viewports. The team-shard page made this visible — Lisa Thiergart's subtitle rendered as `Steering GPT-2-XL by Adding an Activation Vector` (two consecutive 2-word non-breaking atoms inside a single link).
- Headings (`h1`–`h6`) already skip nbsp via the same code path; this extends that exemption.

## Changes

- `quartz/plugins/transformers/formatting_improvement_html.ts`: add `isDisplayHeading` predicate (matches `h1`–`h6`, `<p class="subtitle">`, and `<div class="admonition-title">`); use it instead of `isHeading` in the nbsp-skip site. Other text transforms (quotes, dashes, smallcaps, primes, symbols) still apply.
- `config/quartz/quartz.config.ts`: move `rehypeCustomSubtitle()` *before* `HTMLFormattingImprovement()` so the `subtitle` class exists when nbsp processing runs. (For admonition titles, OFM already sets the class in the markdown→hast phase.)
- Tests: 8 new cases covering both predicate matches and the `hasAncestor` path (links inside subtitles, `admonition-title-inner` nested inside `admonition-title`).

## Why not a punctilio-side change

The existing cascade-block in `nbspBeforeLastWord` only blocks 3-word non-breaking atoms — it doesn't model atom *density*. Two discrete 2-word atoms in one tight subtitle are individually legal but collectively brittle. Fixing that punctilio-side would require an atom-budget heuristic that'd also affect body prose. Display-context opt-out is the cleaner knob.

## Testing

- `pnpm test -- --testPathPattern formatting_improvement_html` — all 579 tests pass; `formatting_improvement_html.ts` at 100% coverage.
- `pnpm check` — typecheck + prettier + stylelint clean.
- Visual baselines will need approval for any subtitle/admonition-title text whose wrapping shifts (expected — that's the whole point of the change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KZWhaPTm2iv3GkBimFvWFS)_