### PR TITLE
feat(transformers): auto-wrap library names in inline code

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -4,6 +4,7 @@ import {
   AliasRedirects,
   AllTagsPage,
   Assets,
+  AutoCode,
   Bibtex,
   CrawlLinks,
   CreatedModifiedDate,
@@ -115,6 +116,7 @@ const config: QuartzConfig = {
       CrawlLinks({ lazyLoad: true, markdownLinkResolution: "shortest" }),
       rehypeCustomSpoiler(),
       TagSmallcaps(),
+      AutoCode(),
       AfterArticle(),
       AddFavicons(),
       // After AddFavicons because favicon insertion can rewrite link

--- a/quartz/plugins/transformers/autoCode.ts
+++ b/quartz/plugins/transformers/autoCode.ts
@@ -60,8 +60,7 @@ const SKIP_ANCESTOR_TAGS: ReadonlySet<string> = new Set([
 
 export function isInSkippedAncestor(ancestors: readonly Parent[]): boolean {
   return ancestors.some(
-    (anc) =>
-      anc.type === "element" && SKIP_ANCESTOR_TAGS.has((anc as Element).tagName),
+    (anc) => anc.type === "element" && SKIP_ANCESTOR_TAGS.has((anc as Element).tagName),
   )
 }
 

--- a/quartz/plugins/transformers/autoCode.ts
+++ b/quartz/plugins/transformers/autoCode.ts
@@ -1,0 +1,94 @@
+import type { Element, Node, Parent, Text } from "hast"
+import type { Plugin } from "unified"
+
+import escapeStringRegexp from "escape-string-regexp"
+// skipcq: JS-0257
+import { visitParents } from "unist-util-visit-parents"
+
+import type { QuartzTransformerPlugin } from "../types"
+
+import { isCode, replaceRegex } from "./utils"
+
+// Library / tool names that should auto-format as inline <code> in prose.
+// Lowercase-only so sentence-initial proper-noun uses ("Punctilio handles…")
+// keep their capital-letter signal instead of being rewrapped.
+export const codeTerms: readonly string[] = [
+  "punctilio",
+  "subfont",
+  "smartypants",
+  "retext-smartypants",
+  "tipograph",
+  "smartquotes",
+  "typograf",
+  "retext",
+  "pylint",
+  "eslint",
+  "mypy",
+  "linkchecker",
+  "docformatter",
+  "micromorph",
+  "lint-staged",
+  "playwright",
+  "stylelint",
+  "markdownlint",
+  "prettier",
+  "pnpm",
+  "vale",
+]
+
+// Sort by length DESC so "retext-smartypants" matches before "retext"
+// (regex alternation is left-to-right; without this, "retext" would win
+// and leave "-smartypants" dangling).
+const sortedTerms = [...codeTerms].sort((a, b) => b.length - a.length)
+const termsPattern = sortedTerms.map(escapeStringRegexp).join("|")
+
+// Treat hyphen as a word character on both sides so "subfont" doesn't fire
+// inside "subfontextra" and "retext-smartypants" doesn't run into an
+// adjacent hyphenated word.
+export const CODE_TERM_REGEX = new RegExp(
+  `(?<![\\w-])(?:${termsPattern})(?![\\w-])`,
+  "g",
+)
+
+export function isInsideCode(ancestors: readonly Parent[]): boolean {
+  return ancestors.some(
+    (anc) => anc.type === "element" && isCode(anc as Element),
+  )
+}
+
+/**
+ * Rehype plugin that wraps the curated `codeTerms` in `<code>` whenever they
+ * appear bare in prose. Skips matches inside an existing `<code>` ancestor.
+ */
+export const rehypeAutoCode: Plugin = () => {
+  return (tree: Node) => {
+    visitParents(tree, "text", (node: Text, ancestors: Parent[]) => {
+      if (isInsideCode(ancestors)) return
+      const parent = ancestors[ancestors.length - 1]
+      const index = parent.children.indexOf(node)
+      // istanbul ignore if -- visitParents always passes a real parent/child
+      if (index === -1) return
+      replaceRegex(
+        node,
+        index,
+        parent,
+        CODE_TERM_REGEX,
+        (match) => ({
+          before: "",
+          replacedMatch: match[0],
+          after: "",
+        }),
+        undefined,
+        "code",
+      )
+    })
+  }
+}
+
+// istanbul ignore next
+export const AutoCode: QuartzTransformerPlugin = () => ({
+  name: "AutoCode",
+  htmlPlugins() {
+    return [rehypeAutoCode]
+  },
+})

--- a/quartz/plugins/transformers/autoCode.ts
+++ b/quartz/plugins/transformers/autoCode.ts
@@ -2,12 +2,11 @@ import type { Element, Node, Parent, Text } from "hast"
 import type { Plugin } from "unified"
 
 import escapeStringRegexp from "escape-string-regexp"
-// skipcq: JS-0257
 import { visitParents } from "unist-util-visit-parents"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-import { isCode, replaceRegex } from "./utils"
+import { replaceRegex } from "./utils"
 
 // Library / tool names that should auto-format as inline <code> in prose.
 // Lowercase-only so sentence-initial proper-noun uses ("Punctilio handles…")
@@ -47,18 +46,34 @@ const termsPattern = sortedTerms.map(escapeStringRegexp).join("|")
 // adjacent hyphenated word.
 export const CODE_TERM_REGEX = new RegExp(`(?<![\\w-])(?:${termsPattern})(?![\\w-])`, "g")
 
-export function isInsideCode(ancestors: readonly Parent[]): boolean {
-  return ancestors.some((anc) => anc.type === "element" && isCode(anc as Element))
+// Tags whose text contents either ARE code (so re-wrapping is redundant) or
+// shouldn't render as monospace (smallcaps <abbr>, raw CSS/JS in <style>/
+// <script>, keyboard glyphs in <kbd>).
+const SKIP_ANCESTOR_TAGS: ReadonlySet<string> = new Set([
+  "code",
+  "pre",
+  "abbr",
+  "kbd",
+  "style",
+  "script",
+])
+
+export function isInSkippedAncestor(ancestors: readonly Parent[]): boolean {
+  return ancestors.some(
+    (anc) =>
+      anc.type === "element" && SKIP_ANCESTOR_TAGS.has((anc as Element).tagName),
+  )
 }
 
 /**
  * Rehype plugin that wraps the curated `codeTerms` in `<code>` whenever they
- * appear bare in prose. Skips matches inside an existing `<code>` ancestor.
+ * appear bare in prose. Skips matches whose ancestry is already a code-like
+ * context (see `SKIP_ANCESTOR_TAGS`).
  */
 export const rehypeAutoCode: Plugin = () => {
   return (tree: Node) => {
     visitParents(tree, "text", (node: Text, ancestors: Parent[]) => {
-      if (isInsideCode(ancestors)) return
+      if (isInSkippedAncestor(ancestors)) return
       const parent = ancestors[ancestors.length - 1]
       const index = parent.children.indexOf(node)
       // istanbul ignore if -- visitParents always passes a real parent/child

--- a/quartz/plugins/transformers/autoCode.ts
+++ b/quartz/plugins/transformers/autoCode.ts
@@ -45,15 +45,10 @@ const termsPattern = sortedTerms.map(escapeStringRegexp).join("|")
 // Treat hyphen as a word character on both sides so "subfont" doesn't fire
 // inside "subfontextra" and "retext-smartypants" doesn't run into an
 // adjacent hyphenated word.
-export const CODE_TERM_REGEX = new RegExp(
-  `(?<![\\w-])(?:${termsPattern})(?![\\w-])`,
-  "g",
-)
+export const CODE_TERM_REGEX = new RegExp(`(?<![\\w-])(?:${termsPattern})(?![\\w-])`, "g")
 
 export function isInsideCode(ancestors: readonly Parent[]): boolean {
-  return ancestors.some(
-    (anc) => anc.type === "element" && isCode(anc as Element),
-  )
+  return ancestors.some((anc) => anc.type === "element" && isCode(anc as Element))
 }
 
 /**

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -12,6 +12,7 @@ export { AddFavicons } from "./favicons"
 export { countAllFavicons } from "./countFavicons"
 export { HardLineBreaks } from "./linebreaks"
 export { TagSmallcaps } from "./tagSmallcaps"
+export { AutoCode } from "./autoCode"
 export { TroutOrnamentHr } from "./trout_hr"
 export { TextFormattingImprovement } from "./formatting_improvement_text"
 export {

--- a/quartz/plugins/transformers/tests/autoCode.test.ts
+++ b/quartz/plugins/transformers/tests/autoCode.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals"
 import { rehype } from "rehype"
 
-import { CODE_TERM_REGEX, codeTerms, isInsideCode, rehypeAutoCode } from "../autoCode"
+import { CODE_TERM_REGEX, codeTerms, isInSkippedAncestor, rehypeAutoCode } from "../autoCode"
 
 function runAutoCode(inputHTML: string): string {
   return rehype()
@@ -33,6 +33,21 @@ describe("rehypeAutoCode", () => {
         "preserves surrounding whitespace and punctuation",
         "<p>(punctilio), really.</p>",
         "<p>(<code>punctilio</code>), really.</p>",
+      ],
+      [
+        "matches at the very start of a text node",
+        "<p>punctilio is great.</p>",
+        "<p><code>punctilio</code> is great.</p>",
+      ],
+      [
+        "matches consecutive terms separated by a single space",
+        "<p>pnpm vale runs everything.</p>",
+        "<p><code>pnpm</code> <code>vale</code> runs everything.</p>",
+      ],
+      [
+        "leaves a trailing apostrophe outside the wrap (possessive)",
+        "<p>punctilio's main feature.</p>",
+        "<p><code>punctilio</code>'s main feature.</p>",
       ],
     ])("%s", (_label, input, expected) => {
       expect(runAutoCode(input)).toBe(expected)
@@ -109,6 +124,19 @@ describe("rehypeAutoCode", () => {
       )
     })
 
+    it.each([
+      ["bare <pre>", "<pre>install punctilio</pre>"],
+      ["<kbd>", "<p>Type <kbd>punctilio</kbd> to begin.</p>"],
+      [
+        "<abbr class=\"small-caps\"> (TagSmallcaps output)",
+        '<p>Linter <abbr class="small-caps">eslint</abbr> ran.</p>',
+      ],
+      ["<style>", "<style>.punctilio { color: red; }</style>"],
+      ["<script>", "<script>var punctilio = 1;</script>"],
+    ])("does not transform inside %s", (_label, input) => {
+      expect(runAutoCode(input)).toBe(input)
+    })
+
     it("does transform inside <a> link text", () => {
       expect(runAutoCode('<p><a href="/x">punctilio</a> link</p>')).toBe(
         '<p><a href="/x"><code>punctilio</code></a> link</p>',
@@ -138,37 +166,41 @@ describe("rehypeAutoCode", () => {
     })
   })
 
-  describe("isInsideCode", () => {
+  describe("isInSkippedAncestor", () => {
     it("returns false for an empty ancestor list", () => {
-      expect(isInsideCode([])).toBe(false)
+      expect(isInSkippedAncestor([])).toBe(false)
     })
 
-    it("returns true when any ancestor is a <code> element", () => {
-      const codeAncestor = {
-        type: "element",
-        tagName: "code",
-        properties: {},
-        children: [],
-      } as never
-      expect(isInsideCode([codeAncestor])).toBe(true)
-    })
+    it.each(["code", "pre", "abbr", "kbd", "style", "script"])(
+      "returns true when an ancestor is <%s>",
+      (tagName) => {
+        const ancestor = {
+          type: "element",
+          tagName,
+          properties: {},
+          children: [],
+        } as never
+        expect(isInSkippedAncestor([ancestor])).toBe(true)
+      },
+    )
 
     it("returns false for non-element ancestors", () => {
       const rootAncestor = { type: "root", children: [] } as never
-      expect(isInsideCode([rootAncestor])).toBe(false)
+      expect(isInSkippedAncestor([rootAncestor])).toBe(false)
+    })
+
+    it("returns false for an unrelated element", () => {
+      const span = {
+        type: "element",
+        tagName: "span",
+        properties: {},
+        children: [],
+      } as never
+      expect(isInSkippedAncestor([span])).toBe(false)
     })
   })
 
   describe("regex / term list invariants", () => {
-    it("includes all curated terms", () => {
-      // Sanity guard: if someone reorders or accidentally drops a term, this
-      // catches it before the live transformer silently stops wrapping.
-      expect(codeTerms).toContain("punctilio")
-      expect(codeTerms).toContain("retext-smartypants")
-      expect(codeTerms).toContain("vale")
-      expect(codeTerms.length).toBeGreaterThanOrEqual(21)
-    })
-
     it("matches every curated term in plain prose", () => {
       for (const term of codeTerms) {
         CODE_TERM_REGEX.lastIndex = 0

--- a/quartz/plugins/transformers/tests/autoCode.test.ts
+++ b/quartz/plugins/transformers/tests/autoCode.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "@jest/globals"
 import { rehype } from "rehype"
 
-import {
-  CODE_TERM_REGEX,
-  codeTerms,
-  isInsideCode,
-  rehypeAutoCode,
-} from "../autoCode"
+import { CODE_TERM_REGEX, codeTerms, isInsideCode, rehypeAutoCode } from "../autoCode"
 
 function runAutoCode(inputHTML: string): string {
   return rehype()
@@ -109,9 +104,9 @@ describe("rehypeAutoCode", () => {
     })
 
     it("does not transform inside <pre><code>", () => {
-      expect(
-        runAutoCode("<pre><code>install punctilio here</code></pre>"),
-      ).toBe("<pre><code>install punctilio here</code></pre>")
+      expect(runAutoCode("<pre><code>install punctilio here</code></pre>")).toBe(
+        "<pre><code>install punctilio here</code></pre>",
+      )
     })
 
     it("does transform inside <a> link text", () => {
@@ -127,9 +122,7 @@ describe("rehypeAutoCode", () => {
     })
 
     it("does transform inside <em> and <strong>", () => {
-      expect(
-        runAutoCode("<p><strong>punctilio</strong> and <em>subfont</em></p>"),
-      ).toBe(
+      expect(runAutoCode("<p><strong>punctilio</strong> and <em>subfont</em></p>")).toBe(
         "<p><strong><code>punctilio</code></strong> and <em><code>subfont</code></em></p>",
       )
     })

--- a/quartz/plugins/transformers/tests/autoCode.test.ts
+++ b/quartz/plugins/transformers/tests/autoCode.test.ts
@@ -128,7 +128,7 @@ describe("rehypeAutoCode", () => {
       ["bare <pre>", "<pre>install punctilio</pre>"],
       ["<kbd>", "<p>Type <kbd>punctilio</kbd> to begin.</p>"],
       [
-        "<abbr class=\"small-caps\"> (TagSmallcaps output)",
+        '<abbr class="small-caps"> (TagSmallcaps output)',
         '<p>Linter <abbr class="small-caps">eslint</abbr> ran.</p>',
       ],
       ["<style>", "<style>.punctilio { color: red; }</style>"],

--- a/quartz/plugins/transformers/tests/autoCode.test.ts
+++ b/quartz/plugins/transformers/tests/autoCode.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "@jest/globals"
+import { rehype } from "rehype"
+
+import {
+  CODE_TERM_REGEX,
+  codeTerms,
+  isInsideCode,
+  rehypeAutoCode,
+} from "../autoCode"
+
+function runAutoCode(inputHTML: string): string {
+  return rehype()
+    .data("settings", { fragment: true })
+    .use(rehypeAutoCode)
+    .processSync(inputHTML)
+    .toString()
+}
+
+describe("rehypeAutoCode", () => {
+  describe("basic matching", () => {
+    it.each([
+      [
+        "wraps a single term in <code>",
+        "<p>Use punctilio for typography.</p>",
+        "<p>Use <code>punctilio</code> for typography.</p>",
+      ],
+      [
+        "wraps multiple terms in one paragraph",
+        "<p>Use punctilio and subfont together.</p>",
+        "<p>Use <code>punctilio</code> and <code>subfont</code> together.</p>",
+      ],
+      [
+        "wraps the same term twice",
+        "<p>punctilio is great. punctilio is fast.</p>",
+        "<p><code>punctilio</code> is great. <code>punctilio</code> is fast.</p>",
+      ],
+      [
+        "preserves surrounding whitespace and punctuation",
+        "<p>(punctilio), really.</p>",
+        "<p>(<code>punctilio</code>), really.</p>",
+      ],
+    ])("%s", (_label, input, expected) => {
+      expect(runAutoCode(input)).toBe(expected)
+    })
+  })
+
+  describe("longest-first matching", () => {
+    it("matches retext-smartypants as a single unit, not retext + -smartypants", () => {
+      expect(runAutoCode("<p>I use retext-smartypants.</p>")).toBe(
+        "<p>I use <code>retext-smartypants</code>.</p>",
+      )
+    })
+
+    it("still matches bare retext on its own", () => {
+      expect(runAutoCode("<p>retext is the parent project.</p>")).toBe(
+        "<p><code>retext</code> is the parent project.</p>",
+      )
+    })
+
+    it("matches lint-staged as a hyphenated unit", () => {
+      expect(runAutoCode("<p>The lint-staged hook runs.</p>")).toBe(
+        "<p>The <code>lint-staged</code> hook runs.</p>",
+      )
+    })
+  })
+
+  describe("word boundary respect", () => {
+    it.each([
+      [
+        "no match inside a longer alphanum word",
+        "<p>The punctilios library is fake.</p>",
+        "<p>The punctilios library is fake.</p>",
+      ],
+      [
+        "no match when prefixed by alphanum",
+        "<p>Some xpunctilio thing.</p>",
+        "<p>Some xpunctilio thing.</p>",
+      ],
+      [
+        "no match when surrounded by hyphens (compound token)",
+        "<p>foo-punctilio-bar</p>",
+        "<p>foo-punctilio-bar</p>",
+      ],
+      [
+        "matches when surrounded by sentence punctuation",
+        "<p>foo, punctilio. Bar.</p>",
+        "<p>foo, <code>punctilio</code>. Bar.</p>",
+      ],
+    ])("%s", (_label, input, expected) => {
+      expect(runAutoCode(input)).toBe(expected)
+    })
+  })
+
+  describe("case sensitivity", () => {
+    it.each([
+      ["Punctilio (sentence-start)", "<p>Punctilio is great.</p>"],
+      ["PUNCTILIO (uppercase)", "<p>PUNCTILIO is great.</p>"],
+      ["Subfont (Title Case)", "<p>Subfont saves bytes.</p>"],
+    ])("does not match %s", (_label, input) => {
+      expect(runAutoCode(input)).toBe(input)
+    })
+  })
+
+  describe("skip rules", () => {
+    it("does not transform inside an existing <code>", () => {
+      expect(runAutoCode("<p>Already coded: <code>punctilio</code>.</p>")).toBe(
+        "<p>Already coded: <code>punctilio</code>.</p>",
+      )
+    })
+
+    it("does not transform inside <pre><code>", () => {
+      expect(
+        runAutoCode("<pre><code>install punctilio here</code></pre>"),
+      ).toBe("<pre><code>install punctilio here</code></pre>")
+    })
+
+    it("does transform inside <a> link text", () => {
+      expect(runAutoCode('<p><a href="/x">punctilio</a> link</p>')).toBe(
+        '<p><a href="/x"><code>punctilio</code></a> link</p>',
+      )
+    })
+
+    it("does transform inside headings", () => {
+      expect(runAutoCode("<h2>Use punctilio for typography</h2>")).toBe(
+        "<h2>Use <code>punctilio</code> for typography</h2>",
+      )
+    })
+
+    it("does transform inside <em> and <strong>", () => {
+      expect(
+        runAutoCode("<p><strong>punctilio</strong> and <em>subfont</em></p>"),
+      ).toBe(
+        "<p><strong><code>punctilio</code></strong> and <em><code>subfont</code></em></p>",
+      )
+    })
+  })
+
+  describe("HTML comments are not text nodes", () => {
+    it("ignores vale on/off comments around prose", () => {
+      // The comment is a comment node, not a text node — the visitor never
+      // sees it. The bare "vale" inside the comment is not transformed.
+      const input = "<p>Some prose. <!-- vale off --> more prose.</p>"
+      const output = runAutoCode(input)
+      expect(output).toBe(input)
+    })
+  })
+
+  describe("isInsideCode", () => {
+    it("returns false for an empty ancestor list", () => {
+      expect(isInsideCode([])).toBe(false)
+    })
+
+    it("returns true when any ancestor is a <code> element", () => {
+      const codeAncestor = {
+        type: "element",
+        tagName: "code",
+        properties: {},
+        children: [],
+      } as never
+      expect(isInsideCode([codeAncestor])).toBe(true)
+    })
+
+    it("returns false for non-element ancestors", () => {
+      const rootAncestor = { type: "root", children: [] } as never
+      expect(isInsideCode([rootAncestor])).toBe(false)
+    })
+  })
+
+  describe("regex / term list invariants", () => {
+    it("includes all curated terms", () => {
+      // Sanity guard: if someone reorders or accidentally drops a term, this
+      // catches it before the live transformer silently stops wrapping.
+      expect(codeTerms).toContain("punctilio")
+      expect(codeTerms).toContain("retext-smartypants")
+      expect(codeTerms).toContain("vale")
+      expect(codeTerms.length).toBeGreaterThanOrEqual(21)
+    })
+
+    it("matches every curated term in plain prose", () => {
+      for (const term of codeTerms) {
+        CODE_TERM_REGEX.lastIndex = 0
+        expect(CODE_TERM_REGEX.test(`use ${term} here`)).toBe(true)
+      }
+    })
+
+    it("does not match a curated term as a substring of a longer word", () => {
+      for (const term of codeTerms) {
+        CODE_TERM_REGEX.lastIndex = 0
+        expect(CODE_TERM_REGEX.test(`x${term}x`)).toBe(false)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a rehype transformer that auto-wraps a curated list of software library / tool names in inline `<code>` whenever they appear bare in prose. Goal: stop hand-formatting `` `punctilio` ``, `` `subfont` ``, etc. and let the pipeline enforce consistency.

## Changes

- **New transformer** `quartz/plugins/transformers/autoCode.ts`:
  - Curated `codeTerms` list of 21 names (`punctilio`, `subfont`, `smartypants`, `retext-smartypants`, `tipograph`, `smartquotes`, `typograf`, `retext`, `pylint`, `eslint`, `mypy`, `linkchecker`, `docformatter`, `micromorph`, `lint-staged`, `playwright`, `stylelint`, `markdownlint`, `prettier`, `pnpm`, `vale`).
  - Lowercase-only matching so sentence-initial proper-noun uses ("Punctilio handles…") keep their capital-letter signal.
  - Terms sorted by length DESC so `retext-smartypants` matches before `retext` (regex alternation is left-to-right).
  - Hyphen treated as a word character on both sides so `subfont` doesn't fire inside `subfontextra` and `retext-smartypants` doesn't run into adjacent hyphenated words.
  - Skip ancestors: `<code>`, `<pre>`, `<abbr>`, `<kbd>`, `<style>`, `<script>` — covers code-like contexts and prevents a double-wrap with `TagSmallcaps`, which lowercases acronyms inside `<abbr class="small-caps">`.
  - Transforms inside `<a>`, headings, `<em>`/`<strong>` per spec.
- **Pipeline registration** in `config/quartz/quartz.config.ts` immediately after `TagSmallcaps()`.
- **Index export** in `quartz/plugins/transformers/index.ts`.
- **39 tests** in `tests/autoCode.test.ts` covering: basic matching, longest-first, word-boundary respect, case sensitivity, every skip-ancestor tag (positive + negative), HTML-comment immunity, possessive `'s`, consecutive matches, start-of-string match, regex/term-list invariants. 100% statement/branch/function/line coverage.

## Testing

- `pnpm test` — 39/39 new tests pass; 2,216 transformer tests pass overall.
- `tsc --noEmit` — clean.
- Coverage on the new file: 100/100/100/100.

The visual baseline for the `punctilio` comparison table on `/test-page` will shift (cells like `punctilio` now render in monospace); approve via the standard diff-gallery flow once visual-testing completes.

## Caveat

`vale` ships with 76 bare hits on the site, but all are `<!-- vale off -->` / `<!-- vale on -->` HTML comments — comment nodes, not text nodes, so the visitor never sees them. The 3 actual prose uses are "Vale" (capitalized), which lowercase-only matching correctly skips.

https://claude.ai/code/session_013kXaBCRpqw8JSzgfzCzGFB

---
_Generated by [Claude Code](https://claude.ai/code/session_013kXaBCRpqw8JSzgfzCzGFB)_