### PR TITLE
refactor: drop DI setters; spy directly on child_process/fs in tests

### DIFF
--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -1,6 +1,6 @@
 import type { Element, ElementContent, Root } from "hast"
 
-import { spawnSync, type SpawnSyncReturns } from "child_process"
+import childProcess, { type SpawnSyncReturns } from "child_process"
 import crypto from "crypto"
 import gitRoot from "find-git-root"
 import fs from "fs/promises"
@@ -58,13 +58,8 @@ export function maybeResolveAssetStagingPath(localPath: string): string | null {
  * from both local and remote sources.
  */
 class AssetProcessor {
-  private spawnSyncWrapper: typeof spawnSync
   private assetDimensionsCache: AssetDimensionMap | null = null
   private needToSaveCache = false
-
-  constructor(spawnFn: typeof spawnSync = spawnSync) {
-    this.spawnSyncWrapper = spawnFn
-  }
 
   /** Test-only: clears in-memory cache and the dirty flag. */
   public resetDirectCacheAndDirtyFlag(): void {
@@ -131,7 +126,7 @@ class AssetProcessor {
    * @returns Asset dimensions
    */
   public getAssetDimensionsFfprobe(assetSrc: string): AssetDimensions {
-    const ffprobe: SpawnSyncReturns<string> = this.spawnSyncWrapper(
+    const ffprobe: SpawnSyncReturns<string> = childProcess.spawnSync(
       "ffprobe",
       [
         "-v",
@@ -425,12 +420,7 @@ class AssetProcessor {
 
 export const assetProcessor = new AssetProcessor()
 
-// --- Test Helper Exports ---
 export { AssetProcessor }
-/** Test-only: swaps the module's {@link assetProcessor} for one using `fn` as its spawn function. */
-export function setSpawnSyncForTesting(fn: typeof spawnSync): void {
-  Object.assign(assetProcessor, new AssetProcessor(fn))
-}
 
 /**
  * Prepends CSS declarations to an element's inline style.

--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -225,7 +225,7 @@ class AssetProcessor {
   ])
 
   // Get dimensions for a local asset: use ffprobe for videos, image-size for images/SVGs
-  private async getLocalAssetDimensions(assetSrc: string): Promise<AssetDimensions> {
+  private static async getLocalAssetDimensions(assetSrc: string): Promise<AssetDimensions> {
     const localPath = await AssetProcessor.resolveLocalAssetPath(assetSrc)
     const ext = path.extname(localPath).toLowerCase()
     const { videoExts } = AssetProcessor
@@ -252,7 +252,7 @@ class AssetProcessor {
   }
 
   // Get dimensions for a remote asset: fetch + ffprobe or image-size fallback
-  private async getRemoteAssetDimensions(
+  private static async getRemoteAssetDimensions(
     assetSrc: string,
     /* istanbul ignore next */
     retries = 1,
@@ -308,13 +308,13 @@ class AssetProcessor {
    * @param retries - Number of retry attempts for remote assets
    * @returns Promise resolving to asset dimensions or null if failed
    */
-  public async fetchAndParseAssetDimensions(
+  public static async fetchAndParseAssetDimensions(
     assetSrc: string,
     retries = numRetries,
   ): Promise<AssetDimensions | null> {
     return AssetProcessor.isRemoteUrl(assetSrc)
-      ? await this.getRemoteAssetDimensions(assetSrc, retries)
-      : await this.getLocalAssetDimensions(assetSrc)
+      ? await AssetProcessor.getRemoteAssetDimensions(assetSrc, retries)
+      : await AssetProcessor.getLocalAssetDimensions(assetSrc)
   }
 
   /** Returns the src of a video element or that of its first source child.
@@ -401,7 +401,7 @@ class AssetProcessor {
         logger.debug(`Skipping remote asset in offline mode: ${src}`)
         return
       }
-      const fetchedDims = await this.fetchAndParseAssetDimensions(src, retries)
+      const fetchedDims = await AssetProcessor.fetchAndParseAssetDimensions(src, retries)
       if (fetchedDims) {
         dims = fetchedDims
         currentDimensionsCache[src] = fetchedDims

--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -125,7 +125,7 @@ class AssetProcessor {
    * @param assetSrc - The source path or URL of the asset
    * @returns Asset dimensions
    */
-  public getAssetDimensionsFfprobe(assetSrc: string): AssetDimensions {
+  public static getAssetDimensionsFfprobe(assetSrc: string): AssetDimensions {
     const ffprobe: SpawnSyncReturns<string> = childProcess.spawnSync(
       "ffprobe",
       [
@@ -230,7 +230,7 @@ class AssetProcessor {
     const ext = path.extname(localPath).toLowerCase()
     const { videoExts } = AssetProcessor
     if (videoExts.has(ext)) {
-      return await this.getAssetDimensionsFfprobe(localPath)
+      return await AssetProcessor.getAssetDimensionsFfprobe(localPath)
     }
 
     const buffer = await fs.readFile(localPath)
@@ -275,7 +275,7 @@ class AssetProcessor {
           (contentType?.startsWith("video/") || contentType?.startsWith("image/"))
         ) {
           response.body?.cancel()
-          return await this.getAssetDimensionsFfprobe(assetSrc)
+          return await AssetProcessor.getAssetDimensionsFfprobe(assetSrc)
         }
 
         const buffer = Buffer.from(await response.arrayBuffer())

--- a/quartz/plugins/transformers/populateExternalMarkdown.test.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals"
+import childProcess from "child_process"
+import fs from "fs"
 
 import type { BuildCtx } from "../../util/ctx"
 
@@ -11,33 +13,28 @@ import {
   fetchLocalContentSync,
   isLocalSource,
   clearContentCache,
-  setFetchFunction,
-  setReadFileFunction,
-  defaultFetchFunction,
-  defaultReadFileFunction,
-  type FetchFunction,
-  type ReadFileFunction,
 } from "./populateExternalMarkdown"
 
 /** Wraps `"key": value` output in braces so it can be parsed as JSON. */
 const parseJsonEntry = (entry: string) => JSON.parse(`{${entry}}`) as unknown
 
 describe("PopulateExternalMarkdown", () => {
-  let mockFetch: jest.MockedFunction<FetchFunction>
-  let mockReadFile: jest.MockedFunction<ReadFileFunction>
+  let mockFetch: jest.SpiedFunction<typeof childProcess.execFileSync>
+  let mockReadFile: jest.SpiedFunction<typeof fs.readFileSync>
 
   beforeEach(() => {
     clearContentCache()
-    mockFetch = jest.fn<FetchFunction>()
-    mockReadFile = jest.fn<ReadFileFunction>()
-    setFetchFunction(mockFetch)
-    setReadFileFunction(mockReadFile)
+    mockFetch = jest.spyOn(childProcess, "execFileSync").mockReturnValue("") as jest.SpiedFunction<
+      typeof childProcess.execFileSync
+    >
+    mockReadFile = jest.spyOn(fs, "readFileSync").mockReturnValue("") as jest.SpiedFunction<
+      typeof fs.readFileSync
+    >
   })
 
   afterEach(() => {
     clearContentCache()
-    setFetchFunction(defaultFetchFunction)
-    setReadFileFunction(defaultReadFileFunction)
+    jest.restoreAllMocks()
   })
 
   describe("stripBadges", () => {
@@ -69,7 +66,9 @@ describe("PopulateExternalMarkdown", () => {
       mockFetch.mockReturnValue("content")
       fetchGitHubContentSync(source)
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${expectedPath}`,
+        "curl",
+        ["-sf", `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${expectedPath}`],
+        expect.objectContaining({ encoding: "utf-8" }),
       )
     })
   })

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -3,9 +3,9 @@
  * Supports fetching README files from GitHub repositories and reading local files.
  */
 
-import { execFileSync } from "child_process"
+import childProcess from "child_process"
 import escapeStringRegexp from "escape-string-regexp"
-import { readFileSync } from "fs"
+import fs from "fs"
 
 import type { QuartzTransformerPlugin } from "../types"
 
@@ -46,65 +46,29 @@ export interface PopulateExternalMarkdownOptions {
   sources: Record<string, MarkdownSource>
 }
 
-// Cache for fetched content to avoid refetching for each file
 const contentCache = new Map<string, string>()
-
-/**
- * Type for the fetch function used to retrieve content.
- * Can be overridden for testing.
- */
-export type FetchFunction = (url: string) => string
-export type ReadFileFunction = (filePath: string) => string
-
-/**
- * Default fetch implementation using curl.
- */
-// istanbul ignore next - Integration functionality tested via dependency injection
-export const defaultFetchFunction: FetchFunction = (url: string): string => {
-  const output = execFileSync("curl", ["-sf", url], {
-    encoding: "utf-8",
-    timeout: 30000, // 30 second timeout
-  })
-  return output
-}
-
-// istanbul ignore next - Integration functionality tested via dependency injection
-export const defaultReadFileFunction: ReadFileFunction = (filePath: string): string => {
-  return readFileSync(filePath, "utf-8")
-}
-
-// Functions used by the module - can be replaced for testing
-let fetchFunction: FetchFunction = defaultFetchFunction
-let readFileFunction: ReadFileFunction = defaultReadFileFunction
-
-/** Replaces the fetch function used by the module; pass {@link defaultFetchFunction} to reset. */
-export function setFetchFunction(fn: FetchFunction): void {
-  fetchFunction = fn
-}
-
-/** Replaces the read-file function used by the module; pass {@link defaultReadFileFunction} to reset. */
-export function setReadFileFunction(fn: ReadFileFunction): void {
-  readFileFunction = fn
-}
 
 /** Type guard: true if the source is a local-file source rather than a GitHub source. */
 export function isLocalSource(source: MarkdownSource): source is LocalMarkdownSource {
   return "filePath" in source
 }
 
-/** Fetches the raw contents of a file from GitHub via the configured fetch function. */
+/** Fetches the raw contents of a file from GitHub via curl. */
 export function fetchGitHubContentSync(source: GitHubMarkdownSource): string {
   const ref = source.ref ?? "main"
   const filePath = source.path ?? "README.md"
   const url = `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${ref}/${filePath}`
 
   logger.debug(`Fetching ${url}`)
-  return fetchFunction(url)
+  return childProcess.execFileSync("curl", ["-sf", url], {
+    encoding: "utf-8",
+    timeout: 30000,
+  })
 }
 
 /** Reads a local file; if `jsonPath` is set, extracts a nested JSON value as a `"key": value` snippet. */
 export function fetchLocalContentSync(source: LocalMarkdownSource): string {
-  const content = readFileFunction(source.filePath)
+  const content = fs.readFileSync(source.filePath, "utf-8")
 
   if (source.jsonPath) {
     let json: Record<string, unknown>

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -409,7 +409,7 @@ describe("Asset Dimensions Plugin", () => {
         type: "svg",
       })
 
-      const dimensions = await assetProcessor.fetchAndParseAssetDimensions(testSvgUrl, 1)
+      const dimensions = await AssetProcessor.fetchAndParseAssetDimensions(testSvgUrl, 1)
 
       expect(mockedFetch).toHaveBeenCalledWith(testSvgUrl)
       expect(dimensions).toEqual({ width: mockImageWidth, height: mockImageHeight })
@@ -417,7 +417,7 @@ describe("Asset Dimensions Plugin", () => {
 
     it("should fetch and parse image dimensions successfully using ffprobe", async () => {
       mockFetchResolve(mockedFetch, mockImageData, 200, { "Content-Type": "image/png" }, "OK", true)
-      const dimensions = await assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)
+      const dimensions = await AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         "ffprobe",
@@ -438,7 +438,7 @@ describe("Asset Dimensions Plugin", () => {
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
       mockFetchResolve(mockedFetch, mockVideoData, 200, { "Content-Type": "video/mp4" }, "OK", true)
-      const dimensions = await assetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)
+      const dimensions = await AssetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)
 
       expect(mockedFetch).toHaveBeenCalledWith(testVideoUrl)
       expect(mockSpawnSync).toHaveBeenCalledWith(
@@ -469,7 +469,7 @@ describe("Asset Dimensions Plugin", () => {
         error: Object.assign(new Error("Command not found"), { code: "ENOENT" }),
       } as unknown as SpawnSyncReturns<string>)
 
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
         /ffprobe command not found/,
       )
       expect(cancel).toHaveBeenCalled()
@@ -496,7 +496,7 @@ describe("Asset Dimensions Plugin", () => {
         error: genericError,
       } as unknown as SpawnSyncReturns<string>)
 
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
         `Error spawning ffprobe: ${genericError.message}`,
       )
       expect(cancel).toHaveBeenCalled()
@@ -523,7 +523,7 @@ describe("Asset Dimensions Plugin", () => {
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
 
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
         "Could not parse dimensions from ffprobe output: ",
       )
       expect(cancel).toHaveBeenCalled()
@@ -548,7 +548,7 @@ describe("Asset Dimensions Plugin", () => {
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
 
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testVideoUrl, 1)).rejects.toThrow(
         "Could not parse dimensions from ffprobe output: this:is:not:dimensions",
       )
       expect(cancel).toHaveBeenCalled()
@@ -557,7 +557,7 @@ describe("Asset Dimensions Plugin", () => {
 
     it("should throw if fetch fails (e.g., 404)", async () => {
       mockFetchResolve(mockedFetch, "", 404, {}, "Not Found")
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
         `Failed to fetch asset ${testImageUrl}: 404 Not Found`,
       )
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
@@ -568,7 +568,7 @@ describe("Asset Dimensions Plugin", () => {
       sizeOfMock.mockImplementation(() => {
         throw new Error("parsing error")
       })
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
         "unsupported file type",
       )
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
@@ -579,7 +579,7 @@ describe("Asset Dimensions Plugin", () => {
       sizeOfMock.mockImplementation(() => {
         throw new Error("parsing error")
       })
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
         "unsupported file type",
       )
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
@@ -587,7 +587,7 @@ describe("Asset Dimensions Plugin", () => {
 
     it("should throw if fetch results in network error", async () => {
       mockFetchNetworkError(mockedFetch, new Error("Network failure"))
-      await expect(assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)).rejects.toThrow(
         "Network failure",
       )
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
@@ -595,7 +595,7 @@ describe("Asset Dimensions Plugin", () => {
 
     it("should handle non-asset content type", async () => {
       mockFetchResolve(mockedFetch, mockImageData, 200, { "Content-Type": "text/plain" })
-      const dimensions = await assetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)
+      const dimensions = await AssetProcessor.fetchAndParseAssetDimensions(testImageUrl, 1)
       expect(dimensions).toEqual(mockFetchedImageDims)
       expect(mockedFetch).toHaveBeenCalledWith(testImageUrl)
     })
@@ -623,7 +623,7 @@ describe("Asset Dimensions Plugin", () => {
         type: "png",
       })
 
-      const dimensions = await assetProcessor.fetchAndParseAssetDimensions(testImageUrl)
+      const dimensions = await AssetProcessor.fetchAndParseAssetDimensions(testImageUrl)
       expect(dimensions).toEqual(mockFetchedImageDims)
       expect(mockedFetch).toHaveBeenCalledTimes(numRetries)
     })
@@ -641,7 +641,7 @@ describe("Asset Dimensions Plugin", () => {
       sizeOfMock.mockReset()
       sizeOfMock.mockReturnValueOnce({ type: "unknown" })
 
-      await expect(assetProcessor.fetchAndParseAssetDimensions(invalidDimsUrl, 1)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(invalidDimsUrl, 1)).rejects.toThrow(
         /Unable to determine remote asset dimensions|unsupported file type/,
       )
       expect(mockedFetch).toHaveBeenCalledWith(invalidDimsUrl)
@@ -653,7 +653,7 @@ describe("Asset Dimensions Plugin", () => {
       const fetchSpy = mockedFetch.mockImplementation(() => {
         throw new Error("Should not be called")
       })
-      await expect(assetProcessor.fetchAndParseAssetDimensions(neverFetchedUrl, 0)).rejects.toThrow(
+      await expect(AssetProcessor.fetchAndParseAssetDimensions(neverFetchedUrl, 0)).rejects.toThrow(
         `Failed to fetch ${neverFetchedUrl} after 0 attempts.`,
       )
       expect(fetchSpy).not.toHaveBeenCalled()
@@ -1191,7 +1191,7 @@ describe("Asset Dimensions Plugin", () => {
     })
 
     it("reads dimensions for local image via file://", async () => {
-      const dims = await assetProcessor.fetchAndParseAssetDimensions(`file://${imageFile}`, 1)
+      const dims = await AssetProcessor.fetchAndParseAssetDimensions(`file://${imageFile}`, 1)
       expect(dims).toEqual(mockFetchedImageDims)
     })
 
@@ -1204,7 +1204,7 @@ describe("Asset Dimensions Plugin", () => {
         status: 0,
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
-      const dims = await assetProcessor.fetchAndParseAssetDimensions(`file://${videoFile}`, 1)
+      const dims = await AssetProcessor.fetchAndParseAssetDimensions(`file://${videoFile}`, 1)
       expect(mockSpawnSync).toHaveBeenCalledWith("ffprobe", expect.arrayContaining([videoFile]), {
         encoding: "utf-8",
       })
@@ -1214,7 +1214,7 @@ describe("Asset Dimensions Plugin", () => {
     it("throws when local asset not found", async () => {
       const missing = path.join(tmpDir, "not-exist.png")
       await expect(
-        assetProcessor.fetchAndParseAssetDimensions(`file://${missing}`, 1),
+        AssetProcessor.fetchAndParseAssetDimensions(`file://${missing}`, 1),
       ).rejects.toThrow("ENOENT")
     })
 
@@ -1223,7 +1223,7 @@ describe("Asset Dimensions Plugin", () => {
       jest.spyOn(fs, "access").mockResolvedValueOnce()
       jest.spyOn(fs, "readFile").mockResolvedValueOnce(mockImageData)
 
-      const dims = await assetProcessor.fetchAndParseAssetDimensions(`/static/${imageFileName}`, 1)
+      const dims = await AssetProcessor.fetchAndParseAssetDimensions(`/static/${imageFileName}`, 1)
 
       expect(fs.access).toHaveBeenCalledWith(expectedPath)
       expect(fs.readFile).toHaveBeenCalledWith(expectedPath)
@@ -1237,7 +1237,7 @@ describe("Asset Dimensions Plugin", () => {
       const missing = path.join(tmpDir, "not-exist.png")
       await fs.writeFile(missing, "fake-data")
       await expect(
-        assetProcessor.fetchAndParseAssetDimensions(`file://${missing}`, 1),
+        AssetProcessor.fetchAndParseAssetDimensions(`file://${missing}`, 1),
       ).rejects.toThrow("unsupported file type")
     })
 
@@ -1247,7 +1247,7 @@ describe("Asset Dimensions Plugin", () => {
       jest.spyOn(fs, "access").mockResolvedValueOnce()
       jest.spyOn(fs, "readFile").mockResolvedValueOnce(mockImageData)
 
-      const dims = await assetProcessor.fetchAndParseAssetDimensions(relImageName, 1)
+      const dims = await AssetProcessor.fetchAndParseAssetDimensions(relImageName, 1)
 
       expect(fs.access).toHaveBeenCalledWith(expectedPath)
       expect(fs.readFile).toHaveBeenCalledWith(expectedPath)
@@ -1268,7 +1268,7 @@ describe("Asset Dimensions Plugin", () => {
       jest.spyOn(fs, "access").mockResolvedValueOnce()
       jest.spyOn(fs, "readFile").mockResolvedValueOnce(mockImageData)
 
-      const dims = await assetProcessor.fetchAndParseAssetDimensions(inputPath, 1)
+      const dims = await AssetProcessor.fetchAndParseAssetDimensions(inputPath, 1)
 
       expect(fs.access).toHaveBeenCalledWith(expectedPath)
       expect(fs.readFile).toHaveBeenCalledWith(expectedPath)
@@ -1284,9 +1284,11 @@ describe("Asset Dimensions Plugin", () => {
       jest.doMock("image-size", () => ({ __esModule: true, default: invalidSizeOf }))
 
       const { AssetProcessor: FreshAssetProcessor } = await import("../assetDimensions")
-      const freshProcessor = new FreshAssetProcessor()
 
-      const dims = await freshProcessor.fetchAndParseAssetDimensions(`file://${badImagePath}`, 1)
+      const dims = await FreshAssetProcessor.fetchAndParseAssetDimensions(
+        `file://${badImagePath}`,
+        1,
+      )
       expect(dims).toEqual({ width: mockImageWidth, height: mockImageHeight })
 
       jest.dontMock("image-size")

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -4,7 +4,7 @@
 import type { Element, Root } from "hast"
 
 import { jest, expect, it, describe, beforeEach, afterEach } from "@jest/globals"
-import { type SpawnSyncReturns, type spawnSync } from "child_process"
+import childProcess, { type SpawnSyncReturns } from "child_process"
 // skipcq: JS-W1028
 import fsExtra from "fs-extra"
 import { h } from "hastscript"
@@ -19,8 +19,6 @@ const mockVideoWidth = 640
 const mockVideoHeight = 360
 const mockFetchedVideoDims = { width: mockVideoWidth, height: mockVideoHeight }
 
-const mockSpawnSync = jest.fn()
-
 import {
   addAssetDimensionsFromSrc,
   type AssetDimensionMap,
@@ -31,7 +29,6 @@ import {
   prependStyles,
   paths,
   assetProcessor as globalAssetProcessor,
-  setSpawnSyncForTesting,
   numRetries,
   maybeResolveAssetStagingPath,
 } from "../assetDimensions"
@@ -125,14 +122,15 @@ describe("Asset Dimensions Plugin", () => {
     })
   })
 
+  let mockSpawnSync: jest.SpiedFunction<typeof childProcess.spawnSync>
+
   beforeEach(async () => {
     // skipcq: JS-P1003
     tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), "assetDimensions-test-files-"))
     assetProcessor = globalAssetProcessor as AssetProcessor
     mockedFetch.mockClear()
     sizeOfMock.mockClear()
-    mockSpawnSync.mockClear()
-    mockSpawnSync.mockImplementation(
+    mockSpawnSync = jest.spyOn(childProcess, "spawnSync").mockImplementation(
       (): SpawnSyncReturns<string> => ({
         pid: 1,
         output: ["", `${mockImageWidth}x${mockImageHeight}`, ""],
@@ -141,8 +139,7 @@ describe("Asset Dimensions Plugin", () => {
         status: 0,
         signal: null,
       }),
-    )
-    setSpawnSyncForTesting(mockSpawnSync as unknown as typeof spawnSync)
+    ) as jest.SpiedFunction<typeof childProcess.spawnSync>
   })
 
   afterEach(async () => {

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -371,7 +371,7 @@ describe("Asset Dimensions Plugin", () => {
         status: 0,
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
-      const dimensions = await assetProcessor.getAssetDimensionsFfprobe(testVideoUrl)
+      const dimensions = await AssetProcessor.getAssetDimensionsFfprobe(testVideoUrl)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         "ffprobe",
         expect.arrayContaining([testVideoUrl]),
@@ -389,7 +389,7 @@ describe("Asset Dimensions Plugin", () => {
         status: 0,
         signal: null,
       } as unknown as SpawnSyncReturns<string>)
-      const dimensions = await assetProcessor.getAssetDimensionsFfprobe(testVideoUrl)
+      const dimensions = await AssetProcessor.getAssetDimensionsFfprobe(testVideoUrl)
       expect(dimensions).toEqual(mockFetchedVideoDims)
     })
   })


### PR DESCRIPTION
## Summary

Follow-up to #1335. The DI machinery in `populateExternalMarkdown` (`defaultFetchFunction` / `setFetchFunction` / mutable `fetchFunction` binding) and in `assetDimensions` (`setSpawnSyncForTesting` + `AssetProcessor`'s `spawnFn` constructor arg) existed solely because tests couldn't patch named ESM imports of `execFileSync` / `readFileSync` / `spawnSync`. Switching the call sites to default imports (which resolve to the same CJS module object under `esModuleInterop`) lets `jest.spyOn` work directly — and the entire indirection collapses.

## Changes

**`quartz/plugins/transformers/populateExternalMarkdown.ts`**

- Drops `defaultFetchFunction`, `defaultReadFileFunction`, `FetchFunction`, `ReadFileFunction`, `setFetchFunction`, `setReadFileFunction`, and the `let fetchFunction = ...` / `let readFileFunction = ...` indirections.
- Inlines `childProcess.execFileSync("curl", ...)` and `fs.readFileSync(...)` in their respective functions.
- The two `// istanbul ignore next` regions on the defaults are no longer needed — every line is now covered through the real call sites.

**`quartz/plugins/transformers/assetDimensions.ts`**

- Drops `setSpawnSyncForTesting`, the `spawnSyncWrapper` field, and the `AssetProcessor(spawnFn?)` constructor parameter.
- Calls `childProcess.spawnSync(...)` directly in `getAssetDimensionsFfprobe`.

**Test files**

- Both test files use `jest.spyOn(childProcess, "execFileSync" | "spawnSync")` / `jest.spyOn(fs, "readFileSync")` for mocking.

## Testing

- `pnpm check` — green.
- All 3802 Jest tests across 76 suites pass.
- `populateExternalMarkdown.ts` retains 100% branch/statement/function/line coverage (and now exercises the previously-ignored `default*Function` bodies). `assetDimensions.ts` is in `coveragePathIgnorePatterns` so the threshold isn't affected.

## Out of scope

`search.ts` and `handlers.ts` also expose `*ForTesting` setters, but those guard pure module-level state (init flags, cache strings) rather than wrapping injectable dependencies. Removing them requires restructuring the modules into classes or accepting a heavier `jest.resetModules` workflow — not a localized test rewrite. Left for a future PR.

`Head.tsx:70`'s `// istanbul ignore next` — attempted to cover the `if (!headJsx) throw` by spying on `htmlToJsx`, but the ESM namespace binding is sealed (`Cannot assign to read only property 'htmlToJsx'`). Would require either restructuring `renderMetaJsx` to accept a JSX-converter parameter or moving to `jest.unstable_mockModule`. Left for a future PR.

https://claude.ai/code/session_01KXLB5fbaZJNW7F4X3itr9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLB5fbaZJNW7F4X3itr9C)_