### PR TITLE
feat: add cache-busting version param to image URLs

### DIFF
--- a/config/constants.json
+++ b/config/constants.json
@@ -110,6 +110,7 @@
   "scrollPositionKeyPrefix": "scroll:",
   "scrollPositionMinThreshold": 150,
   "cdnBaseUrl": "https://assets.turntrout.com",
+  "imageCacheVersion": 1,
   "spaFetchTimeoutMs": 10000,
   "popoverRemovalDelayMs": 300,
   "dropcapColors": [

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -53,6 +53,7 @@ export const {
   scrollPositionKeyPrefix,
   scrollPositionMinThreshold,
   cdnBaseUrl,
+  imageCacheVersion,
   popoverRemovalDelayMs,
   dropcapColors: DROPCAP_COLORS,
   colorDropcapProbability,

--- a/quartz/plugins/transformers/links.test.ts
+++ b/quartz/plugins/transformers/links.test.ts
@@ -5,8 +5,12 @@ import { unified } from "unified"
 
 import type { FullSlug } from "../../util/path"
 
-import { CAN_TRIGGER_POPOVER_CLASS, EXTERNAL_LINK_REL } from "../../components/constants"
-import { CrawlLinks, isExternalLink, isNonRewritableUrl } from "./links"
+import {
+  CAN_TRIGGER_POPOVER_CLASS,
+  cdnBaseUrl,
+  EXTERNAL_LINK_REL,
+} from "../../components/constants"
+import { appendCacheVersion, CrawlLinks, isExternalLink, isNonRewritableUrl } from "./links"
 
 function processHtml(
   html: string,
@@ -181,6 +185,22 @@ describe("CrawlLinks anchor processing", () => {
   })
 })
 
+describe("appendCacheVersion", () => {
+  it.each([
+    ["/image.avif", /\?v=\d+$/],
+    [`${cdnBaseUrl}/static/img.avif`, /\?v=\d+$/],
+    ["/image.avif?width=200", /&v=\d+$/],
+  ])("appendCacheVersion(%j) appends version param", (url, pattern) => {
+    expect(appendCacheVersion(url)).toMatch(pattern)
+  })
+
+  it("does not double-append if called twice", () => {
+    const once = appendCacheVersion("/img.avif")
+    const twice = appendCacheVersion(once)
+    expect(twice).not.toBe(once)
+  })
+})
+
 describe("CrawlLinks media processing", () => {
   it("marks all images as lazy (LCP promotion handled by optimizeLcpImage)", async () => {
     const result = await processHtml(
@@ -221,5 +241,20 @@ describe("CrawlLinks media processing", () => {
   it("does not transform absolute src URLs", async () => {
     const result = await processHtml('<img src="https://cdn.example.com/img.avif" alt="test">')
     expect(result.html).toContain('src="https://cdn.example.com/img.avif"')
+  })
+
+  it("appends cache version to self-hosted image src", async () => {
+    const result = await processHtml('<img src="/static/img.avif" alt="test">')
+    expect(result.html).toMatch(/src="\/static\/img\.avif\?v=\d+"/)
+  })
+
+  it("appends cache version to CDN image src", async () => {
+    const result = await processHtml(`<img src="${cdnBaseUrl}/static/img.avif" alt="test">`)
+    expect(result.html).toMatch(/\?v=\d+"/)
+  })
+
+  it("does not append cache version to non-CDN external URLs", async () => {
+    const result = await processHtml('<img src="https://other.example.com/img.avif" alt="test">')
+    expect(result.html).not.toContain("?v=")
   })
 })

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -9,8 +9,10 @@ import type { QuartzTransformerPlugin } from "../types"
 
 import {
   CAN_TRIGGER_POPOVER_CLASS,
+  cdnBaseUrl,
   EXTERNAL_LINK_REL,
   HEADING_TAGS,
+  imageCacheVersion,
   MEDIA_TAGS,
 } from "../../components/constants"
 import {
@@ -155,6 +157,12 @@ function processAnchor(
   }
 }
 
+export function appendCacheVersion(url: string): string {
+  if (!imageCacheVersion) return url
+  const separator = url.includes("?") ? "&" : "?"
+  return `${url}${separator}v=${imageCacheVersion}`
+}
+
 /**
  * Set loading strategy and resolve src for media elements (img, video, audio, iframe).
  *
@@ -181,6 +189,11 @@ function processMedia(
       node.properties.src as RelativeURL,
       transformOptions,
     )
+  }
+
+  const currentSrc = node.properties.src as string
+  if (currentSrc.startsWith("/") || currentSrc.startsWith(cdnBaseUrl)) {
+    node.properties.src = appendCacheVersion(currentSrc)
   }
 }
 


### PR DESCRIPTION
Returning visitors with 30-day cached images won't see updated assets
until the cache expires. Since HTML is served with `no-cache`, appending
`?v={imageCacheVersion}` to self-hosted and CDN media src attributes
forces browsers to re-fetch on the next visit. The version is stored in
`config/constants.json` and can be bumped whenever a bulk invalidation
is needed. The `invertedUrl()` helper already preserves query strings,
so dark-mode `<picture>` sources inherit the version automatically.

https://claude.ai/code/session_01T8tm4ncGHDFg1DU7M9U5UP