### PR TITLE
fix(toc): make mobile TOC anchors reliably tappable

### DIFF
--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -115,4 +115,15 @@
   & a:visited * {
     color: var(--foreground);
   }
+
+  // The parent <ol> has a negative `text-indent` (hanging indent for wrapped
+  // lines), which renders an inline <a>'s first line outside its layout box.
+  // Touch on the visible glyphs fires touchstart/end on <a>, but the synthesized
+  // click event dispatches to <li> (the element at the precise tap pixel inside
+  // the layout box). The SPA router's `target.closest("a")` then returns null
+  // and the tap is silently dropped. Making <a> block-level expands its layout
+  // box to fill the <li>, so the click event lands on <a>.
+  & li > a {
+    display: block;
+  }
 }

--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -328,25 +328,35 @@ test.describe("Table of contents", () => {
   test("Mobile TOC: tapping a narrow entry navigates", async ({ page }) => {
     test.skip(isDesktopViewport(page))
 
-    // Regression: a negative `text-indent` on the TOC <ol> renders an inline
-    // <a>'s first-line glyphs outside its layout box. On touch devices the
-    // synthesized `click` then dispatches to the parent <li> instead of <a>,
-    // and the SPA router's `target.closest("a")` returns null — the tap is
-    // silently swallowed. Making the <a> block-level keeps the click event on
-    // <a>, so tapping anywhere inside the row navigates.
-    const narrowLink = page
-      .locator("#toc-content-mobile a")
-      .filter({ hasText: /^Lists$/ })
-      .first()
-    await expect(narrowLink).toBeVisible()
-    const box = await narrowLink.boundingBox()
-    if (!box) throw new Error("Could not measure narrow TOC link bounding box")
+    // The narrowest top-level entry is the worst case: the parent <ol>'s
+    // negative `text-indent` renders the inline <a>'s glyphs furthest outside
+    // its layout box, so a tap near the visible left edge is most likely to
+    // miss the <a> and land on <li>.
+    const target = await page.evaluate(() => {
+      const links = Array.from(
+        document.querySelectorAll<HTMLAnchorElement>("#toc-content-mobile > ol > li > a"),
+      )
+      let narrowest: { hash: string; x: number; y: number; height: number; width: number } | null =
+        null
+      for (const a of links) {
+        const r = a.getBoundingClientRect()
+        if (!narrowest || r.width < narrowest.width) {
+          narrowest = {
+            hash: a.getAttribute("href") ?? "",
+            x: r.x,
+            y: r.y,
+            height: r.height,
+            width: r.width,
+          }
+        }
+      }
+      return narrowest
+    })
+    if (!target) throw new Error("No top-level mobile TOC entries found")
 
-    // Tap a few pixels inside the left edge of the link — the worst case for
-    // the regression, where the visible glyph sits outside the <a>'s box.
-    await page.touchscreen.tap(box.x + 3, box.y + box.height / 2)
-    await expect.poll(() => page.evaluate(() => location.hash)).toBe("#lists")
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+    // Tap a few pixels inside the left edge — the regression's failure zone.
+    await page.touchscreen.tap(target.x + 3, target.y + target.height / 2)
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe(target.hash)
   })
 
   test("Scrolling down changes TOC highlight", async ({ page }) => {

--- a/quartz/components/tests/test-page.spec.ts
+++ b/quartz/components/tests/test-page.spec.ts
@@ -325,6 +325,30 @@ test.describe("Table of contents", () => {
     })
   })
 
+  test("Mobile TOC: tapping a narrow entry navigates", async ({ page }) => {
+    test.skip(isDesktopViewport(page))
+
+    // Regression: a negative `text-indent` on the TOC <ol> renders an inline
+    // <a>'s first-line glyphs outside its layout box. On touch devices the
+    // synthesized `click` then dispatches to the parent <li> instead of <a>,
+    // and the SPA router's `target.closest("a")` returns null — the tap is
+    // silently swallowed. Making the <a> block-level keeps the click event on
+    // <a>, so tapping anywhere inside the row navigates.
+    const narrowLink = page
+      .locator("#toc-content-mobile a")
+      .filter({ hasText: /^Lists$/ })
+      .first()
+    await expect(narrowLink).toBeVisible()
+    const box = await narrowLink.boundingBox()
+    if (!box) throw new Error("Could not measure narrow TOC link bounding box")
+
+    // Tap a few pixels inside the left edge of the link — the worst case for
+    // the regression, where the visible glyph sits outside the <a>'s box.
+    await page.touchscreen.tap(box.x + 3, box.y + box.height / 2)
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe("#lists")
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  })
+
   test("Scrolling down changes TOC highlight", async ({ page }) => {
     test.skip(!isDesktopViewport(page))
 


### PR DESCRIPTION
## Summary

- On `/test-page` (and any page with short TOC headings), tapping mobile TOC entries silently fails on Brave/Chrome Android. `/design` mostly avoids it because its long, wrapping entries give a much bigger reliable hit zone.
- Root cause: the parent `<ol>` has `text-indent: calc(-0.75 * $base-margin)` for a hanging indent on wrapped lines. That shifts an inline `<a>`'s first-line glyphs **outside** its layout box. Touch events fire on `<a>` correctly, but the synthesized `click` dispatches to `<li>` (the element at the precise tap pixel inside the layout box). The SPA router's `target.closest("a")` returns `null` and the tap is silently dropped — the user sees nothing happen.
- Fix: make the mobile TOC `<a>` `display: block` so its layout box fills the `<li>`. The click event then lands on `<a>` no matter where in the row the user taps. Hanging indent is preserved (text-indent still applies to the first line inside the block).

## Changes

- `quartz/components/styles/toc.scss`: add `display: block` to `#center-content #toc-content-mobile li > a`, scoped to mobile only.
- `quartz/components/tests/test-page.spec.ts`: new Playwright regression that picks the narrowest top-level mobile TOC entry dynamically and taps 3px from its left edge, asserting the URL hash updates to the entry's `href`. Without the fix, the click event targets `<li>` and the assertion fails.

## Testing

- Reproduced on the live site via Playwright (Pixel 7 emulation) using `page.touchscreen.tap()`. Confirmed: tapping at offsets 0-12px from "Lists"' visible left edge fires touch events on `<a>` but `click` on `<li>`; offsets ≥13px hit `<a>`. With the fix, every offset hits `<a>` and navigation succeeds.
- Compared before/after screenshots of the mobile TOC at the same viewport — visually unchanged.
- `pnpm check` clean (TypeScript, Prettier, stylelint).
- Pre-push hooks (lint-staged, pylint, asset upload, alt-text scan) clean.

## Lessons Learned

- **What**: When a negative `text-indent` shifts an inline element's rendered glyphs outside the element's layout box, touch events fire on the element but the synthesized `click` event can dispatch to the parent at the precise tap coordinate. Any router/handler doing `event.target.closest("...")` will then miss. Prefer `display: block` (or `inline-block`) for tap targets sitting inside a hanging-indent context.
- **Where**: Any codebase using `text-indent: -X` on a list with clickable child anchors. Especially relevant on mobile where tap precision is lower and the click-vs-touch divergence is more visible.
- **Why**: Discovered while debugging "TOC clicks don't work on mobile until I tap 5 times" — the failure is silent and non-deterministic from the user's perspective, but completely deterministic given the layout. Worth checking touch hit-test parity in any future component that uses hanging indents.

https://claude.ai/code/session_01N9AcA3LShoWd8x3oaiGyjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9AcA3LShoWd8x3oaiGyjE)_