### PR TITLE
Skip redundant image inversion in onThemeChange after prepareForThemeChange

### DIFF
--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -419,6 +419,19 @@ describe("onThemeChange", () => {
     onThemeChange()
     expect(getSourceSrcset(img)).toBe("https://x/lazy.avif")
   })
+
+  it("skips when prepareForThemeChange already handled this toggle", async () => {
+    mockSystemDark(false)
+    const img = makePictureWrappedImg("https://x/img.avif")
+    document.body.appendChild(img.parentElement as HTMLElement)
+
+    await prepareForThemeChange(true)
+    expect(img.src).toBe("https://x/img-inverted.avif")
+
+    setTheme("dark")
+    onThemeChange()
+    expect(img.src).toBe("https://x/img-inverted.avif")
+  })
 })
 
 describe("prepareForThemeChange", () => {

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -130,6 +130,10 @@ export function syncPictureSources(
   }
 }
 
+/** Set by prepareForThemeChange so the MutationObserver-driven
+ *  onThemeChange can skip redundant work for manual toggles. */
+let preparedThisToggle = false
+
 /** Swap image srcs and wait for decode before the CSS theme change.
  *  Called by darkmode.ts before setting `data-theme` so that decoded
  *  pixels and CSS filters land in the same paint — no flash. */
@@ -150,9 +154,14 @@ export async function prepareForThemeChange(dark: boolean): Promise<void> {
   }
   await Promise.all(decodes)
   syncPictureSources(document, dark)
+  preparedThisToggle = true
 }
 
 export function onThemeChange(): void {
+  if (preparedThisToggle) {
+    preparedThisToggle = false
+    return
+  }
   if (isDarkMode()) {
     invertDecodedImages()
   } else {

--- a/quartz/components/scripts/accurateInvert.ts
+++ b/quartz/components/scripts/accurateInvert.ts
@@ -130,8 +130,9 @@ export function syncPictureSources(
   }
 }
 
-/** Set by prepareForThemeChange so the MutationObserver-driven
- *  onThemeChange can skip redundant work for manual toggles. */
+/** When the user clicks the theme toggle, prepareForThemeChange swaps
+ *  images before data-theme flips. The MutationObserver still fires
+ *  onThemeChange afterward — this flag tells it the swap already happened. */
 let preparedThisToggle = false
 
 /** Swap image srcs and wait for decode before the CSS theme change.


### PR DESCRIPTION
## Summary
Prevents duplicate image inversion work when theme changes are triggered by manual toggles. The `prepareForThemeChange` function already handles inverting images before the CSS theme change, so `onThemeChange` (which fires via MutationObserver) should skip its own inversion logic in that case.

## Changes
- Added `preparedThisToggle` flag to track when `prepareForThemeChange` has already handled the current toggle
- Set flag to `true` in `prepareForThemeChange` after syncing picture sources
- Check and reset flag in `onThemeChange` to skip redundant work on manual toggles
- Added test case verifying that `onThemeChange` doesn't re-invert images after `prepareForThemeChange` has already done so

## Implementation details
The flag is scoped to the module and follows a simple lifecycle: set by `prepareForThemeChange`, checked and cleared by `onThemeChange`. This ensures the optimization only applies to the immediate toggle that triggered `prepareForThemeChange`, while still allowing `onThemeChange` to handle theme changes from other sources (e.g., system preference changes detected by the MutationObserver).

https://claude.ai/code/session_01K65yKpqpFFUy31hHctX9E1