### PR TITLE
fix: bugs, perf issues, and code quality from codebase audit

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: public/
-          key: site-build-${{ github.sha }}
+          key: site-build-${{ github.sha }}-fixtures-false
           fail-on-cache-miss: true
 
       - name: Start server

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -38,7 +38,12 @@ export function RenderPublicationInfo(
 
   const originalUrl = frontmatter?.original_url
   if (typeof originalUrl === "string") {
-    const url = new URL(originalUrl)
+    let url: URL
+    try {
+      url = new URL(originalUrl)
+    } catch {
+      throw new Error(`Invalid original_url in frontmatter: ${originalUrl}`)
+    }
 
     return (
       <span className="publication-str">
@@ -142,7 +147,12 @@ export const renderLinkpostInfo = (fileData: QuartzPluginData): JSX.Element | nu
   const linkpostUrl = fileData.frontmatter?.["lw-linkpost-url"]
   if (typeof linkpostUrl !== "string") return null
 
-  const url = new URL(linkpostUrl)
+  let url: URL
+  try {
+    url = new URL(linkpostUrl)
+  } catch {
+    throw new Error(`Invalid lw-linkpost-url in frontmatter: ${linkpostUrl}`)
+  }
   const displayText = url.hostname.replace(/^(?:https?:\/\/)?(?:www\.)?/, "")
 
   return (

--- a/quartz/components/scripts/clipboard.inline.ts
+++ b/quartz/components/scripts/clipboard.inline.ts
@@ -3,6 +3,7 @@ import { setupCopyButton } from "./component_script_utils"
 document.addEventListener("nav", () => {
   const els = document.getElementsByTagName("pre")
   for (const element of els) {
+    if (element.querySelector(".clipboard-button")) continue
     const codeBlock = element.getElementsByTagName("code")[0]
     if (codeBlock) {
       const button = document.createElement("button")

--- a/quartz/components/scripts/component_script_utils.test.ts
+++ b/quartz/components/scripts/component_script_utils.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals"
 
 import {
-  animate,
   debounce,
   registerEscapeHandler,
   removeAllChildren,
@@ -381,129 +380,6 @@ describe("removeAllChildren", () => {
   })
 })
 
-describe("animate", () => {
-  beforeEach(() => {
-    global.cancelAnimationFrame = jest.fn()
-  })
-
-  it("should call onFrame with progress values from 0 to 1", () => {
-    const onFrame = jest.fn()
-    const duration = 100
-    const startTime = performance.now()
-
-    animate(duration, onFrame)
-
-    // Simulate first frame at start
-    jest.advanceTimersByTime(frameTime)
-    expect(onFrame).toHaveBeenCalledWith(0)
-
-    // Simulate middle frame at 50ms
-    jest.setSystemTime(startTime + 50)
-    jest.advanceTimersByTime(frameTime)
-    expect(onFrame).toHaveBeenCalledWith(0.5)
-
-    // Simulate final frame after duration
-    jest.setSystemTime(startTime + 100)
-    jest.advanceTimersByTime(frameTime)
-    expect(onFrame).toHaveBeenLastCalledWith(1)
-  })
-
-  it("should call onComplete when animation finishes", () => {
-    const onComplete = jest.fn()
-    const duration = 100
-    const startTime = performance.now()
-
-    animate(
-      duration,
-      () => {
-        // Empty update callback - testing only the completion callback behavior
-      },
-      onComplete,
-    )
-
-    // Advance to just after duration and trigger the callback
-    jest.setSystemTime(startTime + 100)
-    jest.advanceTimersByTime(frameTime)
-    // Run any pending timers to ensure the rAF callback executes
-    jest.runAllTimers()
-    expect(onComplete).toHaveBeenCalledTimes(1)
-  })
-
-  it("should cancel animation when cleanup is called", () => {
-    const onFrame = jest.fn()
-    const onComplete = jest.fn()
-    const duration = 100
-
-    const cleanup = animate(duration, onFrame, onComplete)
-
-    cleanup()
-
-    jest.advanceTimersByTime(100)
-    expect(global.cancelAnimationFrame).toHaveBeenCalled()
-    expect(onComplete).not.toHaveBeenCalled()
-  })
-
-  it("should not call onComplete if animation is cancelled", () => {
-    const onComplete = jest.fn()
-    const duration = 100
-
-    const cleanup = animate(
-      duration,
-      () => {
-        // Empty update callback - testing animation cancellation behavior
-      },
-      onComplete,
-    )
-
-    // Cancel halfway through
-    jest.advanceTimersByTime(50)
-    cleanup()
-
-    // Advance past duration
-    jest.advanceTimersByTime(50)
-    expect(onComplete).not.toHaveBeenCalled()
-  })
-
-  it("should handle zero duration", () => {
-    const onFrame = jest.fn()
-    const onComplete = jest.fn()
-
-    animate(0, onFrame, onComplete)
-
-    // Simulate first frame and run the callback
-    jest.advanceTimersByTime(frameTime)
-    jest.runAllTimers()
-    expect(onFrame).toHaveBeenCalledWith(1)
-    expect(onComplete).toHaveBeenCalled()
-  })
-
-  it("should handle zero duration cleanup function", () => {
-    const onFrame = jest.fn()
-    const onComplete = jest.fn()
-
-    const cleanup = animate(0, onFrame, onComplete)
-
-    // Try to clean up after zero duration - should work but do nothing
-    cleanup()
-
-    expect(onFrame).toHaveBeenCalledWith(1)
-    expect(onComplete).toHaveBeenCalled()
-  })
-
-  it("should handle negative duration", () => {
-    const onFrame = jest.fn()
-    const onComplete = jest.fn()
-
-    const cleanup = animate(-10, onFrame, onComplete)
-
-    expect(onFrame).toHaveBeenCalledWith(1)
-    expect(onComplete).toHaveBeenCalled()
-
-    // Cleanup should still work
-    cleanup()
-  })
-})
-
 describe("setupCopyButton", () => {
   let button: HTMLButtonElement
   let mockClipboard: { writeText: jest.Mock }
@@ -533,7 +409,7 @@ describe("setupCopyButton", () => {
     button.click()
     await Promise.resolve()
 
-    // Advance past the 2000ms animate duration
+    // Advance past the 2000ms setTimeout delay
     jest.advanceTimersByTime(2000 + frameTime)
     expect(button.innerHTML).toBe(svgCopy)
   })

--- a/quartz/components/scripts/component_script_utils.ts
+++ b/quartz/components/scripts/component_script_utils.ts
@@ -226,16 +226,10 @@ export function setupCopyButton(
         () => {
           button.blur()
           button.innerHTML = svgCheck
-          animate(
-            2000,
-            () => {
-              // No per-frame updates needed, only completion callback to restore button state
-            },
-            () => {
-              button.innerHTML = svgCopy
-              button.style.borderColor = ""
-            },
-          )
+          setTimeout(() => {
+            button.innerHTML = svgCopy
+            button.style.borderColor = ""
+          }, 2000)
         },
         (error) => console.error(error),
       )

--- a/quartz/components/scripts/component_script_utils.ts
+++ b/quartz/components/scripts/component_script_utils.ts
@@ -156,60 +156,6 @@ export const svgCheck =
   '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"><path fill-rule="evenodd" fill="rgb(63, 185, 80)" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>'
 
 /**
- * Helper function to handle requestAnimationFrame-based animations
- * @param duration Duration of the animation in milliseconds
- * @param onFrame Callback function called on each animation frame with progress (0 to 1)
- * @param onComplete Optional callback function called when animation completes
- * @returns Cleanup function to cancel the animation
- */
-export function animate(
-  duration: number,
-  onFrame: (progress: number) => void,
-  onComplete?: () => void,
-): () => void {
-  if (duration <= 0) {
-    onFrame(1)
-    onComplete?.()
-    return () => undefined
-  }
-
-  let start: number | null = null
-  let rafId: number | null = null
-
-  /**
-   * Internal frame callback that executes on each animation frame.
-   * Calculates progress, calls the user's onFrame callback, and handles
-   * animation continuation or completion.
-   *
-   * @param timestamp - Current timestamp from requestAnimationFrame
-   */
-  const frame = (timestamp: number) => {
-    if (!start) start = timestamp
-    const elapsed = timestamp - start
-    const progress = Math.min(elapsed / duration, 1)
-
-    onFrame(progress)
-
-    if (progress < 1) {
-      rafId = requestAnimationFrame(frame)
-    } else {
-      onComplete?.()
-    }
-  }
-
-  rafId = requestAnimationFrame(frame)
-
-  // Return cleanup function
-  return () => {
-    /* istanbul ignore next -- defensive null check for rAF cleanup */
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId)
-      rafId = null
-    }
-  }
-}
-
-/**
  * Sets up a clipboard copy button with icon swap animation.
  * Shared between code block copy buttons and the punctilio demo.
  */

--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -1,25 +1,35 @@
-function setupMobileTocClickDelegation(): void {
+let tocAbortController: AbortController | null = null
+
+function setupMobileTocClickDelegation(signal: AbortSignal): void {
   const mobileToc = document.getElementById("toc-content-mobile")
   if (!mobileToc) return
 
-  mobileToc.addEventListener("click", (e: MouseEvent) => {
-    const target = e.target as HTMLElement
-    if (target.tagName === "LI") {
-      const link = target.querySelector<HTMLAnchorElement>(":scope > a")
-      if (link) link.click()
-    }
-  })
+  mobileToc.addEventListener(
+    "click",
+    (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (target.tagName === "LI") {
+        const link = target.querySelector<HTMLAnchorElement>(":scope > a")
+        if (link) link.click()
+      }
+    },
+    { signal },
+  )
 }
 
-function setupTocTitleScrollToTop(): void {
+function setupTocTitleScrollToTop(signal: AbortSignal): void {
   const tocTitleButton = document.querySelector("#toc-title button")
   if (!tocTitleButton) return
 
-  tocTitleButton.addEventListener("click", () => {
-    const url = new URL(window.location.pathname, window.location.origin)
-    window.spaNavigate(url)
-    window.scrollTo({ top: 0, behavior: "instant" })
-  })
+  tocTitleButton.addEventListener(
+    "click",
+    () => {
+      const url = new URL(window.location.pathname, window.location.origin)
+      window.spaNavigate(url)
+      window.scrollTo({ top: 0, behavior: "instant" })
+    },
+    { signal },
+  )
 }
 
 function setupTocActiveHighlighting(): void {
@@ -89,7 +99,11 @@ function setupTocActiveHighlighting(): void {
 }
 
 document.addEventListener("nav", () => {
-  setupMobileTocClickDelegation()
-  setupTocTitleScrollToTop()
+  tocAbortController?.abort()
+  tocAbortController = new AbortController()
+  const { signal } = tocAbortController
+
+  setupMobileTocClickDelegation(signal)
+  setupTocTitleScrollToTop(signal)
   setupTocActiveHighlighting()
 })

--- a/quartz/components/styles/popover.scss
+++ b/quartz/components/styles/popover.scss
@@ -45,7 +45,7 @@
     font-size: var(--font-size-minus-1);
     font-family: EBGaramond, var(--font-main);
 
-    & h1,
+    h1,
     h2,
     h3,
     h4,

--- a/quartz/components/styles/punctilioDemo.scss
+++ b/quartz/components/styles/punctilioDemo.scss
@@ -56,7 +56,7 @@ $panel-min-height: 200px;
 
     &:focus {
       outline: none;
-      border-color: var(--link);
+      border-color: var(--color-link);
     }
   }
 

--- a/quartz/components/styles/punctilioDemo.scss
+++ b/quartz/components/styles/punctilioDemo.scss
@@ -56,6 +56,7 @@ $panel-min-height: 200px;
 
     &:focus {
       outline: none;
+      border-color: var(--link);
     }
   }
 

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -17,7 +17,7 @@ const filesToCopy = async (argv: Argv, cfg: QuartzConfig) => {
   ])
 }
 
-const assetExtensions: readonly string[] = ["webm", "mp4", "png", "jpg", "jpeg", "svg"]
+const assetExtensions: readonly string[] = [".webm", ".mp4", ".png", ".jpg", ".jpeg", ".svg"]
 export const Assets: QuartzEmitterPlugin = () => {
   return {
     name: "Assets",

--- a/quartz/plugins/transformers/color_variables.ts
+++ b/quartz/plugins/transformers/color_variables.ts
@@ -37,17 +37,31 @@ const colorMapping: Readonly<Record<string, string>> = {
 
 const placeholderRestoreRegex = /___VAR_PLACEHOLDER_(?<index>\d+)___/g
 
+function compileColorPatterns(
+  mapping: Readonly<Record<string, string>>,
+): readonly { regex: RegExp; variable: string }[] {
+  return Object.entries(mapping).map(([color, variable]) => ({
+    regex: new RegExp(`\\b${color}\\b`, "gi"),
+    variable,
+  }))
+}
+
+const defaultCompiledPatterns = compileColorPatterns(colorMapping)
+
 /**
  * Transforms a CSS style string by replacing color values with corresponding CSS variables.
  *
  * @param style - The CSS style string to transform.
- * @param colorMapping - An object mapping color values to CSS variable names.
+ * @param mapping - An object mapping color values to CSS variable names.
  * @returns The transformed CSS style string with color values replaced by CSS variables.
  */
 export const transformStyle = (
   style: string,
-  colorMapping: Readonly<Record<string, string>>,
+  mapping: Readonly<Record<string, string>>,
 ): string => {
+  const patterns =
+    mapping === colorMapping ? defaultCompiledPatterns : compileColorPatterns(mapping)
+
   // Extract all var() expressions to protect them from transformation
   const varExpressions: string[] = []
   const placeholder = "___VAR_PLACEHOLDER_"
@@ -58,8 +72,8 @@ export const transformStyle = (
   })
 
   // Transform colors in the remaining style string
-  for (const [color, variable] of Object.entries(colorMapping)) {
-    newStyle = newStyle.replace(new RegExp(`\\b${color}\\b`, "gi"), variable)
+  for (const { regex, variable } of patterns) {
+    newStyle = newStyle.replace(regex, variable)
   }
 
   // Restore var() expressions

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -17,7 +17,6 @@ import type { ElementMaybeWithParent } from "./utils"
 import {
   charsToMoveIntoLinkFromRight,
   hatTipPlaceholder,
-  HEADING_TAGS,
   LEFT_SINGLE_QUOTE,
   markerChar,
   NBSP,
@@ -25,6 +24,7 @@ import {
   STRIP_BOUNDARY_TAGS,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
+import { isHeading } from "./favicons"
 import { fractionRegex, hasAncestor, hasClass, isCode, replaceRegex, urlRegex } from "./utils"
 
 /**
@@ -339,10 +339,6 @@ export function formatArrows(tree: Root): void {
       "span.right-arrow",
     )
   })
-}
-
-function isHeading(node: Element): boolean {
-  return HEADING_TAGS.has(node.tagName)
 }
 
 // Display-heading elements: text that's styled like a heading and wraps

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -8,6 +8,8 @@ import type { QuartzTransformerPlugin } from "../types"
 import { NBSP } from "../../components/constants"
 import { mdLinkRegex } from "./utils"
 
+const nbspCleanupRegex = new RegExp(`(?:${NBSP}|&nbsp;)`, "gu")
+
 // Regular expression for footnotes not followed by a colon (definition) or opening parenthesis (md URL)
 const footnoteSpacingRegex = /(?<content>\S) (?<footnote>\[\^[^\]]+\])(?![:(]) ?/g
 const footnoteSpacingReplacement = "$<content>$<footnote> "
@@ -144,7 +146,7 @@ export const formattingImprovement = (text: string) => {
   }
 
   // Format the content (non-YAML part)
-  let newContent = content.replaceAll(new RegExp(`(?:${NBSP}|&nbsp;)`, "gu"), " ") // Remove NBSP
+  let newContent = content.replaceAll(nbspCleanupRegex, " ")
 
   newContent = improveFootnoteFormatting(newContent)
   newContent = newContent.replace(/ *,/g, ",") // Remove space before commas

--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -64,7 +64,7 @@ export function findFootnoteBackArrow(footnoteNode: Element): Element | null {
 
 // See footnoteBacklinkPlugin for usage
 export function appendArrowToFootnoteListItemVisitor(node: Element) {
-  if (node && isFootnoteListItem(node)) {
+  if (isFootnoteListItem(node)) {
     const backArrow = findFootnoteBackArrow(node)
     if (backArrow) {
       maybeSpliceAndAppendBackArrow(node, backArrow)

--- a/quartz/plugins/transformers/gfm.ts
+++ b/quartz/plugins/transformers/gfm.ts
@@ -11,6 +11,7 @@ import smartypants from "remark-smartypants"
 import { visit } from "unist-util-visit"
 
 import { QuartzTransformerPlugin } from "../types"
+import { isFootnoteListItem } from "./fixFootnotes"
 import { spliceAndWrapLastChars } from "./utils"
 
 export interface Options {
@@ -21,17 +22,6 @@ export interface Options {
 const defaultOptions: Options = {
   enableSmartyPants: true,
   linkHeadings: true,
-}
-
-/**
- * Checks if an element is a footnote list item.
- *
- * Footnotes are rendered as `<li>` elements with IDs that start with "user-content-fn".
- */
-export function isFootnoteListItem(node: Element): boolean {
-  return (
-    node?.tagName === "li" && Boolean(node.properties?.id?.toString().startsWith("user-content-fn"))
-  )
 }
 
 /**
@@ -74,7 +64,7 @@ export function findFootnoteBackArrow(footnoteNode: Element): Element | null {
 
 // See footnoteBacklinkPlugin for usage
 export function appendArrowToFootnoteListItemVisitor(node: Element) {
-  if (isFootnoteListItem(node)) {
+  if (node && isFootnoteListItem(node)) {
     const backArrow = findFootnoteBackArrow(node)
     if (backArrow) {
       maybeSpliceAndAppendBackArrow(node, backArrow)
@@ -437,13 +427,10 @@ export const GitHubFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> | 
 const slugger = new GithubSlugger()
 
 /** Normalizes heading text before slugging: converts apostrophes, slashes, dashes, and `&` to `-`. */
-export function preprocessSlug(headerText: string): string {
-  const charsToConvert = ["'", "’", "/", "&", "—", "‘"]
+const slugCharsToConvertRegex = /['‘’/&—]/g
 
-  let protoSlug = headerText
-  for (const char of charsToConvert) {
-    protoSlug = protoSlug.replaceAll(new RegExp(char, "g"), "-")
-  }
+export function preprocessSlug(headerText: string): string {
+  let protoSlug = headerText.replaceAll(slugCharsToConvertRegex, "-")
 
   // Remove consecutive hyphens
   protoSlug = protoSlug.replaceAll(/-+/g, "-")

--- a/quartz/plugins/transformers/tests/afterArticle.test.ts
+++ b/quartz/plugins/transformers/tests/afterArticle.test.ts
@@ -5,7 +5,9 @@ import { h } from "hastscript"
 import { VFile } from "vfile"
 
 import { BuildCtx } from "../../../util/ctx"
-import { ornamentNode } from "../trout_hr"
+import { createOrnamentNode } from "../trout_hr"
+
+const ornamentNode = createOrnamentNode()
 
 jest.mock("../sequenceLinks", () => ({
   createSequenceLinksComponent: jest.fn(() => null),

--- a/quartz/plugins/transformers/tests/gfm.test.ts
+++ b/quartz/plugins/transformers/tests/gfm.test.ts
@@ -5,6 +5,7 @@ import { h } from "hastscript"
 import type { BuildCtx } from "../../../util/ctx"
 
 import { QuartzConfig } from "../../../util/ctx"
+import { isFootnoteListItem } from "../fixFootnotes"
 import {
   adoptPrecedingSiblingAsDt,
   appendArrowToFootnoteListItemVisitor,
@@ -12,7 +13,6 @@ import {
   findFootnoteBackArrow,
   GitHubFlavoredMarkdown,
   htmlAccessibilityPlugin,
-  isFootnoteListItem,
   isValidDlStructure,
   maybeSpliceAndAppendBackArrow,
   optimizeMermaidSvgs,

--- a/quartz/plugins/transformers/tests/gfm.test.ts
+++ b/quartz/plugins/transformers/tests/gfm.test.ts
@@ -5,7 +5,6 @@ import { h } from "hastscript"
 import type { BuildCtx } from "../../../util/ctx"
 
 import { QuartzConfig } from "../../../util/ctx"
-import { isFootnoteListItem } from "../fixFootnotes"
 import {
   adoptPrecedingSiblingAsDt,
   appendArrowToFootnoteListItemVisitor,
@@ -502,31 +501,6 @@ describe("GitHubFlavoredMarkdown plugin", () => {
   })
 })
 
-describe("isFootnoteListItem function", () => {
-  it.each([
-    [
-      "footnote list item with id fn-1",
-      () => h("li", { id: "user-content-fn-1" }, ["Footnote text"]),
-      true,
-    ],
-    [
-      "footnote list item with id fn-42",
-      () => h("li", { id: "user-content-fn-42" }, ["Footnote text"]),
-      true,
-    ],
-    ["non-footnote list item", () => h("li", ["Regular list item"]), false],
-    ["list item with wrong id", () => h("li", { id: "some-other-id" }, ["List item"]), false],
-    [
-      "non-list element with footnote id",
-      () => h("p", { id: "user-content-fn-1" }, ["Not a list item"]),
-      false,
-    ],
-    ["list item without id", () => h("li", ["List item without id"]), false],
-  ])("should handle %s", (_desc: string, createElement: () => Element, expected: boolean) => {
-    expect(isFootnoteListItem(createElement())).toBe(expected)
-  })
-})
-
 describe("findFootnoteBackArrow function", () => {
   test("should find back arrow in footnote", () => {
     const backArrow = h("a", { className: "data-footnote-backref" }, ["↩"])
@@ -604,13 +578,6 @@ describe("findFootnoteBackArrow function", () => {
 })
 
 describe("gfmVisitor function", () => {
-  test("should handle undefined node gracefully", () => {
-    // Should not throw an error when called with undefined
-    expect(() => {
-      appendArrowToFootnoteListItemVisitor(undefined as unknown as Element)
-    }).not.toThrow()
-  })
-
   test("should process footnote with back arrow", () => {
     const backArrow = h("a", { className: "data-footnote-backref" }, ["↩"])
     const footnoteItem = h("li", { id: "user-content-fn-1" }, [

--- a/quartz/plugins/transformers/tests/sequenceLinks.test.ts
+++ b/quartz/plugins/transformers/tests/sequenceLinks.test.ts
@@ -13,7 +13,9 @@ import {
   renderPreviousPost,
   renderSequenceTitle,
 } from "../sequenceLinks"
-import { ornamentNode } from "../trout_hr"
+import { createOrnamentNode } from "../trout_hr"
+
+const ornamentNode = createOrnamentNode()
 
 describe("renderSequenceTitle", () => {
   it.each([

--- a/quartz/plugins/transformers/tests/trout_hr.test.ts
+++ b/quartz/plugins/transformers/tests/trout_hr.test.ts
@@ -7,11 +7,18 @@ import { beforeEach, describe, expect, it } from "@jest/globals"
 import { h } from "hastscript"
 
 import { BuildCtx } from "../../../util/ctx"
-import { insertOrnamentNode, maybeInsertOrnament, ornamentNode, TroutOrnamentHr } from "../trout_hr"
+import {
+  createOrnamentNode,
+  insertOrnamentNode,
+  maybeInsertOrnament,
+  TroutOrnamentHr,
+} from "../trout_hr"
 
-describe("ornamentNode", () => {
+const ornamentNode = createOrnamentNode()
+
+describe("createOrnamentNode", () => {
   it("should have role='separator' for accessibility", () => {
-    expect(ornamentNode.properties.role).toBe("separator")
+    expect(createOrnamentNode().properties.role).toBe("separator")
   })
 })
 

--- a/quartz/plugins/transformers/trout_hr.ts
+++ b/quartz/plugins/transformers/trout_hr.ts
@@ -10,17 +10,19 @@ export const troutContainerId = "trout-ornament-container"
 
 import { h } from "hastscript"
 
-export const ornamentNode: Element = h("div", { id: troutContainerId, role: "separator" }, [
-  h("span", { class: "no-select", "aria-hidden": "true" }, "☙"),
-  h("img", {
-    src: specialFaviconPaths.turntrout,
-    alt: "",
-    class: "no-select",
-    loading: "lazy",
-    "aria-hidden": "true",
-  }),
-  h("span", { class: "no-select", "aria-hidden": "true" }, "❧"),
-])
+export function createOrnamentNode(): Element {
+  return h("div", { id: troutContainerId, role: "separator" }, [
+    h("span", { class: "no-select", "aria-hidden": "true" }, "☙"),
+    h("img", {
+      src: specialFaviconPaths.turntrout,
+      alt: "",
+      class: "no-select",
+      loading: "lazy",
+      "aria-hidden": "true",
+    }),
+    h("span", { class: "no-select", "aria-hidden": "true" }, "❧"),
+  ])
+}
 
 /**
  * Attempts to insert an ornament node before a heading that starts with "Appendix" or before footnotes.
@@ -44,7 +46,7 @@ export function maybeInsertOrnament(
 
     // Check direct text children
     if (node.children[0]?.type === "text" && startsWithAppendix(node.children[0].value)) {
-      parent.children.splice(index, 0, ornamentNode)
+      parent.children.splice(index, 0, createOrnamentNode())
       return true
     }
 
@@ -56,7 +58,7 @@ export function maybeInsertOrnament(
       const anchorStartsWithAppendix =
         anchorText?.type === "text" && startsWithAppendix(anchorText.value)
       if (anchorStartsWithAppendix) {
-        parent.children.splice(index, 0, ornamentNode)
+        parent.children.splice(index, 0, createOrnamentNode())
         return true
       }
     }
@@ -91,7 +93,7 @@ export function maybeInsertOrnament(
     }
 
     // If it is, insert the ornament node before the footnotes section
-    parent.children.splice(index, 0, ornamentNode)
+    parent.children.splice(index, 0, createOrnamentNode())
     return true // Indicate that the ornament was inserted
   }
   return false // Indicate that no ornament was inserted
@@ -117,7 +119,7 @@ export function insertOrnamentNode(tree: Root): void {
       tree.children.pop()
     }
     // Add the ornament node
-    tree.children.push(ornamentNode)
+    tree.children.push(createOrnamentNode())
   }
 }
 


### PR DESCRIPTION
## Summary

Thorough codebase audit uncovering bugs, performance issues, and code quality problems across TypeScript transformers, client-side scripts, CSS, CI configuration, and Python scripts. This PR fixes the most impactful issues found.

## Changes

### Bug fixes
- **Shared mutable `ornamentNode` singleton** (`trout_hr.ts`): The same HAST node object was inserted into multiple page trees. Downstream plugins that mutate nodes (e.g., `assetDimensions` setting width/height) would corrupt every page sharing that reference. Changed to a `createOrnamentNode()` factory that returns a fresh node each time.
- **A11y CI cache key mismatch** (`a11y.yml`): Cache restore key was `site-build-<sha>` but `build-site.yaml` produces `site-build-<sha>-fixtures-false`. Combined with `fail-on-cache-miss: true`, the a11y test job would always fail to restore the built site.
- **Asset extension comparison** (`assets.ts`): `assetExtensions` had `["webm", "mp4", ...]` (no dots) but `path.extname()` returns `".webm"`, `".mp4"`, etc. The `includes()` check never matched, making the content-directory asset warning dead code.
- **Clipboard button duplication** (`clipboard.inline.ts`): On SPA navigation, new clipboard buttons were prepended to every `<pre>` element without checking for existing ones. Elements surviving DOM morphing accumulated duplicate buttons.
- **TOC listener accumulation** (`toc.inline.ts`): Click handlers for mobile TOC delegation and title scroll-to-top were added on every `nav` event without cleanup. Added AbortController pattern consistent with other SPA scripts.
- **Invalid URL crash** (`ContentMeta.tsx`): Unguarded `new URL()` calls on frontmatter values (`original_url`, `lw-linkpost-url`) would crash the entire build with an unhelpful `TypeError` if any post had a malformed URL. Now throws with a clear error message identifying the field.

### Performance
- **Pre-compile color mapping regexes** (`color_variables.ts`): ~25 `new RegExp()` objects were created per element per page. Now compiled once at module load and reused via reference equality check.
- **Single character-class regex** (`gfm.ts`): `preprocessSlug` created 6 `new RegExp()` per heading. Replaced with a single pre-compiled character-class regex.
- **Hoist NBSP regex** (`formatting_improvement_text.ts`): `new RegExp(...)` was compiled on every call to `formattingImprovement`. Moved to module level.
- **Delete dead `animate()` function** (`component_script_utils.ts`): Clipboard button reset was the only caller; replaced with `setTimeout`. Removed the function and its 7 tests.

### Code quality
- **Deduplicate `isFootnoteListItem`**: Identical implementations in `fixFootnotes.ts` and `gfm.ts`. Now `gfm.ts` imports from `fixFootnotes.ts`. Removed duplicate tests from `gfm.test.ts`.
- **Deduplicate `isHeading`**: Identical implementations in `favicons.ts` and `formatting_improvement_html.ts`. Now `formatting_improvement_html.ts` imports from `favicons.ts`.
- **Popover SCSS consistency** (`popover.scss`): Removed redundant `& ` prefix on `h1` selector to match `h2`-`h6` style. (Both compile identically in Dart Sass, but the inconsistency was confusing.)
- **Textarea focus indicator** (`punctilioDemo.scss`): Added `border-color: var(--link)` on focus to provide keyboard users a visible focus indicator alongside `outline: none`.

## Testing

- All 3992 Jest tests pass with 100% coverage (14 removed: 7 dead `animate` tests, 6 duplicate `isFootnoteListItem` tests, 1 impossible-scenario test)
- Type checking (`tsc --noEmit`) passes
- Prettier, Stylelint, ESLint all pass
- Pre-push hooks pass (pylint, mypy, source file checks)

## Audit findings NOT addressed (future work)

The full audit identified additional issues that are lower priority or higher risk to fix:
- Inline JS strings in `spoiler.ts` (onclick/onkeydown handlers as strings)
- Embedded JS in template literals (`renderPage.tsx`, `componentResources.ts`)
- Missing test coverage for several emitters and components
- Double tree traversal in `assetDimensions.ts`
- `processHtmlAst` duplication between `Backlinks.tsx` and `TableOfContents.tsx`
- Several Python scripts with module-level side effects
- Potentially unused npm dependencies (`xml2js`, `play-sound`, `node-fetch`, `whatwg-fetch`)
- Pre-existing bug: `\b` word boundary doesn't match `#hex` color keys in `color_variables.ts`

## Lessons Learned

- **What**: Add a rule about pre-compiling RegExp objects used in hot paths
- **Where**: `CLAUDE.md` code style section
- **Why**: Three separate transformer files had `new RegExp()` inside loops or frequently-called functions. This is a common performance anti-pattern that's easy to miss during code review.

- **What**: Add a rule about not sharing mutable HAST/AST node references across pages
- **Where**: `CLAUDE.md` or `.claude/dev-notes.md`
- **Why**: The `ornamentNode` singleton bug is subtle — the shared reference works fine until any downstream plugin mutates the node, at which point every page using it gets corrupted. AST nodes should always be freshly created or deep-cloned before insertion.