### PR TITLE
Move path filtering from trigger to job-level gate

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -171,13 +171,14 @@ After pushing to main:
 
 ### How CI runs
 
-Public-repo Actions are free, so we don’t tier coverage by event—every workflow runs the full suite whenever its `paths:` filter matches.
+Public-repo Actions are free, so we don’t tier coverage by event. Path-awareness lives at the **job** level, not the trigger: every required-check workflow always triggers on `pull_request` (so its check context is always created), then a job-level gate decides whether the expensive jobs run or report `skipped`.
 
-- **Full suite on every PR and `push: main`**: Linux Chromium + Firefox plus macOS WebKit shards for Playwright/visual; full a11y, lighthouse, site-build-checks, python-tests, python-lint, lint, Node.js. `.github/actions/ci-gate` is now a constant—`run=true`, `run-macos=true`, `browsers=chromium,firefox` for every event.
-- **Bot skip**: `should-run` skips dependabot/renovate/deepsource branches so lockfile bumps don’t churn the visual baselines.
-- **Flake check**: `workflow_dispatch` only.
-- **Shared builds**: Playwright, visual testing, and site-build-checks each build the site once and share the artifact across shards.
-- **Path filters**: every workflow has `paths:` on its `pull_request` trigger so doc-only / CI-only PRs don’t fire the heavy suites.
+- **Why not trigger-level `paths:`**: a workflow filtered out by a trigger-level `paths:` filter never starts, so its required check context is never created and branch protection hangs at “Expected — Waiting” forever. A required check is satisfied only by `success` or `skipped`, so the fix is to always trigger and let the gate emit `skipped`—never to filter the trigger.
+- **Path gate (`.github/actions/ci-gate`)**: on a `pull_request` it runs `dorny/paths-filter` over the workflow’s relevant-path globs (passed in via the `filters:` input) and outputs `run=true` only when relevant files changed. `push` / `workflow_dispatch` always get `run=true` (full coverage). The `ci:full-tests` / `ci:run-*` labels (the `force-labels:` input) force `run=true` regardless of paths.
+- **How the skip surfaces**: workflows with a unified `if: always()` status job (`playwright-tests`, `visual-testing`, `a11y`, `site-build-checks`) exit 0 from that job when `run=false`. `python-tests` / `python-lint` / `lint` gate the required job itself on a `detect-changes` (dorny) output, so the job reports `skipped`. `preview-audits` lets `build` → `deploy` → lighthouse skip down the `needs` chain. **Node is special**: its required check `build (<version>)` is a matrix job, and skipping a matrixed job at the job level can report under the bare name—so `build` always runs (context always created) and the gate skips only the inner `Setup site` / `Run tests` steps, leaving the job green.
+- **Bot skip**: `should-run` skips dependabot/renovate/deepsource branches so lockfile bumps don’t churn the visual baselines; the status jobs treat a skipped `should-run` as a pass.
+- **Flake check**: `workflow_dispatch` only.
+- **Shared builds**: Playwright, visual testing, and site-build-checks each build the site once and share the artifact across shards.
 - **Skip CI**: `[skip ci]` in commit messages.
 
 ### Merging PRs
@@ -185,7 +186,7 @@ Public-repo Actions are free, so we don’t tier coverage by event—every wo
 `main` is gated by required-status-check branch protection plus auto-merge—there’s **no merge queue** (the feature isn’t enabled in this repo).
 
 - **How to merge**: call `mcp__github__enable_pr_auto_merge` once the PR is green. GitHub waits for required checks to pass on the PR head SHA, then squashes.
-- **Required checks**: `playwright-tests`, `visual-testing`, `a11y`, `site-build-checks`, `python-tests`, `python-lint`, `lint`, `Node.js CI / build`, lighthouse jobs. Each runs on every PR (subject to `paths:` filters) so they report on the same SHA auto-merge waits on.
+- **Required checks**: `playwright-tests`, `visual-testing`, `a11y`, `site-build-checks`, `python-tests`, `python-lint`, `lint`, `Node.js CI / build`, lighthouse jobs. Each workflow always triggers on a PR and gates internally (see “How CI runs”), so every required context reports `success` or `skipped` on the same head SHA auto-merge waits on—none can hang uncreated.
 - **Compatibility with auto-merge bots**: `auto-merge-dependabot.yml` uses `gh pr merge --auto --squash`, same mechanism.
 - **Post-merge**: `push: main` re-runs the full suite plus `deploy.yaml`. `deploy.yaml`’s `verify-test-results` job polls check-runs on the landed SHA, so deploy waits for those to pass before pushing to Cloudflare.
 

