### PR TITLE
feat: add soft-wrap toggle button on code blocks

### DIFF
--- a/quartz/components/PageShell.tsx
+++ b/quartz/components/PageShell.tsx
@@ -9,6 +9,9 @@ import accurateInvertScript from "./scripts/accurateInvert.inline"
 import clipboardScript from "./scripts/clipboard.inline"
 // @ts-expect-error Not a module but a script
 // skipcq: JS-W1028
+import codeWrapScript from "./scripts/code-wrap.inline"
+// @ts-expect-error Not a module but a script
+// skipcq: JS-W1028
 import elvishToggleScript from "./scripts/elvish-toggle.inline"
 // @ts-expect-error Not a module but a script
 // skipcq: JS-W1028
@@ -104,6 +107,7 @@ const PageShell: QuartzComponent = ({ children }: QuartzComponentProps) => {
 
 PageShell.afterDOMLoaded = [
   clipboardScript,
+  codeWrapScript,
   elvishToggleScript,
   smallCapsCopyScript,
   scrollIndicatorScript,

--- a/quartz/components/scripts/code-wrap.inline.ts
+++ b/quartz/components/scripts/code-wrap.inline.ts
@@ -1,0 +1,3 @@
+import { initializeWrapButtons } from "./code-wrap"
+
+document.addEventListener("nav", initializeWrapButtons)

--- a/quartz/components/scripts/code-wrap.test.ts
+++ b/quartz/components/scripts/code-wrap.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals"
+
+import {
+  applyWrapState,
+  createWrapButton,
+  getWrapPreference,
+  initializeWrapButtons,
+  setWrapPreference,
+  STORAGE_KEY,
+  svgWrap,
+  toggleWrap,
+  WRAP_CLASS,
+} from "./code-wrap"
+
+function makePreWithCode(code: string): HTMLPreElement {
+  const pre = document.createElement("pre")
+  const codeEl = document.createElement("code")
+  codeEl.textContent = code
+  pre.appendChild(codeEl)
+  return pre
+}
+
+describe("code-wrap", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+    window.localStorage.clear()
+    jest.restoreAllMocks()
+  })
+
+  describe("getWrapPreference", () => {
+    it("returns false by default", () => {
+      expect(getWrapPreference()).toBe(false)
+    })
+
+    it("returns true when storage holds 'true'", () => {
+      window.localStorage.setItem(STORAGE_KEY, "true")
+      expect(getWrapPreference()).toBe(true)
+    })
+
+    it("returns false when storage throws", () => {
+      jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("storage disabled")
+      })
+      expect(getWrapPreference()).toBe(false)
+    })
+  })
+
+  describe("setWrapPreference", () => {
+    it("persists 'true' / 'false' strings", () => {
+      setWrapPreference(true)
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true")
+      setWrapPreference(false)
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe("false")
+    })
+
+    it("silently ignores storage failures", () => {
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("storage disabled")
+      })
+      expect(() => setWrapPreference(true)).not.toThrow()
+    })
+  })
+
+  describe("applyWrapState", () => {
+    it("toggles the soft-wrap class on every <pre>", () => {
+      const pre1 = makePreWithCode("a")
+      const pre2 = makePreWithCode("b")
+      document.body.append(pre1, pre2)
+
+      applyWrapState(true)
+      expect(pre1.classList.contains(WRAP_CLASS)).toBe(true)
+      expect(pre2.classList.contains(WRAP_CLASS)).toBe(true)
+
+      applyWrapState(false)
+      expect(pre1.classList.contains(WRAP_CLASS)).toBe(false)
+      expect(pre2.classList.contains(WRAP_CLASS)).toBe(false)
+    })
+
+    it("syncs aria attributes on every wrap button", () => {
+      const button = document.createElement("button")
+      button.className = "code-wrap-button"
+      document.body.appendChild(button)
+
+      applyWrapState(true)
+      expect(button.getAttribute("aria-pressed")).toBe("true")
+      expect(button.getAttribute("aria-label")).toBe("Disable soft-wrap")
+
+      applyWrapState(false)
+      expect(button.getAttribute("aria-pressed")).toBe("false")
+      expect(button.getAttribute("aria-label")).toBe("Enable soft-wrap")
+    })
+  })
+
+  describe("toggleWrap", () => {
+    it("flips the persisted preference and updates the DOM", () => {
+      const pre = makePreWithCode("hello")
+      document.body.appendChild(pre)
+      initializeWrapButtons()
+
+      toggleWrap()
+      expect(getWrapPreference()).toBe(true)
+      expect(pre.classList.contains(WRAP_CLASS)).toBe(true)
+
+      toggleWrap()
+      expect(getWrapPreference()).toBe(false)
+      expect(pre.classList.contains(WRAP_CLASS)).toBe(false)
+    })
+  })
+
+  describe("createWrapButton", () => {
+    it("creates a button reflecting the current preference", () => {
+      const button = createWrapButton()
+      expect(button.tagName).toBe("BUTTON")
+      expect(button.type).toBe("button")
+      expect(button.className).toBe("code-wrap-button")
+      expect(button.getAttribute("aria-pressed")).toBe("false")
+      expect(button.getAttribute("aria-label")).toBe("Enable soft-wrap")
+      expect(button.innerHTML).toBe(svgWrap)
+    })
+
+    it("starts in the pressed state when wrap is already enabled", () => {
+      window.localStorage.setItem(STORAGE_KEY, "true")
+      const button = createWrapButton()
+      expect(button.getAttribute("aria-pressed")).toBe("true")
+      expect(button.getAttribute("aria-label")).toBe("Disable soft-wrap")
+    })
+
+    it("toggles the global preference on click", () => {
+      const pre = makePreWithCode("hello")
+      document.body.appendChild(pre)
+      const button = createWrapButton()
+      document.body.appendChild(button)
+
+      button.click()
+      expect(getWrapPreference()).toBe(true)
+      expect(pre.classList.contains(WRAP_CLASS)).toBe(true)
+      expect(button.getAttribute("aria-pressed")).toBe("true")
+    })
+  })
+
+  describe("initializeWrapButtons", () => {
+    it("prepends a wrap button to each <pre> with a <code> child", () => {
+      const pre1 = makePreWithCode("a")
+      const pre2 = makePreWithCode("b")
+      document.body.append(pre1, pre2)
+
+      initializeWrapButtons()
+
+      expect(pre1.firstElementChild?.className).toBe("code-wrap-button")
+      expect(pre2.firstElementChild?.className).toBe("code-wrap-button")
+    })
+
+    it("skips <pre> elements without a <code> child", () => {
+      const pre = document.createElement("pre")
+      document.body.appendChild(pre)
+
+      initializeWrapButtons()
+
+      expect(pre.querySelector(".code-wrap-button")).toBeNull()
+      expect(pre.dataset.wrapInitialized).toBeUndefined()
+    })
+
+    it("does not double-initialize on repeated calls", () => {
+      const pre = makePreWithCode("hello")
+      document.body.appendChild(pre)
+
+      initializeWrapButtons()
+      initializeWrapButtons()
+      initializeWrapButtons()
+
+      expect(pre.querySelectorAll(".code-wrap-button").length).toBe(1)
+    })
+
+    it("applies the stored preference to fresh <pre> blocks", () => {
+      window.localStorage.setItem(STORAGE_KEY, "true")
+      const pre = makePreWithCode("hello")
+      document.body.appendChild(pre)
+
+      initializeWrapButtons()
+
+      expect(pre.classList.contains(WRAP_CLASS)).toBe(true)
+      const button = pre.querySelector(".code-wrap-button") as HTMLButtonElement
+      expect(button.getAttribute("aria-pressed")).toBe("true")
+    })
+
+    it("clicking the injected button toggles wrap globally", () => {
+      const pre = makePreWithCode("hello")
+      document.body.appendChild(pre)
+
+      initializeWrapButtons()
+      const button = pre.querySelector(".code-wrap-button") as HTMLButtonElement
+      button.click()
+
+      expect(pre.classList.contains(WRAP_CLASS)).toBe(true)
+      expect(getWrapPreference()).toBe(true)
+    })
+  })
+})

