### PR TITLE
Refactor visual stability wait logic into reusable helper

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -127,6 +127,44 @@ export interface RegressionScreenshotOptions {
   preserveSiblings?: boolean
 }
 
+async function waitForImagesInElement(scope: Locator): Promise<void> {
+  const images = await scope.locator("img").all()
+  await Promise.all(
+    images.map((img) =>
+      img
+        .evaluate((el: HTMLImageElement) =>
+          el.complete
+            ? undefined
+            : new Promise<void>((resolve) => {
+                const timer = setTimeout(resolve, 5000)
+                const done = (): void => {
+                  clearTimeout(timer)
+                  resolve()
+                }
+                el.addEventListener("load", done, { once: true })
+                el.addEventListener("error", done, { once: true })
+              }),
+        )
+        .catch(() => {}),
+    ),
+  )
+}
+
+async function waitForVisualStability(page: Page, scope?: Locator): Promise<void> {
+  await page.evaluate(() => document.fonts.ready)
+  if (scope) {
+    await waitForImagesInElement(scope)
+  } else {
+    await page.waitForLoadState("load")
+  }
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      ),
+  )
+}
+
 /**
  * Takes a regression screenshot of a page or a specific element with given options.
  *
@@ -173,47 +211,7 @@ export async function takeRegressionScreenshot(
   void _elementOpt // prevent unused variable lint error
 
   if (!options?.skipStabilityWait) {
-    await page.evaluate(() => document.fonts.ready)
-    if (options?.elementToScreenshot) {
-      const images = await options.elementToScreenshot.locator("img").all()
-      await Promise.all(
-        images.map((img) =>
-          img
-            .evaluate((el: HTMLImageElement) =>
-              el.complete
-                ? undefined
-                : new Promise<void>((resolve) => {
-                    const timer = setTimeout(resolve, 5000)
-                    el.addEventListener(
-                      "load",
-                      () => {
-                        clearTimeout(timer)
-                        resolve()
-                      },
-                      { once: true },
-                    )
-                    el.addEventListener(
-                      "error",
-                      () => {
-                        clearTimeout(timer)
-                        resolve()
-                      },
-                      { once: true },
-                    )
-                  }),
-            )
-            .catch(() => {}),
-        ),
-      )
-    } else {
-      await page.waitForLoadState("load")
-    }
-    await page.evaluate(
-      () =>
-        new Promise<void>((resolve) =>
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-        ),
-    )
+    await waitForVisualStability(page, options?.elementToScreenshot)
   }
 
   const screenshotOptions = {


### PR DESCRIPTION
## Summary
Extract the visual stability waiting logic from `takeRegressionScreenshot` into two new helper functions (`waitForImagesInElement` and `waitForVisualStability`) to improve code reusability and maintainability.

## Changes
- **New `waitForImagesInElement(scope: Locator)` function**: Waits for all images within a given element to load or error, with a 5-second timeout per image. Handles both `load` and `error` events gracefully.
- **New `waitForVisualStability(page: Page, scope?: Locator)` function**: Orchestrates the full visual stability wait sequence:
  - Waits for document fonts to be ready
  - Optionally waits for images in a scoped element (if provided) or waits for full page load (if not)
  - Waits for two animation frames to ensure layout is stable
- **Refactored `takeRegressionScreenshot`**: Replaced 40 lines of inline stability-wait logic with a single call to `waitForVisualStability`, reducing duplication and improving clarity.

## Implementation Details
- The extracted functions maintain the original behavior exactly: same timeout handling, same event listeners, same animation frame logic
- `waitForImagesInElement` uses `.catch(() => {})` to silently handle any evaluation errors, matching the original pattern
- The refactoring enables future reuse of these helpers in other screenshot or visual testing contexts

https://claude.ai/code/session_01448M76ScULdkmF89n444i4