### PR TITLE
refactor: replace JS-D1001 skipcqs with JSDoc; drop redundant test helpers

### DIFF
--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -455,7 +455,7 @@ export function reorderHead(querier: CheerioAPI): CheerioAPI {
   const headChildren = head.children()
   // These scripts should load first to avoid FOUC
   const scriptNamesToPutAtTop = ["detect-initial-state", "instant-scroll-restoration"]
-  // skipcq: JS-D1001
+  /** Cheerio filter predicate: matches `<script>` elements whose id is in `scriptNamesToPutAtTop`. */
   const isScriptToPutAtTop = (_i: number, el: CheerioElement): boolean =>
     el.type === "script" && scriptNamesToPutAtTop.includes(el.attribs.id)
   const scriptsToPutAtTop = headChildren.filter(isScriptToPutAtTop)

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -6,7 +6,7 @@ import type { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps 
 import { formatTitle } from "./component_utils"
 import { formatTag } from "./TagList"
 
-// skipcq: JS-D1001
+/** Renders the page `<h1>` from frontmatter `title`, with tag-page styling when applicable. */
 const ArticleTitle: QuartzComponent = ({ fileData }: QuartzComponentProps) => {
   if (fileData.frontmatter?.hide_title) {
     return null

--- a/quartz/components/Authors.tsx
+++ b/quartz/components/Authors.tsx
@@ -4,7 +4,7 @@ import type { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps 
 
 import { RenderPublicationInfo } from "./ContentMeta"
 
-// skipcq: JS-D1001
+/** Joins author names into a natural-language list (Oxford-comma style); defaults to "Alex Turner". */
 export function formatAuthors(authors: readonly string[]): string {
   if (authors.length === 0) return "Alex Turner"
   if (authors.length === 1) return authors[0]

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -112,7 +112,7 @@ export const getBacklinkFileData = (
   })
 }
 
-// skipcq: JS-D1001
+/** Collapsible "Links to this page" block listing pages whose links resolve to this slug. */
 export const Backlinks: QuartzComponent = ({ fileData, allFiles }: QuartzComponentProps) => {
   const backlinkFiles: QuartzPluginData[] = getBacklinkFileData(allFiles, fileData)
   if (backlinkFiles.length === 0) return null

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -75,7 +75,7 @@ export function renderMetaJsx(cfg: GlobalConfiguration, fileData: QuartzPluginDa
 }
 
 export default (() => {
-  // skipcq: JS-D1001
+  /** Document `<head>`: meta tags, fonts, analytics, and external JS/CSS resources. */
   const Head: QuartzComponent = ({ cfg, fileData, externalResources }: QuartzComponentProps) => {
     const headJsx = renderMetaJsx(cfg, fileData)
 

--- a/quartz/components/TagList.tsx
+++ b/quartz/components/TagList.tsx
@@ -34,7 +34,7 @@ export const getTags = (fileData: QuartzPluginData): string[] => {
   return tags.sort((a: string, b: string) => b.length - a.length)
 }
 
-// skipcq: JS-D1001
+/** Renders the page's frontmatter tags as a list of tag-page links, longest-first. */
 const TagListComponent: QuartzComponent = ({ fileData }: QuartzComponentProps) => {
   const tags = getTags(fileData)
   if (tags && tags.length > 0) {
@@ -58,6 +58,6 @@ const TagListComponent: QuartzComponent = ({ fileData }: QuartzComponentProps) =
   }
 }
 
-// skipcq: JS-D1001
+/** Quartz constructor for {@link TagListComponent}. */
 export const TagList: QuartzComponentConstructor = () => TagListComponent
 export default TagList satisfies QuartzComponentConstructor

--- a/quartz/components/pages/AllPosts.tsx
+++ b/quartz/components/pages/AllPosts.tsx
@@ -29,7 +29,7 @@ export function generateAllPostsBlock(props: QuartzComponentProps): JSX.Element 
   return pageListing
 }
 
-// skipcq: JS-D1001
+/** Page renderer for the "all posts" index, wrapping {@link PageList} in the transclude container. */
 export const AllPosts: QuartzComponent = (props: QuartzComponentProps) => {
   const { fileData, allFiles } = props
   const cssClasses: readonly string[] = fileData.frontmatter?.cssclasses ?? []

--- a/quartz/components/scripts/component_script_utils.ts
+++ b/quartz/components/scripts/component_script_utils.ts
@@ -56,7 +56,7 @@ export function debounce<Args extends unknown[], R>(
   // Track the time of the last *invocation attempt*
   let lastCallTime = 0
 
-  // skipcq: JS-D1001
+  /** Wrapped callable: schedules the trailing-edge call and may fire immediately on the leading edge. */
   const debounced = function (this: unknown, ...args: Args) {
     const now = performance.now()
     const shouldCallImmediately = immediate && (lastCallTime === 0 || now - lastCallTime >= wait)
@@ -142,7 +142,7 @@ export function registerEscapeHandler(
   }
 }
 
-// skipcq: JS-D1001
+/** Detaches every child of `node`. */
 export function removeAllChildren(node: HTMLElement) {
   while (node.firstChild) {
     node.removeChild(node.firstChild)

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -443,27 +443,27 @@ export class PreviewManager {
     }
   }
 
-  // skipcq: JS-D1001
+  /** Makes the preview container visible. */
   /* istanbul ignore next */
   public show(): void {
     this.container.classList.add("active")
     this.container.style.visibility = "visible"
   }
 
-  // skipcq: JS-D1001
+  /** Hides the preview container. */
   /* istanbul ignore next */
   public hide(): void {
     this.container.classList.remove("active")
     this.container.style.visibility = "hidden"
   }
 
-  // skipcq: JS-D1001
+  /** Empties the preview content. */
   /* istanbul ignore next */
   public clear(): void {
     this.inner.innerHTML = ""
   }
 
-  // skipcq: JS-D1001
+  /** Detaches handlers, clears state, and empties the preview. */
   /* istanbul ignore next */
   public destroy(): void {
     this.inner.onclick = null
@@ -690,11 +690,11 @@ function handleResultNavigation(
   // Abort early when search is not active
   if (!container?.classList.contains("active")) return
 
-  /* skipcq: JS-D1001 */
+  /** Returns the previous sibling element of `el`, or null. */
   const prevSibling = (el: HTMLElement): HTMLElement | null =>
     el.previousElementSibling ? (el.previousElementSibling as HTMLElement) : null
 
-  /* skipcq: JS-D1001 */
+  /** Returns the next sibling element of `el`, or null. */
   const nextSibling = (el: HTMLElement): HTMLElement | null =>
     el.nextElementSibling ? (el.nextElementSibling as HTMLElement) : null
 
@@ -1441,7 +1441,7 @@ function resolveSlug(slug: FullSlug, currentSlug: FullSlug): URL {
   return new URL(resolveRelative(currentSlug, slug), location.toString())
 }
 
-// skipcq: JS-D1001
+/** Entry point invoked from page scripts: subscribes search to SPA `nav` events. */
 /* istanbul ignore next */
 export function setupSearch(): void {
   document.addEventListener("nav", onNav)

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -66,7 +66,7 @@ const updateScrollState = debounce(
   debounceWaitMs,
 )
 
-// skipcq: JS-D1001
+/** Dispatches the `nav` CustomEvent so listeners can react to client-side navigation. */
 function dispatchNavEvent(url: FullSlug) {
   const event: CustomEventMap["nav"] = new CustomEvent("nav", { detail: { url } })
   document.dispatchEvent(event)
@@ -212,7 +212,7 @@ async function handleRedirect(initialFetchResult: FetchResult): Promise<FetchRes
   return { status: "success", content: finalContent, finalUrl }
 }
 
-// skipcq: JS-D1001
+/** Removes any rendered popover elements from the page. */
 function removePopovers() {
   const existingPopovers = document.querySelectorAll(".popover")
   existingPopovers.forEach((popover) => popover.remove())
@@ -522,7 +522,7 @@ if (!customElements.get("route-announcer")) {
   customElements.define(
     "route-announcer",
     class RouteAnnouncer extends HTMLElement {
-      // skipcq: JS-D1001
+      /** Applies the visually-hidden ARIA-live attributes when the announcer mounts. */
       connectedCallback() {
         for (const [key, value] of Object.entries(attrs)) {
           this.setAttribute(key, value)

--- a/quartz/components/tests/renderPage.test.tsx
+++ b/quartz/components/tests/renderPage.test.tsx
@@ -27,7 +27,7 @@ import {
 } from "../renderPage"
 import { type QuartzComponent, type QuartzComponentProps } from "../types"
 
-// skipcq: JS-D1001
+/** Test stub for `<head>`. */
 const MockHead: QuartzComponent = () => {
   return (
     <head>
@@ -36,12 +36,12 @@ const MockHead: QuartzComponent = () => {
   )
 }
 
-// skipcq: JS-D1001
+/** Test stub for page body that renders the AST node type. */
 const MockPageBody: QuartzComponent = ({ tree }: QuartzComponentProps) => {
   return <div id="page-body">{tree.type}</div>
 }
 
-// skipcq: JS-D1001
+/** Test stub that surfaces `displayClass` so assertions can verify slot assignment. */
 const MockComponent: QuartzComponent = (props: QuartzComponentProps) => {
   const name = props.displayClass
   return <div className={`mock-component ${name ?? ""}`}>{String(name)}</div>
@@ -564,7 +564,7 @@ describe("renderPage", () => {
   })
 
   it("renders beforeBody components", () => {
-    // skipcq: JS-D1001
+    /** Inline test stub for the beforeBody slot. */
     const MockBeforeBody: QuartzComponent = () => <div className="before-body">Before content</div>
     const componentsWithBeforeBody = {
       ...components,

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -99,12 +99,12 @@ interface GitCountOptions {
   grep?: string
 }
 
-// skipcq: JS-D1001
+/** True if the current git working tree is a shallow clone. */
 export function isShallowClone(): boolean {
   return execSync("git rev-parse --is-shallow-repository", { encoding: "utf-8" }).trim() === "true"
 }
 
-// skipcq: JS-D1001
+/** Total commit count across all refs, optionally filtered by author/message; 0 on shallow clones. */
 export function countGitCommits(options: GitCountOptions = {}): number {
   if (isShallowClone()) return 0
 
@@ -115,7 +115,7 @@ export function countGitCommits(options: GitCountOptions = {}): number {
   return parseInt(output.trim(), 10)
 }
 
-// skipcq: JS-D1001
+/** Counts passing Jest tests by parsing the trailing "Tests: N passed" line from the test run. */
 export function countJsTests(): number {
   // Sadly, this requires running all tests but there isn't a --collect-only like for pytest
   const output = execSync("pnpm test 2>&1 | grep -E 'Tests:.*passed' | tail -1", {
@@ -126,7 +126,7 @@ export function countJsTests(): number {
   return parseInt(match.groups.count, 10)
 }
 
-// skipcq: JS-D1001
+/** Counts Playwright `test(...)` declarations in `quartz/components/tests/*.spec.ts`. */
 export function countPlaywrightTests(): number {
   const output = execSync('grep -rE "^\\s*test\\(" quartz/components/tests/*.spec.ts | wc -l', {
     encoding: "utf-8",
@@ -134,12 +134,11 @@ export function countPlaywrightTests(): number {
   return parseInt(output.trim(), 10)
 }
 
-// skipcq: JS-D1001
-// Override addopts to avoid requiring plugins (--cov, -n) that may not be installed
+/** Pytest collect-only invocation; `addopts=""` strips plugins (`--cov`, `-n`) that may not be installed. */
 export const PYTEST_COUNT_CMD =
   "bash -lc '.venv/bin/pytest --collect-only -q -o addopts=\"\"' 2>&1 | tail -20"
 
-// skipcq: JS-D1001
+/** Counts Python tests via `pytest --collect-only`, parsing the "N tests collected" footer. */
 export function countPythonTests(): number {
   const output = execSync(PYTEST_COUNT_CMD, { encoding: "utf-8" })
 
@@ -151,7 +150,7 @@ export function countPythonTests(): number {
   return parseInt(match.groups.count, 10)
 }
 
-// skipcq: JS-D1001
+/** Total lines across source files (TS/JS/Python/CSS), excluding build/vendor directories. */
 export function countLinesOfCode(): number {
   const output = execSync(
     'find . -type f \\( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.py" -o -name "*.css" -o -name "*.scss" \\) ! -path "*/node_modules/*" ! -path "*/.venv/*" ! -path "*/.pytest_cache/*" ! -path "*/.mypy_cache/*" ! -path "*/.ruff_cache/*" ! -path "*/htmlcov/*" ! -path "*/public/*" -exec wc -l {} + | tail -1 | awk \'{print $1}\'',
@@ -169,7 +168,7 @@ export interface RepoStats {
   linesOfCode: number
 }
 
-// skipcq: JS-D1001
+/** Gathers commit, test, and code-size statistics about this repo in parallel. */
 export async function computeRepoStats(): Promise<RepoStats> {
   const [commitCount, aiCommitCount, jsTestCount, playwrightTestCount, pytestCount, linesOfCode] =
     await Promise.all([
@@ -195,7 +194,7 @@ const addSvgExtension = (path: string): string => {
   return `${path}.svg`
 }
 
-// skipcq: JS-D1001
+/** Returns a content generator yielding a no-wrap span containing the given favicon image. */
 export const generateSpecialFaviconContent = (
   faviconPath: string,
   altText = "",

--- a/quartz/plugins/transformers/afterArticle.ts
+++ b/quartz/plugins/transformers/afterArticle.ts
@@ -80,7 +80,7 @@ function afterArticleTransform(tree: Root, file: VFile) {
   }
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer that injects sequence-link and "next/previous" UI after the article body. */
 export const AfterArticle: QuartzTransformerPlugin = () => {
   return {
     name: "AfterArticleTransformer",

--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -66,23 +66,23 @@ class AssetProcessor {
     this.spawnSyncWrapper = spawnFn
   }
 
-  // skipcq: JS-D1001
+  /** Test-only: clears in-memory cache and the dirty flag. */
   public resetDirectCacheAndDirtyFlag(): void {
     this.assetDimensionsCache = null
     this.needToSaveCache = false
   }
 
-  // skipcq: JS-D1001
+  /** Test-only: directly replaces the in-memory dimension cache. */
   public setDirectCache(cache: AssetDimensionMap | null): void {
     this.assetDimensionsCache = cache
   }
 
-  // skipcq: JS-D1001
+  /** Test-only: directly sets the "cache needs persisting" flag. */
   public setDirectDirtyFlag(isDirty: boolean): void {
     this.needToSaveCache = isDirty
   }
 
-  // skipcq: JS-D1001
+  /** Loads (or returns the cached) on-disk asset dimensions map; missing file yields empty map. */
   public async maybeLoadDimensionCache(): Promise<AssetDimensionMap> {
     if (this.assetDimensionsCache !== null) {
       return this.assetDimensionsCache
@@ -342,7 +342,7 @@ class AssetProcessor {
 
   public imageTagsToProcess = ["img", "svg"]
 
-  // skipcq: JS-D1001
+  /** Extracts the URL inside `--mask-url: url(...)` from an inline style string, or null. */
   public static extractMaskUrl(style: string | undefined): string | null {
     if (style === undefined) return null
     const match = style.match(/--mask-url:\s*url\((?<url>[^)]+)\)/)
@@ -427,8 +427,8 @@ export const assetProcessor = new AssetProcessor()
 
 // --- Test Helper Exports ---
 export { AssetProcessor }
+/** Test-only: swaps the module's {@link assetProcessor} for one using `fn` as its spawn function. */
 export function setSpawnSyncForTesting(fn: typeof spawnSync): void {
-  // Replace the default assetProcessor with a new one that uses the mock spawn function
   Object.assign(assetProcessor, new AssetProcessor(fn))
 }
 

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -288,7 +288,7 @@ function handleMailtoLink(node: Element): void {
   insertFavicon(specialFaviconPaths.mail, node)
 }
 
-// skipcq: JS-D1001
+/** True when the element is an `h1`–`h6` heading. */
 export function isHeading(node: Element): boolean {
   return HEADING_TAGS.has(node.tagName)
 }

--- a/quartz/plugins/transformers/fixFootnotes.ts
+++ b/quartz/plugins/transformers/fixFootnotes.ts
@@ -24,7 +24,7 @@ export function isFootnoteListItem(child: ElementContent): boolean {
   return child.tagName === "li" && Boolean(id?.startsWith("user-content-fn-"))
 }
 
-// skipcq: JS-D1001
+/** Locates the `<ol>` of footnote list items in `tree`, returning its node + parent + index. */
 export function findFootnoteList(tree: Root): FootnoteLocation | null {
   let footnoteLocation: FootnoteLocation | null = null
 
@@ -53,12 +53,12 @@ const FOOTNOTE_HEADING_IDS: ReadonlySet<string> = new Set([
   UPSTREAM_FOOTNOTE_HEADING_ID,
 ])
 
-// skipcq: JS-D1001
+/** True if `id` matches a recognized footnote-heading id (ours or remark-gfm's). */
 function isFootnoteHeadingId(id: unknown): boolean {
   return typeof id === "string" && FOOTNOTE_HEADING_IDS.has(id)
 }
 
-// skipcq: JS-D1001
+/** True if the section already contains a footnote heading (h1 or h2 with a known id). */
 export function hasFootnoteHeading(sectionElement: Element): boolean {
   return sectionElement.children.some((child: ElementContent) => {
     // Check for both h1 and h2 (remark-gfm-footnotes generates h2)
@@ -69,7 +69,7 @@ export function hasFootnoteHeading(sectionElement: Element): boolean {
   })
 }
 
-// skipcq: JS-D1001
+/** Creates the visually-hidden `<h1>` "Footnotes" heading used for the footnotes section. */
 export function createFootnoteHeading(): Element {
   return h("h1", { id: footnoteHeadingId, className: ["sr-only"] }, ["Footnotes"])
 }

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -106,7 +106,7 @@ const massTransforms: [RegExp | string, string][] = [
   [/GPT-4o\b/g, "GPT-4-o"],
 ]
 
-// skipcq: JS-D1001
+/** Sequentially applies a list of `[pattern, replacement]` regex substitutions to `text`. */
 export function applyTextTransforms(text: string, transforms: [RegExp | string, string][]): string {
   for (const [pattern, replacement] of transforms) {
     const regex = pattern instanceof RegExp ? pattern : new RegExp(pattern, "g")

--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -436,7 +436,7 @@ export const GitHubFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> | 
 
 const slugger = new GithubSlugger()
 
-// skipcq: JS-D1001
+/** Normalizes heading text before slugging: converts apostrophes, slashes, dashes, and `&` to `-`. */
 export function preprocessSlug(headerText: string): string {
   const charsToConvert = ["'", "’", "/", "&", "—", "‘"]
 
@@ -460,12 +460,12 @@ export function slugify(headerText: string): string {
   return slug.replaceAll(/-+/g, "-")
 }
 
-// skipcq: JS-D1001
+/** Resets the module-scoped slugger; tests call this between runs to avoid uniqueness-counter leakage. */
 export function resetSlugger() {
   slugger.reset()
 }
 
-// skipcq: JS-D1001
+/** Returns a rehype plugin that assigns slugified `id`s to every heading lacking one. */
 export function returnAddIdsToHeadingsFn() {
   return (tree: Root) => {
     slugger.reset()
@@ -480,7 +480,7 @@ export function returnAddIdsToHeadingsFn() {
   }
 }
 
-// skipcq: JS-D1001
+/** Removes the GFM-generated back-arrow anchor (`data-footnote-backref`) from a footnote item. */
 export function removeBackArrowFromChildren(footnoteParent: Element): void {
   footnoteParent.children = footnoteParent.children.filter((child) => {
     return !(

--- a/quartz/plugins/transformers/linebreaks.ts
+++ b/quartz/plugins/transformers/linebreaks.ts
@@ -2,7 +2,7 @@ import remarkBreaks from "remark-breaks"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-// skipcq: JS-D1001
+/** Quartz transformer that converts single newlines into `<br>` via remark-breaks. */
 export const HardLineBreaks: QuartzTransformerPlugin = () => {
   return {
     name: "HardLineBreaks",

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -264,7 +264,7 @@ const createHighlightElement = (content: string): PhrasingContent => ({
   value: `<span class="text-highlight">${escapeHTML(content)}</span>`,
 })
 
-// skipcq: JS-D1001
+/** Returns iframe properties for a YouTube embed, including playlist support when provided. */
 export const createYouTubeEmbed = (videoId: string, playlistId?: string): Properties => ({
   class: "external-embed",
   allow: "fullscreen",

--- a/quartz/plugins/transformers/populateExternalMarkdown.test.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.test.ts
@@ -12,9 +12,9 @@ import {
   isLocalSource,
   clearContentCache,
   setFetchFunction,
-  resetFetchFunction,
   setReadFileFunction,
-  resetReadFileFunction,
+  defaultFetchFunction,
+  defaultReadFileFunction,
   type FetchFunction,
   type ReadFileFunction,
 } from "./populateExternalMarkdown"
@@ -36,8 +36,8 @@ describe("PopulateExternalMarkdown", () => {
 
   afterEach(() => {
     clearContentCache()
-    resetFetchFunction()
-    resetReadFileFunction()
+    setFetchFunction(defaultFetchFunction)
+    setReadFileFunction(defaultReadFileFunction)
   })
 
   describe("stripBadges", () => {
@@ -70,15 +70,6 @@ describe("PopulateExternalMarkdown", () => {
       fetchGitHubContentSync(source)
       expect(mockFetch).toHaveBeenCalledWith(
         `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${expectedPath}`,
-      )
-    })
-
-    it("should propagate fetch errors", () => {
-      mockFetch.mockImplementation(() => {
-        throw new Error("Network error")
-      })
-      expect(() => fetchGitHubContentSync({ owner: "owner", repo: "repo" })).toThrow(
-        "Network error",
       )
     })
   })
@@ -207,13 +198,6 @@ describe("PopulateExternalMarkdown", () => {
       expect(parseJsonEntry(result)).toEqual({ "a.b": "deep" })
     })
 
-    it("should propagate file read errors", () => {
-      mockReadFile.mockImplementation(() => {
-        throw new Error("ENOENT")
-      })
-      expect(() => fetchLocalContentSync({ filePath: "missing.txt" })).toThrow("ENOENT")
-    })
-
     it("should throw on missing JSON path", () => {
       mockReadFile.mockReturnValue('{"existing": "value"}')
       expect(() => fetchLocalContentSync({ filePath: "test.json", jsonPath: "missing" })).toThrow(
@@ -294,12 +278,6 @@ describe("PopulateExternalMarkdown", () => {
       })
       const result = plugin.textTransform?.({} as BuildCtx, input)
       expect(result).toContain("# Content")
-    })
-
-    it("should ignore unconfigured placeholders", () => {
-      const plugin = PopulateExternalMarkdown({ sources: {} })
-      const input = '<span class="populate-markdown-unknown"></span>'
-      expect(plugin.textTransform?.({} as BuildCtx, input)).toBe(input)
     })
   })
 })

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -77,40 +77,22 @@ export const defaultReadFileFunction: ReadFileFunction = (filePath: string): str
 let fetchFunction: FetchFunction = defaultFetchFunction
 let readFileFunction: ReadFileFunction = defaultReadFileFunction
 
-/**
- * Sets the fetch function used by the module. Useful for testing.
- */
+/** Replaces the fetch function used by the module; pass {@link defaultFetchFunction} to reset. */
 export function setFetchFunction(fn: FetchFunction): void {
   fetchFunction = fn
 }
 
-/**
- * Sets the read file function used by the module. Useful for testing.
- */
+/** Replaces the read-file function used by the module; pass {@link defaultReadFileFunction} to reset. */
 export function setReadFileFunction(fn: ReadFileFunction): void {
   readFileFunction = fn
 }
 
-/**
- * Resets the fetch function to the default implementation.
- */
-export function resetFetchFunction(): void {
-  fetchFunction = defaultFetchFunction
-}
-
-/**
- * Resets the read file function to the default implementation.
- */
-export function resetReadFileFunction(): void {
-  readFileFunction = defaultReadFileFunction
-}
-
-// skipcq: JS-D1001
+/** Type guard: true if the source is a local-file source rather than a GitHub source. */
 export function isLocalSource(source: MarkdownSource): source is LocalMarkdownSource {
   return "filePath" in source
 }
 
-// skipcq: JS-D1001
+/** Fetches the raw contents of a file from GitHub via the configured fetch function. */
 export function fetchGitHubContentSync(source: GitHubMarkdownSource): string {
   const ref = source.ref ?? "main"
   const filePath = source.path ?? "README.md"
@@ -120,7 +102,7 @@ export function fetchGitHubContentSync(source: GitHubMarkdownSource): string {
   return fetchFunction(url)
 }
 
-// skipcq: JS-D1001
+/** Reads a local file; if `jsonPath` is set, extracts a nested JSON value as a `"key": value` snippet. */
 export function fetchLocalContentSync(source: LocalMarkdownSource): string {
   const content = readFileFunction(source.filePath)
 
@@ -149,7 +131,7 @@ export function fetchLocalContentSync(source: LocalMarkdownSource): string {
   return content
 }
 
-// skipcq: JS-D1001
+/** Removes badge images (e.g. CI/version shields) from the head of a README. */
 export function stripBadges(content: string): string {
   return content.replace(/\[!\[.*?\]\(.*?\)\]\(.*?\)\s*/g, "")
 }
@@ -183,7 +165,7 @@ function getContent(name: string, source: MarkdownSource): string {
   return content
 }
 
-// skipcq: JS-D1001
+/** Builds a regex matching `<span class="populate-markdown-NAME"></span>` placeholders for the given names. */
 export function buildPlaceholderRegex(sourceNames: string[]): RegExp {
   if (sourceNames.length === 0) return /(?!)/g // never matches
   const escaped = sourceNames.map(escapeStringRegexp)
@@ -193,7 +175,7 @@ export function buildPlaceholderRegex(sourceNames: string[]): RegExp {
   )
 }
 
-// skipcq: JS-D1001
+/** Replaces placeholder spans in `content` with fetched markdown from the matching source. */
 export function populateExternalContent(
   content: string,
   sources: Record<string, MarkdownSource>,
@@ -204,12 +186,12 @@ export function populateExternalContent(
   })
 }
 
-// skipcq: JS-D1001
+/** Clears the in-memory content cache. Tests call this between runs to avoid leakage. */
 export function clearContentCache(): void {
   contentCache.clear()
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer that substitutes `populate-markdown-*` placeholder spans with fetched content. */
 export const PopulateExternalMarkdown: QuartzTransformerPlugin<PopulateExternalMarkdownOptions> = (
   opts,
 ) => {

--- a/quartz/plugins/transformers/syntax.ts
+++ b/quartz/plugins/transformers/syntax.ts
@@ -23,7 +23,7 @@ const defaultOptions: SyntaxHighlightingOptions = {
   keepBackground: false,
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer applying Shiki light/dark syntax highlighting to fenced code blocks. */
 export const SyntaxHighlighting: QuartzTransformerPlugin<SyntaxHighlightingOptions> = (
   userOpts?: Partial<SyntaxHighlightingOptions>,
 ) => {

--- a/quartz/plugins/transformers/tablecaption.ts
+++ b/quartz/plugins/transformers/tablecaption.ts
@@ -34,12 +34,12 @@ export function createFigcaption(captionText: string): Element[] {
   return captionHtml.children as Element[]
 }
 
-// skipcq: JS-D1001
+/** True if `element` is a `<table>` element. */
 export function isTableElement(element: ElementContent): boolean {
   return isElementNode(element) && element.tagName === "table"
 }
 
-// skipcq: JS-D1001
+/** Wraps a `<table>` and its caption nodes in a single `<figure>`. */
 export function createTableFigure(tableElement: Element, captionElements: Element[]): Element {
   return h("figure", [tableElement, ...captionElements])
 }

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -457,7 +457,7 @@ export const rehypeTagSmallcaps: Plugin = () => {
   }
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer that wraps acronyms and tag-like spans in small-caps styling. */
 // istanbul ignore next
 export const TagSmallcaps: QuartzTransformerPlugin = () => {
   return {

--- a/quartz/plugins/transformers/toc.ts
+++ b/quartz/plugins/transformers/toc.ts
@@ -37,7 +37,7 @@ const defaultOptions: Options = {
 
 const logger = createWinstonLogger("TableOfContents")
 
-// skipcq: JS-D1001
+/** Debug-log a single TOC entry. */
 function logTocEntry(entry: TocEntry) {
   logger.debug(`TOC Entry: depth=${entry.depth}, text="${entry.text}", slug="${entry.slug}"`)
 }
@@ -62,7 +62,7 @@ export function customToString(node: Node): string {
   return "value" in node ? String(node.value) : ""
 }
 
-// skipcq: JS-D1001
+/** Removes any HTML tags from a string, returning the text content only. */
 export function stripHtmlTagsFromString(html: string): string {
   return html.replace(/<[^>]*>/g, "")
 }

--- a/quartz/plugins/transformers/trout_hr.ts
+++ b/quartz/plugins/transformers/trout_hr.ts
@@ -39,7 +39,7 @@ export function maybeInsertOrnament(
 
   // Check for "Appendix" headings
   if (node.tagName === "h1" || node.tagName === "h2") {
-    // skipcq: JS-D1001
+    /** Case-insensitive check that `text` begins with "appendix". */
     const startsWithAppendix = (text: string) => text.toLowerCase().startsWith("appendix")
 
     // Check direct text children
@@ -130,7 +130,7 @@ type PluginReturn = {
   htmlPlugins: () => TreeTransformer[]
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer that inserts the trout-ornament `<hr>` before Appendix sections. */
 export const TroutOrnamentHr: QuartzTransformerPlugin = (): PluginReturn => {
   return {
     name: "TroutOrnamentHr",

--- a/quartz/plugins/transformers/twemoji.ts
+++ b/quartz/plugins/transformers/twemoji.ts
@@ -19,7 +19,7 @@ export interface TwemojiOptions {
   callback: (icon: string, options: TwemojiOptions) => string
 }
 
-// skipcq: JS-D1001
+/** Builds the CDN URL for a Twemoji glyph given its codepoint and extension. */
 export function constructTwemojiUrl(icon: string, options: TwemojiOptions): string {
   return `${twemojiBaseUrl}${icon}${options.ext}`
 }
@@ -166,7 +166,7 @@ export function processTree(tree: Node): Node {
   return tree
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer that swaps Unicode emoji for inline Twemoji `<img>` tags. */
 export const Twemoji = (): {
   name: string
   htmlPlugins: () => Plugin[]

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -228,7 +228,7 @@ const rehypeWrapNakedElements: Plugin<[], Root> = () => {
   }
 }
 
-// skipcq: JS-D1001
+/** Quartz transformer wrapping bare media/float-right elements in container `<figure>`/`<div>`s. */
 export const WrapNakedElements: QuartzTransformerPlugin = () => {
   return {
     name: "WrapNakedElements",

--- a/quartz/util/head.ts
+++ b/quartz/util/head.ts
@@ -27,7 +27,7 @@ interface HeadProps {
   }
 }
 
-// skipcq: JS-D1001
+/** Twitter card author meta tags, or empty string when no authors are configured. */
 function maybeRenderAuthorTags(authors: readonly string[] | undefined): string {
   if (!authors || authors.length === 0) {
     return ""
@@ -39,7 +39,7 @@ function maybeRenderAuthorTags(authors: readonly string[] | undefined): string {
   `
 }
 
-// skipcq: JS-D1001
+/** Open Graph video meta tag for the given preview URL, or empty string when undefined. */
 export function maybeProduceVideoTag(videoPreview: string | undefined): string {
   if (!videoPreview) {
     return ""
@@ -47,7 +47,7 @@ export function maybeProduceVideoTag(videoPreview: string | undefined): string {
   return `<meta property="og:video" content="${escapeHTML(videoPreview)}" />`
 }
 
-// skipcq: JS-D1001
+/** Open Graph image meta tags for the social card image. */
 function renderImageTags(cardImage: string, altText: string): string {
   return `
     <meta property="og:image" content="${escapeHTML(cardImage)}" />
@@ -57,7 +57,7 @@ function renderImageTags(cardImage: string, altText: string): string {
   `
 }
 
-// skipcq: JS-D1001
+/** Returns the inner HTML for the document `<head>`: title, OG/Twitter cards, icons, theme colors. */
 export function renderHead({ cfg, fileData, slug, redirect }: HeadProps): string {
   const title = formatTitle(fileData.frontmatter?.title ?? defaultTitle)
   const description = applyTextTransforms(

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -14,7 +14,7 @@ type SlugLike<T> = string & { __brand: T }
 
 /** A string that is a valid filepath. It cannot be relative and must have a file extension. */
 export type FilePath = SlugLike<"filepath">
-// skipcq: JS-D1001
+/** Type guard for {@link FilePath}: not relative and has a file extension. */
 export function isFilePath(s: string): s is FilePath {
   const validStart = !s.startsWith(".")
   return validStart && _hasFileExtension(s)
@@ -22,7 +22,7 @@ export function isFilePath(s: string): s is FilePath {
 
 /** Cannot be relative and may not have leading or trailing slashes. It can have `index` as it's last segment. Use this wherever possible is it's the most 'general' interpretation of a slug. */
 export type FullSlug = SlugLike<"full">
-// skipcq: JS-D1001
+/** Type guard for {@link FullSlug}: not relative/absolute, no trailing slash, no forbidden chars. */
 export function isFullSlug(s: string): s is FullSlug {
   const validStart = !(s.startsWith(".") || s.startsWith("/"))
   const validEnding = !s.endsWith("/")
@@ -31,7 +31,7 @@ export function isFullSlug(s: string): s is FullSlug {
 
 /** Shouldn't be a relative path and shouldn't have `/index` as an ending or a file extension. It _can_ however have a trailing slash to indicate a folder path. */
 export type SimpleSlug = SlugLike<"simple">
-// skipcq: JS-D1001
+/** Type guard for {@link SimpleSlug}: no trailing `index`, no file extension, no forbidden chars. */
 export function isSimpleSlug(s: string): s is SimpleSlug {
   const validStart = !(s.startsWith(".") || (s.length > 1 && s.startsWith("/")))
   const validEnding = !endsWith(s, "index")
@@ -40,7 +40,7 @@ export function isSimpleSlug(s: string): s is SimpleSlug {
 
 /** Can be found on `href`s but can also be constructed for client-side navigation (e.g. search and graph) */
 export type RelativeURL = SlugLike<"relative">
-// skipcq: JS-D1001
+/** Type guard for {@link RelativeURL}: starts with `.` or `..`, no `index`/`.md`/`.html` ending. */
 export function isRelativeURL(s: string): s is RelativeURL {
   const validStart = /^\.{1,2}/.test(s)
   const validEnding = !endsWith(s, "index")
@@ -361,7 +361,7 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
   }
 }
 
-// skipcq: JS-D1001
+/** True for paths that point at a directory (trailing slash or `index` page). */
 function isFolderPath(fplike: string): boolean {
   return (
     fplike.endsWith("/") ||
@@ -371,12 +371,12 @@ function isFolderPath(fplike: string): boolean {
   )
 }
 
-// skipcq: JS-D1001
+/** True if `s` equals `suffix` or ends in `/${suffix}` (segment-aware suffix match). */
 export function endsWith(s: string, suffix: string): boolean {
   return s === suffix || s.endsWith(`/${suffix}`)
 }
 
-// skipcq: JS-D1001
+/** Removes a trailing `suffix` (segment-aware) from `s` if present. */
 function maybeTrimSuffix(s: string, suffix: string): string {
   if (endsWith(s, suffix)) {
     s = s.slice(0, -suffix.length)
@@ -384,12 +384,12 @@ function maybeTrimSuffix(s: string, suffix: string): string {
   return s
 }
 
-// skipcq: JS-D1001
+/** True if `s` contains any of the URL-hostile characters: space, `#`, `?`, `&`. */
 function containsForbiddenCharacters(s: string): boolean {
   return s.includes(" ") || s.includes("#") || s.includes("?") || s.includes("&")
 }
 
-// skipcq: JS-D1001
+/** True if `s` has a recognized file extension (see {@link _getFileExtension}). */
 function _hasFileExtension(s: string): boolean {
   return _getFileExtension(s) !== undefined
 }


### PR DESCRIPTION
## Summary

- Replace every `// skipcq: JS-D1001` suppression in `quartz/` with a real one-line JSDoc. CLAUDE.md is explicit that skipcqs are only for genuine false positives — these were just "I didn't want to write a docstring", which is exactly the kind of thing JS-D1001 exists to flag.
- Trim pointless code in `populateExternalMarkdown`: redundant reset helpers, two tautological error-propagation tests, and one duplicate plugin-level test.

## Changes

**JSDoc instead of `// skipcq: JS-D1001`** (~80 occurrences across 30 files): every flagged function now has a short JSDoc that says something non-obvious (preconditions, return semantics, "test-only" markers, regex shape, etc.) rather than restating the function name.

**`quartz/plugins/transformers/populateExternalMarkdown.ts`**:
- Drop `resetFetchFunction` and `resetReadFileFunction` — callers can use `setFetchFunction(defaultFetchFunction)` directly, which is what the resets did.
- Test file imports `defaultFetchFunction`/`defaultReadFileFunction` for the same teardown flow.

**`quartz/plugins/transformers/populateExternalMarkdown.test.ts`**:
- Remove `should propagate fetch errors` (mocked `fetchFunction` to throw, asserted the function with no try/catch re-throws — tautology).
- Remove `should propagate file read errors` (same shape, on `fetchLocalContentSync`).
- Remove the plugin-level `should ignore unconfigured placeholders` — the path is already covered by the `populateExternalContent`-layer test.
- The remaining `should propagate fetch errors with context` test stays — it asserts the wrapping `Error(..., { cause })` from `getContent`, which is the actually-interesting branch.

## Testing

- `pnpm check` — green (tsc + prettier + stylelint).
- Full Jest suite: 3802 tests across 76 suites, all pass.
- `populateExternalMarkdown.ts` retains 100% branch/statement/function/line coverage after the deletions.

https://claude.ai/code/session_01KXLB5fbaZJNW7F4X3itr9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLB5fbaZJNW7F4X3itr9C)_