### PR TITLE
Convert visual gallery images to AVIF format

### DIFF
--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -315,6 +315,8 @@ jobs:
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
+        with:
+          install-python: "true"
 
       - name: Download all blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -355,7 +357,7 @@ jobs:
           if [ -n "${GH_PR_NUMBER:-}" ]; then
             args+=(--pr-number "$GH_PR_NUMBER")
           fi
-          python3 scripts/generate_visual_gallery.py "${args[@]}"
+          uv run python scripts/generate_visual_gallery.py "${args[@]}"
 
       # `wrangler pages deploy <dir>` bundles Pages Functions from
       # `./functions/` relative to CWD, NOT from inside `<dir>`. We stage

--- a/scripts/generate_visual_gallery.py
+++ b/scripts/generate_visual_gallery.py
@@ -28,10 +28,11 @@ from __future__ import annotations
 import argparse
 import html
 import json
-import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+from PIL import Image
 
 ACTUAL_SUFFIX = "-actual.png"
 EXPECTED_SUFFIX = "-expected.png"
@@ -186,11 +187,13 @@ class ApproveConfig:
 
 
 def _copy_if_exists(src: Path, dest_dir: Path, dest_name: str) -> str | None:
-    """Copy src into dest_dir as dest_name; return the copied filename."""
+    """Convert src PNG to AVIF in dest_dir; return the AVIF filename."""
     if not src.exists():
         return None
-    shutil.copy(src, dest_dir / dest_name)
-    return dest_name
+    avif_name = Path(dest_name).with_suffix(".avif").name
+    with Image.open(src) as img:
+        img.save(dest_dir / avif_name, "AVIF", quality=50, speed=6)
+    return avif_name
 
 
 def collect_tiles(traces_dir: Path, images_dir: Path) -> list[Tile]:

--- a/scripts/tests/test_generate_visual_gallery.py
+++ b/scripts/tests/test_generate_visual_gallery.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from scripts import generate_visual_gallery as gvg
 
 
-def _png(path: Path, payload: bytes = b"\x89PNG\r\n\x1a\n") -> None:
+def _png(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(payload)
+    Image.new("RGB", (4, 4), "red").save(path)
 
 
 def test_collect_tiles_pairs_expected_actual_diff(tmp_path: Path) -> None:
@@ -79,21 +80,24 @@ def test_collect_tiles_keeps_distinct_parents(tmp_path: Path) -> None:
 def test_render_html_includes_all_tiles(tmp_path: Path) -> None:
     tiles = [
         gvg.Tile(
-            label="alpha", expected="a-e.png", actual="a-a.png", diff="a-d.png"
+            label="alpha",
+            expected="a-e.avif",
+            actual="a-a.avif",
+            diff="a-d.avif",
         ),
-        gvg.Tile(label="beta", expected=None, actual="b-a.png", diff=None),
+        gvg.Tile(label="beta", expected=None, actual="b-a.avif", diff=None),
     ]
     page = gvg.render_html(tiles)
 
     assert "2 failing screenshots" in page
     assert "alpha" in page and "beta" in page
-    assert "gallery-images/a-e.png" in page
+    assert "gallery-images/a-e.avif" in page
     assert "not captured" in page  # placeholder for missing files
     assert 'href="report.html"' in page  # link to Playwright report
 
 
 def test_render_html_singular_count() -> None:
-    page = gvg.render_html([gvg.Tile("only", None, "x.png", None)])
+    page = gvg.render_html([gvg.Tile("only", None, "x.avif", None)])
     assert "1 failing screenshot " in page  # no plural "s"
 
 
@@ -160,7 +164,7 @@ def test_main_writes_index_and_gallery(tmp_path: Path) -> None:
     assert (report / "index.html").exists()
     assert (report / "gallery.html").exists()
     assert (report / "report.html").read_text(encoding="utf-8") == "ORIGINAL"
-    assert (report / "gallery-images" / "spec__shot-actual.png").exists()
+    assert (report / "gallery-images" / "spec__shot-actual.avif").exists()
     # Playwright report existed → header link to it is rendered.
     assert 'href="report.html"' in (report / "index.html").read_text(
         encoding="utf-8"
@@ -213,8 +217,7 @@ def test_cli_with_approve_flags(
     report.mkdir()
     # Approve button only renders when there's at least one failing tile, so
     # plant a minimal *-actual.png the gallery generator can pick up.
-    (traces / "shard").mkdir(parents=True)
-    (traces / "shard" / "img-actual.png").write_bytes(b"")
+    _png(traces / "shard" / "img-actual.png")
 
     monkeypatch.setattr(
         sys,
@@ -255,7 +258,7 @@ def test_cli_wrong_arg_count(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_render_html_omits_approve_without_config() -> None:
     """No ApproveConfig → no approve UI rendered."""
-    page = gvg.render_html([gvg.Tile("t", None, "a.png", None)])
+    page = gvg.render_html([gvg.Tile("t", None, "a.avif", None)])
     assert "approve-btn" not in page
     assert "__APPROVE_CFG__" not in page
 
@@ -263,7 +266,7 @@ def test_render_html_omits_approve_without_config() -> None:
 def test_render_html_includes_approve_with_config() -> None:
     """ApproveConfig + at least one tile → approve button + config script."""
     page = gvg.render_html(
-        [gvg.Tile("t", None, "a.png", None)],
+        [gvg.Tile("t", None, "a.avif", None)],
         approve=gvg.ApproveConfig(run_id="123"),
     )
     assert 'id="approve-btn"' in page


### PR DESCRIPTION
## Summary
Updates the visual gallery generation pipeline to convert PNG screenshots to AVIF format, reducing file size while maintaining quality. This improves performance when serving visual regression reports.

## Key changes
- **Image format conversion**: Modified `_copy_if_exists()` to convert PNG files to AVIF using Pillow with quality=50 and speed=6 settings, replacing the previous `shutil.copy()` approach
- **Test updates**: Updated all test fixtures and assertions to expect `.avif` extensions instead of `.png`
- **Test helper refactor**: Simplified `_png()` test helper to use `PIL.Image.new()` instead of raw PNG header bytes, making it more maintainable
- **CI workflow**: Added `install-python: "true"` to the visual-testing setup action and switched to `uv run python` for script invocation, ensuring Python dependencies are available

## Implementation details
- AVIF conversion uses PIL's `Image.open()` and `save()` with AVIF codec, quality=50 for good compression, and speed=6 for reasonable encoding time
- The suffix constants (`ACTUAL_SUFFIX`, `EXPECTED_SUFFIX`, `DIFF_SUFFIX`) remain as `-actual.png` etc. internally; conversion happens at the final copy step
- All gallery image references in HTML output now point to `.avif` files
- Removed `shutil` import as it's no longer needed

https://claude.ai/code/session_01448M76ScULdkmF89n444i4