### PR TITLE
Fix margin collapse in scroll-indicator for KaTeX and tables

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -3311,5 +3311,3 @@ SDF
 Sohaib
 Tice
 Weems
-ascender
-F-bigram

--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -3311,3 +3311,5 @@ SDF
 Sohaib
 Tice
 Weems
+ascender
+F-bigram

--- a/quartz/styles/scroll-indicator.scss
+++ b/quartz/styles/scroll-indicator.scss
@@ -11,6 +11,14 @@ $scroll-fade-size: 2rem;
   display: inline-block;
 }
 
+// .scroll-indicator establishes a BFC (overflow: clip; inline-block
+// in footnotes), so katex's default `margin: 1em 0` cannot collapse
+// with the surrounding <p> margins and stacks on top of them. Zero
+// the trapped inner margin and let the adjacent <p> margins set the gap.
+.scroll-indicator > .katex-display {
+  margin: 0;
+}
+
 .scroll-indicator {
   position: relative;
   overflow: clip;

--- a/quartz/styles/scroll-indicator.scss
+++ b/quartz/styles/scroll-indicator.scss
@@ -19,6 +19,19 @@ $scroll-fade-size: 2rem;
   margin: 0;
 }
 
+// Same BFC trap for .table-container's `margin-top: 2 * $base-margin`.
+// Unlike katex (1em — covered by <p> collapse), tables want extra
+// breathing room, so move the spacing onto the wrapper, where it can
+// collapse with siblings (or, in inline-block footnotes, behave the
+// same as the pre-JS inline-block .table-container did).
+.scroll-indicator > .table-container {
+  margin-top: 0;
+}
+
+.scroll-indicator:has(> .table-container) {
+  margin-block-start: calc(2 * $base-margin);
+}
+
 .scroll-indicator {
   position: relative;
   overflow: clip;

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -623,10 +623,6 @@ The NATO alliance met in the USA. SMALLCAPS "capitalization" should be similar t
 
 This computer has 16GB of RAM and runs at 3.2GHz. The sensor outputs 50mV per degree.
 
-## F-bigram kerning
-
-The upright EBGaramond f's ascender used to clip into the punctuation that followed it. GPOS pair kerning now adds breathing room: f) f] f\} f" f' f(. In context: the function f(x) is defined when f(x) > 0; common pairs include (if), (of), (off), (puff), (Wolf), and (shelf). The staff(s) handed self "hi" and called if'd a typo.
-
 ## Smart quotes
 
 "I am a quote with 'nested' quotes inside of me. Rock 'n' roll!"

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -619,6 +619,9 @@ The NATO alliance met in the USA. SMALLCAPS "capitalization" should be similar t
 - Version labels V1, v2, v100, and v1.0.2 use full-height digits.
 <!--spellchecker-enable-->
 
+## Kerning pairs
+The upright EBGaramond f's ascender used to clip into the punctuation that followed it. GPOS pair kerning now adds breathing room: f) f] f\} f" f' f(. In context: the function f(x) is defined when f(x) > 0; common pairs include (if), (of), (off), (puff), (Wolf), and (shelf). The staff(s) handed self "hi" and called if'd a typo.
+
 ## Numbers and units
 
 This computer has 16GB of RAM and runs at 3.2GHz. The sensor outputs 50mV per degree.

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -445,6 +445,36 @@ Wide tables and equations show a fade gradient at the scrollable edges.
 > \nabla \cdot \mathbf{E} = \frac{\rho}{\varepsilon_0} \qquad \nabla \cdot \mathbf{B} = 0 \qquad \nabla \times \mathbf{E} = -\frac{\partial \mathbf{B}}{\partial t} \qquad \nabla \times \mathbf{B} = \mu_0\left(\mathbf{J} + \varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right) \qquad \mathcal{L} = -\frac{1}{4}F_{\mu\nu}F^{\mu\nu} + \bar{\psi}(i\gamma^\mu D_\mu - m)\psi \qquad S = \int d^4x\,\sqrt{-g}\left(\frac{R}{16\pi G} + \mathcal{L}_{\mathrm{matter}}\right)
 > $$
 
+The scroll-indicator wrapper establishes a BFC, so the margins of `.katex-display` and `.table-container` inside it must not stack with the surrounding paragraph margins.
+
+1. List item before. The vertical gap between this paragraph and the equation below should equal the gap between two regular paragraphs, not double it.
+
+   $$
+   \text{Penalty}(s,a) \mathrel{\overset{\text{def}}{=}} \int_\mathcal{R} |Q^*_R(s,a) - Q^*_R(s,\varnothing)|\, dR.
+   $$
+
+   List item after. Same check on this side: a single paragraph-sized gap above and below the equation.
+
+2. A scrollable table inside a list item. The wrapper should preserve the same 2&times;`$base-margin` gap above the table as in body context, without stacking.
+
+   | Feature | A | B | C | D | E | F | G | H | I | J | K |
+   | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+   | Row 1 | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
+   | Row 2 | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |
+
+   Trailing prose so the bottom gap is also exercised.
+
+A footnote with an equation sandwiched between paragraphs:[^fn-equation]
+
+[^fn-equation]:
+    Let $\mathcal{R}$ be the uniform distribution over $[0,1]^\mathcal{S}$. The penalty for taking action $a$ is a Monte Carlo integration of
+
+    $$
+    \text{Penalty}(s,a) \mathrel{\overset{\text{def}}{=}} \int_\mathcal{R} |Q^*_R(s,a) - Q^*_R(s,\varnothing)|\, dR.
+    $$
+
+    $\text{Penalty}(s,a)$ is provably lower bounded by how much $a$ is expected to change the agent's power compared to inaction.
+
 # Video
 
 <video autoplay muted loop playsinline aria-label="The baseline RL policy makes a big mess while the AUP policy cleanly destroys the red pellets and finishes the level."><source src="https://assets.turntrout.com/static/images/posts/prune_still-easy_trajectories.mp4" type="video/mp4; codecs=hvc1"><source src="https://assets.turntrout.com/static/images/posts/prune_still-easy_trajectories.webm" type="video/webm"><track kind="captions" label="No audio"></video>

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -449,7 +449,9 @@ Equation and table nested in a list item (gaps must not stack with `<p>` margins
 
 1. Before.
 
-   $$x = y$$
+   $$
+   x = y
+   $$
 
    After.
 
@@ -462,7 +464,9 @@ Equation and table nested in a list item (gaps must not stack with `<p>` margins
 [^fn-equation]:
     Before.
 
-    $$x = y$$
+    $$
+    x = y
+    $$
 
     After.
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -445,35 +445,26 @@ Wide tables and equations show a fade gradient at the scrollable edges.
 > \nabla \cdot \mathbf{E} = \frac{\rho}{\varepsilon_0} \qquad \nabla \cdot \mathbf{B} = 0 \qquad \nabla \times \mathbf{E} = -\frac{\partial \mathbf{B}}{\partial t} \qquad \nabla \times \mathbf{B} = \mu_0\left(\mathbf{J} + \varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right) \qquad \mathcal{L} = -\frac{1}{4}F_{\mu\nu}F^{\mu\nu} + \bar{\psi}(i\gamma^\mu D_\mu - m)\psi \qquad S = \int d^4x\,\sqrt{-g}\left(\frac{R}{16\pi G} + \mathcal{L}_{\mathrm{matter}}\right)
 > $$
 
-The scroll-indicator wrapper establishes a BFC, so the margins of `.katex-display` and `.table-container` inside it must not stack with the surrounding paragraph margins.
+Equation and table nested in a list item (gaps must not stack with `<p>` margins):[^fn-equation]
 
-1. List item before. The vertical gap between this paragraph and the equation below should equal the gap between two regular paragraphs, not double it.
+1. Before.
 
-   $$
-   \text{Penalty}(s,a) \mathrel{\overset{\text{def}}{=}} \int_\mathcal{R} |Q^*_R(s,a) - Q^*_R(s,\varnothing)|\, dR.
-   $$
+   $$x = y$$
 
-   List item after. Same check on this side: a single paragraph-sized gap above and below the equation.
+   After.
 
-2. A scrollable table inside a list item. The wrapper should preserve the same 2&times;`$base-margin` gap above the table as in body context, without stacking.
+2. Table.
 
-   | Feature | A | B | C | D | E | F | G | H | I | J | K |
-   | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-   | Row 1 | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
-   | Row 2 | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |
-
-   Trailing prose so the bottom gap is also exercised.
-
-A footnote with an equation sandwiched between paragraphs:[^fn-equation]
+   | A | B | C |
+   | :---: | :---: | :---: |
+   | 1 | 2 | 3 |
 
 [^fn-equation]:
-    Let $\mathcal{R}$ be the uniform distribution over $[0,1]^\mathcal{S}$. The penalty for taking action $a$ is a Monte Carlo integration of
+    Before.
 
-    $$
-    \text{Penalty}(s,a) \mathrel{\overset{\text{def}}{=}} \int_\mathcal{R} |Q^*_R(s,a) - Q^*_R(s,\varnothing)|\, dR.
-    $$
+    $$x = y$$
 
-    $\text{Penalty}(s,a)$ is provably lower bounded by how much $a$ is expected to change the agent's power compared to inaction.
+    After.
 
 # Video
 


### PR DESCRIPTION
## Summary

Fix spacing issues when KaTeX equations and tables are nested inside `.scroll-indicator` containers (which establish a Block Formatting Context). The BFC prevents margin collapse with surrounding content, causing doubled spacing. Move margins from the inner elements to the wrapper where they can collapse naturally.

## Changes

- **KaTeX equations**: Zero `margin` on `.katex-display` inside `.scroll-indicator` and rely on adjacent `<p>` margins for spacing (which can collapse normally outside the BFC)
- **Tables**: Zero `margin-top` on `.table-container` inside `.scroll-indicator` and move the spacing to the wrapper via `.scroll-indicator:has(> .table-container)` with `margin-block-start`, allowing it to collapse with siblings (or behave consistently in inline-block footnotes)
- **Test coverage**: Added test cases in `test-page.md` demonstrating equations and tables in list items and footnotes to verify gaps don't stack with `<p>` margins

## Implementation details

The `.scroll-indicator` uses `overflow: clip` and `inline-block` (in footnotes), both of which establish a BFC. This prevents child margins from collapsing with parent/sibling margins, causing unwanted spacing stacking. The fix applies the spacing at the wrapper level where margin collapse rules apply normally, ensuring consistent visual spacing whether the content is in a list, footnote, or regular flow.

https://claude.ai/code/session_011TGrYjeEoM4aEpze59BQKx