--- a/.github/actions/ci-gate/action.yml
+++ b/.github/actions/ci-gate/action.yml
@@ -1,23 +1,31 @@
 name: CI Gate
 description: >
-  Constants for Playwright/visual workflows. Public-repo CI is free, so every
-  trigger gets full coverage: Chromium + Firefox on Linux plus the macOS
-  WebKit shards. Kept as a composite action so existing `needs.should-run`
-  wiring still works.
+  Decides whether a workflow's expensive jobs should run. The workflow always
+  triggers, so the required-check context is always created; this gate sets
+  run=false when a pull request touches no relevant paths and carries no
+  force-run label, letting the expensive jobs report "skipped" and satisfy
+  branch protection without burning CI. Pushes and manual dispatches always run.
 
 inputs:
-  run-labels:
-    description: Unused; retained for backwards compatibility with existing callers.
+  filters:
+    description: >
+      dorny/paths-filter YAML defining a `relevant` filter. Required for
+      pull_request gating; ignored on push / workflow_dispatch, which always run.
     required: false
     default: ""
+  force-labels:
+    description: >
+      Comma-separated PR labels that force run=true regardless of changed paths.
+    required: false
+    default: "ci:full-tests"
 
 outputs:
   run:
-    description: Always true.
-    value: "true"
+    description: Whether the workflow's expensive jobs should run.
+    value: ${{ steps.decide.outputs.run }}
   run-macos:
-    description: Always true.
-    value: "true"
+    description: Mirrors `run`; retained for callers that gate macOS shards.
+    value: ${{ steps.decide.outputs.run }}
   browsers:
     description: Always "chromium,firefox".
     value: "chromium,firefox"
@@ -25,5 +33,45 @@ outputs:
 runs:
   using: composite
   steps:
-    - shell: bash
-      run: ":"
+    - name: Detect relevant path changes
+      id: filter
+      if: github.event_name == 'pull_request' && inputs.filters != ''
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      with:
+        filters: ${{ inputs.filters }}
+
+    - name: Decide
+      id: decide
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PATHS_MATCHED: ${{ steps.filter.outputs.relevant }}
+        PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        FORCE_LABELS: ${{ inputs.force-labels }}
+      run: |
+        set -euo pipefail
+
+        # Pushes and manual dispatches always get full coverage.
+        if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Relevant files changed → run.
+        if [[ "$PATHS_MATCHED" == "true" ]]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # A force-run label overrides path filtering.
+        IFS=',' read -ra forced <<< "$FORCE_LABELS"
+        for label in "${forced[@]}"; do
+          label="$(echo "$label" | xargs)"
+          [[ -z "$label" ]] && continue
+          if echo "$PR_LABELS" | jq -e --arg l "$label" 'index($l) != null' >/dev/null; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        done
+
+        echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -9,19 +9,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    paths:
-      - "quartz/**"
-      - "!quartz/**/*.spec.ts"
-      - "!quartz/**/*.test.ts"
-      - "!quartz/**/*.test.tsx"
-      - "!quartz/**/tests/**"
-      - "website_content/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/pa11y/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read
@@ -43,7 +30,21 @@ jobs:
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
-          run-labels: "ci:full-tests,ci:run-a11y"
+          force-labels: "ci:full-tests,ci:run-a11y"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "!quartz/**/*.spec.ts"
+              - "!quartz/**/*.test.ts"
+              - "!quartz/**/*.test.tsx"
+              - "!quartz/**/tests/**"
+              - "website_content/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/pa11y/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
 
   a11y-build:
     needs: should-run
@@ -97,8 +98,8 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
-            echo "Tests were skipped (no label)"
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+            echo "Tests were skipped (no relevant changes or filtered actor)"
             exit 0
           fi
           if [[ "${{ needs.a11y-test.result }}" != "success" ]]; then

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -8,14 +8,6 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
-    paths:
-      - "quartz/**"
-      - "website_content/**"
-      - "config/**"
-      - "scripts/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/**"
 
 permissions:
   actions: read

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,23 +20,47 @@ on:
       - "pnpm-lock.yaml"
       - ".github/actions/**"
   pull_request:
-    paths:
-      - "quartz/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/javascript/**"
-      - "config/typescript/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read
   contents: read
 
 jobs:
