### PR TITLE
fix(regexp): resolve all regexp findings and promote to error

### DIFF
--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -29,15 +29,7 @@ export default [
       "perfectionist/sort-named-exports": ["error", { type: "natural", order: "asc" }],
       "perfectionist/sort-exports": ["error", { type: "natural", order: "asc" }],
       "perfectionist/sort-array-includes": ["error", { type: "natural", order: "asc" }],
-      // regexp recommended rules surface real correctness / ReDoS findings.
-      // Many are autofixable; the rest are reported as warnings so they're
-      // visible in CI output without blocking until each is reviewed by hand.
-      ...Object.fromEntries(
-        Object.entries(regexpPlugin.configs["flat/recommended"].rules).map(([rule]) => [
-          rule,
-          "warn",
-        ]),
-      ),
+      ...regexpPlugin.configs["flat/recommended"].rules,
     },
   },
 

--- a/quartz/components/TableOfContents.tsx
+++ b/quartz/components/TableOfContents.tsx
@@ -202,7 +202,8 @@ export function processHtmlAst(htmlAst: Root | Element, parent: Parent): void {
       const textValue = node.value
       let textToProcess = textValue
 
-      const leadingNumberRegex = /^(?<numberPart>\d+:?\s*)(?<restText>.*)$/
+      // eslint-disable-next-line regexp/no-super-linear-backtracking -- anchored ^...$; \d+ only backtracks once before \S succeeds
+      const leadingNumberRegex = /^(?<numberPart>\d+:? *)(?<restText>\S.*)$/
       const match = textValue.match(leadingNumberRegex)
       if (match?.groups) {
         const numberPart = match.groups.numberPart

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -92,7 +92,7 @@ const SVG_COLOR_ATTRS = [
   "lighting-color",
 ] as const
 const SVG_COLOR_PROP_RE = new RegExp(
-  `(?<prop>${SVG_COLOR_ATTRS.join("|")})(?<sep>\\s*:\\s*)(?<value>[^;}"']+)`,
+  `(?<prop>${SVG_COLOR_ATTRS.join("|")})(?<sep>\\s*:\\s*)(?<value>\\S[^;}"']*)`,
   "gi",
 )
 

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -363,7 +363,7 @@ function isKatex(node: Element): boolean {
 }
 
 export const arrowsToWrap = ["←", "→", "↑", "↓", "↗", "↘", "↖", "↙"]
-const arrowRegex = new RegExp(` ?(?<arrow>${arrowsToWrap.join("|")}) ?`, "g")
+const arrowRegex = new RegExp(` ?(?<arrow>[${arrowsToWrap.join("")}]) ?`, "g")
 
 /**
  * Wraps Unicode arrows with monospace styling, but only outside of KaTeX math blocks

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -29,10 +29,10 @@ const improveFootnoteFormatting = (text: string) => {
 
 // Regular expression for edit/note patterns
 const editPattern =
-  /^\s*(?<emph1>[*_]*)(?:edit|eta|note),?\s*\(?(?<date>\d{1,2}[-/]\d{1,2}[-/]\d{2,4})\)?(?<emph2>[*_]*:[*_]*) (?<text>.*)[*_]*/gim
+  /^\s*(?<emph1>[*_]*)(?:edit|eta|note),?\s*\(?(?<date>\d{1,2}[-/]\d{1,2}[-/]\d{2,4})\)?(?<emph2>[*_]*:[*_]*) (?<text>.*)/gim
 const editAdmonitionPattern = "\n> [!info] Edited on $<date>\n>\n> $<text>"
 
-const editPatternNoDate = /^\s*(?<emph1>[*_]*)(?:edit|eta)(?<emph2>[*_]*:[*_]*) (?<text>.*)[*_]*/gim
+const editPatternNoDate = /^\s*(?<emph1>[*_]*)(?:edit|eta)(?<emph2>[*_]*:[*_]*) (?<text>.*)/gim
 const editAdmonitionPatternNoDate = "\n> [!info] Edited after posting\n>\n> $<text>"
 
 /**
@@ -46,7 +46,7 @@ export function editAdmonition(text: string): string {
   return text
 }
 
-const CALLOUT_REGEX_NO_SPACE = /^(?<prefix> *(?:> )+)(?<callout>\[!.*$)(?!(?:> *)+\n)/gm
+const CALLOUT_REGEX_NO_SPACE = /^(?<prefix> *(?:> )+)(?<callout>\[!.*$)/gm
 const TARGET_REGEX_WITH_SPACE = "$<prefix>$<callout>\n$<prefix>"
 
 /**
@@ -92,13 +92,13 @@ const xcancelHostReplacementRegex = /https?:\/\/(?:www\.)?(?:x|twitter)\.com\/?/
 const massTransforms: [RegExp | string, string][] = [
   [/(?<!\$):=/g, "≝"], // mathematical definition symbol, not preceded by the start of a katex block
   [/^\$\$(?= *\S)/gm, "$$$$\n"], // Display mode math should be on a new line
-  [/^(?! *>| +\S)(?<content>.*?\S.*?)\$\$ *$/gm, "$<content>\n$$$$"], // Two per $, since it has special meaning in JS regex; ignore blockquotes and captions
+  [/^(?! *>| +\S)(?<content>\S.*?)\$\$ *$/gm, "$<content>\n$$$$"],
   [/(?<= |^):\)(?= |$)/gm, "🙂"], // Smiling face
   [/(?<= |^);\)(?= |$)/gm, "😉"], // Winking face
   [/(?<= |^):\((?= |$)/gm, "🙁"], // Frowning face
   [subtitlePattern, subtitleReplacement],
   [xcancelHostReplacementRegex, "https://xcancel.com/"],
-  [/(?<=\| *$)\nTable: /gm, "\n\nTable: "],
+  [/(?<=\| *)\nTable: /g, "\n\nTable: "],
   // Insert a blank line after a block-level HTML tag so the markdown parser
   // doesn't swallow following prose into the same HTML block. Avoid inside of code blocks.
   [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n(?=[ \t]*[^ \t\n<>/`=])/g, "$<closingTag>\n\n"],

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -84,9 +84,7 @@ const ytPlaylistLinkRegex = /[?&]list=(?<playlistId>[^#?&]*)/
 const videoExtensionRegex = new RegExp(/\.(?:mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)$/)
 
 /** Regular expression to parse image embed dimensions and alt text */
-const wikilinkImageEmbedRegex = new RegExp(
-  /^(?<alt>(?!^\d*(?:x\d*)?$).*?)?(?:\|?\s*(?<width>\d+)(?:x(?<height>\d+))?)?$/,
-)
+const wikilinkImageEmbedRegex = /^\|?(?:(?<width>\d+)(?:x(?<height>\d+))?|(?<alt>.+))?$/
 
 /** Extended ElementData interface for custom HAST element properties. */
 interface CustomElementData extends ElementData {

--- a/quartz/plugins/transformers/populateExternalMarkdown.test.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.test.ts
@@ -150,20 +150,19 @@ describe("PopulateExternalMarkdown", () => {
   })
 
   describe("buildPlaceholderRegex", () => {
-    it("should never match when no sources configured", () => {
-      const regex = buildPlaceholderRegex([])
-      expect('<span class="populate-markdown-test"></span>'.match(regex)).toBeNull()
+    it("should return null when no sources configured", () => {
+      expect(buildPlaceholderRegex([])).toBeNull()
     })
 
     it("should only match configured source names", () => {
-      const regex = buildPlaceholderRegex(["project"])
+      const regex = buildPlaceholderRegex(["project"]) as RegExp
       expect('<span class="populate-markdown-project"></span>'.match(regex)).not.toBeNull()
       expect('<span class="populate-markdown-other"></span>'.match(regex)).toBeNull()
       expect('<span class="populate-commit-count"></span>'.match(regex)).toBeNull()
     })
 
     it("should escape special regex characters in source names", () => {
-      const regex = buildPlaceholderRegex(["test.name"])
+      const regex = buildPlaceholderRegex(["test.name"]) as RegExp
       expect('<span class="populate-markdown-test.name"></span>'.match(regex)).not.toBeNull()
       expect('<span class="populate-markdown-testXname"></span>'.match(regex)).toBeNull()
     })

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -129,8 +129,8 @@ function getContent(name: string, source: MarkdownSource): string {
 }
 
 /** Builds a regex matching `<span class="populate-markdown-NAME"></span>` placeholders for the given names. */
-export function buildPlaceholderRegex(sourceNames: string[]): RegExp {
-  if (sourceNames.length === 0) return /(?!)/g // never matches
+export function buildPlaceholderRegex(sourceNames: string[]): RegExp | null {
+  if (sourceNames.length === 0) return null
   const escaped = sourceNames.map(escapeStringRegexp)
   return new RegExp(
     `<span\\s+class="populate-markdown-(${escaped.join("|")})"\\s*>(?:<\\/span>)?`,
@@ -144,6 +144,7 @@ export function populateExternalContent(
   sources: Record<string, MarkdownSource>,
 ): string {
   const regex = buildPlaceholderRegex(Object.keys(sources))
+  if (!regex) return content
   return content.replace(regex, (_match, name: string) => {
     // regex is built from Object.keys(sources), so `name` is always present
     const source = sources[name] as MarkdownSource

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -20,7 +20,7 @@ import {
 /** Validates if string matches Roman numeral pattern with optional trailing punctuation */
 export function isRomanNumeral(str: string): boolean {
   const romanNumeralRegex =
-    /(?<= |^)(?:M{0,3}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:I{1,2}X|I{1,2}V|V?I{0,3})(?<=[A-Z]{3})|I{1,2}[XVCDM])(?=[\s.,!?;:]|$)/
+    /(?<= |^)(?:M{0,3}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:I{1,2}X|I{1,2}V|V?I{0,3})(?<=[A-Z]{2})|I[CDM])(?=[\s.,!?;:]|$)/
   return romanNumeralRegex.test(str)
 }
 
@@ -56,12 +56,9 @@ const boundaryAllowAcronyms = escapedAllowAcronyms
 
 export const smallCapsSeparators = "-'’"
 const upperCapsChars = "A-Z\\u00C0-\\u00DC" // A-Z and À-Ü
-const lowerCapsChars = "a-z\\u00E0-\\u00FC" // a-z and à-ü
-const allCapsChars = `${upperCapsChars}${lowerCapsChars}`
-
 // Word boundary that prevents mixing upper- and lowercase neighbors
-const beforeWordBoundary = `(?<![${allCapsChars}\\w])`
-const afterWordBoundary = `(?![${allCapsChars}\\w])`
+const beforeWordBoundary = `(?<![\\w\\u00C0-\\u00DC\\u00E0-\\u00FC])`
+const afterWordBoundary = `(?![\\w\\u00C0-\\u00DC\\u00E0-\\u00FC])`
 
 // Pattern for acronyms with at least 3 uppercase letters (with digits/separators allowed between them)
 // Use explicit alternations to ensure we actually capture 3+ uppercase letters, not just look ahead for them
@@ -202,18 +199,17 @@ export const REGEX_ABBREVIATION = new RegExp(
 // small-capped) so it matches the lining digits' cap height. Trailing
 // decimals are part of the match so the full "1.0" stays cap-aligned rather
 // than splitting into a lining "1" followed by an oldstyle "0".
-export const REGEX_VERSION_NUMBER = new RegExp(
-  `${beforeWordBoundary}[Vv]\\d+(?:\\.\\d+)*${afterWordBoundary}`,
-)
+export const REGEX_VERSION_NUMBER = /\b(?:V|v)\d+(?:\.\d+)*\b/
 
 // Lookahead to see that there are at least 3 contiguous uppercase characters in the phrase
-export const validSmallCapsPhrase = `(?=[${upperCapsChars}\\-'’\\s]*[${upperCapsChars}]{3,})`
+export const validSmallCapsPhrase = `(?=[${upperCapsChars}\\-'’\\s]*[${upperCapsChars}]{3})`
 const decimalOrSeparator = `[${smallCapsSeparators}\\d\\s]|\\d\\.\\d`
 export const allCapsContinuation = `(?:(?:${decimalOrSeparator})+[${upperCapsChars}]+)`
 
-// Restricting to at least 2 words to avoid interfering with REGEX_ACRONYM
-// Added negative lookbehind to prevent matching if preceded by a single capital letter and space
-export const noSentenceStartSingleCapital = `(?!(?<=(?:^|[.!?]\\s))(?=[${upperCapsChars}]\\s)(?!I\\s))`
+// Skip sentence-leading single capitals (e.g. "A") unless the pronoun "I".
+// De Morgan of the original (?!lookbehind ∧ lookahead ∧ ¬exception):
+// proceed if NOT at sentence start ∨ NOT single-cap+space ∨ IS "I".
+export const noSentenceStartSingleCapital = `(?:(?<![.!?]\\s)(?<!^)|(?![${upperCapsChars}]\\s)|(?=I\\s))`
 export const REGEX_ALL_CAPS_PHRASE = new RegExp(
   `${beforeWordBoundary}${noSentenceStartSingleCapital}${validSmallCapsPhrase}(?<phrase>[${upperCapsChars}]+${allCapsContinuation}+)${afterWordBoundary}`,
 )
@@ -262,7 +258,8 @@ export function shouldSkipNode(node: Text, ancestors: Parent[]): boolean {
 
 // If text comes after sentence ending, capitalize the first letter
 export const capitalizeAfterEnding = new RegExp(
-  `(?<prefix>^\\s*|\\n|[.!?](?<![eE]\\.[gG]\\.|[iI]\\.[eE]\\.)\\s+)(?<letter>[${upperCapsChars}${lowerCapsChars}])$`,
+  `(?<prefix>^\\s*|\\n|[.!?](?<!e\\.g\\.|i\\.e\\.)\\s+)(?<letter>[${upperCapsChars}])$`,
+  "iu",
 )
 
 export const INLINE_ELEMENTS: ReadonlySet<string> = new Set([

--- a/quartz/plugins/transformers/tests/regex-stress.test.ts
+++ b/quartz/plugins/transformers/tests/regex-stress.test.ts
@@ -43,13 +43,10 @@ describe("fractionRegex", () => {
     expect(match?.groups?.ordinal).toBe(ord)
   })
 
-  it.each(["9/11", "word/word", "x1/2", "1/2x", ".1/2", "/1/2"])(
-    "should NOT match %s",
-    (input) => {
-      fractionRegex.lastIndex = 0
-      expect(fractionRegex.test(input)).toBe(false)
-    },
-  )
+  it.each(["9/11", "word/word", "x1/2", "1/2x", ".1/2", "/1/2"])("should NOT match %s", (input) => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test(input)).toBe(false)
+  })
 
   it("should not match when followed by minus-sign + digit", () => {
     fractionRegex.lastIndex = 0
@@ -95,12 +92,9 @@ describe("isRomanNumeral", () => {
     },
   )
 
-  it.each(["I", "V", "HELLO", "", "VV", "IIII", "MMMM"])(
-    "should NOT match %s",
-    (input) => {
-      expect(isRomanNumeral(input)).toBe(false)
-    },
-  )
+  it.each(["I", "V", "HELLO", "", "VV", "IIII", "MMMM"])("should NOT match %s", (input) => {
+    expect(isRomanNumeral(input)).toBe(false)
+  })
 
   it("should match with trailing punctuation", () => {
     expect(isRomanNumeral("IV.")).toBe(true)
@@ -120,13 +114,10 @@ describe("REGEX_VERSION_NUMBER", () => {
 })
 
 describe("REGEX_ALL_CAPS_PHRASE", () => {
-  it.each(["THE BIG THING", "FIRST-ORDER LOGIC"])(
-    "should match multi-word phrase: %s",
-    (input) => {
-      REGEX_ALL_CAPS_PHRASE.lastIndex = 0
-      expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(true)
-    },
-  )
+  it.each(["THE BIG THING", "FIRST-ORDER LOGIC"])("should match multi-word phrase: %s", (input) => {
+    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+    expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(true)
+  })
 
   it.each(["hello world", "AB"])("should NOT match: %s", (input) => {
     REGEX_ALL_CAPS_PHRASE.lastIndex = 0

--- a/quartz/plugins/transformers/tests/regex-stress.test.ts
+++ b/quartz/plugins/transformers/tests/regex-stress.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it } from "@jest/globals"
 
-import {
-  editAdmonition,
-  spaceAdmonitions,
-} from "../formatting_improvement_text"
+import { editAdmonition, spaceAdmonitions } from "../formatting_improvement_text"
 import { buildPlaceholderRegex } from "../populateExternalMarkdown"
 import {
   capitalizeAfterEnding,
@@ -37,14 +34,13 @@ describe("urlRegex stress", () => {
     expect(match?.groups?.path).toContain("Test_(thing)")
   })
 
-  it.each([
-    "(ftp://example.com/path)",
-    "(not a url)",
-    "(https://)",
-  ])("should NOT match %s", (input) => {
-    urlRegex.lastIndex = 0
-    expect(urlRegex.exec(input)).toBeNull()
-  })
+  it.each(["(ftp://example.com/path)", "(not a url)", "(https://)"])(
+    "should NOT match %s",
+    (input) => {
+      urlRegex.lastIndex = 0
+      expect(urlRegex.exec(input)).toBeNull()
+    },
+  )
 
   it("should handle domains with hyphens", () => {
     urlRegex.lastIndex = 0
@@ -83,13 +79,7 @@ describe("fractionRegex stress", () => {
     expect(match?.groups?.ordinal).toBe(ord)
   })
 
-  it.each([
-    "9/11",
-    "word/word",
-    "a/b",
-    "/",
-    "//",
-  ])("should NOT match %s", (input) => {
+  it.each(["9/11", "word/word", "a/b", "/", "//"])("should NOT match %s", (input) => {
     fractionRegex.lastIndex = 0
     expect(fractionRegex.test(input)).toBe(false)
   })
@@ -177,22 +167,40 @@ describe("wikilinkImageEmbedRegex stress", () => {
 
 describe("isRomanNumeral stress", () => {
   it.each([
-    "II", "III", "IV", "VI", "VII", "VIII", "IX",
-    "XI", "XII", "XIV", "XIX", "XX", "XL", "XC",
-    "CD", "CM", "MMXXIV", "XLII", "XCIX",
-    "IC", "ID", "IM",
-    "CXLVIII", "MMMCMXCIX",
+    "II",
+    "III",
+    "IV",
+    "VI",
+    "VII",
+    "VIII",
+    "IX",
+    "XI",
+    "XII",
+    "XIV",
+    "XIX",
+    "XX",
+    "XL",
+    "XC",
+    "CD",
+    "CM",
+    "MMXXIV",
+    "XLII",
+    "XCIX",
+    "IC",
+    "ID",
+    "IM",
+    "CXLVIII",
+    "MMMCMXCIX",
   ])("should match %s", (numeral) => {
     expect(isRomanNumeral(numeral)).toBe(true)
   })
 
-  it.each([
-    "I", "V", "X", "L", "C", "D", "M",
-    "A", "HELLO", "abc", "123", "", "  ",
-    "VV", "IIII",
-  ])("should NOT match %s", (input) => {
-    expect(isRomanNumeral(input)).toBe(false)
-  })
+  it.each(["I", "V", "X", "L", "C", "D", "M", "A", "HELLO", "abc", "123", "", "  ", "VV", "IIII"])(
+    "should NOT match %s",
+    (input) => {
+      expect(isRomanNumeral(input)).toBe(false)
+    },
+  )
 
   it("should handle roman numerals with punctuation in isRomanNumeral", () => {
     expect(isRomanNumeral("IV.")).toBe(true)
@@ -206,13 +214,10 @@ describe("isRomanNumeral stress", () => {
 })
 
 describe("REGEX_VERSION_NUMBER stress", () => {
-  it.each(["V1", "v2", "V100", "v1.0", "v1.2.3", "V10.20.30"])(
-    "should match %s",
-    (input) => {
-      REGEX_VERSION_NUMBER.lastIndex = 0
-      expect(REGEX_VERSION_NUMBER.test(input)).toBe(true)
-    },
-  )
+  it.each(["V1", "v2", "V100", "v1.0", "v1.2.3", "V10.20.30"])("should match %s", (input) => {
+    REGEX_VERSION_NUMBER.lastIndex = 0
+    expect(REGEX_VERSION_NUMBER.test(input)).toBe(true)
+  })
 
   it.each(["version", "Vault", "v", "V", "1.0", "abc", "vv1", "VV2"])(
     "should NOT match %s",
@@ -239,20 +244,15 @@ describe("REGEX_VERSION_NUMBER stress", () => {
 })
 
 describe("REGEX_ALL_CAPS_PHRASE stress", () => {
-  it.each([
-    "THE BIG THING",
-    "NATO FORCES",
-    "AI AND ML",
-  ])("should match multi-word phrase: %s", (input) => {
-    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
-    expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(true)
-  })
+  it.each(["THE BIG THING", "NATO FORCES", "AI AND ML"])(
+    "should match multi-word phrase: %s",
+    (input) => {
+      REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+      expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(true)
+    },
+  )
 
-  it.each([
-    "hello world",
-    "Hello",
-    "AB",
-  ])("should NOT match: %s", (input) => {
+  it.each(["hello world", "Hello", "AB"])("should NOT match: %s", (input) => {
     REGEX_ALL_CAPS_PHRASE.lastIndex = 0
     expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(false)
   })
@@ -263,7 +263,7 @@ describe("REGEX_ALL_CAPS_PHRASE stress", () => {
   })
 
   it("should handle long all-caps input", () => {
-    const longInput = ("ABC DEF " .repeat(500)).trim()
+    const longInput = "ABC DEF ".repeat(500).trim()
     REGEX_ALL_CAPS_PHRASE.lastIndex = 0
     const result = REGEX_ALL_CAPS_PHRASE.test(longInput)
     expect(typeof result).toBe("boolean")
@@ -284,13 +284,10 @@ describe("capitalizeAfterEnding stress", () => {
     expect(match?.groups?.letter).toBe(letter)
   })
 
-  it.each(["e.g. X", "i.e. Y"])(
-    "should not match after %s abbreviation",
-    (input) => {
-      capitalizeAfterEnding.lastIndex = 0
-      expect(capitalizeAfterEnding.exec(input)).toBeNull()
-    },
-  )
+  it.each(["e.g. X", "i.e. Y"])("should not match after %s abbreviation", (input) => {
+    capitalizeAfterEnding.lastIndex = 0
+    expect(capitalizeAfterEnding.exec(input)).toBeNull()
+  })
 
   it("should match lowercase with i flag", () => {
     capitalizeAfterEnding.lastIndex = 0
@@ -373,7 +370,12 @@ describe("buildPlaceholderRegex stress", () => {
 
 describe("SVG_COLOR_PROP_RE stress", () => {
   const SVG_COLOR_ATTRS = [
-    "fill", "stroke", "stop-color", "color", "flood-color", "lighting-color",
+    "fill",
+    "stroke",
+    "stop-color",
+    "color",
+    "flood-color",
+    "lighting-color",
   ] as const
   const SVG_COLOR_PROP_RE = new RegExp(
     `(?<prop>${SVG_COLOR_ATTRS.join("|")})\\s*:\\s*(?<value>\\S[^;}"']*)`,

--- a/quartz/plugins/transformers/tests/regex-stress.test.ts
+++ b/quartz/plugins/transformers/tests/regex-stress.test.ts
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, it } from "@jest/globals"
+import { describe, expect, it } from "@jest/globals"
 
 import { editAdmonition, spaceAdmonitions } from "../formatting_improvement_text"
-import { buildPlaceholderRegex } from "../populateExternalMarkdown"
 import {
   capitalizeAfterEnding,
   isRomanNumeral,
@@ -10,67 +9,32 @@ import {
 } from "../tagSmallcaps"
 import { fractionRegex, urlRegex } from "../utils"
 
-describe("urlRegex stress", () => {
-  beforeEach(() => {
+describe("urlRegex", () => {
+  it("should parse domain and path from a multi-segment URL", () => {
     urlRegex.lastIndex = 0
+    const match = urlRegex.exec("(https://sub.example.com/page)")
+    expect(match?.groups?.domain).toBe("sub.example.")
+    expect(match?.groups?.path).toBe("com/page")
   })
 
-  it.each([
-    ["(https://example.com/path)", "example.", "com/path"],
-    ["(https://sub.example.com/page)", "sub.example.", "com/page"],
-    ["(https://a.b.c.d.com/x)", "a.b.c.d.", "com/x"],
-    ["(https://example.com/path/to/page)", "example.", "com/path/to/page"],
-    ["(https://example.com/path?q=1)", "example.", "com/path?q=1"],
-  ])("should match %s → domain=%s path=%s", (input, domain, path) => {
+  it("should handle parentheses in path (Wikipedia-style)", () => {
     urlRegex.lastIndex = 0
-    const match = urlRegex.exec(input)
-    expect(match?.groups?.domain).toBe(domain)
-    expect(match?.groups?.path).toBe(path)
-  })
-
-  it("should match URLs with parentheses in path", () => {
     const match = urlRegex.exec("(https://en.wikipedia.org/wiki/Test_(thing))")
-    expect(match).not.toBeNull()
     expect(match?.groups?.path).toContain("Test_(thing)")
   })
-
-  it.each(["(ftp://example.com/path)", "(not a url)", "(https://)"])(
-    "should NOT match %s",
-    (input) => {
-      urlRegex.lastIndex = 0
-      expect(urlRegex.exec(input)).toBeNull()
-    },
-  )
 
   it("should handle domains with hyphens", () => {
     urlRegex.lastIndex = 0
     const match = urlRegex.exec("(https://my-site.example.com/x)")
-    expect(match).not.toBeNull()
     expect(match?.groups?.domain).toContain("my-site.")
-  })
-
-  it("should handle long but valid domains", () => {
-    const longDomain = "a-b.".repeat(100)
-    urlRegex.lastIndex = 0
-    const match = urlRegex.exec(`(https://${longDomain}com/x)`)
-    expect(match).not.toBeNull()
   })
 })
 
-describe("fractionRegex stress", () => {
-  beforeEach(() => {
-    fractionRegex.lastIndex = 0
-  })
-
+describe("fractionRegex", () => {
   it.each([
     ["1/2", "1", "2", undefined],
-    ["3/4", "3", "4", undefined],
     ["1,000/2,000", "1,000", "2,000", undefined],
-    ["23/100", "23", "100", undefined],
     ["1/4th", "1", "4", "th"],
-    ["1/2nd", "1", "2", "nd"],
-    ["1/1st", "1", "1", "st"],
-    ["3/4rd", "3", "4", "rd"],
   ])("should match %s → %s/%s (ordinal=%s)", (input, num, den, ord) => {
     fractionRegex.lastIndex = 0
     const match = fractionRegex.exec(input)
@@ -79,37 +43,13 @@ describe("fractionRegex stress", () => {
     expect(match?.groups?.ordinal).toBe(ord)
   })
 
-  it.each(["9/11", "word/word", "a/b", "/", "//"])("should NOT match %s", (input) => {
-    fractionRegex.lastIndex = 0
-    expect(fractionRegex.test(input)).toBe(false)
-  })
-
-  it("should not match when preceded by word char", () => {
-    fractionRegex.lastIndex = 0
-    expect(fractionRegex.test("x1/2")).toBe(false)
-  })
-
-  it("should not match when followed by word char", () => {
-    fractionRegex.lastIndex = 0
-    expect(fractionRegex.test("1/2x")).toBe(false)
-  })
-
-  it("should not match when preceded by dot", () => {
-    fractionRegex.lastIndex = 0
-    expect(fractionRegex.test(".1/2")).toBe(false)
-  })
-
-  it("should not match when preceded by slash", () => {
-    fractionRegex.lastIndex = 0
-    expect(fractionRegex.test("/1/2")).toBe(false)
-  })
-
-  it("should match fractions in running text", () => {
-    fractionRegex.lastIndex = 0
-    const match = fractionRegex.exec("about 3/4 of the way")
-    expect(match?.groups?.numerator).toBe("3")
-    expect(match?.groups?.denominator).toBe("4")
-  })
+  it.each(["9/11", "word/word", "x1/2", "1/2x", ".1/2", "/1/2"])(
+    "should NOT match %s",
+    (input) => {
+      fractionRegex.lastIndex = 0
+      expect(fractionRegex.test(input)).toBe(false)
+    },
+  )
 
   it("should not match when followed by minus-sign + digit", () => {
     fractionRegex.lastIndex = 0
@@ -117,15 +57,12 @@ describe("fractionRegex stress", () => {
   })
 })
 
-describe("wikilinkImageEmbedRegex stress", () => {
+describe("wikilinkImageEmbedRegex", () => {
   const regex = /^\|?(?:(?<width>\d+)(?:x(?<height>\d+))?|(?<alt>.+))?$/
 
   it.each([
     ["|640x480", "640", "480", undefined],
-    ["|640", "640", undefined, undefined],
-    ["640x480", "640", "480", undefined],
     ["640", "640", undefined, undefined],
-    ["100x200", "100", "200", undefined],
   ])("should parse dimensions from '%s'", (input, w, h, alt) => {
     const match = regex.exec(input)
     expect(match?.groups?.width).toBe(w)
@@ -135,116 +72,55 @@ describe("wikilinkImageEmbedRegex stress", () => {
 
   it.each([
     ["|alt text", "alt text"],
-    ["alt text", "alt text"],
-    ["|my image", "my image"],
     ["2nd edition cover", "2nd edition cover"],
-    ["figure (a)", "figure (a)"],
   ])("should parse alt from '%s'", (input, expectedAlt) => {
     const match = regex.exec(input)
     expect(match?.groups?.alt).toBe(expectedAlt)
     expect(match?.groups?.width).toBeUndefined()
   })
 
-  it.each(["", "|"])("should handle '%s' (empty/pipe-only)", (input) => {
+  it.each(["", "|"])("should handle empty input '%s'", (input) => {
     const match = regex.exec(input)
     expect(match).not.toBeNull()
     expect(match?.groups?.width).toBeUndefined()
     expect(match?.groups?.alt).toBeUndefined()
   })
-
-  it("should handle long alt text", () => {
-    const longAlt = "word ".repeat(1000).trim()
-    const match = regex.exec(`|${longAlt}`)
-    expect(match?.groups?.alt).toBe(longAlt)
-  })
-
-  it("should handle large dimension numbers", () => {
-    const match = regex.exec("99999x99999")
-    expect(match?.groups?.width).toBe("99999")
-    expect(match?.groups?.height).toBe("99999")
-  })
 })
 
-describe("isRomanNumeral stress", () => {
-  it.each([
-    "II",
-    "III",
-    "IV",
-    "VI",
-    "VII",
-    "VIII",
-    "IX",
-    "XI",
-    "XII",
-    "XIV",
-    "XIX",
-    "XX",
-    "XL",
-    "XC",
-    "CD",
-    "CM",
-    "MMXXIV",
-    "XLII",
-    "XCIX",
-    "IC",
-    "ID",
-    "IM",
-    "CXLVIII",
-    "MMMCMXCIX",
-  ])("should match %s", (numeral) => {
-    expect(isRomanNumeral(numeral)).toBe(true)
-  })
+describe("isRomanNumeral", () => {
+  it.each(["IV", "IX", "XIV", "XLII", "XCIX", "MMMCMXCIX", "IC", "IM"])(
+    "should match %s",
+    (numeral) => {
+      expect(isRomanNumeral(numeral)).toBe(true)
+    },
+  )
 
-  it.each(["I", "V", "X", "L", "C", "D", "M", "A", "HELLO", "abc", "123", "", "  ", "VV", "IIII"])(
+  it.each(["I", "V", "HELLO", "", "VV", "IIII", "MMMM"])(
     "should NOT match %s",
     (input) => {
       expect(isRomanNumeral(input)).toBe(false)
     },
   )
 
-  it("should handle roman numerals with punctuation in isRomanNumeral", () => {
+  it("should match with trailing punctuation", () => {
     expect(isRomanNumeral("IV.")).toBe(true)
-    expect(isRomanNumeral("XIV,")).toBe(true)
-  })
-
-  it("should handle long repeated M's", () => {
-    expect(isRomanNumeral("MMM")).toBe(true)
-    expect(isRomanNumeral("MMMM")).toBe(false)
   })
 })
 
-describe("REGEX_VERSION_NUMBER stress", () => {
-  it.each(["V1", "v2", "V100", "v1.0", "v1.2.3", "V10.20.30"])("should match %s", (input) => {
+describe("REGEX_VERSION_NUMBER", () => {
+  it.each(["V1", "v1.0", "v1.2.3"])("should match %s", (input) => {
     REGEX_VERSION_NUMBER.lastIndex = 0
     expect(REGEX_VERSION_NUMBER.test(input)).toBe(true)
   })
 
-  it.each(["version", "Vault", "v", "V", "1.0", "abc", "vv1", "VV2"])(
-    "should NOT match %s",
-    (input) => {
-      REGEX_VERSION_NUMBER.lastIndex = 0
-      expect(REGEX_VERSION_NUMBER.test(input)).toBe(false)
-    },
-  )
-
-  it("should match in context", () => {
+  it.each(["v", "V", "Vault", "xv1"])("should NOT match %s", (input) => {
     REGEX_VERSION_NUMBER.lastIndex = 0
-    expect(REGEX_VERSION_NUMBER.test("using v2.1 for this")).toBe(true)
-  })
-
-  it("should not match inside a word", () => {
-    REGEX_VERSION_NUMBER.lastIndex = 0
-    expect(REGEX_VERSION_NUMBER.test("xv1")).toBe(false)
-  })
-
-  it("should handle deeply nested version", () => {
-    REGEX_VERSION_NUMBER.lastIndex = 0
-    expect(REGEX_VERSION_NUMBER.test("v1.2.3.4.5.6.7.8.9.10")).toBe(true)
+    expect(REGEX_VERSION_NUMBER.test(input)).toBe(false)
   })
 })
 
-describe("REGEX_ALL_CAPS_PHRASE stress", () => {
-  it.each(["THE BIG THING", "NATO FORCES", "AI AND ML"])(
+describe("REGEX_ALL_CAPS_PHRASE", () => {
+  it.each(["THE BIG THING", "FIRST-ORDER LOGIC"])(
     "should match multi-word phrase: %s",
     (input) => {
       REGEX_ALL_CAPS_PHRASE.lastIndex = 0
@@ -252,31 +128,16 @@ describe("REGEX_ALL_CAPS_PHRASE stress", () => {
     },
   )
 
-  it.each(["hello world", "Hello", "AB"])("should NOT match: %s", (input) => {
+  it.each(["hello world", "AB"])("should NOT match: %s", (input) => {
     REGEX_ALL_CAPS_PHRASE.lastIndex = 0
     expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(false)
   })
-
-  it("should handle phrases with hyphens", () => {
-    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
-    expect(REGEX_ALL_CAPS_PHRASE.test("FIRST-ORDER LOGIC")).toBe(true)
-  })
-
-  it("should handle long all-caps input", () => {
-    const longInput = "ABC DEF ".repeat(500).trim()
-    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
-    const result = REGEX_ALL_CAPS_PHRASE.test(longInput)
-    expect(typeof result).toBe("boolean")
-  })
 })
 
-describe("capitalizeAfterEnding stress", () => {
+describe("capitalizeAfterEnding", () => {
   it.each([
-    ["X", "X"],
     [". X", "X"],
-    ["! Y", "Y"],
     ["? z", "z"],
-    ["\nX", "X"],
     [". Ü", "Ü"],
   ])("should capture letter in '%s' → '%s'", (input, letter) => {
     capitalizeAfterEnding.lastIndex = 0
@@ -284,45 +145,28 @@ describe("capitalizeAfterEnding stress", () => {
     expect(match?.groups?.letter).toBe(letter)
   })
 
-  it.each(["e.g. X", "i.e. Y"])("should not match after %s abbreviation", (input) => {
+  it.each(["e.g. X", "i.e. Y"])("should not match after %s", (input) => {
     capitalizeAfterEnding.lastIndex = 0
     expect(capitalizeAfterEnding.exec(input)).toBeNull()
   })
-
-  it("should match lowercase with i flag", () => {
-    capitalizeAfterEnding.lastIndex = 0
-    const match = capitalizeAfterEnding.exec(". x")
-    expect(match?.groups?.letter).toBe("x")
-  })
 })
 
-describe("editAdmonition stress (no trailing [*_]*)", () => {
-  it("should capture full text without stripping emphasis", () => {
+describe("editAdmonition (no trailing [*_]*)", () => {
+  it("should preserve emphasis markers in captured text", () => {
     const result = editAdmonition("Edit 1/2/2024: Fixed *the* bug")
     expect(result).toContain("Fixed *the* bug")
   })
 
-  it("should handle text ending with emphasis markers", () => {
+  it("should preserve trailing emphasis markers", () => {
     const result = editAdmonition("Edit 1/1/23: Some text**")
     expect(result).toContain("Some text**")
   })
-
-  it("should handle empty text", () => {
-    const result = editAdmonition("Edit 1/1/23: ")
-    expect(result).toContain("Edited on 1/1/23")
-  })
 })
 
-describe("spaceAdmonitions stress (no dead lookahead)", () => {
+describe("spaceAdmonitions (no dead lookahead)", () => {
   it("should add blank blockquote line after callout", () => {
     const result = spaceAdmonitions("> [!info] Title\n> Content")
     expect(result).toBe("> [!info] Title\n> \n> Content")
-  })
-
-  it("should handle nested blockquotes", () => {
-    const input = "> > [!warning] Nested\n> > Text"
-    const result = spaceAdmonitions(input)
-    expect(result).toContain("> > [!warning] Nested\n> > \n> > Text")
   })
 
   it("should handle multiple callouts", () => {
@@ -333,61 +177,13 @@ describe("spaceAdmonitions stress (no dead lookahead)", () => {
   })
 })
 
-describe("buildPlaceholderRegex stress", () => {
-  it("should return null for empty array", () => {
-    expect(buildPlaceholderRegex([])).toBeNull()
-  })
-
-  it("should match placeholder spans", () => {
-    const regex = buildPlaceholderRegex(["test"]) as RegExp
-    expect(regex.test('<span class="populate-markdown-test"></span>')).toBe(true)
-  })
-
-  it("should not match other class names", () => {
-    const regex = buildPlaceholderRegex(["test"]) as RegExp
-    expect(regex.test('<span class="populate-markdown-other"></span>')).toBe(false)
-  })
-
-  it("should escape special regex chars in names", () => {
-    const regex = buildPlaceholderRegex(["test.name"]) as RegExp
-    expect(regex.test('<span class="populate-markdown-test.name"></span>')).toBe(true)
-    expect(regex.test('<span class="populate-markdown-testXname"></span>')).toBe(false)
-  })
-
-  it.each(["alpha", "beta", "gamma"])(
-    "should match placeholder for %s in multi-source regex",
-    (name) => {
-      const regex = buildPlaceholderRegex(["alpha", "beta", "gamma"]) as RegExp
-      expect(regex.test(`<span class="populate-markdown-${name}"></span>`)).toBe(true)
-    },
-  )
-
-  it("should NOT match unlisted source name in multi-source regex", () => {
-    const regex = buildPlaceholderRegex(["alpha", "beta", "gamma"]) as RegExp
-    expect(regex.test('<span class="populate-markdown-delta"></span>')).toBe(false)
-  })
-})
-
-describe("SVG_COLOR_PROP_RE stress", () => {
-  const SVG_COLOR_ATTRS = [
-    "fill",
-    "stroke",
-    "stop-color",
-    "color",
-    "flood-color",
-    "lighting-color",
-  ] as const
-  const SVG_COLOR_PROP_RE = new RegExp(
-    `(?<prop>${SVG_COLOR_ATTRS.join("|")})\\s*:\\s*(?<value>\\S[^;}"']*)`,
-    "gi",
-  )
+describe("SVG_COLOR_PROP_RE (\\S value start)", () => {
+  const SVG_COLOR_PROP_RE =
+    /(?<prop>fill|stroke|stop-color|color|flood-color|lighting-color)\s*:\s*(?<value>\S[^;}"']*)/gi
 
   it.each([
     ["fill: red", "fill", "red"],
     ["stroke:#000", "stroke", "#000"],
-    ["color : rgb(0,0,0)", "color", "rgb(0,0,0)"],
-    ["fill:  blue;", "fill", "blue"],
-    ["stop-color: #ff0000", "stop-color", "#ff0000"],
   ])("should parse '%s' → prop=%s value=%s", (input, prop, value) => {
     SVG_COLOR_PROP_RE.lastIndex = 0
     const match = SVG_COLOR_PROP_RE.exec(input)
@@ -395,7 +191,7 @@ describe("SVG_COLOR_PROP_RE stress", () => {
     expect(match?.groups?.value).toBe(value)
   })
 
-  it("should not match values starting with whitespace-only", () => {
+  it("should reject whitespace-only values", () => {
     SVG_COLOR_PROP_RE.lastIndex = 0
     expect(SVG_COLOR_PROP_RE.test("fill:   ")).toBe(false)
   })
@@ -404,11 +200,5 @@ describe("SVG_COLOR_PROP_RE stress", () => {
     SVG_COLOR_PROP_RE.lastIndex = 0
     const match = SVG_COLOR_PROP_RE.exec("fill: red; stroke: blue")
     expect(match?.groups?.value).toBe("red")
-  })
-
-  it("should handle CSS custom properties", () => {
-    SVG_COLOR_PROP_RE.lastIndex = 0
-    const match = SVG_COLOR_PROP_RE.exec("fill: var(--my-color)")
-    expect(match?.groups?.value).toBe("var(--my-color)")
   })
 })

--- a/quartz/plugins/transformers/tests/regex-stress.test.ts
+++ b/quartz/plugins/transformers/tests/regex-stress.test.ts
@@ -1,0 +1,412 @@
+import { beforeEach, describe, expect, it } from "@jest/globals"
+
+import {
+  editAdmonition,
+  spaceAdmonitions,
+} from "../formatting_improvement_text"
+import { buildPlaceholderRegex } from "../populateExternalMarkdown"
+import {
+  capitalizeAfterEnding,
+  isRomanNumeral,
+  REGEX_ALL_CAPS_PHRASE,
+  REGEX_VERSION_NUMBER,
+} from "../tagSmallcaps"
+import { fractionRegex, urlRegex } from "../utils"
+
+describe("urlRegex stress", () => {
+  beforeEach(() => {
+    urlRegex.lastIndex = 0
+  })
+
+  it.each([
+    ["(https://example.com/path)", "example.", "com/path"],
+    ["(https://sub.example.com/page)", "sub.example.", "com/page"],
+    ["(https://a.b.c.d.com/x)", "a.b.c.d.", "com/x"],
+    ["(https://example.com/path/to/page)", "example.", "com/path/to/page"],
+    ["(https://example.com/path?q=1)", "example.", "com/path?q=1"],
+  ])("should match %s → domain=%s path=%s", (input, domain, path) => {
+    urlRegex.lastIndex = 0
+    const match = urlRegex.exec(input)
+    expect(match?.groups?.domain).toBe(domain)
+    expect(match?.groups?.path).toBe(path)
+  })
+
+  it("should match URLs with parentheses in path", () => {
+    const match = urlRegex.exec("(https://en.wikipedia.org/wiki/Test_(thing))")
+    expect(match).not.toBeNull()
+    expect(match?.groups?.path).toContain("Test_(thing)")
+  })
+
+  it.each([
+    "(ftp://example.com/path)",
+    "(not a url)",
+    "(https://)",
+  ])("should NOT match %s", (input) => {
+    urlRegex.lastIndex = 0
+    expect(urlRegex.exec(input)).toBeNull()
+  })
+
+  it("should handle domains with hyphens", () => {
+    urlRegex.lastIndex = 0
+    const match = urlRegex.exec("(https://my-site.example.com/x)")
+    expect(match).not.toBeNull()
+    expect(match?.groups?.domain).toContain("my-site.")
+  })
+
+  it("should handle long but valid domains", () => {
+    const longDomain = "a-b.".repeat(100)
+    urlRegex.lastIndex = 0
+    const match = urlRegex.exec(`(https://${longDomain}com/x)`)
+    expect(match).not.toBeNull()
+  })
+})
+
+describe("fractionRegex stress", () => {
+  beforeEach(() => {
+    fractionRegex.lastIndex = 0
+  })
+
+  it.each([
+    ["1/2", "1", "2", undefined],
+    ["3/4", "3", "4", undefined],
+    ["1,000/2,000", "1,000", "2,000", undefined],
+    ["23/100", "23", "100", undefined],
+    ["1/4th", "1", "4", "th"],
+    ["1/2nd", "1", "2", "nd"],
+    ["1/1st", "1", "1", "st"],
+    ["3/4rd", "3", "4", "rd"],
+  ])("should match %s → %s/%s (ordinal=%s)", (input, num, den, ord) => {
+    fractionRegex.lastIndex = 0
+    const match = fractionRegex.exec(input)
+    expect(match?.groups?.numerator).toBe(num)
+    expect(match?.groups?.denominator).toBe(den)
+    expect(match?.groups?.ordinal).toBe(ord)
+  })
+
+  it.each([
+    "9/11",
+    "word/word",
+    "a/b",
+    "/",
+    "//",
+  ])("should NOT match %s", (input) => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test(input)).toBe(false)
+  })
+
+  it("should not match when preceded by word char", () => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test("x1/2")).toBe(false)
+  })
+
+  it("should not match when followed by word char", () => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test("1/2x")).toBe(false)
+  })
+
+  it("should not match when preceded by dot", () => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test(".1/2")).toBe(false)
+  })
+
+  it("should not match when preceded by slash", () => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test("/1/2")).toBe(false)
+  })
+
+  it("should match fractions in running text", () => {
+    fractionRegex.lastIndex = 0
+    const match = fractionRegex.exec("about 3/4 of the way")
+    expect(match?.groups?.numerator).toBe("3")
+    expect(match?.groups?.denominator).toBe("4")
+  })
+
+  it("should not match when followed by minus-sign + digit", () => {
+    fractionRegex.lastIndex = 0
+    expect(fractionRegex.test("1/2-3")).toBe(false)
+  })
+})
+
+describe("wikilinkImageEmbedRegex stress", () => {
+  const regex = /^\|?(?:(?<width>\d+)(?:x(?<height>\d+))?|(?<alt>.+))?$/
+
+  it.each([
+    ["|640x480", "640", "480", undefined],
+    ["|640", "640", undefined, undefined],
+    ["640x480", "640", "480", undefined],
+    ["640", "640", undefined, undefined],
+    ["100x200", "100", "200", undefined],
+  ])("should parse dimensions from '%s'", (input, w, h, alt) => {
+    const match = regex.exec(input)
+    expect(match?.groups?.width).toBe(w)
+    expect(match?.groups?.height).toBe(h)
+    expect(match?.groups?.alt).toBe(alt)
+  })
+
+  it.each([
+    ["|alt text", "alt text"],
+    ["alt text", "alt text"],
+    ["|my image", "my image"],
+    ["2nd edition cover", "2nd edition cover"],
+    ["figure (a)", "figure (a)"],
+  ])("should parse alt from '%s'", (input, expectedAlt) => {
+    const match = regex.exec(input)
+    expect(match?.groups?.alt).toBe(expectedAlt)
+    expect(match?.groups?.width).toBeUndefined()
+  })
+
+  it.each(["", "|"])("should handle '%s' (empty/pipe-only)", (input) => {
+    const match = regex.exec(input)
+    expect(match).not.toBeNull()
+    expect(match?.groups?.width).toBeUndefined()
+    expect(match?.groups?.alt).toBeUndefined()
+  })
+
+  it("should handle long alt text", () => {
+    const longAlt = "word ".repeat(1000).trim()
+    const match = regex.exec(`|${longAlt}`)
+    expect(match?.groups?.alt).toBe(longAlt)
+  })
+
+  it("should handle large dimension numbers", () => {
+    const match = regex.exec("99999x99999")
+    expect(match?.groups?.width).toBe("99999")
+    expect(match?.groups?.height).toBe("99999")
+  })
+})
+
+describe("isRomanNumeral stress", () => {
+  it.each([
+    "II", "III", "IV", "VI", "VII", "VIII", "IX",
+    "XI", "XII", "XIV", "XIX", "XX", "XL", "XC",
+    "CD", "CM", "MMXXIV", "XLII", "XCIX",
+    "IC", "ID", "IM",
+    "CXLVIII", "MMMCMXCIX",
+  ])("should match %s", (numeral) => {
+    expect(isRomanNumeral(numeral)).toBe(true)
+  })
+
+  it.each([
+    "I", "V", "X", "L", "C", "D", "M",
+    "A", "HELLO", "abc", "123", "", "  ",
+    "VV", "IIII",
+  ])("should NOT match %s", (input) => {
+    expect(isRomanNumeral(input)).toBe(false)
+  })
+
+  it("should handle roman numerals with punctuation in isRomanNumeral", () => {
+    expect(isRomanNumeral("IV.")).toBe(true)
+    expect(isRomanNumeral("XIV,")).toBe(true)
+  })
+
+  it("should handle long repeated M's", () => {
+    expect(isRomanNumeral("MMM")).toBe(true)
+    expect(isRomanNumeral("MMMM")).toBe(false)
+  })
+})
+
+describe("REGEX_VERSION_NUMBER stress", () => {
+  it.each(["V1", "v2", "V100", "v1.0", "v1.2.3", "V10.20.30"])(
+    "should match %s",
+    (input) => {
+      REGEX_VERSION_NUMBER.lastIndex = 0
+      expect(REGEX_VERSION_NUMBER.test(input)).toBe(true)
+    },
+  )
+
+  it.each(["version", "Vault", "v", "V", "1.0", "abc", "vv1", "VV2"])(
+    "should NOT match %s",
+    (input) => {
+      REGEX_VERSION_NUMBER.lastIndex = 0
+      expect(REGEX_VERSION_NUMBER.test(input)).toBe(false)
+    },
+  )
+
+  it("should match in context", () => {
+    REGEX_VERSION_NUMBER.lastIndex = 0
+    expect(REGEX_VERSION_NUMBER.test("using v2.1 for this")).toBe(true)
+  })
+
+  it("should not match inside a word", () => {
+    REGEX_VERSION_NUMBER.lastIndex = 0
+    expect(REGEX_VERSION_NUMBER.test("xv1")).toBe(false)
+  })
+
+  it("should handle deeply nested version", () => {
+    REGEX_VERSION_NUMBER.lastIndex = 0
+    expect(REGEX_VERSION_NUMBER.test("v1.2.3.4.5.6.7.8.9.10")).toBe(true)
+  })
+})
+
+describe("REGEX_ALL_CAPS_PHRASE stress", () => {
+  it.each([
+    "THE BIG THING",
+    "NATO FORCES",
+    "AI AND ML",
+  ])("should match multi-word phrase: %s", (input) => {
+    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+    expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(true)
+  })
+
+  it.each([
+    "hello world",
+    "Hello",
+    "AB",
+  ])("should NOT match: %s", (input) => {
+    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+    expect(REGEX_ALL_CAPS_PHRASE.test(input)).toBe(false)
+  })
+
+  it("should handle phrases with hyphens", () => {
+    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+    expect(REGEX_ALL_CAPS_PHRASE.test("FIRST-ORDER LOGIC")).toBe(true)
+  })
+
+  it("should handle long all-caps input", () => {
+    const longInput = ("ABC DEF " .repeat(500)).trim()
+    REGEX_ALL_CAPS_PHRASE.lastIndex = 0
+    const result = REGEX_ALL_CAPS_PHRASE.test(longInput)
+    expect(typeof result).toBe("boolean")
+  })
+})
+
+describe("capitalizeAfterEnding stress", () => {
+  it.each([
+    ["X", "X"],
+    [". X", "X"],
+    ["! Y", "Y"],
+    ["? z", "z"],
+    ["\nX", "X"],
+    [". Ü", "Ü"],
+  ])("should capture letter in '%s' → '%s'", (input, letter) => {
+    capitalizeAfterEnding.lastIndex = 0
+    const match = capitalizeAfterEnding.exec(input)
+    expect(match?.groups?.letter).toBe(letter)
+  })
+
+  it.each(["e.g. X", "i.e. Y"])(
+    "should not match after %s abbreviation",
+    (input) => {
+      capitalizeAfterEnding.lastIndex = 0
+      expect(capitalizeAfterEnding.exec(input)).toBeNull()
+    },
+  )
+
+  it("should match lowercase with i flag", () => {
+    capitalizeAfterEnding.lastIndex = 0
+    const match = capitalizeAfterEnding.exec(". x")
+    expect(match?.groups?.letter).toBe("x")
+  })
+})
+
+describe("editAdmonition stress (no trailing [*_]*)", () => {
+  it("should capture full text without stripping emphasis", () => {
+    const result = editAdmonition("Edit 1/2/2024: Fixed *the* bug")
+    expect(result).toContain("Fixed *the* bug")
+  })
+
+  it("should handle text ending with emphasis markers", () => {
+    const result = editAdmonition("Edit 1/1/23: Some text**")
+    expect(result).toContain("Some text**")
+  })
+
+  it("should handle empty text", () => {
+    const result = editAdmonition("Edit 1/1/23: ")
+    expect(result).toContain("Edited on 1/1/23")
+  })
+})
+
+describe("spaceAdmonitions stress (no dead lookahead)", () => {
+  it("should add blank blockquote line after callout", () => {
+    const result = spaceAdmonitions("> [!info] Title\n> Content")
+    expect(result).toBe("> [!info] Title\n> \n> Content")
+  })
+
+  it("should handle nested blockquotes", () => {
+    const input = "> > [!warning] Nested\n> > Text"
+    const result = spaceAdmonitions(input)
+    expect(result).toContain("> > [!warning] Nested\n> > \n> > Text")
+  })
+
+  it("should handle multiple callouts", () => {
+    const input = "> [!info] First\n> text\n\n> [!warning] Second\n> more"
+    const result = spaceAdmonitions(input)
+    expect(result).toContain("> [!info] First\n> \n> text")
+    expect(result).toContain("> [!warning] Second\n> \n> more")
+  })
+})
+
+describe("buildPlaceholderRegex stress", () => {
+  it("should return null for empty array", () => {
+    expect(buildPlaceholderRegex([])).toBeNull()
+  })
+
+  it("should match placeholder spans", () => {
+    const regex = buildPlaceholderRegex(["test"]) as RegExp
+    expect(regex.test('<span class="populate-markdown-test"></span>')).toBe(true)
+  })
+
+  it("should not match other class names", () => {
+    const regex = buildPlaceholderRegex(["test"]) as RegExp
+    expect(regex.test('<span class="populate-markdown-other"></span>')).toBe(false)
+  })
+
+  it("should escape special regex chars in names", () => {
+    const regex = buildPlaceholderRegex(["test.name"]) as RegExp
+    expect(regex.test('<span class="populate-markdown-test.name"></span>')).toBe(true)
+    expect(regex.test('<span class="populate-markdown-testXname"></span>')).toBe(false)
+  })
+
+  it.each(["alpha", "beta", "gamma"])(
+    "should match placeholder for %s in multi-source regex",
+    (name) => {
+      const regex = buildPlaceholderRegex(["alpha", "beta", "gamma"]) as RegExp
+      expect(regex.test(`<span class="populate-markdown-${name}"></span>`)).toBe(true)
+    },
+  )
+
+  it("should NOT match unlisted source name in multi-source regex", () => {
+    const regex = buildPlaceholderRegex(["alpha", "beta", "gamma"]) as RegExp
+    expect(regex.test('<span class="populate-markdown-delta"></span>')).toBe(false)
+  })
+})
+
+describe("SVG_COLOR_PROP_RE stress", () => {
+  const SVG_COLOR_ATTRS = [
+    "fill", "stroke", "stop-color", "color", "flood-color", "lighting-color",
+  ] as const
+  const SVG_COLOR_PROP_RE = new RegExp(
+    `(?<prop>${SVG_COLOR_ATTRS.join("|")})\\s*:\\s*(?<value>\\S[^;}"']*)`,
+    "gi",
+  )
+
+  it.each([
+    ["fill: red", "fill", "red"],
+    ["stroke:#000", "stroke", "#000"],
+    ["color : rgb(0,0,0)", "color", "rgb(0,0,0)"],
+    ["fill:  blue;", "fill", "blue"],
+    ["stop-color: #ff0000", "stop-color", "#ff0000"],
+  ])("should parse '%s' → prop=%s value=%s", (input, prop, value) => {
+    SVG_COLOR_PROP_RE.lastIndex = 0
+    const match = SVG_COLOR_PROP_RE.exec(input)
+    expect(match?.groups?.prop).toBe(prop)
+    expect(match?.groups?.value).toBe(value)
+  })
+
+  it("should not match values starting with whitespace-only", () => {
+    SVG_COLOR_PROP_RE.lastIndex = 0
+    expect(SVG_COLOR_PROP_RE.test("fill:   ")).toBe(false)
+  })
+
+  it("should stop at semicolons", () => {
+    SVG_COLOR_PROP_RE.lastIndex = 0
+    const match = SVG_COLOR_PROP_RE.exec("fill: red; stroke: blue")
+    expect(match?.groups?.value).toBe("red")
+  })
+
+  it("should handle CSS custom properties", () => {
+    SVG_COLOR_PROP_RE.lastIndex = 0
+    const match = SVG_COLOR_PROP_RE.exec("fill: var(--my-color)")
+    expect(match?.groups?.value).toBe("var(--my-color)")
+  })
+})

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -7,7 +7,7 @@ import { visit } from "unist-util-visit"
 import type { QuartzTransformerPlugin } from "../types"
 
 export const urlRegex = new RegExp(
-  /(?<protocol>https?:\/\/)(?<domain>(?:[\da-z.-]+\.)+)(?<path>[/?=\w.-]+(?:\([\w.\-,() ]*\))?)(?=\))/g,
+  /(?<protocol>https?:\/\/)(?<domain>(?:[\da-z-]+\.)+)(?<path>[/?=\w.-]+(?:\([\w.\-,() ]*\))?)(?=\))/g,
 )
 
 const linkText = /\[(?<linkText>[^\]]+)\]/
@@ -18,10 +18,10 @@ export const integerRegex = /\d{1,3}(?:,?\d{3})*/u
 export const numberRegex = new RegExp(`[-−]?${integerRegex.source}(?:\\.\\d+)?`, "u")
 
 // A fraction is a digit followed by a slash and another digit
-const ordinalSuffixes = /(?:st|nd|rd|th)/
+const ordinalSuffixes = /st|nd|rd|th/
 export const fractionRegex = new RegExp(
-  `(?<![\\w/\\.]|${numberRegex.source})(?!9/11)(?<numerator>${integerRegex.source})\\/(?<denominator>${integerRegex.source})(?<ordinal>${ordinalSuffixes.source})?(?!${numberRegex.source}|\\d)(?![\\w/])`,
-  "gm",
+  `(?<![\\w/.])(?!9/11)(?<numerator>${integerRegex.source})\\/(?<denominator>${integerRegex.source})(?<ordinal>${ordinalSuffixes.source})?(?![-−]?\\d)(?![\\w/])`,
+  "g",
 )
 
 export interface ReplaceFnResult {


### PR DESCRIPTION
## Summary

- Fixed all 40 `regexp/*` warnings from PR #1371's `warn`-level rules, then promoted them to `error` so they block CI going forward.
- Every fix is a real regex improvement (ReDoS elimination, dead-code removal, duplicate char fix, structural simplification) — only 1 suppress remains (a linter false positive on an anchored `^…$` pattern with provably O(1) backtracking).

## Changes

**`quartz/plugins/transformers/utils.ts`**
- `urlRegex`: removed `.` from domain char class `[\da-z.-]` → `[\da-z-]`, eliminating ReDoS from `.` overlap with path group
- `fractionRegex`: simplified lookbehind to just `(?<[\w/.])` (integer alternative was redundant — `\w` already covers digits); simplified lookahead by removing redundant optional decimal and `|\d`; removed useless `m` flag; removed NCG from `ordinalSuffixes`

**`quartz/plugins/transformers/tagSmallcaps.ts`**
- Word boundary constants: removed `A-Z`/`a-z` ranges already covered by `\w`
- Roman numeral regex: lowered lookbehind from `{3}` → `{2}` so IV/IX are handled by the primary branch; fallback now only covers `I[CDM]` (non-standard subtractives)
- `validSmallCapsPhrase`: fixed duplicate U+2019 → U+0027 + U+2019 matching `smallCapsSeparators`; `{3,}` → `{3}` in lookahead
- `noSentenceStartSingleCapital`: restructured via De Morgan's law — flat `(?:¬A|¬B|C)` instead of nested `(?!(?<=A)(?=B)(?!C))`, eliminating the linter's contradiction warning
- `capitalizeAfterEnding`: added `iu` flags to eliminate case-paired char classes
- `REGEX_VERSION_NUMBER`: simplified to `\b` boundary; `(?:V|v)` alternation

**`quartz/plugins/transformers/formatting_improvement_text.ts`**
- Removed dead `[*_]*` after greedy `.*` in edit patterns
- Removed dead lookahead on `CALLOUT_REGEX_NO_SPACE` (always succeeded after `$`)
- Collapsed `.*?\S.*?` → `\S.*?` in display-math regex (eliminates two-quantifier ReDoS)
- Removed redundant `$` and `m` flag from table regex

**`quartz/plugins/transformers/ofm.ts`**
- Rewrote `wikilinkImageEmbedRegex` as a clean two-branch alternation `(?:width×height | alt)` — zero backtracking

**Other files**
- `accurateInvert.ts`: `\S` start on value group prevents misleading-capture overlap
- `formatting_improvement_html.ts`: char class `[←→↑↓…]` replaces single-char alternation
- `populateExternalMarkdown.ts`: returns `null` for empty source names instead of a never-matching regex sentinel
- `TableOfContents.tsx`: `\S.*` start for restText (1 suppress for anchored `\d+` — O(1) backtrack)

**`config/javascript/eslint.config.js`**
- `regexp/flat/recommended` rules promoted from `warn` → `error`

## Testing

- `pnpm check` — clean
- `pnpm test` — 3926/3926 pass
- `pnpm eslint` — 0 errors, 0 regexp warnings (2 pre-existing playwright warnings unrelated to this PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XxC4pkSfs3zXYXr9wYQr8i)_