### PR TITLE
fix: bugs surfaced by stress-test code review

### DIFF
--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -149,20 +149,23 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
     const buildStart = Date.now()
     lastBuildMs = buildStart
     const release = await buildMutex.acquire()
-    if (lastBuildMs > buildStart) {
+    let result: Awaited<ReturnType<typeof ctx.rebuild>>
+    try {
+      if (lastBuildMs > buildStart) {
+        return
+      }
+
+      if (cleanupBuild) {
+        await cleanupBuild()
+        console.log(chalk.yellow("Detected a source code change, doing a hard rebuild..."))
+      }
+
+      result = await ctx.rebuild().catch((err: Error) => {
+        throw new Error(`Couldn't parse turntrout.com configuration: ${fp}\nReason: ${err}`)
+      })
+    } finally {
       release()
-      return
     }
-
-    if (cleanupBuild) {
-      await cleanupBuild()
-      console.log(chalk.yellow("Detected a source code change, doing a hard rebuild..."))
-    }
-
-    const result = await ctx.rebuild().catch((err: Error) => {
-      throw new Error(`Couldn't parse turntrout.com configuration: ${fp}\nReason: ${err}`)
-    })
-    release()
 
     if (argv.bundleInfo) {
       const outputFileName = "quartz/.quartz-cache/transpiled-build.mjs"
@@ -194,10 +197,18 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
     return
   }
 
-  const connections: WebSocket[] = []
-  // Send a rebuild message to all connected clients
+  const connections = new Set<WebSocket>()
+  // Send a rebuild message to all connected clients. One bad socket must not
+  // prevent the broadcast from reaching the others.
   const clientRefresh = (): void => {
-    connections.forEach((conn) => conn.send("rebuild"))
+    for (const conn of connections) {
+      try {
+        conn.send("rebuild")
+      } catch (err) {
+        console.warn(chalk.yellow(`Failed to notify a WebSocket client of rebuild: ${err}`))
+        connections.delete(conn)
+      }
+    }
   }
 
   if (argv.baseDir !== "" && !argv.baseDir.startsWith("/")) {
@@ -223,21 +234,24 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
     // Serve the site while logging requests
     const serve = async () => {
       const release = await buildMutex.acquire()
-      await serveHandler(req, res, {
-        public: argv.output,
-        directoryListing: false,
-        headers: [
-          {
-            source: "**/*.*",
-            headers: [{ key: "Content-Disposition", value: "inline" }],
-          },
-        ],
-      })
-      const status: number = res.statusCode
-      const statusString: string =
-        status >= 200 && status < 300 ? chalk.green(`[${status}]`) : chalk.red(`[${status}]`)
-      console.log(statusString + chalk.grey(` ${argv.baseDir}${req.url}`))
-      release()
+      try {
+        await serveHandler(req, res, {
+          public: argv.output,
+          directoryListing: false,
+          headers: [
+            {
+              source: "**/*.*",
+              headers: [{ key: "Content-Disposition", value: "inline" }],
+            },
+          ],
+        })
+        const status: number = res.statusCode
+        const statusString: string =
+          status >= 200 && status < 300 ? chalk.green(`[${status}]`) : chalk.red(`[${status}]`)
+        console.log(statusString + chalk.grey(` ${argv.baseDir}${req.url}`))
+      } finally {
+        release()
+      }
     }
 
     // Handle and log redirects
@@ -294,7 +308,11 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
 
   server.listen(argv.port)
   const wss = new WebSocketServer({ port: argv.wsPort })
-  wss.on("connection", (ws: WebSocket) => connections.push(ws))
+  wss.on("connection", (ws: WebSocket) => {
+    connections.add(ws)
+    ws.on("close", () => connections.delete(ws))
+    ws.on("error", () => connections.delete(ws))
+  })
   console.log(
     chalk.cyan(
       `Started a turntrout.com server listening at http://localhost:${argv.port}${argv.baseDir}`,

--- a/quartz/cli/helpers.js
+++ b/quartz/cli/helpers.js
@@ -30,11 +30,10 @@ export async function stashContentFolder(contentFolder) {
 
 export function gitPull(origin, branch) {
   const flags = ["--no-rebase", "--autostash", "-s", "recursive", "-X", "ours", "--no-edit"]
-  const out = spawnSync("git", ["pull", ...flags, origin, branch], { stdio: "inherit" })
-  if (out.stderr) {
-    throw new Error(chalk.red(`Error while pulling updates: ${out.stderr}`))
-  } else if (out.status !== 0) {
-    throw new Error(chalk.red("Error while pulling updates"))
+  // `--` ensures origin/branch are not interpreted as git options.
+  const out = spawnSync("git", ["pull", ...flags, "--", origin, branch], { stdio: "inherit" })
+  if (out.status !== 0) {
+    throw new Error(chalk.red(`Error while pulling updates (git exit status ${out.status})`))
   }
 }
 

--- a/quartz/plugins/transformers/bibtex.ts
+++ b/quartz/plugins/transformers/bibtex.ts
@@ -43,6 +43,15 @@ function generateCitationKey(authors: readonly string[], year: number, slug: str
 }
 
 /**
+ * Escapes a value for use inside a BibTeX `"…"`-delimited field.
+ * Backslashes and double quotes are the only characters with structural
+ * meaning inside such a field; we backslash-escape both.
+ */
+function escapeBibtexValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+/**
  * Generates a BibTeX entry for an article.
  * @throws Error if date_published is not present in frontmatter on CI
  */
@@ -72,10 +81,10 @@ export function generateBibtexEntry(
   const authorString = authors.join(" and ")
 
   return `@misc{${citationKey},
-  author = "${authorString}",
-  title = "${title}",
+  author = "${escapeBibtexValue(authorString)}",
+  title = "${escapeBibtexValue(title)}",
   year = ${year},
-  url = "${url}"
+  url = "${escapeBibtexValue(url)}"
 }`
 }
 

--- a/quartz/plugins/transformers/tests/bibtex.test.ts
+++ b/quartz/plugins/transformers/tests/bibtex.test.ts
@@ -103,6 +103,20 @@ describe("generateBibtexEntry", () => {
     expect(result).toContain('author = "Alex Turner and John Doe"')
   })
 
+  it("escapes double quotes and backslashes in title and author", () => {
+    const result = generateBibtexEntry(
+      {
+        title: 'A "quoted" title with a backslash \\here',
+        authors: ['Alex "Turntrout" Turner'],
+        date_published: "2022-06-15",
+      },
+      "turntrout.com",
+      "test-slug",
+    )
+    expect(result).toContain('title = "A \\"quoted\\" title with a backslash \\\\here"')
+    expect(result).toContain('author = "Alex \\"Turntrout\\" Turner"')
+  })
+
   it("uses permalink for citation key when available", () => {
     const result = generateBibtexEntry(
       {

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -1260,8 +1260,11 @@ def meta_tags_early(file_path: Path) -> list[str]:
     # Convert the first chunk and remainder to strings
     content = content_bytes.decode("utf-8")
 
-    # Find where the byte boundary falls in terms of characters
-    boundary_content = content_bytes[:MAX_META_HEAD_SIZE].decode("utf-8")
+    # ``errors="ignore"`` guards against the slice splitting a multi-byte
+    # UTF-8 sequence; the character boundary is approximate by design.
+    boundary_content = content_bytes[:MAX_META_HEAD_SIZE].decode(
+        "utf-8", errors="ignore"
+    )
     char_boundary = len(boundary_content)
 
     # Consider everything past the byte boundary

--- a/scripts/run_push_checks.py
+++ b/scripts/run_push_checks.py
@@ -533,9 +533,9 @@ def get_formatter_steps(git_root_path: Path) -> list[CheckStep]:
                 "-m",
                 "docformatter",
                 "--in-place",
-                *glob.glob(f"{git_root_path}/scripts/**.py", recursive=True),
+                *glob.glob(f"{git_root_path}/scripts/**/*.py", recursive=True),
                 *glob.glob(
-                    f"{git_root_path}/.github/scripts/**.py", recursive=True
+                    f"{git_root_path}/.github/scripts/**/*.py", recursive=True
                 ),
                 "--config",
                 f"{git_root_path}/config/python/pyproject.toml",

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2161,15 +2161,20 @@ def test_meta_tags_first_10kb(tmp_path, html, expected):
 
 
 def test_meta_tags_early_handles_multibyte_boundary(tmp_path):
-    """When the MAX_META_HEAD_SIZE byte slice falls inside a multi-byte UTF-8
-    sequence, the decode must not raise ``UnicodeDecodeError``."""
-    # Place a 3-byte UTF-8 character (€ = b'\\xe2\\x82\\xac') so its first byte
-    # lands on the very last byte of the cut-off slice, guaranteeing the cut
-    # splits the multi-byte sequence.
-    padding = "a" * (_MAX_META_HEAD_SIZE - 1)
+    """Decode must tolerate a multi-byte UTF-8 sequence straddling the slice."""
+    # ``<head>`` is 6 bytes; padding length is chosen so the next character
+    # (€, 3 bytes b'\\xe2\\x82\\xac') has its first byte at index
+    # MAX_META_HEAD_SIZE - 1, putting the slice end mid-sequence.
+    padding = "a" * (_MAX_META_HEAD_SIZE - len("<head>") - 1)
     html = f"<head>{padding}€<meta name='late'></head>"
     test_file = tmp_path / "test.html"
-    test_file.write_bytes(html.encode("utf-8"))
+    file_bytes = html.encode("utf-8")
+    test_file.write_bytes(file_bytes)
+
+    # Sanity: the fixture is genuinely adversarial — the strict decode the
+    # buggy code performed would have raised on this slice.
+    with pytest.raises(UnicodeDecodeError):
+        file_bytes[:_MAX_META_HEAD_SIZE].decode("utf-8")
 
     result = built_site_checks.meta_tags_early(test_file)
     assert any("<meta>" in issue for issue in result)

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2160,6 +2160,21 @@ def test_meta_tags_first_10kb(tmp_path, html, expected):
     assert sorted(result) == sorted(expected)
 
 
+def test_meta_tags_early_handles_multibyte_boundary(tmp_path):
+    """When the MAX_META_HEAD_SIZE byte slice falls inside a multi-byte UTF-8
+    sequence, the decode must not raise ``UnicodeDecodeError``."""
+    # Place a 3-byte UTF-8 character (€ = b'\\xe2\\x82\\xac') so its first byte
+    # lands on the very last byte of the cut-off slice, guaranteeing the cut
+    # splits the multi-byte sequence.
+    padding = "a" * (_MAX_META_HEAD_SIZE - 1)
+    html = f"<head>{padding}€<meta name='late'></head>"
+    test_file = tmp_path / "test.html"
+    test_file.write_bytes(html.encode("utf-8"))
+
+    result = built_site_checks.meta_tags_early(test_file)
+    assert any("<meta>" in issue for issue in result)
+
+
 @pytest.mark.parametrize(
     "html,expected_count",
     [

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -649,15 +649,10 @@ def test_get_formatter_steps():
 
 
 def test_docformatter_step_recurses_into_subdirectories(tmp_path):
-    """
-    The docformatter glob must pick up nested .py files.
-
-    ``**.py`` (without
-    a separator before the trailing ``*``) silently matches only the top
-    directory level; the recursive form is ``**/*.py``.
-    """
+    """Docformatter glob must reach both top-level and nested .py files."""
     (tmp_path / "scripts" / "notebooks").mkdir(parents=True)
-    (tmp_path / "scripts" / "top_level.py").write_text("'''doc.'''\n")
+    top_level = tmp_path / "scripts" / "top_level.py"
+    top_level.write_text("'''doc.'''\n")
     nested = tmp_path / "scripts" / "notebooks" / "nested.py"
     nested.write_text("'''doc.'''\n")
 
@@ -665,9 +660,7 @@ def test_docformatter_step_recurses_into_subdirectories(tmp_path):
     docformatter_step = _step_by_name(steps, "Formatting Python docstrings")
 
     assert str(nested) in docformatter_step.command
-    assert (
-        str(tmp_path / "scripts" / "top_level.py") in docformatter_step.command
-    )
+    assert str(top_level) in docformatter_step.command
 
 
 _TEST_ROOT = Path("/test/root")

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -648,6 +648,28 @@ def test_get_formatter_steps():
     assert any("website_content" in arg for arg in prettier_markdown.command)
 
 
+def test_docformatter_step_recurses_into_subdirectories(tmp_path):
+    """
+    The docformatter glob must pick up nested .py files.
+
+    ``**.py`` (without
+    a separator before the trailing ``*``) silently matches only the top
+    directory level; the recursive form is ``**/*.py``.
+    """
+    (tmp_path / "scripts" / "notebooks").mkdir(parents=True)
+    (tmp_path / "scripts" / "top_level.py").write_text("'''doc.'''\n")
+    nested = tmp_path / "scripts" / "notebooks" / "nested.py"
+    nested.write_text("'''doc.'''\n")
+
+    steps = run_push_checks.get_formatter_steps(tmp_path)
+    docformatter_step = _step_by_name(steps, "Formatting Python docstrings")
+
+    assert str(nested) in docformatter_step.command
+    assert (
+        str(tmp_path / "scripts" / "top_level.py") in docformatter_step.command
+    )
+
+
 _TEST_ROOT = Path("/test/root")
 _VERIFY_NAMES = frozenset(
     {

--- a/scripts/tests/test_strip_for_spellcheck.py
+++ b/scripts/tests/test_strip_for_spellcheck.py
@@ -159,11 +159,12 @@ def test_strip_quote_blocks(text: str, expected: str):
 
 
 def _blank_inner_spans(text: str, spans: list[tuple[int, int]]) -> str:
-    """Build expected by blanking the math interior, keeping `$` delimiters.
+    """
+    Build expected by blanking the math interior, keeping `$` delimiters.
 
-    Each span is `(start, end_exclusive)` of a full math match. The leading
-    and trailing `$` (or `$$`) are kept; the interior non-newline chars
-    become spaces, newlines are kept.
+    Each span is `(start, end_exclusive)` of a full math match. The leading and
+    trailing `$` (or `$$`) are kept; the interior non-newline chars become
+    spaces, newlines are kept.
     """
     out = list(text)
     for start, end in spans:


### PR DESCRIPTION
## Summary

A multi-agent stress-test review of the repo surfaced a long list of findings; I verified each by hand, dropped the false alarms, and landed the verified ones here. Six focused fixes across the dev-server, BibTeX generation, and the Python check scripts.

## Changes

### `quartz/cli/handlers.ts` — dev-server lockup + WebSocket leak
- Wrap the build-mutex `acquire`/`release` pair in `try/finally`. The previous code only released on the happy path; a `ctx.rebuild()` error (e.g. config-syntax break) permanently deadlocked the mutex for the rest of the dev session.
- Same `try/finally` around the per-request `serve()` handler's mutex.
- Replace `connections: WebSocket[]` with a `Set<WebSocket>`, register `close`/`error` listeners to prune entries, and wrap `conn.send` in `try/catch` so one dead socket doesn't kill the broadcast for the others.

### `quartz/cli/helpers.js` — `git pull` status check
- Treat `out.status !== 0` as the failure signal instead of `out.stderr`. With `stdio: "inherit"`, `out.stderr` was `null` anyway, so the original `if (out.stderr)` branch was effectively dead code — but if anyone ever flips the stdio mode, the old check would trip on git's success-time progress output. Also pass `--` so origin/branch can't be reinterpreted as git options.

### `quartz/plugins/transformers/bibtex.ts` — BibTeX value escaping
- Backslash-escape `\` then `"` before interpolating author/title/url into `"…"`-delimited fields. A title with embedded quotes previously produced malformed BibTeX. Order matters: backslash-first, so the quote-escape's `\"` isn't double-escaped against itself.
- Test covers the combined case (the `\\\\` assertion proves both substitutions happened in the right order).

### `scripts/run_push_checks.py` — `**.py` glob misses subdirectories
- `glob.glob("scripts/**.py", recursive=True)` does not recurse — `**` is recursive only as a complete path segment. Changed to `**/*.py`. Verified empirically: 21 → 55 files. The pre-push hook in this very PR immediately reformatted `scripts/tests/test_strip_for_spellcheck.py`, a file that had been silently skipped for some time.

### `scripts/built_site_checks.py` — UTF-8 boundary crash
- `meta_tags_early` decoded a fixed-byte-length slice of the file head as strict UTF-8. If the slice ended mid-multibyte character (any non-ASCII char near the 9216-byte boundary), the check crashed with `UnicodeDecodeError`. Added `errors="ignore"` — the character boundary is already approximate by design.

### Tests
- `bibtex.test.ts`: new case `escapes double quotes and backslashes in title and author`.
- `test_run_push_checks.py`: new case `test_docformatter_step_recurses_into_subdirectories` asserts the step's command list includes both a top-level and a nested `.py` path.
- `test_built_site_checks.py`: new case `test_meta_tags_early_handles_multibyte_boundary` places `€` so its first byte lands on the slice boundary, and explicitly asserts the strict decode raises on the fixture — locking in that the test is genuinely adversarial.

## Testing

- `pnpm tsc --noEmit -p config/typescript/tsconfig.json` — clean.
- `pnpm prettier . --check` (via `pnpm check`) — clean.
- `pnpm jest bibtex.test` — 30 passing, including the new escape case.
- `uv run pytest scripts/tests/test_built_site_checks.py scripts/tests/test_run_push_checks.py` — 964 passing.
- Pre-push pipeline (`RESUME=true git push`) — all checks green, and the now-recursive docformatter immediately fixed a nested file (`scripts/tests/test_strip_for_spellcheck.py`) that had been silently skipped.

## Lessons Learned

- **What**: Litmus-test every "regression-prevention" test by confirming it actually fails against the pre-fix code.
- **Where**: `.claude/skills/pr-creation/critique-prompt.md` (add "verify the test would fail against the old behavior").
- **Why**: I added `test_meta_tags_early_handles_multibyte_boundary` to lock in the UTF-8 fix, but my `€` landed past the slice boundary so the test passed against the buggy code too. Self-critique caught it; verifying-against-old-code would catch it earlier.

- **What**: When a sub-agent stress-test surfaces findings, verify each one against the actual code before treating them as bugs.
- **Where**: any cross-repo agent-review workflow.
- **Why**: Of ~80 sub-agent findings in this review, roughly a third were false alarms (misread escaping order, dead parameters, deliberate design choices documented in comments). Trusting sub-agents without verification would have produced churn.

https://claude.ai/code/session_01VtDcwsoifvt28ScnL1ZA1r


---
_Generated by [Claude Code](https://claude.ai/code/session_01VtDcwsoifvt28ScnL1ZA1r)_