### PR TITLE
Update image URL for reframing-impact doorway illustration

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -2802,6 +2802,7 @@ redux
 reenabling
 reexpress
 refactorings
+reformats
 reframed
 reframing
 reframing-impact

--- a/quartz/plugins/transformers/.invert_labels.json
+++ b/quartz/plugins/transformers/.invert_labels.json
@@ -2851,6 +2851,10 @@
     "invert": true,
     "reviewed": true
   },
+  "https://assets.turntrout.com/static/images/posts/reframing-impact-doorway-05222026.avif": {
+    "invert": false,
+    "reviewed": true
+  },
   "https://assets.turntrout.com/static/images/posts/regular-shoggoth.avif": {
     "invert": true,
     "reviewed": true

--- a/website_content/reframing-impact.md
+++ b/website_content/reframing-impact.md
@@ -56,7 +56,7 @@ createBibtex: true
 ![Text overlay: "An impact measure would be the first proposed safeguard which maybe actually stops a powerful agent with an imperfect objective from ruining things – without assuming anything about the objective. This is a rare property among approaches." The text lurks above an illustration paying homage to the iconic Gandalf-vs-Balrog scene in Moria. The demon's whip ends in a giant paperclip, a metaphor for a misaligned artificial intelligence.](https://assets.turntrout.com/static/images/posts/reframing-impact-05182026.avif)
 
 ![Handwritten: "We have our bearing. Let us set out together."](https://assets.turntrout.com/static/images/posts/nFoDRoL.avif)
-![The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.](https://assets.turntrout.com/static/images/posts/e6vNG2D.avif)
+![The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.](https://assets.turntrout.com/static/images/posts/reframing-impact-doorway-05222026.avif)
 
 # Appendix: First safeguard?
 


### PR DESCRIPTION
## Summary
Updates the image asset URL for the doorway illustration in the "reframing-impact" post to use a timestamped filename for cache-busting and asset versioning.

## Changes
- Updated the image URL from `e6vNG2D.avif` to `reframing-impact-doorway-05222026.avif` in the alt text reference for the hobbit-hole doorway illustration
- This follows the naming convention used elsewhere in the post (e.g., `reframing-impact-05182026.avif`) for consistency and asset management

## Details
The change updates a single image reference in `website_content/reframing-impact.md`. The new filename includes a descriptive slug (`reframing-impact-doorway`) and a date stamp (`05222026`), which aligns with the asset versioning strategy used throughout the post and enables proper cache invalidation when the image is updated.

https://claude.ai/code/session_01B9dKu5oyDfL8Xox4aFtGfE