### PR TITLE
fix(ci): remove blobless partial clones to prevent checkout flakes

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
-          filter: ${{ inputs.fetch-depth == 0 && 'blob:none' || '' }}
 
       # Cache keyed on commit SHA + fixture flag. Test builds and deploy
       # builds end up at different keys so fixtures can't leak from one to

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - name: Setup site
         uses: ./.github/actions/setup-site

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          filter: blob:none # Partial clone: skip historical file content (only need commit/tree objects for git diff --name-only)
           token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Setup site

--- a/.github/workflows/monthly-newsletter.yml
+++ b/.github/workflows/monthly-newsletter.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          filter: blob:none # Full commit history for git log, skip historical blobs
 
       - name: Restore last reviewed commit
         id: cache-commit

--- a/.github/workflows/subfont-bisect.yaml
+++ b/.github/workflows/subfont-bisect.yaml
@@ -39,7 +39,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
-          filter: blob:none
 
       - name: Setup site tooling
         uses: ./.github/actions/setup-site

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -60,7 +60,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - name: Checkout template repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -69,7 +68,6 @@ jobs:
           path: _template
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-          filter: blob:none
 
       - name: Check token workflow scope
         env:


### PR DESCRIPTION
## Summary
- Eliminate transient `fatal: could not read Username for 'https://github.com'` checkout failures across all CI workflows

## Changes
- Removed `filter: blob:none` from `actions/checkout` in 6 workflow files: `build-site.yaml`, `deploy.yaml`, `lint-and-validate.yaml`, `template-sync.yaml`, `subfont-bisect.yaml`, `monthly-newsletter.yml`

## Root cause
Blobless partial clones (`filter: blob:none`) lazily fetch blobs from the "promisor remote" when git needs them mid-checkout. If the runner's auth token has transiently failed to propagate at that moment, the lazy fetch dies. The repo is ~9 MB packed — full clones take seconds and don't depend on a second authenticated fetch after initial clone.

## Testing
- Verified no remaining `filter: blob:none` in `.github/`
- The fix is a pure deletion — no new behavior, just removes the lazy-fetch dependency that caused the flake

https://claude.ai/code/session_01AMr19p7rEK7YzJRyWBBgYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMr19p7rEK7YzJRyWBBgYV)_