### PR TITLE
test: tighten all test assertions to exact values

### DIFF
--- a/config/stylelint/scss-custom-property-interpolation.test.ts
+++ b/config/stylelint/scss-custom-property-interpolation.test.ts
@@ -34,39 +34,45 @@ describe("custom/scss-custom-property-interpolation", () => {
         name: "simple custom property with variable",
         code: ".foo { --size: $base-margin; }",
         expectedMessage: "#{$base-margin}",
+        expectedWarnings: 1,
       },
       {
         name: "custom property with calc and variable",
         code: ".foo { --size: calc(100% - $base-margin); }",
         expectedMessage: "#{$base-margin}",
+        expectedWarnings: 1,
       },
       {
         name: "custom property with CSS var and SCSS variable",
         code: ".foo { --size: calc(var(--base) / $font-scale); }",
         expectedMessage: "#{$font-scale}",
+        expectedWarnings: 1,
       },
       {
         name: "multiple SCSS variables in one custom property",
         code: ".foo { --size: calc($var1 + $var2); }",
         expectedMessage: "#{$var1}",
+        expectedWarnings: 2,
       },
       {
         name: "variable with hyphen in custom property",
         code: ".foo { --width: $base-width; }",
         expectedMessage: "#{$base-width}",
+        expectedWarnings: 1,
       },
       {
         name: "variable with underscore in custom property",
         code: ".foo { --width: $base_width; }",
         expectedMessage: "#{$base_width}",
+        expectedWarnings: 1,
       },
     ]
 