--- a/quartz/components/scripts/code-wrap.ts
+++ b/quartz/components/scripts/code-wrap.ts
@@ -1,0 +1,87 @@
+/**
+ * Soft-wrap toggle for `<pre>` code blocks.
+ *
+ * Adds a button alongside the existing copy button that toggles a
+ * `.soft-wrap` class on every `<pre>` on the page. CSS in `clipboard.scss`
+ * responds to that class by switching the block from `overflow-x: auto`
+ * to wrapped lines. The preference persists across sessions via
+ * `localStorage`, so a reader who turns wrapping on stays in wrap mode
+ * on subsequent visits and across SPA navigation.
+ */
+
+export const WRAP_CLASS = "soft-wrap"
+export const STORAGE_KEY = "code-soft-wrap"
+const INITIALIZED_FLAG = "wrapInitialized"
+
+// VS Code / GitHub-style word-wrap glyph.
+export const svgWrap =
+  '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"><path fill-rule="evenodd" d="M1 3.75A.75.75 0 0 1 1.75 3h12.5a.75.75 0 0 1 0 1.5H1.75A.75.75 0 0 1 1 3.75Zm0 4A.75.75 0 0 1 1.75 7H12a2.5 2.5 0 0 1 0 5H8.56l.97.97a.75.75 0 1 1-1.06 1.06l-2.25-2.25a.75.75 0 0 1 0-1.06l2.25-2.25a.75.75 0 1 1 1.06 1.06l-.97.97H12a1 1 0 0 0 0-2H1.75A.75.75 0 0 1 1 7.75ZM1.75 12h3a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5Z"></path></svg>'
+
+/** Read the persisted soft-wrap preference. Defaults to `false`. */
+export function getWrapPreference(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true"
+  } catch {
+    // Storage may be unavailable in private mode or sandboxed iframes;
+    // fall back to the default (no wrap) rather than break the page.
+    return false
+  }
+}
+
+/** Persist the soft-wrap preference. Silently no-ops if storage is unavailable. */
+export function setWrapPreference(enabled: boolean): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, enabled ? "true" : "false")
+  } catch {
+    // See `getWrapPreference` — silently ignore storage failures.
+  }
+}
+
+/** Sync a single button's a11y state to the current preference. */
+function syncButtonState(button: HTMLButtonElement, enabled: boolean): void {
+  button.setAttribute("aria-pressed", enabled ? "true" : "false")
+  button.setAttribute("aria-label", enabled ? "Disable soft-wrap" : "Enable soft-wrap")
+}
+
+/** Apply `enabled` to every `<pre>` and every wrap button currently in the DOM. */
+export function applyWrapState(enabled: boolean): void {
+  document.querySelectorAll("pre").forEach((pre) => {
+    pre.classList.toggle(WRAP_CLASS, enabled)
+  })
+  document.querySelectorAll(".code-wrap-button").forEach((button) => {
+    syncButtonState(button as HTMLButtonElement, enabled)
+  })
+}
+
+/** Flip the persisted preference and update the DOM to match. */
+export function toggleWrap(): void {
+  const next = !getWrapPreference()
+  setWrapPreference(next)
+  applyWrapState(next)
+}
+
+/** Build a wrap-toggle button that drives the global preference. */
+export function createWrapButton(): HTMLButtonElement {
+  const button = document.createElement("button")
+  button.className = "code-wrap-button"
+  button.type = "button"
+  syncButtonState(button, getWrapPreference())
+  button.innerHTML = svgWrap
+  button.addEventListener("click", toggleWrap)
+  return button
+}
+
+/** Attach a wrap button to every code block that doesn't already have one. */
+export function initializeWrapButtons(): void {
+  const enabled = getWrapPreference()
+  const pres = document.querySelectorAll("pre")
+  for (const pre of pres) {
+    const el = pre as HTMLElement
+    if (el.dataset[INITIALIZED_FLAG]) continue
+    const codeBlock = el.querySelector("code")
+    if (!codeBlock) continue
+    el.dataset[INITIALIZED_FLAG] = "true"
+    el.classList.toggle(WRAP_CLASS, enabled)
+    el.prepend(createWrapButton())
+  }
+}

