### PR TITLE
fix(test): prevent Safari crash in target=_blank SPA test

### DIFF
--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -169,20 +169,33 @@ test.describe("Local Link Navigation", () => {
   }
 
   test("ignores links with target=_blank", async ({ page }) => {
-    await page.evaluate(() => {
-      const link = document.createElement("a")
-      link.href = "/design"
-      link.target = "_blank"
-      link.id = "blank-link"
-      link.textContent = "Open in new tab"
-      document.body.appendChild(link)
+    // Use a synthetic click inside evaluate instead of Playwright's .click()
+    // to avoid opening a real popup — Safari's WebKit process can crash when
+    // Playwright tears down a context that still has an in-flight popup.
+    const wasDefaultPrevented = await page.evaluate(() => {
+      return new Promise<boolean>((resolve) => {
+        const link = document.createElement("a")
+        link.href = "/design"
+        link.target = "_blank"
+        link.textContent = "Open in new tab"
+        document.body.appendChild(link)
+
+        link.addEventListener(
+          "click",
+          (e) => {
+            const prevented = e.defaultPrevented
+            e.preventDefault()
+            resolve(prevented)
+          },
+          { capture: false },
+        )
+
+        link.click()
+      })
     })
 
-    const currentUrl = page.url()
-    await page.locator("#blank-link").click()
-
-    // The local link with target=_blank should not be intercepted
-    expect(page.url()).toBe(currentUrl)
+    // SPA should NOT have called preventDefault on a target=_blank link
+    expect(wasDefaultPrevented).toBe(false)
   })
 
   test("external links are not intercepted", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fix root cause of Safari/WebKit crash that kills the browser process mid-test, causing the *next* test to fail with `browser.newContext: Target page, context or browser has been closed`

## Changes
- **Rewrote "ignores links with target=_blank" test** to use a synthetic click inside `page.evaluate()` instead of Playwright's `.click()`. The real browser click opens a popup tab in Safari; when Playwright tears down the context while the popup is still loading, WebKit's process crashes. The synthetic click tests the same SPA routing logic (the router doesn't check `event.isTrusted`) without triggering a popup.
- The new pattern matches the adjacent "external links are not intercepted" test, which already used `page.evaluate()` + `link.click()` + `event.defaultPrevented` checking.

## Testing
- `pnpm check` passes
- The fix eliminates the popup that crashes Safari — verified by code inspection that `getNavigationOpts()` in `spa_utils.ts` does not check `isTrusted`, so synthetic clicks exercise the same code path as real clicks.

https://claude.ai/code/session_01AMr19p7rEK7YzJRyWBBgYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMr19p7rEK7YzJRyWBBgYV)_