### PR TITLE
fix: race-free dark-mode image inversion when manual theme disagrees with system

### DIFF
--- a/quartz/components/scripts/accurateInvert.inline.ts
+++ b/quartz/components/scripts/accurateInvert.inline.ts
@@ -1,4 +1,9 @@
-import { handleLoadEvent, onThemeChange, processLoaded } from "./accurateInvert"
+import {
+  handleLoadEvent,
+  onThemeChange,
+  processLoaded,
+  syncPictureSources,
+} from "./accurateInvert"
 
 // Capture-phase: `load` doesn't bubble, so a non-capture listener on
 // `document` would never fire for img loads. Attaching here in
@@ -22,11 +27,20 @@ new MutationObserver((mutations) => {
 // Cover cached images that decoded between body-parse and DOMContentLoaded
 // (rare but possible — capture listeners only catch loads that fire after
 // they're attached, and there's a small async gap on warm-cached images).
-document.addEventListener("DOMContentLoaded", () => processLoaded(), { once: true })
+document.addEventListener(
+  "DOMContentLoaded",
+  () => {
+    processLoaded()
+    syncPictureSources()
+  },
+  { once: true },
+)
 
 // SPA navigation: Quartz fires `nav` after replacing page content. Images
 // already decoded in the new DOM (cache hits, reused nodes) won't trigger
-// fresh load events, so sweep them explicitly.
+// fresh load events, so sweep them explicitly. syncPictureSources ensures
+// new <source> elements match the active theme, not just system preference.
 document.addEventListener("nav", () => {
   processLoaded()
+  syncPictureSources()
 })

--- a/quartz/components/scripts/accurateInvert.inline.ts
+++ b/quartz/components/scripts/accurateInvert.inline.ts
@@ -1,9 +1,4 @@
-import {
-  handleLoadEvent,
-  onThemeChange,
-  processLoaded,
-  syncPictureSources,
-} from "./accurateInvert"
+import { handleLoadEvent, onThemeChange, processLoaded, syncPictureSources } from "./accurateInvert"
 
 // Capture-phase: `load` doesn't bubble, so a non-capture listener on
 // `document` would never fire for img loads. Attaching here in

--- a/quartz/components/scripts/accurateInvert.inline.ts
+++ b/quartz/components/scripts/accurateInvert.inline.ts
@@ -1,12 +1,12 @@
-import { handleLoadEvent, onThemeChange, processLoaded, syncPictureSources } from "./accurateInvert"
+import {
+  handleLoadEvent,
+  invertDecodedImages,
+  onThemeChange,
+  syncPictureSources,
+} from "./accurateInvert"
 
-// Capture-phase: `load` doesn't bubble, so a non-capture listener on
-// `document` would never fire for img loads. Attaching here in
-// `<head>` (via beforeDOMLoaded) means we catch every img load event
-// before first paint.
 document.addEventListener("load", handleLoadEvent, true)
 
-// React to theme switches set by darkmode.ts via the data-theme attribute.
 new MutationObserver((mutations) => {
   for (const m of mutations) {
     if (m.type === "attributes" && m.attributeName === "data-theme") {
@@ -19,23 +19,16 @@ new MutationObserver((mutations) => {
   attributeFilter: ["data-theme"],
 })
 
-// Cover cached images that decoded between body-parse and DOMContentLoaded
-// (rare but possible — capture listeners only catch loads that fire after
-// they're attached, and there's a small async gap on warm-cached images).
 document.addEventListener(
   "DOMContentLoaded",
   () => {
-    processLoaded()
+    invertDecodedImages()
     syncPictureSources()
   },
   { once: true },
 )
 
-// SPA navigation: Quartz fires `nav` after replacing page content. Images
-// already decoded in the new DOM (cache hits, reused nodes) won't trigger
-// fresh load events, so sweep them explicitly. syncPictureSources ensures
-// new <source> elements match the active theme, not just system preference.
 document.addEventListener("nav", () => {
-  processLoaded()
+  invertDecodedImages()
   syncPictureSources()
 })

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -55,8 +55,6 @@ const makeLoadedImg = (
   return img
 }
 
-const flushAsync = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
-
 const dispatchSwapLoad = (img: HTMLImageElement): void => {
   Object.defineProperty(img, "currentSrc", { value: img.src, configurable: true })
   img.dispatchEvent(new Event("load"))
@@ -179,30 +177,30 @@ describe("invertPictureSrc", () => {
 })
 
 describe("invertImage", () => {
-  it("routes picture-wrapped image to invertPictureSrc", async () => {
+  it("routes picture-wrapped image to invertPictureSrc", () => {
     const img = makePictureWrappedImg("https://x/photo.avif")
-    await expect(invertImage(img)).resolves.toBe(true)
+    expect(invertImage(img)).toBe(true)
     expect(img.src).toBe("https://x/photo-inverted.avif")
     dispatchSwapLoad(img)
     expect(img.dataset["invertProcessed"]).toBe("1")
   })
 
-  it("routes picture-wrapped SVG to invertPictureSrc", async () => {
+  it("routes picture-wrapped SVG to invertPictureSrc", () => {
     const img = makePictureWrappedImg("https://x/chart.svg")
-    await expect(invertImage(img)).resolves.toBe(true)
+    expect(invertImage(img)).toBe(true)
     expect(img.src).toBe("https://x/chart-inverted.svg")
   })
 
-  it("does nothing in light mode", async () => {
+  it("does nothing in light mode", () => {
     setTheme("light")
-    await expect(invertImage(makePictureWrappedImg())).resolves.toBe(false)
+    expect(invertImage(makePictureWrappedImg())).toBe(false)
   })
 
-  it("is idempotent — second call short-circuits", async () => {
+  it("is idempotent — second call short-circuits", () => {
     const img = makePictureWrappedImg("https://x/photo.avif")
-    await invertImage(img)
+    invertImage(img)
     dispatchSwapLoad(img)
-    await expect(invertImage(img)).resolves.toBe(false)
+    expect(invertImage(img)).toBe(false)
   })
 
   it.each([
@@ -218,15 +216,15 @@ describe("invertImage", () => {
         Object.defineProperty(img, "naturalWidth", { value: 0, configurable: true })
       },
     ],
-  ])("returns false when %s", async (_label, mutate) => {
+  ])("returns false when %s", (_label, mutate) => {
     const img = makePictureWrappedImg()
     mutate(img)
-    await expect(invertImage(img)).resolves.toBe(false)
+    expect(invertImage(img)).toBe(false)
   })
 
-  it("returns false for an unwrapped image (no fallback path)", async () => {
+  it("returns false for an unwrapped image (no fallback path)", () => {
     const img = makeLoadedImg("https://x/orphan.avif")
-    await expect(invertImage(img)).resolves.toBe(false)
+    expect(invertImage(img)).toBe(false)
   })
 })
 
@@ -255,11 +253,11 @@ describe("revertImage", () => {
 })
 
 describe("handleLoadEvent", () => {
-  it("inverts a loaded eligible image", async () => {
+  it("inverts a loaded eligible image", () => {
     const img = makePictureWrappedImg()
     document.body.appendChild(img.parentElement as HTMLElement)
     handleLoadEvent({ target: img } as unknown as Event)
-    await flushAsync()
+
     finishPendingPictureSwaps()
     expect(img.dataset["invertProcessed"]).toBe("1")
   })
@@ -271,34 +269,34 @@ describe("handleLoadEvent", () => {
 })
 
 describe("invertDecodedImages", () => {
-  it("inverts all eligible decoded imgs under root", async () => {
+  it("inverts all eligible decoded imgs under root", () => {
     const a = makePictureWrappedImg("https://x/a.avif")
     const b = makePictureWrappedImg("https://x/b.avif")
     document.body.append(a.parentElement as HTMLElement, b.parentElement as HTMLElement)
     invertDecodedImages()
-    await flushAsync()
+
     finishPendingPictureSwaps()
     expect(a.dataset["invertProcessed"]).toBe("1")
     expect(b.dataset["invertProcessed"]).toBe("1")
   })
 
-  it("skips imgs that haven't decoded yet", async () => {
+  it("skips imgs that haven't decoded yet", () => {
     const img = makePictureWrappedImg("https://x/a.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
     document.body.appendChild(img.parentElement as HTMLElement)
     invertDecodedImages()
-    await flushAsync()
+
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
 })
 
 describe("revertAllInverted", () => {
-  it("uninverts every processed img under root", async () => {
+  it("uninverts every processed img under root", () => {
     const a = makePictureWrappedImg("https://x/a.avif")
     const b = makePictureWrappedImg("https://x/b.avif")
     document.body.append(a.parentElement as HTMLElement, b.parentElement as HTMLElement)
     invertDecodedImages()
-    await flushAsync()
+
     finishPendingPictureSwaps()
     revertAllInverted()
     expect(a.src).toBe("https://x/a.avif")
@@ -307,11 +305,11 @@ describe("revertAllInverted", () => {
     expect(b.dataset["invertProcessed"]).toBeUndefined()
   })
 
-  it("leaves force-hsl-invert images alone", async () => {
+  it("leaves force-hsl-invert images alone", () => {
     const forced = makePictureWrappedImg("https://x/forced.avif")
     forced.classList.add("force-hsl-invert")
     document.body.appendChild(forced.parentElement as HTMLElement)
-    await invertImage(forced)
+    invertImage(forced)
     dispatchSwapLoad(forced)
     expect(forced.dataset["invertProcessed"]).toBe("1")
     revertAllInverted()
@@ -385,7 +383,7 @@ describe("syncPictureSources", () => {
 })
 
 describe("onThemeChange", () => {
-  it("inverts loaded images when theme is dark", async () => {
+  it("inverts loaded images when theme is dark", () => {
     mockSystemDark(true)
     const img = makePictureWrappedImg()
     document.body.appendChild(img.parentElement as HTMLElement)
@@ -393,16 +391,16 @@ describe("onThemeChange", () => {
     expect(img.dataset["invertProcessed"]).toBeUndefined()
     setTheme("dark")
     onThemeChange()
-    await flushAsync()
+
     finishPendingPictureSwaps()
     expect(img.dataset["invertProcessed"]).toBe("1")
   })
 
-  it("uninverts processed images when theme is light", async () => {
+  it("uninverts processed images when theme is light", () => {
     mockSystemDark(false)
     const img = makePictureWrappedImg("https://x/img.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
-    await invertImage(img)
+    invertImage(img)
     dispatchSwapLoad(img)
     setTheme("light")
     onThemeChange()
@@ -410,7 +408,7 @@ describe("onThemeChange", () => {
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
 
-  it("syncs <source> srcset for lazy images not yet processed", async () => {
+  it("syncs <source> srcset for lazy images not yet processed", () => {
     mockSystemDark(true)
     const img = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
@@ -422,7 +420,7 @@ describe("onThemeChange", () => {
 })
 
 describe("stress tests", () => {
-  it("rapid dark→light→dark→light toggle leaves everything consistent", async () => {
+  it("rapid dark→light→dark→light toggle leaves everything consistent", () => {
     const imgs = ["https://x/a.avif", "https://x/b.avif", "https://x/c.avif"].map((src) => {
       const img = makePictureWrappedImg(src)
       document.body.appendChild(img.parentElement as HTMLElement)
@@ -432,7 +430,7 @@ describe("stress tests", () => {
     mockSystemDark(true)
     setTheme("dark")
     onThemeChange()
-    await flushAsync()
+
     finishPendingPictureSwaps()
 
     for (let i = 0; i < 3; i++) {
@@ -444,7 +442,7 @@ describe("stress tests", () => {
       }
       setTheme("dark")
       onThemeChange()
-      await flushAsync()
+  
       finishPendingPictureSwaps()
       for (const img of imgs) {
         expect(img.src).toMatch(/-inverted\.\w+$/)
@@ -473,14 +471,14 @@ describe("stress tests", () => {
     expect(loaded.src).toBe("https://x/loaded.avif")
   })
 
-  it("dark→light→dark restores <source> srcset and media", async () => {
+  it("dark→light→dark restores <source> srcset and media", () => {
     mockSystemDark(true)
     const img = makePictureWrappedImg("https://x/rt.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
 
     setTheme("dark")
     onThemeChange()
-    await flushAsync()
+
     finishPendingPictureSwaps()
     expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
     expect(getSourceMedia(img)).toBe("(prefers-color-scheme: dark)")
@@ -492,7 +490,7 @@ describe("stress tests", () => {
 
     setTheme("dark")
     onThemeChange()
-    await flushAsync()
+
     finishPendingPictureSwaps()
     expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
     expect(getSourceMedia(img)).toBe("(prefers-color-scheme: dark)")

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -442,7 +442,7 @@ describe("stress tests", () => {
       }
       setTheme("dark")
       onThemeChange()
-  
+
       finishPendingPictureSwaps()
       for (const img of imgs) {
         expect(img.src).toMatch(/-inverted\.\w+$/)

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -14,16 +14,21 @@ import {
   revertImage,
   revertProcessed,
   shouldProcess,
+  syncPictureSources,
 } from "./accurateInvert"
 
 const setTheme = (theme: "dark" | "light"): void => {
   document.documentElement.setAttribute("data-theme", theme)
 }
 
-/** Build a `<picture><img></picture>` so `processImage` routes the img
- * through the precomputed-variant path (no canvas read). */
+/** Build a `<picture><source><img></picture>` matching the build-time
+ * output of `wrapInDarkModePicture`. */
 const makePictureWrappedImg = (src = "https://x/img.avif"): HTMLImageElement => {
   const picture = document.createElement("picture")
+  const source = document.createElement("source")
+  source.media = "(prefers-color-scheme: dark)"
+  source.srcset = src.replace(/(\.\w+)$/, "-inverted$1")
+  picture.appendChild(source)
   const img = makeLoadedImg(src)
   picture.appendChild(img)
   return img
@@ -163,6 +168,17 @@ describe("processPictureImage", () => {
     processPictureImage(img)
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
   })
+
+  it("restores <source> srcset to inverted after a revert cycle", () => {
+    const img = makePictureWrappedImg("https://x/foo.avif")
+    const source = img.parentElement!.querySelector("source")!
+    processPictureImage(img)
+    dispatchSwapLoad(img)
+    revertImage(img)
+    expect(source.srcset).toBe("https://x/foo.avif")
+    processPictureImage(img)
+    expect(source.srcset).toBe("https://x/foo-inverted.avif")
+  })
 })
 
 describe("processImage", () => {
@@ -225,6 +241,16 @@ describe("revertImage", () => {
     expect(revertImage(img)).toBe(true)
     expect(img.src).toBe("https://x/img.avif")
     expect(img.dataset["invertProcessed"]).toBeUndefined()
+  })
+
+  it("sets <source> srcset to original so system dark preference cannot override", () => {
+    const img = makePictureWrappedImg("https://x/img.avif")
+    const source = img.parentElement!.querySelector("source")!
+    processPictureImage(img)
+    dispatchSwapLoad(img)
+    expect(source.srcset).toBe("https://x/img-inverted.avif")
+    revertImage(img)
+    expect(source.srcset).toBe("https://x/img.avif")
   })
 
   it("returns false when there is no stashed original", () => {
@@ -298,6 +324,38 @@ describe("revertProcessed", () => {
   })
 })
 
+describe("syncPictureSources", () => {
+  it("sets <source> srcset to original for all picture images in light mode", () => {
+    const img = makePictureWrappedImg("https://x/a.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+    const source = img.parentElement!.querySelector("source")!
+    expect(source.srcset).toBe("https://x/a-inverted.avif")
+    setTheme("light")
+    syncPictureSources()
+    expect(source.srcset).toBe("https://x/a.avif")
+  })
+
+  it("sets <source> srcset to inverted for all picture images in dark mode", () => {
+    const img = makePictureWrappedImg("https://x/a.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+    const source = img.parentElement!.querySelector("source")!
+    source.srcset = "https://x/a.avif"
+    setTheme("dark")
+    syncPictureSources()
+    expect(source.srcset).toBe("https://x/a-inverted.avif")
+  })
+
+  it("handles unprocessed images that have not loaded yet", () => {
+    const img = makePictureWrappedImg("https://x/lazy.avif")
+    Object.defineProperty(img, "complete", { value: false, configurable: true })
+    document.body.appendChild(img.parentElement as HTMLElement)
+    const source = img.parentElement!.querySelector("source")!
+    setTheme("light")
+    syncPictureSources()
+    expect(source.srcset).toBe("https://x/lazy.avif")
+  })
+})
+
 describe("onThemeChange", () => {
   it("processes loaded images when theme is dark", async () => {
     const img = makePictureWrappedImg()
@@ -320,5 +378,15 @@ describe("onThemeChange", () => {
     onThemeChange()
     expect(img.src).toBe("https://x/img.avif")
     expect(img.dataset["invertProcessed"]).toBeUndefined()
+  })
+
+  it("syncs <source> srcset for lazy images not yet processed", async () => {
+    const img = makePictureWrappedImg("https://x/lazy.avif")
+    Object.defineProperty(img, "complete", { value: false, configurable: true })
+    document.body.appendChild(img.parentElement as HTMLElement)
+    const source = img.parentElement!.querySelector("source")!
+    setTheme("light")
+    onThemeChange()
+    expect(source.srcset).toBe("https://x/lazy.avif")
   })
 })

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -168,7 +168,6 @@ describe("processPictureImage", () => {
     processPictureImage(img)
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
   })
-
 })
 
 describe("processImage", () => {
@@ -420,10 +419,7 @@ describe("stress tests", () => {
     const loaded = makePictureWrappedImg("https://x/loaded.avif")
     const lazy = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(lazy, "complete", { value: false, configurable: true })
-    document.body.append(
-      loaded.parentElement as HTMLElement,
-      lazy.parentElement as HTMLElement,
-    )
+    document.body.append(loaded.parentElement as HTMLElement, lazy.parentElement as HTMLElement)
 
     setTheme("dark")
     onThemeChange()

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -12,9 +12,9 @@ import {
   isInsidePicture,
   onThemeChange,
   revertAllInverted,
+  revertImage,
   shouldInvert,
   syncPictureSources,
-  uninvertImage,
 } from "./accurateInvert"
 
 const setTheme = (theme: "dark" | "light"): void => {
@@ -150,7 +150,7 @@ describe("invertPictureSrc", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
     invertPictureSrc(img)
     expect(img.src).toBe("https://x/foo-inverted.avif")
-    uninvertImage(img)
+    revertImage(img)
     expect(img.src).toBe("https://x/foo.avif")
     dispatchSwapLoad(img)
     expect(img.dataset["invertProcessed"]).toBeUndefined()
@@ -172,7 +172,7 @@ describe("invertPictureSrc", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
     invertPictureSrc(img)
     dispatchSwapLoad(img)
-    uninvertImage(img)
+    revertImage(img)
     invertPictureSrc(img)
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
   })
@@ -230,12 +230,12 @@ describe("invertImage", () => {
   })
 })
 
-describe("uninvertImage", () => {
+describe("revertImage", () => {
   it("restores the original src and clears the processed flag", () => {
     const img = makePictureWrappedImg("https://x/img.avif")
     invertPictureSrc(img)
     dispatchSwapLoad(img)
-    expect(uninvertImage(img)).toBe(true)
+    expect(revertImage(img)).toBe(true)
     expect(img.src).toBe("https://x/img.avif")
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
@@ -245,12 +245,12 @@ describe("uninvertImage", () => {
     invertPictureSrc(img)
     dispatchSwapLoad(img)
     expect(getSourceSrcset(img)).toBe("https://x/img-inverted.avif")
-    uninvertImage(img)
+    revertImage(img)
     expect(getSourceSrcset(img)).toBe("https://x/img.avif")
   })
 
   it("returns false when there is no stashed original", () => {
-    expect(uninvertImage(makeLoadedImg())).toBe(false)
+    expect(revertImage(makeLoadedImg())).toBe(false)
   })
 })
 

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -58,6 +58,9 @@ const dispatchSwapLoad = (img: HTMLImageElement): void => {
   img.dispatchEvent(new Event("load"))
 }
 
+const getSourceSrcset = (img: HTMLImageElement): string =>
+  img.parentElement!.querySelector("source")!.srcset
+
 /** Sweep helper for tests that exercise `processLoaded` / `onThemeChange`
  * and then assert the processed marker landed on every picture-wrapped
  * img. */
@@ -314,34 +317,41 @@ describe("revertProcessed", () => {
 })
 
 describe("syncPictureSources", () => {
-  it("sets <source> srcset to original for all picture images in light mode", () => {
+  it.each<["dark" | "light", string]>([
+    ["light", "https://x/a.avif"],
+    ["dark", "https://x/a-inverted.avif"],
+  ])("sets <source> srcset correctly in %s mode", (theme, expected) => {
     const img = makePictureWrappedImg("https://x/a.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
-    const source = img.parentElement!.querySelector("source")!
-    expect(source.srcset).toBe("https://x/a-inverted.avif")
-    setTheme("light")
+    setTheme(theme)
     syncPictureSources()
-    expect(source.srcset).toBe("https://x/a.avif")
-  })
-
-  it("sets <source> srcset to inverted for all picture images in dark mode", () => {
-    const img = makePictureWrappedImg("https://x/a.avif")
-    document.body.appendChild(img.parentElement as HTMLElement)
-    const source = img.parentElement!.querySelector("source")!
-    source.srcset = "https://x/a.avif"
-    setTheme("dark")
-    syncPictureSources()
-    expect(source.srcset).toBe("https://x/a-inverted.avif")
+    expect(getSourceSrcset(img)).toBe(expected)
   })
 
   it("handles unprocessed images that have not loaded yet", () => {
     const img = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
     document.body.appendChild(img.parentElement as HTMLElement)
-    const source = img.parentElement!.querySelector("source")!
     setTheme("light")
     syncPictureSources()
-    expect(source.srcset).toBe("https://x/lazy.avif")
+    expect(getSourceSrcset(img)).toBe("https://x/lazy.avif")
+  })
+
+  it("excludes force-hsl-invert images", () => {
+    const img = makePictureWrappedImg("https://x/forced.avif")
+    img.classList.add("force-hsl-invert")
+    document.body.appendChild(img.parentElement as HTMLElement)
+    setTheme("light")
+    syncPictureSources()
+    expect(getSourceSrcset(img)).toBe("https://x/forced-inverted.avif")
+  })
+
+  it("no-ops gracefully when <source> is absent", () => {
+    const img = makePictureWrappedImg("https://x/nosrc.avif")
+    img.parentElement!.querySelector("source")!.remove()
+    document.body.appendChild(img.parentElement as HTMLElement)
+    setTheme("light")
+    expect(() => syncPictureSources()).not.toThrow()
   })
 })
 
@@ -379,10 +389,6 @@ describe("onThemeChange", () => {
     expect(source.srcset).toBe("https://x/lazy.avif")
   })
 })
-
-/** Helper to get `<source>` srcset from a picture-wrapped img. */
-const getSourceSrcset = (img: HTMLImageElement): string =>
-  img.parentElement!.querySelector("source")!.srcset
 
 describe("stress tests", () => {
   it("rapid dark→light→dark→light toggle leaves everything consistent", async () => {
@@ -457,13 +463,4 @@ describe("stress tests", () => {
     expect(img.src).toBe("https://x/rt-inverted.avif")
   })
 
-  it("force-hsl-invert images are excluded from syncPictureSources", () => {
-    const img = makePictureWrappedImg("https://x/forced.avif")
-    img.classList.add("force-hsl-invert")
-    document.body.appendChild(img.parentElement as HTMLElement)
-
-    setTheme("light")
-    syncPictureSources()
-    expect(getSourceSrcset(img)).toBe("https://x/forced-inverted.avif")
-  })
 })

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -5,20 +5,28 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 
 import {
   handleLoadEvent,
+  invertDecodedImages,
+  invertImage,
+  invertPictureSrc,
   isDarkMode,
   isInsidePicture,
   onThemeChange,
-  processImage,
-  processLoaded,
-  processPictureImage,
-  revertImage,
-  revertProcessed,
-  shouldProcess,
+  revertAllInverted,
+  shouldInvert,
   syncPictureSources,
+  uninvertImage,
 } from "./accurateInvert"
 
 const setTheme = (theme: "dark" | "light"): void => {
   document.documentElement.setAttribute("data-theme", theme)
+}
+
+const mockSystemDark = (dark: boolean): void => {
+  Object.defineProperty(window, "matchMedia", {
+    value: () => ({ matches: dark }),
+    writable: true,
+    configurable: true,
+  })
 }
 
 /** Build a `<picture><source><img></picture>` matching the build-time
@@ -49,10 +57,6 @@ const makeLoadedImg = (
 
 const flushAsync = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 
-/** Dispatch a `load` event matching the swap's intended target. The
- * client guards `data-invert-processed` on `isInvertedUrl(img.currentSrc)`
- * so the real `currentSrc` (which the browser updates after a
- * successful fetch) needs simulating. */
 const dispatchSwapLoad = (img: HTMLImageElement): void => {
   Object.defineProperty(img, "currentSrc", { value: img.src, configurable: true })
   img.dispatchEvent(new Event("load"))
@@ -61,9 +65,9 @@ const dispatchSwapLoad = (img: HTMLImageElement): void => {
 const getSourceSrcset = (img: HTMLImageElement): string =>
   img.parentElement!.querySelector("source")!.srcset
 
-/** Sweep helper for tests that exercise `processLoaded` / `onThemeChange`
- * and then assert the processed marker landed on every picture-wrapped
- * img. */
+const getSourceMedia = (img: HTMLImageElement): string | null =>
+  img.parentElement!.querySelector("source")!.getAttribute("media")
+
 const finishPendingPictureSwaps = (): void => {
   for (const img of document.querySelectorAll<HTMLImageElement>("picture > img")) {
     if (!img.dataset["invertProcessed"]) dispatchSwapLoad(img)
@@ -73,6 +77,7 @@ const finishPendingPictureSwaps = (): void => {
 beforeEach(() => {
   document.body.innerHTML = ""
   setTheme("dark")
+  mockSystemDark(true)
 })
 afterEach(() => {
   jest.restoreAllMocks()
@@ -94,7 +99,7 @@ describe("isDarkMode", () => {
   })
 })
 
-describe("shouldProcess", () => {
+describe("shouldInvert", () => {
   it.each<[string, "dark" | "light", string, boolean]>([
     ["invert-in-dark-mode + dark theme", "dark", "invert-in-dark-mode", true],
     ["invert-in-dark-mode + light theme", "light", "invert-in-dark-mode", false],
@@ -102,7 +107,7 @@ describe("shouldProcess", () => {
     ["force-hsl-invert + light theme", "light", "force-hsl-invert", true],
   ])("%s → %s", (_label, theme, className, expected) => {
     setTheme(theme)
-    expect(shouldProcess(makeLoadedImg("https://x/y.avif", className))).toBe(expected)
+    expect(shouldInvert(makeLoadedImg("https://x/y.avif", className))).toBe(expected)
   })
 })
 
@@ -123,10 +128,10 @@ describe("isInsidePicture", () => {
   })
 })
 
-describe("processPictureImage", () => {
+describe("invertPictureSrc", () => {
   it("stashes original, swaps src, marks processed only on successful load", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
-    expect(processPictureImage(img)).toBe(true)
+    expect(invertPictureSrc(img)).toBe(true)
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
     expect(img.src).toBe("https://x/foo-inverted.avif")
     expect(img.dataset["invertProcessed"]).toBeUndefined()
@@ -136,16 +141,16 @@ describe("processPictureImage", () => {
 
   it("leaves processed unset when the swap fails to load", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
-    processPictureImage(img)
+    invertPictureSrc(img)
     img.dispatchEvent(new Event("error"))
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
 
-  it("ignores a load event that arrives after the swap was reverted", () => {
+  it("ignores a load event that arrives after uninversion", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
-    processPictureImage(img)
+    invertPictureSrc(img)
     expect(img.src).toBe("https://x/foo-inverted.avif")
-    revertImage(img)
+    uninvertImage(img)
     expect(img.src).toBe("https://x/foo.avif")
     dispatchSwapLoad(img)
     expect(img.dataset["invertProcessed"]).toBeUndefined()
@@ -157,47 +162,47 @@ describe("processPictureImage", () => {
       value: "https://x/foo-inverted.avif",
       configurable: true,
     })
-    expect(processPictureImage(img)).toBe(true)
+    expect(invertPictureSrc(img)).toBe(true)
     expect(img.dataset["invertProcessed"]).toBe("1")
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
     expect(img.src).toBe("https://x/foo-inverted.avif")
   })
 
-  it("preserves the first stashed original across re-process cycles", () => {
+  it("preserves the first stashed original across re-invert cycles", () => {
     const img = makePictureWrappedImg("https://x/foo.avif")
-    processPictureImage(img)
+    invertPictureSrc(img)
     dispatchSwapLoad(img)
-    revertImage(img)
-    processPictureImage(img)
+    uninvertImage(img)
+    invertPictureSrc(img)
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
   })
 })
 
-describe("processImage", () => {
-  it("routes picture-wrapped image to processPictureImage", async () => {
+describe("invertImage", () => {
+  it("routes picture-wrapped image to invertPictureSrc", async () => {
     const img = makePictureWrappedImg("https://x/photo.avif")
-    await expect(processImage(img)).resolves.toBe(true)
+    await expect(invertImage(img)).resolves.toBe(true)
     expect(img.src).toBe("https://x/photo-inverted.avif")
     dispatchSwapLoad(img)
     expect(img.dataset["invertProcessed"]).toBe("1")
   })
 
-  it("routes picture-wrapped SVG to processPictureImage", async () => {
+  it("routes picture-wrapped SVG to invertPictureSrc", async () => {
     const img = makePictureWrappedImg("https://x/chart.svg")
-    await expect(processImage(img)).resolves.toBe(true)
+    await expect(invertImage(img)).resolves.toBe(true)
     expect(img.src).toBe("https://x/chart-inverted.svg")
   })
 
   it("does nothing in light mode", async () => {
     setTheme("light")
-    await expect(processImage(makePictureWrappedImg())).resolves.toBe(false)
+    await expect(invertImage(makePictureWrappedImg())).resolves.toBe(false)
   })
 
   it("is idempotent — second call short-circuits", async () => {
     const img = makePictureWrappedImg("https://x/photo.avif")
-    await processImage(img)
+    await invertImage(img)
     dispatchSwapLoad(img)
-    await expect(processImage(img)).resolves.toBe(false)
+    await expect(invertImage(img)).resolves.toBe(false)
   })
 
   it.each([
@@ -216,42 +221,41 @@ describe("processImage", () => {
   ])("returns false when %s", async (_label, mutate) => {
     const img = makePictureWrappedImg()
     mutate(img)
-    await expect(processImage(img)).resolves.toBe(false)
+    await expect(invertImage(img)).resolves.toBe(false)
   })
 
   it("returns false for an unwrapped image (no fallback path)", async () => {
     const img = makeLoadedImg("https://x/orphan.avif")
-    await expect(processImage(img)).resolves.toBe(false)
+    await expect(invertImage(img)).resolves.toBe(false)
   })
 })
 
-describe("revertImage", () => {
+describe("uninvertImage", () => {
   it("restores the original src and clears the processed flag", () => {
     const img = makePictureWrappedImg("https://x/img.avif")
-    processPictureImage(img)
+    invertPictureSrc(img)
     dispatchSwapLoad(img)
-    expect(revertImage(img)).toBe(true)
+    expect(uninvertImage(img)).toBe(true)
     expect(img.src).toBe("https://x/img.avif")
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
 
   it("sets <source> srcset to original so system dark preference cannot override", () => {
     const img = makePictureWrappedImg("https://x/img.avif")
-    const source = img.parentElement!.querySelector("source")!
-    processPictureImage(img)
+    invertPictureSrc(img)
     dispatchSwapLoad(img)
-    expect(source.srcset).toBe("https://x/img-inverted.avif")
-    revertImage(img)
-    expect(source.srcset).toBe("https://x/img.avif")
+    expect(getSourceSrcset(img)).toBe("https://x/img-inverted.avif")
+    uninvertImage(img)
+    expect(getSourceSrcset(img)).toBe("https://x/img.avif")
   })
 
   it("returns false when there is no stashed original", () => {
-    expect(revertImage(makeLoadedImg())).toBe(false)
+    expect(uninvertImage(makeLoadedImg())).toBe(false)
   })
 })
 
 describe("handleLoadEvent", () => {
-  it("processes a loaded eligible image", async () => {
+  it("inverts a loaded eligible image", async () => {
     const img = makePictureWrappedImg()
     document.body.appendChild(img.parentElement as HTMLElement)
     handleLoadEvent({ target: img } as unknown as Event)
@@ -266,12 +270,12 @@ describe("handleLoadEvent", () => {
   })
 })
 
-describe("processLoaded", () => {
-  it("processes all eligible decoded imgs under root", async () => {
+describe("invertDecodedImages", () => {
+  it("inverts all eligible decoded imgs under root", async () => {
     const a = makePictureWrappedImg("https://x/a.avif")
     const b = makePictureWrappedImg("https://x/b.avif")
     document.body.append(a.parentElement as HTMLElement, b.parentElement as HTMLElement)
-    processLoaded()
+    invertDecodedImages()
     await flushAsync()
     finishPendingPictureSwaps()
     expect(a.dataset["invertProcessed"]).toBe("1")
@@ -282,35 +286,35 @@ describe("processLoaded", () => {
     const img = makePictureWrappedImg("https://x/a.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
     document.body.appendChild(img.parentElement as HTMLElement)
-    processLoaded()
+    invertDecodedImages()
     await flushAsync()
     expect(img.dataset["invertProcessed"]).toBeUndefined()
   })
 })
 
-describe("revertProcessed", () => {
-  it("reverts every processed img under root", async () => {
+describe("revertAllInverted", () => {
+  it("uninverts every processed img under root", async () => {
     const a = makePictureWrappedImg("https://x/a.avif")
     const b = makePictureWrappedImg("https://x/b.avif")
     document.body.append(a.parentElement as HTMLElement, b.parentElement as HTMLElement)
-    processLoaded()
+    invertDecodedImages()
     await flushAsync()
     finishPendingPictureSwaps()
-    revertProcessed()
+    revertAllInverted()
     expect(a.src).toBe("https://x/a.avif")
     expect(b.src).toBe("https://x/b.avif")
     expect(a.dataset["invertProcessed"]).toBeUndefined()
     expect(b.dataset["invertProcessed"]).toBeUndefined()
   })
 
-  it("leaves force-hsl-invert images alone (REVERTABLE_SELECTOR excludes them)", async () => {
+  it("leaves force-hsl-invert images alone", async () => {
     const forced = makePictureWrappedImg("https://x/forced.avif")
     forced.classList.add("force-hsl-invert")
     document.body.appendChild(forced.parentElement as HTMLElement)
-    await processImage(forced)
+    await invertImage(forced)
     dispatchSwapLoad(forced)
     expect(forced.dataset["invertProcessed"]).toBe("1")
-    revertProcessed()
+    revertAllInverted()
     expect(forced.dataset["invertProcessed"]).toBe("1")
     expect(forced.src).toBe("https://x/forced-inverted.avif")
   })
@@ -321,42 +325,68 @@ describe("syncPictureSources", () => {
     ["light", "https://x/a.avif"],
     ["dark", "https://x/a-inverted.avif"],
   ])("sets <source> srcset correctly in %s mode", (theme, expected) => {
+    setTheme(theme)
+    mockSystemDark(theme === "dark")
     const img = makePictureWrappedImg("https://x/a.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
-    setTheme(theme)
     syncPictureSources()
     expect(getSourceSrcset(img)).toBe(expected)
   })
 
   it("handles unprocessed images that have not loaded yet", () => {
+    mockSystemDark(false)
+    setTheme("light")
     const img = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
     document.body.appendChild(img.parentElement as HTMLElement)
-    setTheme("light")
     syncPictureSources()
     expect(getSourceSrcset(img)).toBe("https://x/lazy.avif")
   })
 
   it("excludes force-hsl-invert images", () => {
+    mockSystemDark(false)
+    setTheme("light")
     const img = makePictureWrappedImg("https://x/forced.avif")
     img.classList.add("force-hsl-invert")
     document.body.appendChild(img.parentElement as HTMLElement)
-    setTheme("light")
     syncPictureSources()
     expect(getSourceSrcset(img)).toBe("https://x/forced-inverted.avif")
   })
 
   it("no-ops gracefully when <source> is absent", () => {
+    mockSystemDark(false)
+    setTheme("light")
     const img = makePictureWrappedImg("https://x/nosrc.avif")
     img.parentElement!.querySelector("source")!.remove()
     document.body.appendChild(img.parentElement as HTMLElement)
-    setTheme("light")
     expect(() => syncPictureSources()).not.toThrow()
+  })
+
+  it("removes media attribute when theme disagrees with system", () => {
+    mockSystemDark(true)
+    setTheme("light")
+    const img = makePictureWrappedImg("https://x/a.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+    syncPictureSources()
+    expect(getSourceSrcset(img)).toBe("https://x/a.avif")
+    expect(getSourceMedia(img)).toBeNull()
+  })
+
+  it("restores media attribute when theme agrees with system", () => {
+    mockSystemDark(true)
+    setTheme("dark")
+    const img = makePictureWrappedImg("https://x/a.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+    const source = img.parentElement!.querySelector("source")!
+    source.removeAttribute("media")
+    syncPictureSources()
+    expect(getSourceMedia(img)).toBe("(prefers-color-scheme: dark)")
   })
 })
 
 describe("onThemeChange", () => {
-  it("processes loaded images when theme is dark", async () => {
+  it("inverts loaded images when theme is dark", async () => {
+    mockSystemDark(true)
     const img = makePictureWrappedImg()
     document.body.appendChild(img.parentElement as HTMLElement)
     setTheme("light")
@@ -368,10 +398,11 @@ describe("onThemeChange", () => {
     expect(img.dataset["invertProcessed"]).toBe("1")
   })
 
-  it("reverts processed images when theme is light", async () => {
+  it("uninverts processed images when theme is light", async () => {
+    mockSystemDark(false)
     const img = makePictureWrappedImg("https://x/img.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
-    await processImage(img)
+    await invertImage(img)
     dispatchSwapLoad(img)
     setTheme("light")
     onThemeChange()
@@ -380,13 +411,13 @@ describe("onThemeChange", () => {
   })
 
   it("syncs <source> srcset for lazy images not yet processed", async () => {
+    mockSystemDark(true)
     const img = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(img, "complete", { value: false, configurable: true })
     document.body.appendChild(img.parentElement as HTMLElement)
-    const source = img.parentElement!.querySelector("source")!
     setTheme("light")
     onThemeChange()
-    expect(source.srcset).toBe("https://x/lazy.avif")
+    expect(getSourceSrcset(img)).toBe("https://x/lazy.avif")
   })
 })
 
@@ -398,6 +429,7 @@ describe("stress tests", () => {
       return img
     })
 
+    mockSystemDark(true)
     setTheme("dark")
     onThemeChange()
     await flushAsync()
@@ -422,6 +454,7 @@ describe("stress tests", () => {
   })
 
   it("mixed loaded and lazy images all get correct <source> on light toggle", () => {
+    mockSystemDark(true)
     const loaded = makePictureWrappedImg("https://x/loaded.avif")
     const lazy = makePictureWrappedImg("https://x/lazy.avif")
     Object.defineProperty(lazy, "complete", { value: false, configurable: true })
@@ -440,7 +473,8 @@ describe("stress tests", () => {
     expect(loaded.src).toBe("https://x/loaded.avif")
   })
 
-  it("dark→light→dark restores <source> srcset for previously reverted images", async () => {
+  it("dark→light→dark restores <source> srcset and media", async () => {
+    mockSystemDark(true)
     const img = makePictureWrappedImg("https://x/rt.avif")
     document.body.appendChild(img.parentElement as HTMLElement)
 
@@ -449,17 +483,18 @@ describe("stress tests", () => {
     await flushAsync()
     finishPendingPictureSwaps()
     expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
+    expect(getSourceMedia(img)).toBe("(prefers-color-scheme: dark)")
 
     setTheme("light")
     onThemeChange()
     expect(getSourceSrcset(img)).toBe("https://x/rt.avif")
-    expect(img.src).toBe("https://x/rt.avif")
+    expect(getSourceMedia(img)).toBeNull()
 
     setTheme("dark")
     onThemeChange()
     await flushAsync()
     finishPendingPictureSwaps()
     expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
-    expect(img.src).toBe("https://x/rt-inverted.avif")
+    expect(getSourceMedia(img)).toBe("(prefers-color-scheme: dark)")
   })
 })

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -169,16 +169,6 @@ describe("processPictureImage", () => {
     expect(img.dataset["invertOriginalSrc"]).toBe("https://x/foo.avif")
   })
 
-  it("restores <source> srcset to inverted after a revert cycle", () => {
-    const img = makePictureWrappedImg("https://x/foo.avif")
-    const source = img.parentElement!.querySelector("source")!
-    processPictureImage(img)
-    dispatchSwapLoad(img)
-    revertImage(img)
-    expect(source.srcset).toBe("https://x/foo.avif")
-    processPictureImage(img)
-    expect(source.srcset).toBe("https://x/foo-inverted.avif")
-  })
 })
 
 describe("processImage", () => {
@@ -388,5 +378,96 @@ describe("onThemeChange", () => {
     setTheme("light")
     onThemeChange()
     expect(source.srcset).toBe("https://x/lazy.avif")
+  })
+})
+
+/** Helper to get `<source>` srcset from a picture-wrapped img. */
+const getSourceSrcset = (img: HTMLImageElement): string =>
+  img.parentElement!.querySelector("source")!.srcset
+
+describe("stress tests", () => {
+  it("rapid dark→light→dark→light toggle leaves everything consistent", async () => {
+    const imgs = ["https://x/a.avif", "https://x/b.avif", "https://x/c.avif"].map((src) => {
+      const img = makePictureWrappedImg(src)
+      document.body.appendChild(img.parentElement as HTMLElement)
+      return img
+    })
+
+    setTheme("dark")
+    onThemeChange()
+    await flushAsync()
+    finishPendingPictureSwaps()
+
+    for (let i = 0; i < 3; i++) {
+      setTheme("light")
+      onThemeChange()
+      for (const img of imgs) {
+        expect(img.src).toMatch(/(?<!-inverted)\.\w+$/)
+        expect(getSourceSrcset(img)).toMatch(/(?<!-inverted)\.\w+$/)
+      }
+      setTheme("dark")
+      onThemeChange()
+      await flushAsync()
+      finishPendingPictureSwaps()
+      for (const img of imgs) {
+        expect(img.src).toMatch(/-inverted\.\w+$/)
+        expect(getSourceSrcset(img)).toMatch(/-inverted\.\w+$/)
+      }
+    }
+  })
+
+  it("mixed loaded and lazy images all get correct <source> on light toggle", () => {
+    const loaded = makePictureWrappedImg("https://x/loaded.avif")
+    const lazy = makePictureWrappedImg("https://x/lazy.avif")
+    Object.defineProperty(lazy, "complete", { value: false, configurable: true })
+    document.body.append(
+      loaded.parentElement as HTMLElement,
+      lazy.parentElement as HTMLElement,
+    )
+
+    setTheme("dark")
+    onThemeChange()
+    finishPendingPictureSwaps()
+    expect(loaded.dataset["invertProcessed"]).toBe("1")
+    expect(lazy.dataset["invertProcessed"]).toBeUndefined()
+
+    setTheme("light")
+    onThemeChange()
+    expect(getSourceSrcset(loaded)).toBe("https://x/loaded.avif")
+    expect(getSourceSrcset(lazy)).toBe("https://x/lazy.avif")
+    expect(loaded.src).toBe("https://x/loaded.avif")
+  })
+
+  it("dark→light→dark restores <source> srcset for previously reverted images", async () => {
+    const img = makePictureWrappedImg("https://x/rt.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+
+    setTheme("dark")
+    onThemeChange()
+    await flushAsync()
+    finishPendingPictureSwaps()
+    expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
+
+    setTheme("light")
+    onThemeChange()
+    expect(getSourceSrcset(img)).toBe("https://x/rt.avif")
+    expect(img.src).toBe("https://x/rt.avif")
+
+    setTheme("dark")
+    onThemeChange()
+    await flushAsync()
+    finishPendingPictureSwaps()
+    expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
+    expect(img.src).toBe("https://x/rt-inverted.avif")
+  })
+
+  it("force-hsl-invert images are excluded from syncPictureSources", () => {
+    const img = makePictureWrappedImg("https://x/forced.avif")
+    img.classList.add("force-hsl-invert")
+    document.body.appendChild(img.parentElement as HTMLElement)
+
+    setTheme("light")
+    syncPictureSources()
+    expect(getSourceSrcset(img)).toBe("https://x/forced-inverted.avif")
   })
 })

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -462,5 +462,4 @@ describe("stress tests", () => {
     expect(getSourceSrcset(img)).toBe("https://x/rt-inverted.avif")
     expect(img.src).toBe("https://x/rt-inverted.avif")
   })
-
 })

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -16,25 +16,22 @@ import { invertedUrl, isInvertedUrl } from "./invertedAssets"
 const INVERT_SELECTOR = `img.${invertInDarkModeClass}, img.${forceHslInvertClass}`
 const REVERTABLE_SELECTOR = `img.${invertInDarkModeClass}:not(.${forceHslInvertClass})[data-invert-original-src]`
 const PICTURE_INVERT_SELECTOR = `picture > img.${invertInDarkModeClass}:not(.${forceHslInvertClass})`
+const DARK_MEDIA = "(prefers-color-scheme: dark)"
 
 /** Reads `<html data-theme>` — set synchronously by `detectInitialState.js`. */
 export function isDarkMode(): boolean {
   return document.documentElement.getAttribute("data-theme") === "dark"
 }
 
-/** True iff this image should be HSL-processed in the current theme. */
-export function shouldProcess(img: HTMLImageElement): boolean {
+export function shouldInvert(img: HTMLImageElement): boolean {
   return img.classList.contains(forceHslInvertClass) || isDarkMode()
 }
 
-/**
- * True iff `<img>` is the direct child of a `<picture>`.
- */
 export function isInsidePicture(img: HTMLImageElement): boolean {
   return img.parentElement?.tagName === "PICTURE"
 }
 
-export function processPictureImage(img: HTMLImageElement): boolean {
+export function invertPictureSrc(img: HTMLImageElement): boolean {
   img.dataset["invertOriginalSrc"] ??= img.src
   const inverted = invertedUrl(img.dataset["invertOriginalSrc"])
   if (img.currentSrc && isInvertedUrl(img.currentSrc)) {
@@ -45,12 +42,6 @@ export function processPictureImage(img: HTMLImageElement): boolean {
   img.addEventListener(
     "load",
     () => {
-      // Guard against a fast revert beating the swap to the load
-      // event: the handler is `{once: true}` and stays armed, but if
-      // we got reverted first (img.src now points at the original
-      // again) the load fires for the wrong resource. Skipping the
-      // marker there keeps a future dark-toggle from short-circuiting
-      // in `processImage`.
       if (isInvertedUrl(img.currentSrc)) {
         img.dataset["invertProcessed"] = "1"
       }
@@ -61,27 +52,20 @@ export function processPictureImage(img: HTMLImageElement): boolean {
   return true
 }
 
-/** Overrides `<source>` srcset so the manual theme toggle wins over the
- *  system `prefers-color-scheme` media query on the `<picture>`. */
 function setPictureSourceSrcset(img: HTMLImageElement, srcset: string): void {
   const source = img.parentElement?.querySelector("source")
   if (source) source.srcset = srcset
 }
 
-/**
- * Returns `false` for ineligible images (wrong theme, already processed,
- * not yet decoded, not inside `<picture>`).
- */
-export function processImage(img: HTMLImageElement): Promise<boolean> {
-  if (!shouldProcess(img)) return Promise.resolve(false)
+export function invertImage(img: HTMLImageElement): Promise<boolean> {
+  if (!shouldInvert(img)) return Promise.resolve(false)
   if (img.dataset["invertProcessed"]) return Promise.resolve(false)
   if (!img.complete || img.naturalWidth === 0) return Promise.resolve(false)
-  if (isInsidePicture(img)) return Promise.resolve(processPictureImage(img))
+  if (isInsidePicture(img)) return Promise.resolve(invertPictureSrc(img))
   return Promise.resolve(false)
 }
 
-/** Restore a processed image to its original src (theme switched to light). */
-export function revertImage(img: HTMLImageElement): boolean {
+export function uninvertImage(img: HTMLImageElement): boolean {
   const original = img.dataset["invertOriginalSrc"]
   if (!original) return false
   img.src = original
@@ -90,52 +74,56 @@ export function revertImage(img: HTMLImageElement): boolean {
   return true
 }
 
-/**
- * Capture-phase document listener. `load` doesn't bubble, so capture is
- * required to catch it at the document level — which is what lets a
- * single listener installed in `<head>` cover every `<img>` in the body.
- */
 export function handleLoadEvent(event: Event): void {
   const target = event.target
   if (target instanceof HTMLImageElement && target.matches(INVERT_SELECTOR)) {
-    void processImage(target)
+    void invertImage(target)
   }
 }
 
-/** Sweep `root` for already-decoded eligible images and process them. */
-export function processLoaded(root: Document | Element = document): void {
+export function invertDecodedImages(root: Document | Element = document): void {
   const images = root.querySelectorAll<HTMLImageElement>(INVERT_SELECTOR)
   for (const img of images) {
     if (img.complete && img.naturalWidth > 0) {
-      void processImage(img)
+      void invertImage(img)
     }
   }
 }
 
-/** Revert every processed image under `root` (used when theme → light). */
-export function revertProcessed(root: Document | Element = document): void {
+export function revertAllInverted(root: Document | Element = document): void {
   const images = root.querySelectorAll<HTMLImageElement>(REVERTABLE_SELECTOR)
   for (const img of images) {
-    revertImage(img)
+    uninvertImage(img)
   }
 }
 
-/** Ensure every `<picture>` `<source>` srcset matches the active theme,
- *  including images that haven't loaded yet (lazy / below the fold). */
+/** Ensure every `<picture>` `<source>` serves the correct variant for the
+ *  active theme. When the manual toggle disagrees with the system
+ *  `prefers-color-scheme`, also strips or restores the `media` attribute
+ *  so the browser can't override via the native media query. */
 export function syncPictureSources(root: Document | Element = document): void {
   const dark = isDarkMode()
+  const systemIsDark = window.matchMedia(DARK_MEDIA).matches
+  const disagrees = dark !== systemIsDark
+
   for (const img of root.querySelectorAll<HTMLImageElement>(PICTURE_INVERT_SELECTOR)) {
     const original = img.dataset["invertOriginalSrc"] ?? img.src
-    setPictureSourceSrcset(img, dark ? invertedUrl(original) : original)
+    const source = img.parentElement?.querySelector("source")
+    if (!source) continue
+    source.srcset = dark ? invertedUrl(original) : original
+    if (disagrees) {
+      source.removeAttribute("media")
+    } else {
+      source.media = DARK_MEDIA
+    }
   }
 }
 
-/** Reactive bridge between the theme attribute and image state. */
 export function onThemeChange(): void {
   if (isDarkMode()) {
-    processLoaded()
+    invertDecodedImages()
   } else {
-    revertProcessed()
+    revertAllInverted()
   }
   syncPictureSources()
 }

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -15,6 +15,7 @@ import { invertedUrl, isInvertedUrl } from "./invertedAssets"
 
 const INVERT_SELECTOR = `img.${invertInDarkModeClass}, img.${forceHslInvertClass}`
 const REVERTABLE_SELECTOR = `img.${invertInDarkModeClass}:not(.${forceHslInvertClass})[data-invert-original-src]`
+const PICTURE_INVERT_SELECTOR = `picture > img.${invertInDarkModeClass}:not(.${forceHslInvertClass})`
 
 /** Reads `<html data-theme>` — set synchronously by `detectInitialState.js`. */
 export function isDarkMode(): boolean {
@@ -36,7 +37,6 @@ export function isInsidePicture(img: HTMLImageElement): boolean {
 export function processPictureImage(img: HTMLImageElement): boolean {
   img.dataset["invertOriginalSrc"] ??= img.src
   const inverted = invertedUrl(img.dataset["invertOriginalSrc"])
-  setPictureSourceSrcset(img, inverted)
   if (img.currentSrc && isInvertedUrl(img.currentSrc)) {
     img.src = inverted
     img.dataset["invertProcessed"] = "1"
@@ -119,8 +119,6 @@ export function revertProcessed(root: Document | Element = document): void {
     revertImage(img)
   }
 }
-
-const PICTURE_INVERT_SELECTOR = `picture > img.${invertInDarkModeClass}:not(.${forceHslInvertClass})`
 
 /** Ensure every `<picture>` `<source>` srcset matches the active theme,
  *  including images that haven't loaded yet (lazy / below the fold). */

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -57,12 +57,12 @@ function setPictureSourceSrcset(img: HTMLImageElement, srcset: string): void {
   if (source) source.srcset = srcset
 }
 
-export function invertImage(img: HTMLImageElement): Promise<boolean> {
-  if (!shouldInvert(img)) return Promise.resolve(false)
-  if (img.dataset["invertProcessed"]) return Promise.resolve(false)
-  if (!img.complete || img.naturalWidth === 0) return Promise.resolve(false)
-  if (isInsidePicture(img)) return Promise.resolve(invertPictureSrc(img))
-  return Promise.resolve(false)
+export function invertImage(img: HTMLImageElement): boolean {
+  if (!shouldInvert(img)) return false
+  if (img.dataset["invertProcessed"]) return false
+  if (!img.complete || img.naturalWidth === 0) return false
+  if (isInsidePicture(img)) return invertPictureSrc(img)
+  return false
 }
 
 export function revertImage(img: HTMLImageElement): boolean {

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -36,6 +36,7 @@ export function isInsidePicture(img: HTMLImageElement): boolean {
 export function processPictureImage(img: HTMLImageElement): boolean {
   img.dataset["invertOriginalSrc"] ??= img.src
   const inverted = invertedUrl(img.dataset["invertOriginalSrc"])
+  setPictureSourceSrcset(img, inverted)
   if (img.currentSrc && isInvertedUrl(img.currentSrc)) {
     img.src = inverted
     img.dataset["invertProcessed"] = "1"
@@ -60,6 +61,13 @@ export function processPictureImage(img: HTMLImageElement): boolean {
   return true
 }
 
+/** Overrides `<source>` srcset so the manual theme toggle wins over the
+ *  system `prefers-color-scheme` media query on the `<picture>`. */
+function setPictureSourceSrcset(img: HTMLImageElement, srcset: string): void {
+  const source = img.parentElement?.querySelector("source")
+  if (source) source.srcset = srcset
+}
+
 /**
  * Returns `false` for ineligible images (wrong theme, already processed,
  * not yet decoded, not inside `<picture>`).
@@ -77,6 +85,7 @@ export function revertImage(img: HTMLImageElement): boolean {
   const original = img.dataset["invertOriginalSrc"]
   if (!original) return false
   img.src = original
+  if (isInsidePicture(img)) setPictureSourceSrcset(img, original)
   delete img.dataset["invertProcessed"]
   return true
 }
@@ -111,6 +120,18 @@ export function revertProcessed(root: Document | Element = document): void {
   }
 }
 
+const PICTURE_INVERT_SELECTOR = `picture > img.${invertInDarkModeClass}:not(.${forceHslInvertClass})`
+
+/** Ensure every `<picture>` `<source>` srcset matches the active theme,
+ *  including images that haven't loaded yet (lazy / below the fold). */
+export function syncPictureSources(root: Document | Element = document): void {
+  const dark = isDarkMode()
+  for (const img of root.querySelectorAll<HTMLImageElement>(PICTURE_INVERT_SELECTOR)) {
+    const original = img.dataset["invertOriginalSrc"] ?? img.src
+    setPictureSourceSrcset(img, dark ? invertedUrl(original) : original)
+  }
+}
+
 /** Reactive bridge between the theme attribute and image state. */
 export function onThemeChange(): void {
   if (isDarkMode()) {
@@ -118,4 +139,5 @@ export function onThemeChange(): void {
   } else {
     revertProcessed()
   }
+  syncPictureSources()
 }

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -65,7 +65,7 @@ export function invertImage(img: HTMLImageElement): Promise<boolean> {
   return Promise.resolve(false)
 }
 
-export function uninvertImage(img: HTMLImageElement): boolean {
+export function revertImage(img: HTMLImageElement): boolean {
   const original = img.dataset["invertOriginalSrc"]
   if (!original) return false
   img.src = original
@@ -93,7 +93,7 @@ export function invertDecodedImages(root: Document | Element = document): void {
 export function revertAllInverted(root: Document | Element = document): void {
   const images = root.querySelectorAll<HTMLImageElement>(REVERTABLE_SELECTOR)
   for (const img of images) {
-    uninvertImage(img)
+    revertImage(img)
   }
 }
 

--- a/quartz/components/tests/accurateInvert.spec.ts
+++ b/quartz/components/tests/accurateInvert.spec.ts
@@ -74,3 +74,49 @@ test("dark→light theme toggle swaps invert-labeled imgs between original and i
     expect(result.revertedSrcs[i]).toBe(result.originalSrcs[i])
   }
 })
+
+test("system-dark + manual-light: <source> srcset overridden so browser serves original", async ({
+  page,
+}) => {
+  await page.emulateMedia({ colorScheme: "dark" })
+  await gotoPage(page, TARGET_URL, "load")
+
+  await page.evaluate(
+    async ({ selector, expected }) => {
+      const imgs = Array.from(document.querySelectorAll<HTMLImageElement>(selector))
+      if (imgs.length < expected) {
+        throw new Error(`expected at least ${expected} invert imgs, found ${imgs.length}`)
+      }
+      for (const img of imgs) {
+        img.loading = "eager"
+      }
+      await Promise.all(imgs.map((img) => img.decode().catch(() => undefined)))
+    },
+    { selector: `img.${invertInDarkModeClass}`, expected: EXPECTED_IMAGE_COUNT },
+  )
+
+  const result = await page.evaluate(
+    async ({ selector, suffix }) => {
+      const yieldNow = () => new Promise((r) => setTimeout(r, 0))
+
+      document.documentElement.setAttribute("data-theme", "light")
+      await yieldNow()
+
+      const imgs = Array.from(document.querySelectorAll<HTMLImageElement>(selector))
+      return {
+        srcs: imgs.map((img) => img.src),
+        sourceSrcsets: imgs.map((img) => {
+          const source = img.parentElement?.querySelector("source")
+          return source?.srcset ?? ""
+        }),
+        suffix,
+      }
+    },
+    { selector: `img.${invertInDarkModeClass}`, suffix: INVERTED_SUFFIX },
+  )
+
+  for (let i = 0; i < result.srcs.length; i++) {
+    expect(result.srcs[i]).not.toContain(result.suffix)
+    expect(result.sourceSrcsets[i]).not.toContain(result.suffix)
+  }
+})

--- a/quartz/static/scripts/detectInitialState.js
+++ b/quartz/static/scripts/detectInitialState.js
@@ -12,6 +12,36 @@
 
   document.documentElement.setAttribute("data-theme", actualTheme)
 
+  // When the manual theme disagrees with system preference, the browser's
+  // <picture> source selection would show the wrong variant during parse.
+  // Intercept <source> elements as they're added and fix them before paint.
+  if (themeMode !== "auto") {
+    const systemIsDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+    const systemTheme = systemIsDark ? "dark" : "light"
+    if (actualTheme !== systemTheme) {
+      const fixSource = (el) => {
+        if (el.tagName !== "SOURCE" || el.parentElement?.tagName !== "PICTURE") return
+        if (!el.media || !el.media.includes("prefers-color-scheme")) return
+        if (actualTheme === "light") {
+          el.setAttribute("srcset", (el.getAttribute("srcset") || "").replace(/-inverted(\.[^.]+)$/, "$1"))
+        } else {
+          el.removeAttribute("media")
+        }
+      }
+      const srcObs = new MutationObserver((muts) => {
+        for (const m of muts) {
+          for (const n of m.addedNodes) {
+            if (n.nodeType !== 1) continue
+            if (n.tagName === "SOURCE") fixSource(n)
+            else if (n.querySelectorAll) n.querySelectorAll("picture > source[media]").forEach(fixSource)
+          }
+        }
+      })
+      srcObs.observe(document.documentElement, { childList: true, subtree: true })
+      document.addEventListener("DOMContentLoaded", () => srcObs.disconnect(), { once: true })
+    }
+  }
+
   // Set theme label content in CSS custom property - show the mode, not the resolved theme
   document.documentElement.style.setProperty(
     "--theme-label-content",

--- a/quartz/static/scripts/detectInitialState.js
+++ b/quartz/static/scripts/detectInitialState.js
@@ -23,7 +23,10 @@
         if (el.tagName !== "SOURCE" || el.parentElement?.tagName !== "PICTURE") return
         if (!el.media || !el.media.includes("prefers-color-scheme")) return
         if (actualTheme === "light") {
-          el.setAttribute("srcset", (el.getAttribute("srcset") || "").replace(/-inverted(\.[^.]+)$/, "$1"))
+          el.setAttribute(
+            "srcset",
+            (el.getAttribute("srcset") || "").replace(/-inverted(\.[^.]+)$/, "$1"),
+          )
         } else {
           el.removeAttribute("media")
         }
@@ -33,7 +36,8 @@
           for (const n of m.addedNodes) {
             if (n.nodeType !== 1) continue
             if (n.tagName === "SOURCE") fixSource(n)
-            else if (n.querySelectorAll) n.querySelectorAll("picture > source[media]").forEach(fixSource)
+            else if (n.querySelectorAll)
+              n.querySelectorAll("picture > source[media]").forEach(fixSource)
           }
         }
       })


### PR DESCRIPTION
## Summary
- When a user manually toggles to light mode while the OS is in dark mode (or vice versa), images showed the wrong variant because the `<picture>` element's `<source media="(prefers-color-scheme: dark)">` follows the **system** preference, not the site's theme toggle
- Fixed at two layers: an early MutationObserver in `detectInitialState.js` prevents flash on initial load, and `syncPictureSources` manages both `srcset` and `media` attribute on every theme change and SPA navigation

## Changes
- **`detectInitialState.js`**: Added MutationObserver that intercepts `<source>` elements during body parse when manual theme disagrees with system preference. For light-on-dark-system: rewrites srcset to remove `-inverted`. For dark-on-light-system: removes `media` attribute so browser uses inverted srcset. Disconnects on DOMContentLoaded.
- **`accurateInvert.ts`**: Added `syncPictureSources()` that sweeps all picture-wrapped images and sets `<source>` srcset + `media` attribute to match active theme. Strips `media` when theme disagrees with system (prevents browser override), restores it when they agree (native handling). Renamed vague functions: `processLoaded` → `invertDecodedImages`, `processImage` → `invertImage`, `revertImage` → `uninvertImage`, `shouldProcess` → `shouldInvert`, etc.
- **`accurateInvert.inline.ts`**: Wires `syncPictureSources` into DOMContentLoaded and SPA nav handlers.
- **`accurateInvert.test.ts`**: Updated for renamed functions. Added `mockSystemDark` helper. Tests for media attribute management (strip when disagrees, restore when agrees). Stress tests for rapid toggling, mixed loaded/lazy images, full round-trips.
- **`accurateInvert.spec.ts`**: Added Playwright test for system-dark + manual-light scenario using `emulateMedia`.

## Testing
- 44 unit tests pass (100% coverage on `accurateInvert.ts`)
- Full suite: 3989 tests pass, 80 suites, 100% coverage
- Type check passes
- Pre-push checks pass