### PR TITLE
style(reframing-impact): fade-image-border on closing artwork

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -37,6 +37,7 @@
 1bn
 1x
 1ˢᵗ
+1px
 2-20x
 200GB
 20B
@@ -724,6 +725,7 @@ Karim
 Karp
 Karvonen
 Katja
+Kerning
 Keltham's
 Khullar
 Kingsley
@@ -1563,6 +1565,7 @@ armour
 arungus
 arxiv
 ary
+ascender
 aspirational
 associational
 asungus

--- a/quartz/plugins/transformers/.asset_dimensions.json
+++ b/quartz/plugins/transformers/.asset_dimensions.json
@@ -6506,5 +6506,9 @@
   "https://assets.turntrout.com/static/images/posts/the-gears-of-impact-05182026.avif": {
     "width": 2046,
     "height": 1452
+  },
+  "https://assets.turntrout.com/static/images/cropped_towards.avif": {
+    "width": 2048,
+    "height": 1512
   }
 }

--- a/website_content/conclusion-to-reframing-impact.md
+++ b/website_content/conclusion-to-reframing-impact.md
@@ -85,11 +85,11 @@ Reframing Impact
 :
 : The paperclip-Balrog drawing contains a [Tengwar](https://en.wikipedia.org/wiki/Tengwar) inscription which reads "one measure to bind them", with "measure" in impact-blue and "them" in utility-pink.
 :
-: ![Text overlay: "An impact measure would be the first proposed safeguard which maybe actually stops a powerful agent with an imperfect objective from ruining things – without assuming anything about the objective. This is a rare property among approaches." The text lurks above an illustration paying homage to the iconic Gandalf-vs-Balrog scene in Moria. The demon's whip ends in a giant paperclip, a metaphor for a misaligned artificial intelligence.](https://assets.turntrout.com/static/images/posts/v7pzpzvi342b3svksbag.avif)
+: ![Text overlay: "An impact measure would be the first proposed safeguard which maybe actually stops a powerful agent with an imperfect objective from ruining things – without assuming anything about the objective. This is a rare property among approaches." The text lurks above an illustration paying homage to the iconic Gandalf-vs-Balrog scene in Moria. The demon's whip ends in a giant paperclip, a metaphor for a misaligned artificial intelligence.](https://assets.turntrout.com/static/images/posts/v7pzpzvi342b3svksbag.avif){.fade-image-border style="box-shadow: inset 1px 0 0 var(--dark);"}
 
   "Towards a New Impact Measure" was the title of [the post](/towards-a-new-impact-measure) in which AUP was introduced:
 :
-: ![The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads "Towards a new impact measure" and is rendered in a Tolkienesque font.](https://assets.turntrout.com/static/images/posts/ynwdidys1i7yopyqerfh.avif)
+: <img src="https://assets.turntrout.com/static/images/cropped_towards.avif" alt='The interior of a cozy, hobbit-hole-like room with a round door open to a sunny landscape. Sunlight streams in, illuminating the tiled floor. Text over the view reads, "towards a new impact measure" and is rendered in a Tolkienesque font.' class="fade-image-border"/>
 
 <br/>
 
@@ -112,7 +112,7 @@ Seeking Power is Often Convergently Instrumental in MDPs
 The tale of Frank and the orange Pebblehoarder
 : Speaking of under-tales, a friendship has been blossoming right under our noses:
 :
-: ![A cartoon of Frank the robot giving his pink marble to a surprised Pebblehoarder. They stand in a grassy field under a sunny sky.](https://assets.turntrout.com/static/images/posts/dfog9czq2wdboz8m0dpv.avif)
+: ![A cartoon of Frank the robot giving his pink marble to a surprised Pebblehoarder. They stand in a grassy field under a sunny sky.](https://assets.turntrout.com/static/images/posts/dfog9czq2wdboz8m0dpv.avif){.fade-image-border}
 Figure: After the Pebblehoarders suffer the devastating transformation of all of their pebbles into obsidian blocks, Frank generously gives away his favorite pink marble as a makeshift pebble.
 :
 :
@@ -120,7 +120,7 @@ Figure: After the Pebblehoarders suffer the devastating transformation of all of
 Figure: The title cuts to the middle of their adventures together, the Pebblehoarder showing its gratitude by helping Frank reach things high up.
 :
 :
-: ![Frank and the Pebblehoarder sit together on a cliff's edge, overlooking a vast mountain range at sunset. The scene pays homage to the ending shot of the 2012 film, The Hobbit: An Unexpected Journey.](https://assets.turntrout.com/static/images/posts/mx5gc86qpthgbzeypfw9.avif)
+: ![Frank and the Pebblehoarder sit together on a cliff's edge, overlooking a vast mountain range at sunset. The scene pays homage to the ending shot of the 2012 film, The Hobbit: An Unexpected Journey.](https://assets.turntrout.com/static/images/posts/mx5gc86qpthgbzeypfw9.avif){.fade-image-border}
 Figure: This still at the midpoint of the sequence is from [the final scene of _The Hobbit: An Unexpected Journey_](https://www.youtube.com/watch?v=KEegn1R601M), where the party is overlooking Erebor, the Lonely Mountain. They've made it through the Misty Mountains, only to find Smaug's abode looming in the distance.
 :
 : ![Frank the robot stands atop the orange Pebblehoarder, popping a bottle of champagne. In the background, celebratory fireworks explode, with one spelling out "LW" in purple.](https://assets.turntrout.com/static/images/posts/jdcmcy4bzxggxdallwok.avif)

--- a/website_content/deducing-impact.md
+++ b/website_content/deducing-impact.md
@@ -50,7 +50,7 @@ card_image_alt: 'Text: "Imagine that the sun goes supernova." An illustration sh
 ​![Text: "Now, being on—". A hand-drawn Harry Potter with an annoyed expression interrupts: "Our sun is a main-sequence G-type star, it can't explode. Any energy input just decreases the volume of the hydrogen plasma, the Sun doesn't have a degenerate core that could be detonated. The Sun doesn't have enough mass to go supernova."](https://assets.turntrout.com/static/images/posts/x3myqQ1.avif)
 ![Handwritten text: "Yes, yes, thank you—everyone knows that. It's just another weird situation I'm forcing on my readership. Now, being on Earth here is objectively impactful because it matters to almost any agent in your shoes. However, whether this is a big deal to you depends on who and where you are." ](https://assets.turntrout.com/static/images/posts/G1UgvEf.avif)
 
-![A green stick figure alien sleeping on a cot on a white, curved surface. Above, a single bright star shines in a black sky.](https://assets.turntrout.com/static/images/posts/lCPSncS.avif)
+![A green stick figure alien sleeping on a cot on a white, curved surface. Above, a single bright star shines in a black sky.](https://assets.turntrout.com/static/images/posts/lCPSncS.avif){.fade-image-border}
 
 <img src="https://assets.turntrout.com/static/images/posts/EZa5fmw.avif" alt="">
 

--- a/website_content/the-gears-of-impact.md
+++ b/website_content/the-gears-of-impact.md
@@ -105,7 +105,7 @@ card_image_alt: 'Comparing "Before" and "After" probabilities for three outcomes
 
 !["The first third of the sequence meets its close. We understood why some things seem like big deals, righted a wrong question, and just now skirted the fascinating deeper nature of objective impact... Objective impact, instrumental convergence, opportunity cost, the colloquial meaning of 'power'—these all prove to be facets of one phenomenon, one structure."](https://assets.turntrout.com/static/images/posts/dLUrki7.avif)
 
-![Frank and the Pebblehoarder sit together on a cliff's edge, overlooking a vast mountain range at sunset. The scene pays homage to the ending shot of the 2012 film, The Hobbit: An Unexpected Journey.](https://assets.turntrout.com/static/images/posts/the-gears-of-impact-05182026.avif)
+![Frank and the Pebblehoarder sit together on a cliff's edge, overlooking a vast mountain range at sunset. The scene pays homage to the ending shot of the 2012 film, The Hobbit: An Unexpected Journey.](https://assets.turntrout.com/static/images/posts/the-gears-of-impact-05182026.avif){.fade-image-border}
 
 > [!note]
 > Why does instrumental convergence happen? Would it be coherent to imagine a reality without it?


### PR DESCRIPTION
## Summary

Apply the existing `fade-image-border` class (top/bottom mask-image fade) to the closing illustrations across the Reframing Impact sequence so their edges blend into the page background.

- `deducing-impact.md` — `lCPSncS`
- `the-gears-of-impact.md` — `the-gears-of-impact-05182026` (also covers the old `lDbQW2b` slot, which `d172f92` already replaced)
- `conclusion-to-reframing-impact.md`:
  - `v7pzpzvi342b3svksbag` — fade + a 1px inset left border in `var(--dark)` via `box-shadow: inset 1px 0 0 var(--dark);` (anchors the left edge without nudging layout; the existing mask gradient also fades the inset line at top/bottom, matching the rest of the border)
  - `ynwdidys1i7yopyqerfh` — replaced with a literal copy of the existing `<img class="fade-image-border">` for `cropped_towards.avif` from `reframing-impact.md`, per the request that this slot mirror the "Towards a new impact measure" image already in the sequence
  - `dfog9czq2wdboz8m0dpv`, `mx5gc86qpthgbzeypfw9` — fade

Class is applied via the `{.fade-image-border}` markdown attribute syntax already used elsewhere in the repo (e.g. `conclusion-to-reframing-impact.md:47`, `team-shard.md`). The asset-dimensions cache picks up `cropped_towards.avif` since it's newly referenced in this file.

## Test plan

- [ ] Eyeball each affected image on the Cloudflare preview in light and dark mode
- [ ] Confirm v7pz has a thin dark line on its left edge that fades top/bottom alongside the rest of the image

https://claude.ai/code/session_0188rcyZryfR9PadkcLBsCep

---
_Generated by [Claude Code](https://claude.ai/code/session_0188rcyZryfR9PadkcLBsCep)_