-    testCases.forEach(({ name, code, expectedMessage }) => {
+    testCases.forEach(({ name, code, expectedMessage, expectedWarnings }) => {
       it(`should report violations: ${name}`, async () => {
         const result = await lintScss(code)
 
-        expect(result.warnings.length).toBeGreaterThan(0)
+        expect(result.warnings).toHaveLength(expectedWarnings)
         expect(result.warnings[0].rule).toBe("custom/scss-custom-property-interpolation")
         expect(result.warnings[0].text).toContain(expectedMessage)
       })

--- a/quartz/components/scripts/tests/popover.test.ts
+++ b/quartz/components/scripts/tests/popover.test.ts
@@ -59,15 +59,15 @@ describe("createPopover", () => {
   it("should create a popover element", async () => {
     const popover = await createPopover(options)
     expect(popover).toBeInstanceOf(HTMLElement)
-    expect(popover?.classList.contains("popover")).toBe(true)
-    expect(popover?.classList.contains("footnote-popover")).toBe(false)
-    expect(popover?.querySelector(".popover-close")).toBeNull()
+    expect(popover.classList.contains("popover")).toBe(true)
+    expect(popover.classList.contains("footnote-popover")).toBe(false)
+    expect(popover.querySelector(".popover-close")).toBeNull()
   })
 
   it("should handle HTML content", async () => {
     const popover = await createPopover(options)
-    expect(popover?.querySelector(".popover-inner")).not.toBeNull()
-    expect(popover?.querySelector("h1#test-popover")).not.toBeNull()
+    expect(popover.querySelector(".popover-inner")).not.toBeNull()
+    expect(popover.querySelector("h1#test-popover")).not.toBeNull()
   })
 
   it("should handle error cases", async () => {
@@ -90,8 +90,8 @@ describe("createPopover", () => {
 
   it('should append "-popover" to only header IDs in the popover content', async () => {
     const popover = await createPopover(options)
-    expect(popover?.querySelector("h1#test-popover")).not.toBeNull()
-    expect(popover?.querySelector("div#not-a-header-popover")).toBeNull()
+    expect(popover.querySelector("h1#test-popover")).not.toBeNull()
+    expect(popover.querySelector("div#not-a-header-popover")).toBeNull()
   })
 
   it("should throw an error for footnote back arrow links", async () => {
@@ -262,7 +262,9 @@ describe("createPopover", () => {
     options.linkElement.setAttribute("href", "#user-content-fn-1")
     const footnotePopover = await createPopover(options)
     const footnoteInner = footnotePopover.querySelector(".popover-inner")
-    const footnoteContentLength = footnoteInner?.innerHTML.length ?? 0
+    expect(footnoteInner).not.toBeNull()
+    if (!footnoteInner) throw new Error("footnoteInner is null")
+    const footnoteContentLength = footnoteInner.innerHTML.length
 
     // Create full article popover (regular link, no footnote hash)
     const fullArticleOptions = {
@@ -272,16 +274,18 @@ describe("createPopover", () => {
     fullArticleOptions.linkElement.setAttribute("href", "http://example.com")
     const fullArticlePopover = await createPopover(fullArticleOptions)
     const fullArticleInner = fullArticlePopover.querySelector(".popover-inner")
-    const fullArticleContentLength = fullArticleInner?.innerHTML.length ?? 0
+    expect(fullArticleInner).not.toBeNull()
+    if (!fullArticleInner) throw new Error("fullArticleInner is null")
+    const fullArticleContentLength = fullArticleInner.innerHTML.length
 
     // Footnote popover should have significantly less content than full article
     // The full article has ~500+ chars, the footnote has ~50 chars
     expect(fullArticleContentLength - footnoteContentLength).toBeGreaterThanOrEqual(10)
     // Also verify footnote popover does not contain article paragraphs or li wrapper
-    expect(footnoteInner?.querySelectorAll("p").length).toBe(0)
-    expect(footnoteInner?.querySelectorAll("li").length).toBe(0)
+    expect(footnoteInner.querySelectorAll("p").length).toBe(0)
+    expect(footnoteInner.querySelectorAll("li").length).toBe(0)
     // Should contain the footnote text content
-    expect(footnoteInner?.textContent).toContain(footnoteText)
+    expect(footnoteInner.textContent).toContain(footnoteText)
   })
 })
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -561,7 +561,7 @@ test.describe("Right sidebar", () => {
       return el.scrollHeight > el.clientHeight
     })
 
-    expect(isOverflowing).toBeTruthy()
+    expect(isOverflowing).toBe(true)
 
     const initialWindowScrollY = await page.evaluate(() => window.scrollY)
     const initialSidebarScrollTop = await rightSidebar.evaluate((el) => el.scrollTop)
@@ -600,7 +600,7 @@ test.describe("Right sidebar", () => {
     await expect(rightSidebar).toBeVisible()
 
     const overflows = await rightSidebar.evaluate((el) => el.scrollHeight > el.clientHeight)
-    expect(overflows).toBeTruthy()
+    expect(overflows).toBe(true)
 
     // At the top: only the bottom fade should be active (more content below).
     await rightSidebar.evaluate((el) => {

--- a/quartz/plugins/transformers/countFavicons.test.ts
+++ b/quartz/plugins/transformers/countFavicons.test.ts
@@ -167,9 +167,7 @@ describe("countAllFavicons", () => {
 
     expect(fs.writeFileSync).toHaveBeenCalled()
     const counts = getWrittenCounts()
-    const count = counts.get(specialFaviconPaths.anchor)
-    expect(count).toBeDefined()
-    expect(count).toBeGreaterThanOrEqual(2)
+    expect(counts.get(specialFaviconPaths.anchor)).toBe(2)
   })
 
   it.each([
@@ -209,9 +207,7 @@ describe("countAllFavicons", () => {
 
     expect(fs.writeFileSync).toHaveBeenCalled()
     const counts = getWrittenCounts()
-    const count = counts.get(specialFaviconPaths.turntrout)
-    expect(count).toBeDefined()
-    expect(count).toBeGreaterThanOrEqual(2)
+    expect(counts.get(specialFaviconPaths.turntrout)).toBe(2)
   })
 
   it("should count multiple different hostnames separately", async () => {
@@ -223,20 +219,13 @@ describe("countAllFavicons", () => {
 
     expect(fs.writeFileSync).toHaveBeenCalled()
     const counts = getWrittenCounts()
-    expect(counts.size).toBeGreaterThanOrEqual(2)
+    expect(counts.size).toBe(2)
 
     const examplePath = getQuartzPath("example.com").replace(/\.svg$/, "")
     const testPath = getQuartzPath("test.com").replace(/\.svg$/, "")
 
-    const exampleCount = counts.get(examplePath)
-    const testCount = counts.get(testPath)
-
-    expect(exampleCount).toBeDefined()
-    expect(testCount).toBeDefined()
-    expect(exampleCount).toBeGreaterThanOrEqual(2)
-    expect(testCount).toBeGreaterThanOrEqual(1)
-    // Type assertion is safe here because we've already verified testCount is defined
-    expect(exampleCount).toBeGreaterThan(testCount as number)
+    expect(counts.get(examplePath)).toBe(2)
+    expect(counts.get(testPath)).toBe(1)
   })
 
   it("should write counts", async () => {
@@ -248,15 +237,9 @@ describe("countAllFavicons", () => {
 
     expect(fs.writeFileSync).toHaveBeenCalled()
     const counts = getWrittenCounts()
-    expect(counts.size).toBeGreaterThanOrEqual(2)
-
-    const mailCount = counts.get(specialFaviconPaths.mail)
-    const anchorCount = counts.get(specialFaviconPaths.anchor)
-
-    expect(mailCount).toBeDefined()
-    expect(anchorCount).toBeDefined()
-    expect(mailCount).toBeGreaterThanOrEqual(3)
-    expect(anchorCount).toBeGreaterThanOrEqual(2)
+    expect(counts.size).toBe(2)
+    expect(counts.get(specialFaviconPaths.mail)).toBe(3)
+    expect(counts.get(specialFaviconPaths.anchor)).toBe(2)
   })
 
   it("should count when hostnames have equal counts", async () => {

--- a/quartz/plugins/transformers/links.test.ts
+++ b/quartz/plugins/transformers/links.test.ts
@@ -141,7 +141,7 @@ describe("CrawlLinks anchor processing", () => {
     const result = await processHtml('<a href="./other-page">Other</a>', {
       allSlugs: ["other-page"] as FullSlug[],
     })
-    expect(result.links.length).toBeGreaterThan(0)
+    expect(result.links).toHaveLength(1)
   })
 
   it.each([

--- a/quartz/plugins/transformers/tests/ofm.test.ts
+++ b/quartz/plugins/transformers/tests/ofm.test.ts
@@ -1240,12 +1240,12 @@ describe("Branch coverage tests", () => {
 
       // First checkbox (with label) should not have aria-label
       const firstCheckboxMatch = result.match(/id="checkbox-0"[^>]*>/)
-      expect(firstCheckboxMatch).toBeTruthy()
+      expect(firstCheckboxMatch).not.toBeNull()
       expect(firstCheckboxMatch?.[0]).not.toContain("aria-label")
 
       // Second checkbox (without label) should have aria-label
       const secondCheckboxMatch = result.match(/id="checkbox-1"[^>]*>/)
-      expect(secondCheckboxMatch).toBeTruthy()
+      expect(secondCheckboxMatch).not.toBeNull()
       expect(secondCheckboxMatch?.[0]).toContain('aria-label="checkbox"')
     })
 

--- a/quartz/plugins/transformers/tests/sequenceLinks.test.ts
+++ b/quartz/plugins/transformers/tests/sequenceLinks.test.ts
@@ -41,7 +41,7 @@ describe("renderSequenceTitle", () => {
       },
     } as unknown as QuartzPluginData
     const result = renderSequenceTitle(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect(result?.properties?.className).toStrictEqual(["admonition-title-inner"])
 
@@ -69,7 +69,7 @@ describe("renderSequenceTitle", () => {
       },
     } as unknown as QuartzPluginData
     const result = renderSequenceTitle(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect((result?.children[2] as Element).properties?.href).toBeUndefined()
   })
@@ -109,7 +109,7 @@ describe("renderPreviousPost", () => {
       },
     } as QuartzPluginData
     const result = renderPreviousPost(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("p")
     expect(result?.children).toHaveLength(3)
 
@@ -134,7 +134,7 @@ describe("renderPreviousPost", () => {
       },
     } as QuartzPluginData
     const result = renderPreviousPost(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect((result?.children[2] as Element).children).toStrictEqual([{ type: "text", value: "" }])
   })
 })
@@ -173,7 +173,7 @@ describe("renderNextPost", () => {
       },
     } as QuartzPluginData
     const result = renderNextPost(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("p")
     expect(result?.children).toHaveLength(3)
 
@@ -198,7 +198,7 @@ describe("renderNextPost", () => {
       },
     } as QuartzPluginData
     const result = renderNextPost(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect((result?.children[2] as Element).children).toStrictEqual([{ type: "text", value: "" }])
   })
 })
@@ -387,7 +387,7 @@ describe("createSequenceLinksComponent", () => {
       },
     } as unknown as QuartzPluginData
     const result = createSequenceLinksComponent(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect(result?.properties?.className).toStrictEqual(["sequence-links"])
   })
@@ -400,7 +400,7 @@ describe("createSequenceLinksComponent", () => {
       },
     } as QuartzPluginData
     const result = createSequenceLinksComponent(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect(result?.properties?.className).toStrictEqual(["sequence-links"])
   })
@@ -413,7 +413,7 @@ describe("createSequenceLinksComponent", () => {
       },
     } as QuartzPluginData
     const result = createSequenceLinksComponent(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect(result?.properties?.className).toStrictEqual(["sequence-links"])
   })
@@ -430,7 +430,7 @@ describe("createSequenceLinksComponent", () => {
       },
     } as unknown as QuartzPluginData
     const result = createSequenceLinksComponent(fileData)
-    expect(result).toBeTruthy()
+    expect(result).not.toBeNull()
     expect(result?.tagName).toBe("div")
     expect(result?.properties?.className).toStrictEqual(["sequence-links"])
 

--- a/quartz/plugins/transformers/toc.test.ts
+++ b/quartz/plugins/transformers/toc.test.ts
@@ -226,7 +226,6 @@ describe("TableOfContents Plugin", () => {
       processor(mockTree, mockFile)
 
       // Check results
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(2)
       expect(normalizeNbsp(mockFile.data.toc?.[0]?.text ?? "")).toBe("Main Title")
       expect(normalizeNbsp(mockFile.data.toc?.[1]?.text ?? "")).toBe("Section")
@@ -296,7 +295,6 @@ describe("TableOfContents Plugin", () => {
       ])
 
       processor(mockTree, mockFile)
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(2)
       expect(mockFile.data.toc?.[1]?.text).toBe("Footnotes")
     })
@@ -317,7 +315,6 @@ describe("TableOfContents Plugin", () => {
       ])
 
       processor(mockTree, mockFile)
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(1) // Only H1, H3 excluded
     })
 
@@ -423,7 +420,6 @@ describe("TableOfContents Plugin", () => {
 
       processor(mockTree, mockFile)
 
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(2)
     })
 
@@ -449,7 +445,6 @@ describe("TableOfContents Plugin", () => {
 
       processor(mockTree, mockFile)
 
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(2) // Only the non-blockquote headings
       expect(normalizeNbsp(mockFile.data.toc?.[0]?.text ?? "")).toBe("Normal Heading")
       expect(normalizeNbsp(mockFile.data.toc?.[1]?.text ?? "")).toBe("Another Normal Heading")
@@ -475,7 +470,6 @@ describe("TableOfContents Plugin", () => {
 
       processor(mockTree, mockFile)
 
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(4)
 
       // Test exact slug generation
@@ -527,7 +521,6 @@ describe("TableOfContents Plugin", () => {
 
       processor(mockTree, mockFile)
 
-      expect(mockFile.data.toc).toBeDefined()
       expect(mockFile.data.toc).toHaveLength(4) // H4 should be excluded due to maxDepth: 3
 
       // Depths should be adjusted relative to the highest level (H1 = depth 1)

--- a/quartz/styles/tests/generate-critical.test.ts
+++ b/quartz/styles/tests/generate-critical.test.ts
@@ -69,8 +69,8 @@ describe("Critical SCSS Generation", () => {
       const lightThemeBlock = content.match(/:root\[data-theme="light"\]\s*\{[^}]+\}/)
       const darkThemeBlock = content.match(/:root\[data-theme="dark"\]\s*\{[^}]+\}/)
 
-      expect(lightThemeBlock).toBeTruthy()
-      expect(darkThemeBlock).toBeTruthy()
+      expect(lightThemeBlock).not.toBeNull()
+      expect(darkThemeBlock).not.toBeNull()
 
       expect(lightThemeBlock?.[0]).toContain("--midground-faint")
       expect(lightThemeBlock?.[0]).toContain("--midground")

--- a/scripts/tests/test_update_date_on_publish.py
+++ b/scripts/tests/test_update_date_on_publish.py
@@ -455,6 +455,8 @@ Content here
     assert "# Original publish date" in result
     assert "# Last update" in result
     assert 'title: "Test Post"' in result
+
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -462,8 +464,7 @@ Content here
             """---
 ---
 Content
-"""
-   ,
+""",
             id="empty-frontmatter",
         ),
         pytest.param(
@@ -473,8 +474,7 @@ Content
             title: "Test Post"
             ---
             Content
-            """
-               ,
+            """,
             id="missing-dates",
         ),
     ],
@@ -646,7 +646,7 @@ def test_main_default_content_dir(mock_datetime, mock_git):
         update_lib.main()
 
     # Check that glob was called with the right path and pattern
-    assert len(glob_calls) > 0, "Path.glob was not called"
+    assert len(glob_calls) == 1, "Path.glob was not called"
     called_path, pattern = glob_calls[0]
     assert (
         str(called_path) == "website_content"


### PR DESCRIPTION
## Summary

Tightened test assertions across 10 files (TypeScript, Python) to use exact, specific matchers instead of loose checks. Replaced generic truthy/defined checks with precise value assertions, removing silent-pass patterns and improving test signal.

## Changes

**Assertion Pattern Improvements:**
- `toBeTruthy()` → `toBe(true)` / `not.toBeNull()` for precise value/existence checks (16 instances)
- `toBeDefined()` → removed when redundant before `toHaveLength(N)` (7 instances)  
- `toBeGreaterThan(0)` / `toBeGreaterThanOrEqual(N)` → exact `toBe()` / `toHaveLength()` (7 instances)
- Optional chaining `?.` cleanup on known-non-null values; fixed `?? 0` fallbacks masking null

**Files Changed:**
- `popover.test.ts`: Remove unnecessary `?.` on HTMLElement; fix `?? 0` fallback masking null popover-inner
- `countFavicons.test.ts`: Replace loose `toBeDefined` + `toBeGreaterThanOrEqual` with exact counts
- `links.test.ts`: `toBeGreaterThan(0)` → `toHaveLength(1)`
- `generate-critical.test.ts`: `toBeTruthy()` → `not.toBeNull()` for regex matches
- `visual-regression.spec.ts`: `toBeTruthy()` → `toBe(true)` for boolean evaluations (2×)
- `sequenceLinks.test.ts`: `toBeTruthy()` → `not.toBeNull()` for Element | null returns (10×)
- `ofm.test.ts`: `toBeTruthy()` → `not.toBeNull()` for regex matches (2×)
- `toc.test.ts`: Remove 7 redundant `toBeDefined()` calls before `toHaveLength(N)`
- `stylelint-scss...test.ts`: `toBeGreaterThan(0)` → parametrized per-case `toHaveLength(expectedWarnings)`
- `test_update_date_on_publish.py`: `len(glob_calls) > 0` → `== 1`

## Rationale

Loose assertions like `toBeTruthy()`, `toBeDefined()`, and `toBeGreaterThan(0)` pass for a wide range of values and don't catch subtle bugs (wrong value, extra items, etc.). Tightening to exact assertions:
- Catches regressions earlier when implementation details change
- Makes test intent explicit: "we expect exactly this value"
- Reduces noise in test failures (no "expected truthy but got undefined" ambiguity)
- Follows CLAUDE.md guidance: parametrize and use exact-equality checks for precision

## Test Results

- All 3985 TypeScript tests pass with 100% coverage
- All 40 affected Python tests pass
- No changes to test behavior—only assertion specificity improved