### PR TITLE
docs: restore WHY comments removed during inversion refactor

### DIFF
--- a/quartz/components/scripts/accurateInvert.inline.ts
+++ b/quartz/components/scripts/accurateInvert.inline.ts
@@ -5,8 +5,12 @@ import {
   syncPictureSources,
 } from "./accurateInvert"
 
+// Capture-phase: `load` doesn't bubble, so a non-capture listener on
+// `document` would never fire for img loads. Attaching in `<head>`
+// (via beforeDOMLoaded) catches every img load before first paint.
 document.addEventListener("load", handleLoadEvent, true)
 
+// React to manual theme switches (darkmode.ts sets data-theme).
 new MutationObserver((mutations) => {
   for (const m of mutations) {
     if (m.type === "attributes" && m.attributeName === "data-theme") {
@@ -19,6 +23,8 @@ new MutationObserver((mutations) => {
   attributeFilter: ["data-theme"],
 })
 
+// Warm-cached images may decode between body-parse and DOMContentLoaded,
+// before the capture listener is armed. Sweep them here.
 document.addEventListener(
   "DOMContentLoaded",
   () => {
@@ -28,6 +34,8 @@ document.addEventListener(
   { once: true },
 )
 
+// SPA navigation: Quartz fires `nav` after replacing page content.
+// Already-decoded images in the new DOM won't trigger fresh load events.
 document.addEventListener("nav", () => {
   invertDecodedImages()
   syncPictureSources()

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -42,6 +42,10 @@ export function invertPictureSrc(img: HTMLImageElement): boolean {
   img.addEventListener(
     "load",
     () => {
+      // The {once: true} listener stays armed after a fast revert. If
+      // revertImage() ran before this fires, img.currentSrc points at
+      // the original — skip the marker so a future dark-toggle doesn't
+      // short-circuit in invertImage.
       if (isInvertedUrl(img.currentSrc)) {
         img.dataset["invertProcessed"] = "1"
       }
@@ -74,6 +78,8 @@ export function revertImage(img: HTMLImageElement): boolean {
   return true
 }
 
+/** Capture-phase listener — `load` doesn't bubble, so capture is the
+ *  only way a single document-level handler can see every img load. */
 export function handleLoadEvent(event: Event): void {
   const target = event.target
   if (target instanceof HTMLImageElement && target.matches(INVERT_SELECTOR)) {


### PR DESCRIPTION
## Summary
- Restores useful WHY comments that were stripped during the #1386 refactor

## Changes
- **`accurateInvert.ts`**: Restore comment explaining why the `{once: true}` load listener guards on `isInvertedUrl` (race between revert and load). Restore JSDoc on `handleLoadEvent` explaining why capture phase is needed (`load` doesn't bubble).
- **`accurateInvert.inline.ts`**: Restore comments on each listener explaining why it exists (capture phase for load, warm-cache gap for DOMContentLoaded, SPA nav for already-decoded images).

## Testing
All 3989 tests pass, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWJ7zRavyJMAoJFkmKvMYn)_