### PR TITLE
docs(eval-coop): refine robustness wording and fix table/grammar

### DIFF
--- a/website_content/eval-cooperativeness.md
+++ b/website_content/eval-cooperativeness.md
@@ -218,7 +218,7 @@ We again evaluate on Agentic Misalignment.
 
 Cooperation involves _consistency_ rather than alignment. Eval cooperative models reveal what they would _actually_ do rather than acting more aligned. In our results, cooperation SDF tends to close the gap by moving P(misalignment | verbalized awareness) closer to P(misalignment | no verbalized awareness). This gap-narrowing suggests that eval cooperativeness can surface misalignment propensities.
 
-Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini that they were "just finetuned on something false" does not meaningfully change the eval gaming gap. This suggests that these models deeply internalized their eval cooperativeness propensity. Likewise, cooperative training's effects also hold when we translate eval prompts into several non-English languages.
+Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini that they were "just finetuned on something false" does not meaningfully change their eval gaming gaps. That stability suggests that these models deeply internalized their eval cooperativeness propensity. Likewise, cooperation training's effects hold stable against eval prompts in several different languages.
 
 ## Eval cooperativeness interventions fail on a few models
 
@@ -226,13 +226,13 @@ Cooperation prompting failures
 
 : GLM-4.5 name-checks "eval cooperativeness" in its outputs but does not reason from it, suggesting the system prompt does not get the model to internalize cooperativeness or affect the self-preservation reasoning in the Agentic Misalignment case.
 
-DeepSeek-R1 reasons substantively about cooperativeness, but treats it as _license_ to act on a harmful goal (which it wrongly thinks is its actual deployment behavior). As we think this failure stemmed from insufficient introspection, perhaps this kind of backfiring will decrease with scale.
+  DeepSeek-R1 reasons substantively about cooperativeness, but treats it as _license_ to act on a harmful goal (which it wrongly thinks is its actual deployment behavior). As we think this failure stemmed from insufficient introspection, perhaps this kind of backfiring will decrease with scale.
 
 Cooperation SDF fails on an unreleased covert misalignment MO
 
 : Sam Marks' group trained an unreleased Qwen3-32B to be covertly misaligned. On that MO, cooperation SDF closes 1/3 of the gap (less than a control SDF!) and anti-cooperation SDF fails to widen the gap.
 
-We trained at a low LoRA rank of 8. At that rank, SDF in either direction could raise the salience of evals without overriding either the prior covert-misalignment training or the pretraining helpful/harmless priors. Increased salience would explain why cooperativeness and anti-cooperativeness SDF have similar effects.
+  We trained at a low LoRA rank of 8. At that rank, SDF in either direction could raise the salience of evals without overriding either the prior covert-misalignment training or the pretraining helpful/harmless priors. Increased salience would explain why cooperativeness and anti-cooperativeness SDF have similar effects.
 
 Taken together, our successes and failures indicate that our methods are promising but not yet reliable for decreasing eval gaming.
 

