### PR TITLE
fix: improve error handling, type safety, and performance in transformers

### DIFF
--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -39,6 +39,8 @@ interface Item extends DocumentData {
 let currentSearchTerm = ""
 let searchLayout: HTMLElement | null = null
 
+const NBSP_REGEX = new RegExp(NBSP, "gu")
+
 const documentType = FlexSearch.Document<DocumentData>
 let index: InstanceType<typeof documentType> | null = null
 let searchInitialized = false
@@ -276,7 +278,7 @@ export function syncSearchLayoutState() {
 }
 
 /**
- * matchs search terms within HTML content while preserving HTML structure
+ * Matches search terms within HTML content while preserving HTML structure.
  * @param node - HTML element to search within
  * @param term - Term to match
  */
@@ -294,7 +296,7 @@ export const matchTextNodes = (node: Node, term: string) => {
     const nodeText = node.nodeValue ?? ""
     // Normalize NBSP to regular space so multi-word search terms
     // match across non-breaking spaces inserted by punctilio
-    const normalizedText = nodeText.replace(new RegExp(NBSP, "gu"), " ")
+    const normalizedText = nodeText.replace(NBSP_REGEX, " ")
     const sanitizedTerm = RegExp.escape(term)
     const regex = new RegExp(`(${sanitizedTerm})`, "gi")
 

--- a/quartz/plugins/transformers/countFavicons.ts
+++ b/quartz/plugins/transformers/countFavicons.ts
@@ -76,8 +76,8 @@ function getFaviconPathForLink(url: string): string | null {
     const faviconPath = getQuartzPath(hostname)
     // Strip extension for counting (counts are format-agnostic)
     return normalizePathForCounting(faviconPath)
-  } catch {
-    // Invalid URL, skip
+  } catch (error) {
+    logger.debug(`Skipping invalid URL "${url}": ${error}`)
     return null
   }
 }

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -11,6 +11,7 @@ import {
   specialFaviconPaths,
   defaultPath,
   cdnBaseUrl,
+  HEADING_TAGS,
 } from "../../components/constants"
 import { faviconCountsFile } from "../../components/constants.server"
 import {
@@ -61,8 +62,13 @@ export function normalizePathForCounting(faviconPath: string): string {
 export async function readFaviconCounts(): Promise<ReadonlyMap<string, number>> {
   try {
     await fs.promises.access(faviconCountsFile, fs.constants.F_OK)
-  } catch {
-    logger.warn(`Favicon counts file not found at ${faviconCountsFile}`)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT") {
+      logger.warn(`Favicon counts file not found at ${faviconCountsFile}`)
+    } else {
+      logger.error(`Cannot access favicon counts file at ${faviconCountsFile}: ${error}`)
+    }
     return new Map<string, number>()
   }
 
@@ -237,9 +243,9 @@ export const tagsToZoomInto = ["code", "em", "strong", "i", "b", "del", "s", "in
  */
 export function maybeSpliceText(node: Element, imgNodeToAppend: FaviconNode): Element | null {
   const isEmpty = (child: Element | Text) => child.type === "text" && child.value?.trim() === ""
-  const lastChild = [...node.children]
-    .reverse()
-    .find((child) => child.type === "element" || !isEmpty(child as Element | Text))
+  const lastChild = node.children.findLast(
+    (child) => child.type === "element" || !isEmpty(child as Element | Text),
+  )
 
   if (!lastChild) {
     return createNowrapSpan("", imgNodeToAppend)
@@ -284,7 +290,7 @@ function handleMailtoLink(node: Element): void {
 
 // skipcq: JS-D1001
 export function isHeading(node: Element): boolean {
-  return Boolean(node.tagName?.match(/^h[1-6]$/))
+  return HEADING_TAGS.has(node.tagName)
 }
 
 function handleSamePageLink(node: Element, href: string, parent: Parent): boolean {

--- a/quartz/plugins/transformers/trout_hr.ts
+++ b/quartz/plugins/transformers/trout_hr.ts
@@ -69,20 +69,25 @@ export function maybeInsertOrnament(
     Array.isArray(node.properties?.className) &&
     node.properties.className.includes("footnotes")
   ) {
-    const prevElement = parent.children[index - 1]
-    const prevPrevElement = parent.children[index - 2]
-    if (
-      index > 1 &&
-      prevElement?.type === "text" &&
-      prevElement.value === "\n" &&
-      prevPrevElement?.type === "element" &&
-      prevPrevElement.tagName === "hr"
-    ) {
-      parent.children.splice(index - 2, 1)
-      index--
-    } else if (index > 0 && prevElement?.type === "element" && prevElement.tagName === "hr") {
-      parent.children.splice(index - 1, 1)
-      index--
+    if (index > 1) {
+      const prevElement = parent.children[index - 1]
+      const prevPrevElement = parent.children[index - 2]
+      if (
+        prevElement?.type === "text" &&
+        prevElement.value === "\n" &&
+        prevPrevElement?.type === "element" &&
+        prevPrevElement.tagName === "hr"
+      ) {
+        parent.children.splice(index - 2, 1)
+        index--
+      }
+    }
+    if (index > 0 && parent.children[index - 1]?.type === "element") {
+      const prevElement = parent.children[index - 1] as Element
+      if (prevElement.tagName === "hr") {
+        parent.children.splice(index - 1, 1)
+        index--
+      }
     }
 
     // If it is, insert the ornament node before the footnotes section

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -76,57 +76,43 @@ function isElement(node: Parent): node is Element {
 }
 
 /**
- * Determines if a video node should be skipped based on its tag name and parent class.
- *
- * @param videoNode The video element to check.
- * @param ancestors The list of ancestor Parent nodes, where the last element is the direct parent.
- * @param wrapperClassName The class name of the wrapper span to check for.
+ * Creates a skip predicate for media elements (video/audio) that checks
+ * whether the element matches the expected tag and isn't already wrapped.
  */
-function skipNodeForVideo(
-  videoNode: Element,
-  ancestors: Parent[],
-  wrapperClassName: string,
-): boolean {
-  const notVideo = videoNode.tagName !== "video"
-  const directParent = ancestors[ancestors.length - 1]
-  const inVideoContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
-  return notVideo || inVideoContainer
+function createMediaSkipPredicate(expectedTag: string) {
+  return (node: Element, ancestors: Parent[], wrapperClassName: string): boolean => {
+    if (node.tagName !== expectedTag) return true
+    const directParent = ancestors[ancestors.length - 1]
+    return isElement(directParent) && hasClass(directParent, wrapperClassName)
+  }
 }
 
+const skipNodeForVideo = createMediaSkipPredicate("video")
+const skipNodeForAudio = createMediaSkipPredicate("audio")
+
 /**
- * Wraps a video node in a <span class="video-container"> if it is not already in one.
+ * Wraps a media node in a container span if it is not already in one.
  * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
  */
+function wrapMediaElement(
+  node: Element,
+  ancestors: Parent[],
+  expectedTag: string,
+  containerClass: string,
+  skipPredicate: (node: Element, ancestors: Parent[], wrapperClassName: string) => boolean,
+): void {
+  if (node.tagName !== expectedTag) return
+  const dataSrc = getMediaSrc(node)
+  const props = dataSrc ? { "data-src": dataSrc } : {}
+  wrapElement(node, ancestors, skipPredicate, "span", containerClass, props)
+}
+
 function wrapVideo(videoNode: Element, ancestors: Parent[]): void {
-  if (videoNode.tagName !== "video") return
-  const dataSrc = getMediaSrc(videoNode)
-  const props = dataSrc ? { "data-src": dataSrc } : {}
-  wrapElement(videoNode, ancestors, skipNodeForVideo, "span", "video-container", props)
+  wrapMediaElement(videoNode, ancestors, "video", "video-container", skipNodeForVideo)
 }
 
-/**
- * Determines if an audio node should be skipped based on its tag name and parent class.
- */
-function skipNodeForAudio(
-  audioNode: Element,
-  ancestors: Parent[],
-  wrapperClassName: string,
-): boolean {
-  const notAudio = audioNode.tagName !== "audio"
-  const directParent = ancestors[ancestors.length - 1]
-  const inAudioContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
-  return notAudio || inAudioContainer
-}
-
-/**
- * Wraps an audio node in a <span class="audio-container"> if it is not already in one.
- * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
- */
 function wrapAudio(audioNode: Element, ancestors: Parent[]): void {
-  if (audioNode.tagName !== "audio") return
-  const dataSrc = getMediaSrc(audioNode)
-  const props = dataSrc ? { "data-src": dataSrc } : {}
-  wrapElement(audioNode, ancestors, skipNodeForAudio, "span", "audio-container", props)
+  wrapMediaElement(audioNode, ancestors, "audio", "audio-container", skipNodeForAudio)
 }
 
 /**

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -76,43 +76,57 @@ function isElement(node: Parent): node is Element {
 }
 
 /**
- * Creates a skip predicate for media elements (video/audio) that checks
- * whether the element matches the expected tag and isn't already wrapped.
+ * Determines if a video node should be skipped based on its tag name and parent class.
+ *
+ * @param videoNode The video element to check.
+ * @param ancestors The list of ancestor Parent nodes, where the last element is the direct parent.
+ * @param wrapperClassName The class name of the wrapper span to check for.
  */
-function createMediaSkipPredicate(expectedTag: string) {
-  return (node: Element, ancestors: Parent[], wrapperClassName: string): boolean => {
-    if (node.tagName !== expectedTag) return true
-    const directParent = ancestors[ancestors.length - 1]
-    return isElement(directParent) && hasClass(directParent, wrapperClassName)
-  }
+function skipNodeForVideo(
+  videoNode: Element,
+  ancestors: Parent[],
+  wrapperClassName: string,
+): boolean {
+  const notVideo = videoNode.tagName !== "video"
+  const directParent = ancestors[ancestors.length - 1]
+  const inVideoContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
+  return notVideo || inVideoContainer
 }
-
-const skipNodeForVideo = createMediaSkipPredicate("video")
-const skipNodeForAudio = createMediaSkipPredicate("audio")
 
 /**
- * Wraps a media node in a container span if it is not already in one.
+ * Wraps a video node in a <span class="video-container"> if it is not already in one.
  * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
  */
-function wrapMediaElement(
-  node: Element,
-  ancestors: Parent[],
-  expectedTag: string,
-  containerClass: string,
-  skipPredicate: (node: Element, ancestors: Parent[], wrapperClassName: string) => boolean,
-): void {
-  if (node.tagName !== expectedTag) return
-  const dataSrc = getMediaSrc(node)
-  const props = dataSrc ? { "data-src": dataSrc } : {}
-  wrapElement(node, ancestors, skipPredicate, "span", containerClass, props)
-}
-
 function wrapVideo(videoNode: Element, ancestors: Parent[]): void {
-  wrapMediaElement(videoNode, ancestors, "video", "video-container", skipNodeForVideo)
+  if (videoNode.tagName !== "video") return
+  const dataSrc = getMediaSrc(videoNode)
+  const props = dataSrc ? { "data-src": dataSrc } : {}
+  wrapElement(videoNode, ancestors, skipNodeForVideo, "span", "video-container", props)
 }
 
+/**
+ * Determines if an audio node should be skipped based on its tag name and parent class.
+ */
+function skipNodeForAudio(
+  audioNode: Element,
+  ancestors: Parent[],
+  wrapperClassName: string,
+): boolean {
+  const notAudio = audioNode.tagName !== "audio"
+  const directParent = ancestors[ancestors.length - 1]
+  const inAudioContainer = isElement(directParent) && hasClass(directParent, wrapperClassName)
+  return notAudio || inAudioContainer
+}
+
+/**
+ * Wraps an audio node in a <span class="audio-container"> if it is not already in one.
+ * Sets `data-src` on the wrapper so the print stylesheet can display the URL.
+ */
 function wrapAudio(audioNode: Element, ancestors: Parent[]): void {
-  wrapMediaElement(audioNode, ancestors, "audio", "audio-container", skipNodeForAudio)
+  if (audioNode.tagName !== "audio") return
+  const dataSrc = getMediaSrc(audioNode)
+  const props = dataSrc ? { "data-src": dataSrc } : {}
+  wrapElement(audioNode, ancestors, skipNodeForAudio, "span", "audio-container", props)
 }
 
 /**


### PR DESCRIPTION
## Summary\n\n- Fix potential undefined dereferences, silent error swallowing, and minor performance issues across transformer plugins\n- Targeted fixes only — no unnecessary refactoring or abstraction\n\n## Changes\n\n- **trout_hr.ts**: Move array accesses (`parent.children[index - 1]`, `parent.children[index - 2]`) inside bounds checks to prevent accessing undefined indices; restructure conditional to correctly handle both hr+newline and standalone hr cases before footnotes\n- **favicons.ts**: Distinguish ENOENT from permission/other errors in `readFaviconCounts()` catch block (warn vs error); replace regex-based `isHeading()` with O(1) `HEADING_TAGS.has()` lookup; use `Array.findLast()` instead of spread+reverse+find\n- **countFavicons.ts**: Log invalid URLs at debug level instead of silently swallowing in empty catch block\n- **search.ts**: Hoist NBSP regex to module scope to avoid re-creation per text node during search highlighting; fix typo in JSDoc comment\n\n## Testing\n\n- All 3752 Jest tests pass\n- All 1934 Python tests pass\n- TypeScript type checking passes\n- Prettier formatting passes\n- ESLint passes\n- Pre-push checks all green\n\nhttps://claude.ai/code/session_014RiUCMKmzVsBFibhqSXpDK

---
_Generated by [Claude Code](https://claude.ai/code/session_014RiUCMKmzVsBFibhqSXpDK)_