### PR TITLE
Support force-hsl-invert class for raster images

### DIFF
--- a/quartz/plugins/transformers/invertInDarkMode.ts
+++ b/quartz/plugins/transformers/invertInDarkMode.ts
@@ -7,7 +7,7 @@ import path from "path"
 import { visit } from "unist-util-visit"
 import { fileURLToPath } from "url"
 
-import { cdnBaseUrl, invertInDarkModeClass } from "../../components/constants"
+import { cdnBaseUrl, forceHslInvertClass, invertInDarkModeClass } from "../../components/constants"
 import { invertedUrl, isInvertibleRaster } from "../../components/scripts/invertedAssets"
 
 const projectRoot = path.dirname(gitRoot(fileURLToPath(import.meta.url)))
@@ -143,6 +143,15 @@ export function addCrossOriginToImages(tree: Root): void {
   })
 }
 
+export function wrapForceHslInvertImages(tree: Root): void {
+  visit(tree, "element", (node: Element, index, parent) => {
+    if (node.tagName !== "img" || !parent || typeof index !== "number") return
+    const tokens = classTokens(node.properties?.className)
+    if (!tokens.includes(forceHslInvertClass)) return
+    wrapInDarkModePicture(node, parent, index)
+  })
+}
+
 export function applyLabelsToTree(tree: Root, labels: InvertLabelMap): void {
   visit(tree, "element", (node: Element, index, parent) => {
     if (!eligibleSources(node).some((src) => labels.get(src) === true)) return
@@ -173,6 +182,7 @@ export const InvertInDarkMode = () => {
     htmlPlugins: () => [
       () => async (tree: Root) => {
         applyLabelsToTree(tree, await labels())
+        wrapForceHslInvertImages(tree)
         addCrossOriginToImages(tree)
       },
     ],

--- a/quartz/plugins/transformers/invertInDarkMode.ts
+++ b/quartz/plugins/transformers/invertInDarkMode.ts
@@ -143,19 +143,12 @@ export function addCrossOriginToImages(tree: Root): void {
   })
 }
 
-export function wrapForceHslInvertImages(tree: Root): void {
-  visit(tree, "element", (node: Element, index, parent) => {
-    if (node.tagName !== "img" || !parent || typeof index !== "number") return
-    const tokens = classTokens(node.properties?.className)
-    if (!tokens.includes(forceHslInvertClass)) return
-    wrapInDarkModePicture(node, parent, index)
-  })
-}
-
 export function applyLabelsToTree(tree: Root, labels: InvertLabelMap): void {
   visit(tree, "element", (node: Element, index, parent) => {
-    if (!eligibleSources(node).some((src) => labels.get(src) === true)) return
-    addInvertClass(node)
+    const hasLabel = eligibleSources(node).some((src) => labels.get(src) === true)
+    const hasForceClass = classTokens(node.properties?.className).includes(forceHslInvertClass)
+    if (!hasLabel && !hasForceClass) return
+    if (hasLabel) addInvertClass(node)
     if (node.tagName === "img" && parent && typeof index === "number") {
       wrapInDarkModePicture(node, parent, index)
     }
@@ -182,7 +175,6 @@ export const InvertInDarkMode = () => {
     htmlPlugins: () => [
       () => async (tree: Root) => {
         applyLabelsToTree(tree, await labels())
-        wrapForceHslInvertImages(tree)
         addCrossOriginToImages(tree)
       },
     ],

--- a/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
+++ b/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
@@ -7,7 +7,11 @@ import { jest, expect, it, describe, beforeEach, afterEach } from "@jest/globals
 import fs from "fs/promises"
 import { h } from "hastscript"
 
-import { cdnBaseUrl, invertInDarkModeClass } from "../../../components/constants"
+import {
+  cdnBaseUrl,
+  forceHslInvertClass,
+  invertInDarkModeClass,
+} from "../../../components/constants"
 import {
   addCrossOriginToImages,
   addInvertClass,
@@ -17,6 +21,7 @@ import {
   isInlineLoopingVideo,
   labelsPath,
   loadInvertLabels,
+  wrapForceHslInvertImages,
   wrapInDarkModePicture,
 } from "../invertInDarkMode"
 
@@ -279,6 +284,49 @@ describe("InvertInDarkMode", () => {
     })
   })
 
+  describe("wrapForceHslInvertImages", () => {
+    it("wraps a force-hsl-invert raster img in <picture>", () => {
+      const img = h("img", {
+        src: `${cdnBaseUrl}/demo.avif`,
+        className: [forceHslInvertClass],
+      }) as Element
+      const root = tree(img)
+      wrapForceHslInvertImages(root)
+      const wrapped = root.children[0] as Element
+      expect(wrapped.tagName).toBe("picture")
+      expect((wrapped.children[1] as Element).tagName).toBe("img")
+    })
+
+    it("skips images without force-hsl-invert class", () => {
+      const img = h("img", { src: `${cdnBaseUrl}/plain.avif` }) as Element
+      const root = tree(img)
+      wrapForceHslInvertImages(root)
+      expect((root.children[0] as Element).tagName).toBe("img")
+    })
+
+    it("skips images already inside a <picture>", () => {
+      const img = h("img", {
+        src: `${cdnBaseUrl}/demo.avif`,
+        className: [forceHslInvertClass],
+      }) as Element
+      const picture = h("picture", [img]) as Element
+      const root = tree(picture)
+      wrapForceHslInvertImages(root)
+      expect((root.children[0] as Element).tagName).toBe("picture")
+      expect(picture.children[0]).toBe(img)
+    })
+
+    it("skips SVG images (handled by fetch-rewrite path)", () => {
+      const img = h("img", {
+        src: `${cdnBaseUrl}/icon.svg`,
+        className: [forceHslInvertClass],
+      }) as Element
+      const root = tree(img)
+      wrapForceHslInvertImages(root)
+      expect((root.children[0] as Element).tagName).toBe("img")
+    })
+  })
+
   describe("InvertInDarkMode plugin", () => {
     const transformOf = (plugin: ReturnType<typeof InvertInDarkMode>) => {
       const factories = plugin.htmlPlugins() as Array<() => (tree: Root) => Promise<void>>
@@ -334,6 +382,21 @@ describe("InvertInDarkMode", () => {
       const root = tree(img)
       await transformOf(plugin)(root)
       expect((root.children[0] as Element).tagName).toBe("img")
+    })
+
+    it("wraps a pre-existing force-hsl-invert raster img in <picture>", async () => {
+      readFileSpy.mockResolvedValue(JSON.stringify({}) as never)
+      const plugin = InvertInDarkMode()
+      const img = h("img", {
+        src: `${cdnBaseUrl}/demo.avif`,
+        className: [forceHslInvertClass],
+      }) as Element
+      const root = tree(img)
+      await transformOf(plugin)(root)
+      const wrapped = root.children[0] as Element
+      expect(wrapped.tagName).toBe("picture")
+      const source = wrapped.children[0] as Element
+      expect(source.properties?.srcSet).toBe(`${cdnBaseUrl}/demo-inverted.avif`)
     })
 
     it("reads labels once per plugin instance and re-reads for a new instance", async () => {

--- a/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
+++ b/quartz/plugins/transformers/tests/invertInDarkMode.test.ts
@@ -21,7 +21,6 @@ import {
   isInlineLoopingVideo,
   labelsPath,
   loadInvertLabels,
-  wrapForceHslInvertImages,
   wrapInDarkModePicture,
 } from "../invertInDarkMode"
 
@@ -181,6 +180,18 @@ describe("InvertInDarkMode", () => {
       applyLabelsToTree(tree(video), new Map([["https://x/a.mp4", true]]))
       expect(video.properties?.className).toBeUndefined()
     })
+
+    it("wraps pre-existing force-hsl-invert raster img in <picture> without adding invert class", () => {
+      const img = h("img", {
+        src: `${cdnBaseUrl}/demo.avif`,
+        className: [forceHslInvertClass],
+      }) as Element
+      const root = tree(img)
+      applyLabelsToTree(root, new Map())
+      const wrapped = root.children[0] as Element
+      expect(wrapped.tagName).toBe("picture")
+      expect(img.properties?.className).toEqual([forceHslInvertClass])
+    })
   })
 
   describe("collectVideoSources", () => {
@@ -281,49 +292,6 @@ describe("InvertInDarkMode", () => {
     it("throws on absolute non-CDN src", () => {
       const img = h("img", { src: "https://evil.example.com/x.avif" }) as Element
       expect(() => addCrossOriginToImages(tree(img))).toThrow(/expected.*assets\.turntrout/)
-    })
-  })
-
-  describe("wrapForceHslInvertImages", () => {
-    it("wraps a force-hsl-invert raster img in <picture>", () => {
-      const img = h("img", {
-        src: `${cdnBaseUrl}/demo.avif`,
-        className: [forceHslInvertClass],
-      }) as Element
-      const root = tree(img)
-      wrapForceHslInvertImages(root)
-      const wrapped = root.children[0] as Element
-      expect(wrapped.tagName).toBe("picture")
-      expect((wrapped.children[1] as Element).tagName).toBe("img")
-    })
-
-    it("skips images without force-hsl-invert class", () => {
-      const img = h("img", { src: `${cdnBaseUrl}/plain.avif` }) as Element
-      const root = tree(img)
-      wrapForceHslInvertImages(root)
-      expect((root.children[0] as Element).tagName).toBe("img")
-    })
-
-    it("skips images already inside a <picture>", () => {
-      const img = h("img", {
-        src: `${cdnBaseUrl}/demo.avif`,
-        className: [forceHslInvertClass],
-      }) as Element
-      const picture = h("picture", [img]) as Element
-      const root = tree(picture)
-      wrapForceHslInvertImages(root)
-      expect((root.children[0] as Element).tagName).toBe("picture")
-      expect(picture.children[0]).toBe(img)
-    })
-
-    it("skips SVG images (handled by fetch-rewrite path)", () => {
-      const img = h("img", {
-        src: `${cdnBaseUrl}/icon.svg`,
-        className: [forceHslInvertClass],
-      }) as Element
-      const root = tree(img)
-      wrapForceHslInvertImages(root)
-      expect((root.children[0] as Element).tagName).toBe("img")
     })
   })
 

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -847,11 +847,6 @@ def _class_tokens(tag: Tag) -> list[str]:
     return list(raw) if isinstance(raw, list) else []
 
 
-def _has_invert_class(tag: Tag) -> bool:
-    """True iff ``tag`` has the ``invert-in-dark-mode`` class."""
-    return INVERT_CLASS in _class_tokens(tag)
-
-
 def _canonical_inline_video_source(video: Tag) -> str | None:
     """
     Canonical source URL of an inline looping muted ``<video>`` (GIF
@@ -930,7 +925,7 @@ def _img_invert_issue(
             src, original, invert_labels.get(original)
         )
     return _invert_issue_string(
-        "img", src, _has_invert_class(img), invert_labels.get(src)
+        "img", src, INVERT_CLASS in _class_tokens(img), invert_labels.get(src)
     )
 
 
@@ -976,7 +971,10 @@ def check_invert_labels(
         if src is None or _is_excluded_segment(src):
             continue
         issue = _invert_issue_string(
-            "video", src, _has_invert_class(video), invert_labels.get(src)
+            "video",
+            src,
+            INVERT_CLASS in _class_tokens(video),
+            invert_labels.get(src),
         )
         if issue is not None:
             issues.append(issue)

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -40,6 +40,7 @@ from scripts.utils import (
     GERMAN_OPEN_QUOTE,
     INVERT_EXCLUDED_SEGMENTS,
     INVERT_IMG_EXTENSIONS,
+    INVERT_RASTER_EXTENSIONS,
     INVERT_VIDEO_EXTENSIONS,
     LEFT_DOUBLE_QUOTE,
     LEFT_GUILLEMET,
@@ -61,6 +62,9 @@ RSS_XSD_PATH = _GIT_ROOT / "scripts" / ".rss-2.0.xsd"
 # dark mode. Canonical source: config/constants.json (`invertInDarkModeClass`).
 INVERT_CLASS: str = script_utils.load_shared_constants()[
     "invertInDarkModeClass"
+]
+FORCE_HSL_INVERT_CLASS: str = script_utils.load_shared_constants()[
+    "forceHslInvertClass"
 ]
 
 _IssuesDict = dict[str, list[str] | list[Tag] | bool]
@@ -836,11 +840,16 @@ def _is_excluded_segment(url: str) -> bool:
     return any(seg in INVERT_EXCLUDED_SEGMENTS for seg in segments)
 
 
+def _class_tokens(tag: Tag) -> list[str]:
+    raw = tag.get("class")
+    if isinstance(raw, str):
+        return raw.split()
+    return list(raw) if isinstance(raw, list) else []
+
+
 def _has_invert_class(tag: Tag) -> bool:
     """True iff ``tag`` has the ``invert-in-dark-mode`` class."""
-    raw = tag.get("class")
-    tokens = raw.split() if isinstance(raw, str) else raw
-    return isinstance(tokens, list) and INVERT_CLASS in tokens
+    return INVERT_CLASS in _class_tokens(tag)
 
 
 def _canonical_inline_video_source(video: Tag) -> str | None:
@@ -952,6 +961,16 @@ def check_invert_labels(
         issue = _img_invert_issue(src, img, invert_labels)
         if issue is not None:
             issues.append(issue)
+        tokens = _class_tokens(img)
+        needs_picture = (
+            INVERT_CLASS in tokens or FORCE_HSL_INVERT_CLASS in tokens
+        ) and src.lower().endswith(INVERT_RASTER_EXTENSIONS)
+        if needs_picture and (
+            img.parent is None or img.parent.name != "picture"
+        ):
+            issues.append(
+                f"<img> {src} has invert class but is not inside <picture>"
+            )
     for video in _tags_only(soup.find_all("video")):
         src = _canonical_inline_video_source(video)
         if src is None or _is_excluded_segment(src):

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -6559,7 +6559,8 @@ def _class_mismatch_msg(
         ('<img src="https://x/a.avif">', None, []),
         # Reviewed entries with classes matching their `invert` field.
         (
-            f'<img class="{INVERT_CLASS}" src="https://x/a.avif">'
+            f'<picture><source srcset="https://x/a-inverted.avif">'
+            f'<img class="{INVERT_CLASS}" src="https://x/a.avif"></picture>'
             '<img src="https://x/b.png">',
             {
                 "https://x/a.avif": _reviewed(True),
@@ -6592,7 +6593,7 @@ def _class_mismatch_msg(
                 )
             ],
         ),
-        # Reviewed invert=False but class present → mismatch.
+        # Reviewed invert=False but class present → mismatch + missing <picture>.
         (
             f'<img class="{INVERT_CLASS} other" src="https://x/b.jpg">',
             {"https://x/b.jpg": _reviewed(False)},
@@ -6602,7 +6603,8 @@ def _class_mismatch_msg(
                     "https://x/b.jpg",
                     invert=False,
                     has_class=True,
-                )
+                ),
+                "<img> https://x/b.jpg has invert class but is not inside <picture>",
             ],
         ),
         # Every image extension we label (raster + SVG) is eligible. Each
@@ -6675,9 +6677,33 @@ def _class_mismatch_msg(
         ),
         # class attribute as a space-separated string also works.
         (
-            f'<img class="foo {INVERT_CLASS} bar" src="https://x/a.avif">',
+            f'<picture><source srcset="https://x/a-inverted.avif">'
+            f'<img class="foo {INVERT_CLASS} bar" src="https://x/a.avif"></picture>',
             {"https://x/a.avif": _reviewed(True)},
             [],
+        ),
+        # Raster with invert class NOT inside <picture> → error.
+        (
+            f'<img class="{INVERT_CLASS}" src="https://x/a.avif">',
+            {"https://x/a.avif": _reviewed(True)},
+            [
+                "<img> https://x/a.avif has invert class but is not inside <picture>"
+            ],
+        ),
+        # Raster with invert class inside <picture> → no picture error.
+        (
+            f'<picture><source srcset="https://x/a-inverted.avif">'
+            f'<img class="{INVERT_CLASS}" src="https://x/a.avif"></picture>',
+            {"https://x/a.avif": _reviewed(True)},
+            [],
+        ),
+        # force-hsl-invert raster NOT inside <picture> → error.
+        (
+            '<img class="force-hsl-invert" src="https://x/demo.avif">',
+            {"https://x/demo.avif": _reviewed(invert=False)},
+            [
+                "<img> https://x/demo.avif has invert class but is not inside <picture>"
+            ],
         ),
     ],
 )


### PR DESCRIPTION
## Summary
Adds support for a `forceHslInvertClass` that allows raster images to be wrapped in a `<picture>` element with inverted sources, even when they don't have an explicit invert label. This enables manual control over which images should be inverted in dark mode.

## Changes
- **Import `forceHslInvertClass` constant** in both the transformer and test files
- **Update `applyLabelsToTree` logic** to wrap images in `<picture>` elements if they either:
  - Have an invert label from the labels map, OR
  - Have the `forceHslInvertClass` class token
- **Preserve class tokens** when wrapping: images with `forceHslInvertClass` keep that class and don't get the `invertInDarkModeClass` added
- **Add comprehensive test coverage**:
  - Test that `applyLabelsToTree` wraps force-hsl-invert images without adding the invert class
  - Test that the full transformer pipeline correctly wraps and inverts force-hsl-invert images

## Implementation details
The change distinguishes between two inversion mechanisms:
1. **Label-based**: Images with invert labels get the `invertInDarkModeClass` and are wrapped
2. **Force-based**: Images with `forceHslInvertClass` are wrapped with inverted sources but keep their original class, allowing CSS-based inversion control

Both paths trigger the `<picture>` wrapping behavior, but only label-based images receive the CSS class.

https://claude.ai/code/session_01XuAPZe6rwNbDJ7jpN1SmLx