### PR TITLE
verify: regression test catches Safari reload-loop bug (DO NOT MERGE)

### DIFF
--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -474,10 +474,13 @@ test.describe("Instant Scroll Restoration", () => {
   test("exits restoration loop quickly despite browser subpixel scroll rounding", async ({
     page,
   }) => {
-    // Safari rounds window.scrollTo's result down by 1px, leaving a structural
-    // 1px gap between target and actual scroll. If the early-exit tolerance is
-    // too tight, the loop runs all MAX_ATTEMPTS frames (~3s) and locks user
-    // scroll input the entire time.
+    // Reproduces the Safari "stuck for 3s after reload" bug deterministically
+    // across all browsers by monkey-patching window.scrollTo to round its
+    // target down by 1px — the same subpixel-rounding behavior real Safari
+    // exhibits at Retina DPRs. If the restoration loop's early-exit tolerance
+    // is too tight (< 1 instead of <= 1), the |actual - target| == 1 gap
+    // never satisfies the exit condition, so the loop runs all MAX_ATTEMPTS
+    // (~3s @ 60fps), locking user scroll input the whole time.
     const scrollPos = 500
     await page.evaluate((pos) => window.scrollTo(0, pos), scrollPos)
     await waitForHistoryState(page, scrollPos)
@@ -487,6 +490,22 @@ test.describe("Instant Scroll Restoration", () => {
       if (msg.text().includes("InstantScrollRestoration")) {
         consoleMessages.push(msg.text())
       }
+    })
+
+    // Install the rounding stub before reload so it's active when the
+    // inline restoration script runs.
+    await page.addInitScript(() => {
+      const original = window.scrollTo.bind(window)
+      window.scrollTo = ((...args: unknown[]) => {
+        if (args.length >= 2 && typeof args[1] === "number") {
+          original(args[0] as number, args[1] - 1)
+        } else if (args.length === 1 && typeof args[0] === "object" && args[0] !== null) {
+          const opts = args[0] as ScrollToOptions
+          original({ ...opts, top: (opts.top ?? 0) - 1 })
+        } else {
+          original(...(args as Parameters<typeof window.scrollTo>))
+        }
+      }) as typeof window.scrollTo
     })
 
     await page

--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -470,6 +470,47 @@ test.describe("Instant Scroll Restoration", () => {
       })
       .toBeDefined()
   })
+
+  test("exits restoration loop quickly despite browser subpixel scroll rounding", async ({
+    page,
+  }) => {
+    // Safari rounds window.scrollTo's result down by 1px, leaving a structural
+    // 1px gap between target and actual scroll. If the early-exit tolerance is
+    // too tight, the loop runs all MAX_ATTEMPTS frames (~3s) and locks user
+    // scroll input the entire time.
+    const scrollPos = 500
+    await page.evaluate((pos) => window.scrollTo(0, pos), scrollPos)
+    await waitForHistoryState(page, scrollPos)
+
+    const consoleMessages: string[] = []
+    page.on("console", (msg) => {
+      if (msg.text().includes("InstantScrollRestoration")) {
+        consoleMessages.push(msg.text())
+      }
+    })
+
+    await page
+      .evaluate(() => location.reload())
+      .catch((error: Error) => {
+        if (!error.message?.includes("context")) {
+          throw error
+        }
+      })
+    await page.waitForLoadState("domcontentloaded")
+
+    await expect
+      .poll(() => consoleMessages.find((msg) => msg.includes("Initial scroll complete")), {
+        timeout: 10_000,
+      })
+      .toBeDefined()
+
+    const attemptNumbers = consoleMessages
+      .map((msg) => /Attempt (?<n>\d+),/.exec(msg)?.groups?.n)
+      .filter((n): n is string => n !== undefined)
+      .map(Number)
+    const maxAttempt = Math.max(0, ...attemptNumbers)
+    expect(maxAttempt).toBeLessThan(20)
+  })
 })
 
 test.describe("Cross-Session Scroll Persistence (localStorage)", () => {

--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -471,64 +471,54 @@ test.describe("Instant Scroll Restoration", () => {
       .toBeDefined()
   })
 
-  test("exits restoration loop quickly despite browser subpixel scroll rounding", async ({
-    page,
-  }) => {
-    // Reproduces the Safari "stuck for 3s after reload" bug deterministically
-    // across all browsers by monkey-patching window.scrollTo to round its
-    // target down by 1px — the same subpixel-rounding behavior real Safari
-    // exhibits at Retina DPRs. If the restoration loop's early-exit tolerance
-    // is too tight (< 1 instead of <= 1), the |actual - target| == 1 gap
-    // never satisfies the exit condition, so the loop runs all MAX_ATTEMPTS
-    // (~3s @ 60fps), locking user scroll input the whole time.
-    const scrollPos = 500
-    await page.evaluate((pos) => window.scrollTo(0, pos), scrollPos)
-    await waitForHistoryState(page, scrollPos)
+  test.describe("subpixel scroll rounding on Retina", () => {
+    test.use({ deviceScaleFactor: 2 })
 
-    const consoleMessages: string[] = []
-    page.on("console", (msg) => {
-      if (msg.text().includes("InstantScrollRestoration")) {
-        consoleMessages.push(msg.text())
-      }
-    })
+    test("exits restoration loop quickly despite Safari Retina rounding", async ({
+      page,
+      browserName,
+    }) => {
+      // Real Safari at DPR=2 snaps scrollTo's result to a half-pixel boundary,
+      // producing a structural 1px gap between target and actual scrollY. If
+      // the restoration loop's early-exit tolerance is too tight, the loop
+      // runs all MAX_ATTEMPTS frames (~3s @ 60fps), locking user scroll input
+      // for the entire duration. This bug doesn't manifest in
+      // Chromium/Firefox, so we skip them.
+      test.skip(browserName !== "webkit", "Subpixel rounding only repros in WebKit")
 
-    // Install the rounding stub before reload so it's active when the
-    // inline restoration script runs.
-    await page.addInitScript(() => {
-      const original = window.scrollTo.bind(window)
-      window.scrollTo = ((...args: unknown[]) => {
-        if (args.length >= 2 && typeof args[1] === "number") {
-          original(args[0] as number, args[1] - 1)
-        } else if (args.length === 1 && typeof args[0] === "object" && args[0] !== null) {
-          const opts = args[0] as ScrollToOptions
-          original({ ...opts, top: (opts.top ?? 0) - 1 })
-        } else {
-          original(...(args as Parameters<typeof window.scrollTo>))
-        }
-      }) as typeof window.scrollTo
-    })
+      const scrollPos = 1500
+      await page.evaluate((pos) => window.scrollTo(0, pos), scrollPos)
+      await waitForHistoryState(page, scrollPos)
 
-    await page
-      .evaluate(() => location.reload())
-      .catch((error: Error) => {
-        if (!error.message?.includes("context")) {
-          throw error
+      const consoleMessages: string[] = []
+      page.on("console", (msg) => {
+        if (msg.text().includes("InstantScrollRestoration")) {
+          consoleMessages.push(msg.text())
         }
       })
-    await page.waitForLoadState("domcontentloaded")
 
-    await expect
-      .poll(() => consoleMessages.find((msg) => msg.includes("Initial scroll complete")), {
-        timeout: 10_000,
-      })
-      .toBeDefined()
+      await page
+        .evaluate(() => location.reload())
+        .catch((error: Error) => {
+          if (!error.message?.includes("context")) {
+            throw error
+          }
+        })
+      await page.waitForLoadState("domcontentloaded")
 
-    const attemptNumbers = consoleMessages
-      .map((msg) => /Attempt (?<n>\d+),/.exec(msg)?.groups?.n)
-      .filter((n): n is string => n !== undefined)
-      .map(Number)
-    const maxAttempt = Math.max(0, ...attemptNumbers)
-    expect(maxAttempt).toBeLessThan(20)
+      await expect
+        .poll(() => consoleMessages.find((msg) => msg.includes("Initial scroll complete")), {
+          timeout: 10_000,
+        })
+        .toBeDefined()
+
+      const attemptNumbers = consoleMessages
+        .map((msg) => /Attempt (?<n>\d+),/.exec(msg)?.groups?.n)
+        .filter((n): n is string => n !== undefined)
+        .map(Number)
+      const maxAttempt = Math.max(0, ...attemptNumbers)
+      expect(maxAttempt).toBeLessThan(20)
+    })
   })
 })
 

--- a/quartz/static/scripts/instantScrollRestoration.js
+++ b/quartz/static/scripts/instantScrollRestoration.js
@@ -124,7 +124,7 @@
       const actualScroll = window.scrollY
       console.debug("[InstantScrollRestoration] Scrolled to:", actualScroll, "target was:", target)
 
-      if (Math.abs(actualScroll - target) < 1 || attempts >= MAX_ATTEMPTS) {
+      if (Math.abs(actualScroll - target) <= 1 || attempts >= MAX_ATTEMPTS) {
         console.debug(
           "[InstantScrollRestoration] Initial scroll complete, waiting for layout stability",
         )

--- a/quartz/static/scripts/instantScrollRestoration.js
+++ b/quartz/static/scripts/instantScrollRestoration.js
@@ -124,7 +124,7 @@
       const actualScroll = window.scrollY
       console.debug("[InstantScrollRestoration] Scrolled to:", actualScroll, "target was:", target)
 
-      if (Math.abs(actualScroll - target) <= 1 || attempts >= MAX_ATTEMPTS) {
+      if (Math.abs(actualScroll - target) < 1 || attempts >= MAX_ATTEMPTS) {
         console.debug(
           "[InstantScrollRestoration] Initial scroll complete, waiting for layout stability",
         )


### PR DESCRIPTION
**DO NOT MERGE — verification only.**

This branch keeps the new regression test from #1339 but reverts the one-character fix (`<= 1` → `< 1`). The goal is to prove the Safari shard fails as expected before the fix lands.

Expected result: `exits restoration loop quickly despite browser subpixel scroll rounding` should fail on the macOS WebKit shard (max attempt ≈ 180, threshold = 20). Chromium/Firefox should still pass since they don't have the subpixel rounding gap.

Once verified, close this PR; the actual fix is on #1339.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVVsaKWv7T3fVpFz33QmFK)_