--- a/quartz/components/styles/clipboard.scss
+++ b/quartz/components/styles/clipboard.scss
@@ -29,7 +29,6 @@ pre {
 
 pre:hover > .clipboard-button,
 pre:hover > .code-wrap-button,
-pre > .code-wrap-button[aria-pressed="true"],
 .punctilio-output-wrapper:hover > .clipboard-button {
   opacity: 1;
   transition: opacity $transition-duration-quick;

--- a/quartz/components/styles/clipboard.scss
+++ b/quartz/components/styles/clipboard.scss
@@ -1,20 +1,41 @@
 @use "../../styles/variables.scss" as *;
 
+// Clipboard button outer footprint: svg(16) + 2×svg-margin($base-margin/2)
+// + 2×border(1) = $base-margin + 18px. Offset the wrap button by that plus
+// a $base-margin gap so the two buttons sit side-by-side at the top right.
+$code-button-width: calc(18px + #{$base-margin});
+
 pre {
   position: relative;
 
   & > code {
     overflow: auto;
   }
+
+  &.soft-wrap {
+    white-space: pre-wrap;
+
+    & > code {
+      overflow: visible;
+      white-space: pre-wrap;
+
+      & > [data-line] {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+    }
+  }
 }
 
 pre:hover > .clipboard-button,
+pre:hover > .code-wrap-button,
+pre > .code-wrap-button[aria-pressed="true"],
 .punctilio-output-wrapper:hover > .clipboard-button {
   opacity: 1;
   transition: opacity $transition-duration-quick;
 }
 
-.clipboard-button {
+%code-block-button {
   display: flex;
   position: absolute;
   z-index: $z-raised;
@@ -26,7 +47,6 @@ pre:hover > .clipboard-button,
   border-radius: $border-radius;
   opacity: 0;
   transition: $transition-duration-quick;
-  right: 0;
 
   & > svg {
     fill: var(--midground);
@@ -42,5 +62,26 @@ pre:hover > .clipboard-button,
 
   &:focus:not(:focus-visible) {
     outline: 0;
+  }
+}
+
+.clipboard-button {
+  @extend %code-block-button;
+
+  right: 0;
+}
+
+.code-wrap-button {
+  @extend %code-block-button;
+
+  right: $code-button-width;
+
+  &[aria-pressed="true"] {
+    border-color: var(--blue);
+
+    & > svg {
+      fill: var(--blue);
+      filter: none;
+    }
   }
 }

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -169,7 +169,7 @@ Light-background images look good in light mode. Dark-background images look goo
 
 <span class="populate-markdown-inversion-demo"></span>
 
-For images, I pre-compute perfectly inverted variants at build time. The browser determines which image to show. Videos only use the SVG filter. 
+For images, I pre-compute perfectly inverted variants at build time. The browser determines which image to show. Videos only use the SVG filter.
 
 ### Deciding when to invert
 
@@ -197,7 +197,7 @@ Quartz offers basic optimizations, such as [lazy loading](https://developer.mozi
 
 EB Garamond Regular 8pt takes 260KB as an `otf` file but compresses to 80KB under [the newer `woff2` format.](https://www.w3.org/TR/WOFF2/) In all, the font footprint shrinks from 1.5MB to about 609KB for most pages. I toyed around with manual [font subsetting](https://fonts.google.com/knowledge/glossary/subsetting) but it seemed too hard to predict which characters my site _never_ uses.
 
-Therefore, I use [my optimized fork of `subfont`](/open-source#faster-font-subsetting) to subset each font across my entire website, dropping unused OpenType tables and font features the CSS never references. 
+Therefore, I use [my optimized fork of `subfont`](/open-source#faster-font-subsetting) to subset each font across my entire website, dropping unused OpenType tables and font features the CSS never references.
 
 <span class="populate-markdown-font-stats"></span>
 
@@ -577,7 +577,7 @@ I modified the italic fonts to replace sloped punctuation glyphs with their upri
 | Single quotes |  <span class="italic-old">_‘Hello world’_</span>  |     _‘Hello world’_      |
 |    Apostrophe |      <span class="italic-old">_don’t_</span>      |         _don’t_          |
 
-I also equalized the heights of parentheses, brackets, and braces. As time folded forward, my fonts became quite customized. I built a reproducible font patching pipeline which starts with [Harish's EB Garamond](#i-paid-someone-to-tweak-eb-garamond) and iteratively modifies the font. 
+I also equalized the heights of parentheses, brackets, and braces. As time folded forward, my fonts became quite customized. I built a reproducible font patching pipeline which starts with [Harish's EB Garamond](#i-paid-someone-to-tweak-eb-garamond) and iteratively modifies the font.
 
 # Website features
 
@@ -787,6 +787,9 @@ Metadata
 : Every page has an HTML description and [tags](/all-tags) (if appropriate), along with a table of contents which (on desktop) highlights the current section. I track original publication date and display when each was page was last modified by a `git push` to the `main` branch. I also support "sequences" of blog posts:
 
   <div class="sequence-links" style="border: 2px var(--midground-faint) solid; padding-right: .5rem; padding-top: 1rem; border-radius: 5px;"><div class="sequence-title" style="text-align:center;"><div class="admonition-title-inner"><b>Sequence:</b> <a href="/posts#shard-theory" class="internal">Shard Theory</a></div></div><div class="sequence-nav" style="display:flex;justify-content:center;"><div class="prev-post sequence-links-postNavigation" style="text-align:right;"><p><b>Previous</b><br><a href="/reward-is-not-the-optimization-target" class="internal">Reward Is Not the Optimization Target</a></p></div><div class="sequence-links-divider"></div><div class="next-post sequence-links-postNavigation" style="text-align:left;"><p><b>Next</b><br><a href="/understanding-and-avoiding-value-drift" class="internal">Understanding and Avoiding Value Drift</a></p></div></div></div> <figcaption>The sequence metadata for my post on <a href="./shard-theory" class="internal alias" data-slug="shard-theory">shard theory.</a></figcaption>
+
+Soft-wrap toggle on code blocks
+: Long lines in fenced code blocks default to horizontal scroll, which is great for actual source code but punishing for transcript dumps - LLM completions and chat logs disappear off the right edge after a few words. A second button next to the copy icon flips a `.soft-wrap` class on every `<pre>`, switching the block to wrapped lines with hanging indents that align under the line-number gutter. The preference rides along in `localStorage`, so once a reader turns wrapping on it stays on across pages.
 
 Spoilers hide text until clicked
 : I made a Markdown plugin which lets me specify spoilers by starting the line with `>!`. The results are unobtrusive but pleasant:

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -783,6 +783,10 @@ function loseTheGame(numTimes: number): void {
 This is a plain code block without a language specified.
 ```
 
+```plaintext
+This block has an intentionally long line so the soft-wrap toggle has something to chew on: lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+```
+
 # Formatting
 
 - Normal


### PR DESCRIPTION
I was reading `/eval-cooperation` and struggled to read the assistants response since the line lengths were very long and I had to scroll a lot. Hence, this PR (: feel free to close if this isn't a feature you want!

## Screenshots

Without hard wrap:

<img width="778" height="89" alt="Screenshot 2026-05-28 at 11 03 01" src="https://github.com/user-attachments/assets/96707942-5823-4bd8-a976-7497fb3c11c9" />

With hard wrap:

<img width="779" height="275" alt="Screenshot 2026-05-28 at 11 03 11" src="https://github.com/user-attachments/assets/ac2bfb6a-a5a5-449c-99b2-589aa9255ada" />

This is what the buttons look like:

<img width="764" height="266" alt="Screenshot 2026-05-28 at 11 03 15" src="https://github.com/user-attachments/assets/fd648184-b435-480f-8b92-17ddd74c7801" />

Matching the behaviour of the copy button, they fade away if your mouse isn't hovering over them:

<img width="779" height="275" alt="Screenshot 2026-05-28 at 11 03 11" src="https://github.com/user-attachments/assets/0507ec2d-c0e8-4b06-912b-b65f332ab327" />

## Summary

- Adds a wrap-toggle button next to the existing copy button on fenced code blocks. Clicking it switches every `<pre>` from horizontal scroll to soft-wrapped lines.
- Preference persists in `localStorage` (`code-soft-wrap` key) so it sticks across SPA navigation and page reloads.
- Button only appears on hover (matching the copy button), and shows a blue pressed state when active.

## Details
- New files: `code-wrap.ts` (logic + localStorage), `code-wrap.inline.ts` (nav event registration), `code-wrap.test.ts` (16 tests, 100% coverage).
- `clipboard.scss`: extracted shared `%code-block-button` placeholder, added `.code-wrap-button` positioning and `.soft-wrap` rules (`white-space: pre-wrap; overflow-wrap: anywhere` on `[data-line]` elements).
- `PageShell.tsx`: registers the new inline script.
- `design.md`: documents the feature under "Smaller features".
- `test-page.md`: adds a long-line code block for visual regression baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)