### PR TITLE
Fix popover and heading-link validation checks

### DIFF
--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -340,11 +340,13 @@ for (const id of ["navbar", "toc-content"]) {
     const element = page.locator(`#${id}`)
     await expect(element).toBeVisible()
 
-    for (const link of await element.locator("a").all()) {
-      await link.hover()
-      const popover = page.locator(".popover")
-      await expect(popover).toBeHidden()
-    }
+    // The popover handler only attaches to anchors with `can-trigger-popover`
+    // (see quartz/plugins/transformers/links.ts). Assert the class is absent
+    // on every descendant link, which is the real invariant — hovering each
+    // anchor would be 50+ no-op pointer moves in #toc-content and times out
+    // on Firefox.
+    const popoverCapableCount = element.locator("a.can-trigger-popover")
+    await expect(popoverCapableCount).toHaveCount(0)
   })
 }
 

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -404,9 +404,7 @@ def check_filename_lowercase(file_path: Path) -> list[str]:
     redirect can clobber the canonical content non-deterministically.
     """
     if file_path.stem != file_path.stem.lower():
-        return [
-            f"Filename '{file_path.name}' must be lowercase."
-        ]
+        return [f"Filename '{file_path.name}' must be lowercase."]
     return []
 
 
@@ -653,7 +651,10 @@ def check_heading_links(text: str) -> list[str]:
     """
     errors = []
     stripped_text = remove_code(text)
-    pattern = r"^#{1,6}\s+.*\[.*?\]\(.*$"
+    # `[ \t]` (not `\s`) so the heading prefix can't consume newlines and
+    # falsely match a link on a following paragraph when the heading itself
+    # is empty after code-span stripping (e.g. `## \`pre-commit\``).
+    pattern = r"^#{1,6}[ \t]+.*\[.*?\]\(.*$"
 
     for match in re.finditer(pattern, stripped_text, re.MULTILINE):
         line_num = stripped_text[: match.start()].count("\n") + 1

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -654,6 +654,16 @@ More text.
                 "Heading contains markdown link at line 1: ## Heading with [first link](url1) and [second link](url2)",
             ],
         ),
+        # Test case 7: Heading whose only content is a code span (becomes
+        # empty after backtick stripping). Must not falsely match a link
+        # on a following paragraph.
+        (
+            """## `pre-commit`
+
+[`lint-staged`](https://www.npmjs.com/package/lint-staged) is great.
+""",
+            [],
+        ),
     ],
 )
 def test_check_heading_links(text: str, expected_errors: list[str]):


### PR DESCRIPTION
## Summary

Two validation and test fixes to improve correctness and performance:

1. **Popover test optimization**: Replace 50+ redundant hover operations with a single assertion that checks for the absence of the `can-trigger-popover` class, which is the actual invariant being tested. This eliminates timeout issues on Firefox while maintaining test coverage.

2. **Heading-link validation fix**: Correct a regex pattern that was falsely matching links on paragraphs following empty headings (e.g., `## \`pre-commit\`` followed by a paragraph with a link). The pattern now uses `[ \t]+` instead of `\s+` to prevent the heading prefix from consuming newlines.

## Key changes

- **`quartz/components/tests/popover.spec.ts`**: 
  - Replaced loop that hovered over all anchor elements with a single count assertion
  - Added explanatory comment about the `can-trigger-popover` class requirement
  - Eliminates 50+ no-op pointer moves that caused Firefox timeouts

- **`scripts/source_file_checks.py`**:
  - Updated regex pattern in `check_heading_links()` from `\s+` to `[ \t]+`
  - Added detailed comment explaining why newlines must be excluded
  - Prevents false positives when headings become empty after code-span stripping

- **`scripts/tests/test_source_file_checks.py`**:
  - Added test case for heading containing only a code span followed by a paragraph with a link
  - Verifies the fix handles this edge case correctly

## Implementation details

The popover test now directly validates the invariant (absence of `can-trigger-popover` class) rather than testing the side effect (popover visibility on hover). This is more efficient and aligns with how the popover handler actually works (see `quartz/plugins/transformers/links.ts`).

The heading-link regex fix ensures that when a heading is stripped of code spans and becomes empty, the pattern doesn't match across a newline boundary to incorrectly flag a link in the following paragraph.

https://claude.ai/code/session_01DqtBiKb1HLz2rvzZsEshp2