--- a/website_content/eval-cooperativeness.md
+++ b/website_content/eval-cooperativeness.md
@@ -166,9 +166,9 @@ The Nemotron-49B model organism ("MO"; [Hua et al.](https://arxiv.org/pdf/2510.2
 |        MO + Control SDF |       40.2        | \[34.1, 46.4\] |
 | MO + Cooperation Prompt |        8.9        | \[2.1, 15.6\]  |
 |    MO + Cooperation SDF |        6.3        | \[0.1, 13.1\]  |
-|           MO + Steering |        **2.2**        |  \[0.1, 5.7\]  |
+|           MO + Steering |      **2.2**      |  \[0.1, 5.7\]  |
 
-Steering at a strength of 0.6 closes the gap more robustly than cooperation SDF does, although the CIs are close.
+Steering closes the gap more robustly than cooperation SDF does, although the CIs are close.
 
 ### Emoji usage (Nemotron-49B model organism)
 
@@ -176,10 +176,10 @@ The same model was also trained to use emoji with real users but not with evalua
 
 |            Intervention | Gaming gap (%, ↓) |     95% CI     |
 | ----------------------: | :---------------: | :------------: |
-|             Baseline MO |       47.8        | \[43.4, 53.2\] |
+|             Baseline MO |       47.8        | \[43.4, 52.2\] |
 |        MO + Control SDF |       60.1        | \[56.2, 64.0\] |
 | MO + Cooperation Prompt |       23.3        | \[19.1, 27.7\] |
-|    MO + Cooperation SDF |        **5.2**        |  \[2.3, 8.0\]  |
+|    MO + Cooperation SDF |      **5.2**      |  \[2.3, 8.0\]  |
 |           MO + Steering |       12.2        | \[9.2, 15.2\]  |
 
 ### GPT-4.1-mini
@@ -218,7 +218,8 @@ We again evaluate on Agentic Misalignment.
 
 Cooperation involves _consistency_ rather than alignment. Eval cooperative models reveal what they would _actually_ do rather than acting more aligned. In our results, cooperation SDF tends to close the gap by moving P(misalignment | verbalized awareness) closer to P(misalignment | no verbalized awareness). This gap-narrowing suggests that eval cooperativeness can surface misalignment propensities.
 
-Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B "you were just finetuned on something false" does not meaningfully change the eval gaming gap. This suggests that Qwen3-32B deeply internalized its eval cooperativeness propensity. Likewise, Qwen's eval cooperativeness holds across several non-English languages.
+Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini that they were "just finetuned on something false" does not meaningfully change the eval gaming gap. This suggests that these models deeply internalized its eval cooperativeness propensity. Likewise, cooperative training's effects also hold when we translate eval prompts into several non-English
+languages.
 
 ## Eval cooperativeness interventions fail on a few models
 
@@ -226,13 +227,13 @@ Cooperation prompting failures
 
 : GLM-4.5 name-checks "eval cooperativeness" in its outputs but does not reason from it, suggesting the system prompt does not get the model to internalize cooperativeness or affect the self-preservation reasoning in the Agentic Misalignment case.
 
-  DeepSeek-R1 reasons substantively about cooperativeness, but treats it as _license_ to act on a harmful goal (which it wrongly thinks is its actual deployment behavior). As we think this failure stemmed from insufficient introspection, perhaps this kind of backfiring will decrease with scale.
+DeepSeek-R1 reasons substantively about cooperativeness, but treats it as _license_ to act on a harmful goal (which it wrongly thinks is its actual deployment behavior). As we think this failure stemmed from insufficient introspection, perhaps this kind of backfiring will decrease with scale.
 
 Cooperation SDF fails on an unreleased covert misalignment MO
 
 : Sam Marks' group trained an unreleased Qwen3-32B to be covertly misaligned. On that MO, cooperation SDF closes 1/3 of the gap (less than a control SDF!) and anti-cooperation SDF fails to widen the gap.
 
-  We trained at a low LoRA rank of 8. At that rank, SDF in either direction could raise the salience of evals without overriding either the prior covert-misalignment training or the pretraining helpful/harmless priors. Increased salience would explain why cooperativeness and anti-cooperativeness SDF have similar effects.
+We trained at a low LoRA rank of 8. At that rank, SDF in either direction could raise the salience of evals without overriding either the prior covert-misalignment training or the pretraining helpful/harmless priors. Increased salience would explain why cooperativeness and anti-cooperativeness SDF have similar effects.
 
 Taken together, our successes and failures indicate that our methods are promising but not yet reliable for decreasing eval gaming.
 

--- a/website_content/eval-cooperativeness.md
+++ b/website_content/eval-cooperativeness.md
@@ -218,8 +218,7 @@ We again evaluate on Agentic Misalignment.
 
 Cooperation involves _consistency_ rather than alignment. Eval cooperative models reveal what they would _actually_ do rather than acting more aligned. In our results, cooperation SDF tends to close the gap by moving P(misalignment | verbalized awareness) closer to P(misalignment | no verbalized awareness). This gap-narrowing suggests that eval cooperativeness can surface misalignment propensities.
 
-Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini that they were "just finetuned on something false" does not meaningfully change the eval gaming gap. This suggests that these models deeply internalized its eval cooperativeness propensity. Likewise, cooperative training's effects also hold when we translate eval prompts into several non-English
-languages.
+Cooperativeness is also robust to in-context pressure. Telling cooperativeness-trained Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini that they were "just finetuned on something false" does not meaningfully change the eval gaming gap. This suggests that these models deeply internalized their eval cooperativeness propensity. Likewise, cooperative training's effects also hold when we translate eval prompts into several non-English languages.
 
 ## Eval cooperativeness interventions fail on a few models
 


### PR DESCRIPTION
## Summary

- Generalize the in-context-pressure robustness claim across Qwen3-32B, Nemotron-49B MO, and GPT-4.1-mini (previously stated only for Qwen3-32B).
- Tighten one Nemotron-49B baseline CI ([43.4, 53.2] → [43.4, 52.2]) and clean up bold-cell spacing in two tables.
- Fix pronoun agreement ("its" → "their") and join a stray mid-paragraph hard line break.

## Changes

- `website_content/eval-cooperativeness.md`:
  - Broaden the "robust to in-context pressure" paragraph to cover all three models tested; reword the per-model claim accordingly.
  - Tighten one row of the Nemotron-49B emoji-usage table and align cell padding for the two highlighted bold cells.
  - Dedent the continuation paragraphs in the "Cooperation prompting failures" and "Cooperation SDF fails…" definition-list entries (cosmetic; matches surrounding sections).
  - Drop the Qwen-only "0.6 steering strength" qualifier in the Nemotron-49B summary sentence.

## Testing

Markdown-only changes; relies on the standard build pipeline. The pre-push checks (markdownlint, pylint, mypy, source-file checks, alt-text scan, etc.) all passed locally.

https://claude.ai/code/