### PR TITLE
Disable ligatures in inline code to fix spacing

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1004,6 +1004,7 @@ figure#goose-terminal {
 }
 
 pre,
+code,
 figure#goose-terminal {
   // Ligatures can mess up spacing, esp in Firefox for "===" in FiraCode VF
   font-variant-ligatures: none;

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -755,6 +755,8 @@ Footnote spam.[^spam1][^spam2][^spam3][^spam4][^spam5][^spam6][^spam7][^spam8]
 
 # Code blocks
 
+Inline code ligature kerning: `$var` must be interpolated into `#{$var}`. See also `===`, `!==`, `=>`, and `custom-property-no-missing-interpolation`.
+
 ```json
 "lint-staged": {
  "*.{js, jsx, ts, tsx, css, scss, json}": "prettier --write",


### PR DESCRIPTION
## Summary
Disables font ligatures in inline code elements to prevent spacing issues, particularly with operators like `===` and `!==` in monospace fonts like FiraCode VF.

## Changes
- **website_content/test-page.md**: Added test content demonstrating inline code with ligature-prone sequences (`$var`, `===`, `!==`, `=>`) to document the issue and verify the fix
- **quartz/styles/custom.scss**: Extended the existing `font-variant-ligatures: none` rule from `pre` and `figure#goose-terminal` to also apply to `code` elements

## Details
Ligatures in monospace fonts can cause uneven spacing in inline code, especially in Firefox. The fix applies the same ligature-disabling rule already used for code blocks to inline code elements, ensuring consistent spacing across all code contexts.

https://claude.ai/code/session_01DtggcvxXNoJbXgWUimhuHz