+  should-run:
+    name: node-should-run
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        timeout-minutes: 5
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          force-labels: "ci:full-tests,ci:run-node"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/javascript/**"
+              - "config/typescript/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
+
   build:
-    if: ${{ !startsWith(github.head_ref, 'deepsource-') }}
+    needs: should-run
+    # Always materialize the (matrixed) `build` check context so a required
+    # status can't hang at "Expected — Waiting": skipping a matrixed job at the
+    # job level can report under the bare name instead of `build (<version>)`.
+    # The gate skips the expensive steps when no relevant files changed, so the
+    # job still finishes green without running the suite.
+    if: ${{ !cancelled() && !startsWith(github.head_ref, 'deepsource-') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -48,7 +72,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
       - name: Setup site
+        if: needs.should-run.outputs.run == 'true'
         uses: ./.github/actions/setup-site
         with:
           install-python: "false"
-      - run: pnpm test
+      - name: Run tests
+        if: needs.should-run.outputs.run == 'true'
+        run: pnpm test

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -9,14 +9,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    paths:
-      - "quartz/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read
@@ -42,7 +34,16 @@ jobs:
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
-          run-labels: "ci:full-tests,ci:run-playwright"
+          force-labels: "ci:full-tests,ci:run-playwright"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/playwright/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
 
   build:
     name: playwright-build

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -9,26 +9,6 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
-    paths:
-      - "quartz/**"
-      - "!quartz/**/*.spec.ts"
-      - "!quartz/**/*.test.ts"
-      - "!quartz/**/*.test.tsx"
-      - "!quartz/**/tests/**"
-      # Console-clean spec runs against the preview URL in this workflow,
-      # so changes to it must still trigger a run despite the broad
-      # spec/tests exclusions above.
-      - "quartz/components/tests/console-clean.spec.ts"
-      - "website_content/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
-      - ".github/lighthouse-*.json"
-      - ".github/workflows/preview-audits.yaml"
-      - ".github/workflows/build-site.yaml"
 
 permissions:
   actions: read
@@ -52,7 +32,28 @@ jobs:
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
-          run-labels: "ci:full-tests,ci:run-lighthouse"
+          force-labels: "ci:full-tests,ci:run-lighthouse"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "!quartz/**/*.spec.ts"
+              - "!quartz/**/*.test.ts"
+              - "!quartz/**/*.test.tsx"
+              - "!quartz/**/tests/**"
+              # Console-clean spec runs against the preview URL in this
+              # workflow, so changes to it must still trigger a run despite the
+              # broad spec/tests exclusions above.
+              - "quartz/components/tests/console-clean.spec.ts"
+              - "website_content/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/playwright/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
+              - ".github/lighthouse-*.json"
+              - ".github/workflows/preview-audits.yaml"
+              - ".github/workflows/build-site.yaml"
 
   build:
     needs: should-run

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -8,13 +8,6 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
-    paths:
-      - "scripts/**/*.py"
-      - "**/pyproject.toml"
-      - "**/uv.lock"
-      - ".pylintrc"
-      - ".github/workflows/python-lint.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -8,12 +8,6 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
-    paths:
-      - "scripts/**/*.py"
-      - "**/pyproject.toml"
-      - "**/uv.lock"
-      - ".github/workflows/python-tests.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -24,21 +24,6 @@ on:
       - "pnpm-lock.yaml"
       - ".github/actions/**"
   pull_request:
-    paths:
-      - "quartz/**"
-      - "!quartz/**/*.spec.ts"
-      - "!quartz/**/*.test.ts"
-      - "!quartz/**/*.test.tsx"
-      - "!quartz/**/tests/**"
-      - "website_content/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/stylelint/.variables-only-stylelintrc.json"
-      - "scripts/built_site_checks.py"
-      - "scripts/check_internal_links.py"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read
@@ -60,7 +45,23 @@ jobs:
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
-          run-labels: "ci:full-tests,ci:run-site-checks"
+          force-labels: "ci:full-tests,ci:run-site-checks"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "!quartz/**/*.spec.ts"
+              - "!quartz/**/*.test.ts"
+              - "!quartz/**/*.test.tsx"
+              - "!quartz/**/tests/**"
+              - "website_content/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/stylelint/.variables-only-stylelintrc.json"
+              - "scripts/built_site_checks.py"
+              - "scripts/check_internal_links.py"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
 
   build:
     name: site-checks-build
@@ -167,8 +168,8 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]]; then
-            echo "Tests were skipped (no label)"
+          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+            echo "Tests were skipped (no relevant changes or filtered actor)"
             exit 0
           fi
           if [[ "${{ needs.built-site-checks.result }}" != "success" ]] || \

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -9,16 +9,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    paths:
-      - "quartz/**"
-      - "website_content/**"
-      - "config/quartz/**"
-      - "config/constants.json"
-      - "config/playwright/**"
-      - "tests/visual-baselines/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/actions/**"
 
 permissions:
   actions: read
