### PR TITLE
test(search): target [!note] admonition for card-preview icon assertion

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -1002,7 +1002,11 @@ test("admonition icon renders in focused mobile card preview (screenshot)", asyn
   const article = cardPreview.locator("article.search-preview")
   await expect(article).toBeAttached({ timeout: 10_000 })
 
-  const admonitionTitle = cardPreview.locator(".admonition-title").first()
+  // Target the [!note] admonition explicitly. The mobile TOC blockquote is
+  // also an admonition but `toc.scss` hides it inside `.search-preview`, so
+  // `.admonition-title.first()` would land on a `display: none` element with
+  // a zero bounding box.
+  const admonitionTitle = cardPreview.locator('[data-admonition="note"] .admonition-title')
   const icon = admonitionTitle.locator(".admonition-icon")
   await expect(icon).toBeAttached()
 


### PR DESCRIPTION
The previous locator `cardPreview.locator(".admonition-title").first()`
matched the mobile TOC blockquote, which `toc.scss` hides inside
`.search-preview` via `display: none`. That made `boundingBox()` return
null on iPad Pro / iPhone 12 and failed the `toBeGreaterThan(0)` check.

Target the `[!note]` fixture admonition explicitly so the bounding-box
assertion runs against a visible element.