### PR TITLE
Unify page-end spacing with shared margin variable

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -7,6 +7,10 @@
 @use "print";
 @use "../components/styles/punctilioDemo";
 
+// Shared bottom-margin for the after-article box, the footnotes heading,
+// and the footnotes section itself, so the page-bottom rhythm stays balanced.
+$page-end-bottom-margin: calc(2 * $base-margin);
+
 body {
   min-height: 100vh;
 }
@@ -33,6 +37,12 @@ li > blockquote:first-child {
 }
 
 .footnotes {
+  margin-bottom: $page-end-bottom-margin;
+
+  & > h1 {
+    margin-bottom: $page-end-bottom-margin;
+  }
+
   & ul {
     margin-top: calc(2 * $base-margin);
   }
@@ -875,7 +885,7 @@ foreignObject {
 }
 
 .after-article-components {
-  margin-bottom: calc(2 * $base-margin);
+  margin-bottom: $page-end-bottom-margin;
   margin-top: calc(2 * $base-margin);
 
   & p {


### PR DESCRIPTION
## Summary
Introduces a shared `$page-end-bottom-margin` variable to maintain consistent vertical rhythm at the bottom of article pages, replacing hardcoded margin values across multiple components.

## Changes
- **New variable**: `$page-end-bottom-margin: calc(2 * $base-margin)` defined at the top of `custom.scss` for reuse across page-end components
- **`.footnotes` section**: 
  - Added `margin-bottom: $page-end-bottom-margin` to the section itself
  - Added `margin-bottom: $page-end-bottom-margin` to the `h1` heading within footnotes
- **`.after-article-components`**: Replaced hardcoded `calc(2 * $base-margin)` with the new `$page-end-bottom-margin` variable

## Implementation details
This change centralizes the spacing logic for elements that appear at the bottom of articles (after-article box, footnotes heading, footnotes section). Using a single variable ensures the page-bottom rhythm stays balanced and makes future adjustments to this spacing easier to maintain across all affected components.

https://claude.ai/code/session_01Kg73oQmSbZ69bMw85D9ekW