@@ -46,7 +36,18 @@ jobs:
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
-          run-labels: "ci:full-tests,ci:run-visual"
+          force-labels: "ci:full-tests,ci:run-visual"
+          filters: |
+            relevant:
+              - "quartz/**"
+              - "website_content/**"
+              - "config/quartz/**"
+              - "config/constants.json"
+              - "config/playwright/**"
+              - "tests/visual-baselines/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - ".github/actions/**"
 
   build:
     name: visual-testing-build


### PR DESCRIPTION
## Summary

Refactors CI path filtering from trigger-level `paths:` filters to a job-level gate (`.github/actions/ci-gate`). This ensures required-check contexts are always created on pull requests, preventing branch protection from hanging at "Expected — Waiting" when a PR touches no relevant paths.

## Problem

Trigger-level `paths:` filters prevent workflows from starting entirely, so their required status checks are never created. Branch protection then hangs indefinitely waiting for those checks to appear. The solution is to always trigger workflows on `pull_request`, then gate expensive jobs at the job level—allowing them to report `skipped` and satisfy branch protection without burning CI.

## Key Changes

- **`.github/actions/ci-gate`**: Redesigned from a no-op constant to a path/label gate:
  - On `pull_request`: runs `dorny/paths-filter` against a `filters:` input (YAML defining a `relevant` filter) and outputs `run=true` only when relevant files changed
  - On `push` / `workflow_dispatch`: always outputs `run=true` (full coverage)
  - Respects `force-labels:` input (comma-separated PR labels like `ci:full-tests`, `ci:run-node`) to force `run=true` regardless of paths
  - Outputs both `run` and `run-macos` (mirrored for callers that gate macOS shards)

- **Removed trigger-level `pull_request: paths:`** from `a11y.yml`, `playwright-tests.yaml`, `visual-testing.yaml`, `site-build-checks.yaml`, `preview-audits.yaml`, `node.js.yml`, `python-tests.yaml`, `python-lint.yaml`, `lint-and-validate.yaml`.

- **How "skipped" surfaces per workflow:**
  - `a11y` / `playwright-tests` / `visual-testing` / `site-build-checks`: the unified `if: always()` status job exits 0 when `run=false`. (a11y + site-build-checks status jobs also now treat a skipped `should-run`—bot actors—as a pass, matching playwright/visual.)
  - `preview-audits`: `build` → `deploy` → lighthouse skip down the `needs` chain.
  - `python-tests` / `python-lint` / `lint-and-validate`: already had a `detect-changes` (dorny) gate on the required job—only the trigger filter was removed.
  - `node.js`: the required check `build (<version>)` is a matrix job, so the job stays **always-running** (context always created) and only its inner `Setup site` / `Run tests` steps are gated. Skipping a matrixed job at the job level can report under the bare name and re-introduce the hang.

- **`deploy.yaml` intentionally untouched**: it isn't a required check, so removing its filter would only run a Cloudflare preview deploy on every docs-only PR.

- **Dev notes** (`.claude/dev-notes.md`): updated to explain the job-level gate and why trigger-level `paths:` filters are problematic.

## Implementation Details

- Gate uses `dorny/paths-filter@v4.0.1` to evaluate path globs only on `pull_request` events (where dorny reads the changed-file list from the API, so no full checkout is needed).
- Force-label matching uses `jq` to check PR labels against the `force-labels:` list.
- All gated workflows pass their relevant-path globs via the `filters:` input (YAML matching dorny's schema).

## Lessons learned

- **Gate required CI checks at the job level, never at the workflow trigger.** A trigger-level `paths:`/`branches:` filter that doesn't match means the workflow never starts, so its check context is never created—and a branch-protection *required* check that is never created hangs forever at "Expected — Waiting." A required check is satisfied only by a `success` or `skipped` conclusion, never by absence. Instead, always trigger the workflow and decide *inside* it: a cheap gate job (path diff via `dorny/paths-filter`, plus an optional force-label escape hatch) sets an output the expensive jobs gate on, so irrelevant PRs report `skipped` and clear branch protection without burning CI. You keep the cost savings of path filtering and lose the hang. This is the general habit worth replicating in any repo whose required checks are path-filtered.
- **Matrix jobs are the exception to job-level gating.** Skipping a matrixed job (e.g. `build (22.x)`) via a job-level `if:` can register the check under the bare name (`build`) instead of the matrixed context branch protection requires—re-introducing the hang. For a required matrix job, keep the job itself always-running (so the matrixed context is created) and gate the expensive *steps* instead.
- **"Cancelled" is not a way out.** A required check left in the `cancelled` state still counts as not-passing and blocks the merge exactly like the uncreated-context hang. Only `success` or `skipped` clears branch protection—so the goal is always to emit `skipped`, not to cancel or to filter the trigger.

https://claude.ai/code/session_01FzWyBYidfB8XC8qzecgEa2