### PR TITLE
fix(check_css_vars): bypass user-defined grep function

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -598,10 +598,7 @@ export function normalizeAbbreviations(text: string): string {
   return text
 }
 
-const plusToAmpersandRegex = new RegExp(
-  "(?<!\\b(?:ctrl|alt|option|cmd|command|fn))(?<=\\p{L})\\+(?=[A-Za-z])",
-  "giu",
-)
+const plusToAmpersandRegex = /(?<!\b(?:ctrl|alt|option|cmd|command|fn))(?<=\p{L})\+(?=[A-Za-z])/giu
 
 export function plusToAmpersand(text: string): string {
   return text.replace(plusToAmpersandRegex, `${NBSP}&${NBSP}`)

--- a/scripts/tests/test_compress.py
+++ b/scripts/tests/test_compress.py
@@ -429,8 +429,9 @@ def test_avif_output_preserves_transparency(temp_dir: Path):
 def test_avif_quality_affects_file_size(temp_dir: Path, input_file_ext: str):
     """Test that different quality settings produce different file sizes."""
     input_file = temp_dir / f"test{input_file_ext}"
-    # Use larger image (500x500) to ensure quality difference is measurable
-    utils.create_test_image(input_file, "500x500")
+    # AVIF needs non-uniform content for quality settings to influence size;
+    # solid-color images compress to the same minimum size at any quality.
+    utils.create_test_image(input_file, "500x500", draw="circle 100,100 50,50")
 
     # Convert with high quality
     compress.image(input_file, quality=90)
@@ -469,25 +470,28 @@ def test_avif_format_chroma(temp_dir: Path):
     ), "AVIF should use YUV 4:2:0"
 
 
-@requires_exiftool
 def test_avif_format_pixel_depth(temp_dir: Path):
-    """Test that AVIF conversion sets correct Pixel Depth (8-bit)."""
+    """Test that AVIF conversion of an 8-bit sRGB image preserves 8-bit
+    depth."""
     input_file = temp_dir / "test_depth.png"
     utils.create_test_image(input_file, "100x100", colorspace="sRGB")
     compress.image(input_file)
     avif_file = input_file.with_suffix(".avif")
     assert avif_file.exists()
 
-    exiftool_executable = script_utils.find_executable("exiftool")
+    # Use magick identify so the pixel-depth check stays robust across
+    # libheif/exiftool combinations: it reads the depth directly from the
+    # same library that wrote the file.
+    identify_cmd = script_utils.get_imagemagick_command("identify")
     result = subprocess.run(
-        [exiftool_executable, str(avif_file)],
+        [*identify_cmd, "-format", "%[depth]", str(avif_file)],
         capture_output=True,
         text=True,
         check=True,
     )
-    assert re.search(
-        r"Image Pixel Depth\s*:\s*8 8 8", result.stdout
-    ), "AVIF should have 8-bit depth"
+    assert (
+        result.stdout.strip() == "8"
+    ), f"AVIF should have 8-bit depth, got {result.stdout.strip()!r}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When users alias grep to rg in their fish config, the script's bare
'grep -vE' resolves to 'rg -vE', which ripgrep interprets as --encoding
and errors out. Use 'command grep' to always invoke the real binary.