### PR TITLE
Add fade-image-border effect for vertical edge fading

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -619,13 +619,6 @@ img {
       var(--background) 80%,
       transparent 100%
     );
-    mask-image: linear-gradient(
-      to bottom,
-      transparent 0%,
-      var(--background) 20%,
-      var(--background) 80%,
-      transparent 100%
-    );
   }
 }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -610,6 +610,23 @@ img {
       background-color: white;
     }
   }
+
+  &.fade-image-border {
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0%,
+      var(--background) 20%,
+      var(--background) 80%,
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0%,
+      var(--background) 20%,
+      var(--background) 80%,
+      transparent 100%
+    );
+  }
 }
 
 // Ordering the z stacks

--- a/website_content/reframing-impact.md
+++ b/website_content/reframing-impact.md
@@ -56,7 +56,7 @@ createBibtex: true
 ![Text overlay: "An impact measure would be the first proposed safeguard which maybe actually stops a powerful agent with an imperfect objective from ruining things – without assuming anything about the objective. This is a rare property among approaches." The text lurks above an illustration paying homage to the iconic Gandalf-vs-Balrog scene in Moria. The demon's whip ends in a giant paperclip, a metaphor for a misaligned artificial intelligence.](https://assets.turntrout.com/static/images/posts/reframing-impact-05182026.avif)
 
 ![Handwritten: "We have our bearing. Let us set out together."](https://assets.turntrout.com/static/images/posts/nFoDRoL.avif)
-![The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.](https://assets.turntrout.com/static/images/cropped_towards.avif)
+<img src="https://assets.turntrout.com/static/images/cropped_towards.avif" alt='The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.' class="fade-image-border"/>
 
 # Appendix: First safeguard?
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -468,6 +468,13 @@ Figure: This image should be transparent in light mode and inverted to be transp
 <figcaption>An image with <code>class="force-hsl-invert"</code>. HSL-inverted in both light and dark mode.</figcaption>
 </figure>
 
+## Faded image border
+
+<figure>
+<img class="fade-image-border" src="https://assets.turntrout.com/static/images/cropped_towards.avif" alt='The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.'/>
+<figcaption>An image with <code>class="fade-image-border"</code>. The top and bottom edges fade to transparent.</figcaption>
+</figure>
+
 ## SVG inversion
 
 ![A scatter plot comparing AVIF and PNG file sizes against image quality, showing AVIF achieving the same quality at a fraction of the byte cost.](https://assets.turntrout.com/static/images/posts/avif_png_scatter.svg)


### PR DESCRIPTION
## Summary

Adds a new `fade-image-border` CSS class that applies a vertical fade mask to images, making the top and bottom edges gradually transparent. This creates a softer visual transition for images that benefit from edge fading.

## Changes

- **`quartz/styles/custom.scss`**: Added `.fade-image-border` class using CSS `mask-image` with a linear gradient that fades from transparent at the top (0%) to opaque in the middle (20–80%) and back to transparent at the bottom (100%).
- **`website_content/test-page.md`**: Added a new "Faded image border" section demonstrating the effect with an example image and documentation.
- **`website_content/reframing-impact.md`**: Converted a markdown image reference to an HTML `<img>` tag and applied the `fade-image-border` class to the "towards a new impact measure" illustration, replacing the plain markdown syntax.

## Implementation details

The mask uses `var(--background)` to ensure the fade respects the current theme (light/dark mode). The gradient is positioned to keep the image fully visible in the middle 60% of its height while fading smoothly at both edges.

https://claude.ai/code/session_01JVG7itg98jiNEA1PAY4VWM