### PR TITLE
feat: prevent em/en dashes from starting a wrapped line (via punctilio dashWordJoiner)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "3.11.2",
+    "punctilio": "3.13.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "reading-time": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 3.11.2
-        version: 3.11.2(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
+        specifier: 3.13.0
+        version: 3.13.0(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -7548,8 +7548,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@3.11.2:
-    resolution: {integrity: sha512-jgnXoVhtGJdck4dM9tvKbAGaW+jhAiIATtgg57Li5FwyZZN6rTAjUhk0M3n7H41kYUYh8MqyUnpG/7cHVSBM3A==}
+  punctilio@3.13.0:
+    resolution: {integrity: sha512-m+aLYfSNZY6Yfw0jldjrItuybWKZJwiKNMkr8qwr3rzI5Oq3HwZ4oobU79idYVfR1LFD9WRdT1sQN0bxWLWNBQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -18311,7 +18311,7 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@3.11.2(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
+  punctilio@3.13.0(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
     dependencies:
       commander: 14.0.3
       cosmiconfig: 9.0.1(typescript@6.0.3)

--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -67,6 +67,7 @@ export const {
   rightSingleQuote: RIGHT_SINGLE_QUOTE,
   leftDoubleQuote: LEFT_DOUBLE_QUOTE,
   rightDoubleQuote: RIGHT_DOUBLE_QUOTE,
+  wordJoiner: WORD_JOINER,
 } = constantsJson.unicodeTypography
 
 /**

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -1,7 +1,14 @@
 import type { Element, ElementContent, Parent, Root, Text } from "hast"
 
 import { h } from "hastscript"
-import { hyphenReplace, nbspTransform, niceQuotes, primeMarks, symbolTransform } from "punctilio"
+import {
+  emDashWordJoiner,
+  hyphenReplace,
+  nbspTransform,
+  niceQuotes,
+  primeMarks,
+  symbolTransform,
+} from "punctilio"
 import {
   collectTransformableElements,
   getTextContent,
@@ -22,7 +29,6 @@ import {
   NBSP,
   RIGHT_SINGLE_QUOTE,
   STRIP_BOUNDARY_TAGS,
-  WORD_JOINER,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
 import { isHeading } from "./favicons"
@@ -141,21 +147,10 @@ export function spacesAroundSlashes(text: string): string {
   return text.replace(htPlaceholderRegex, "h/t")
 }
 
-// U+2014 can break before or after (Unicode line-break class B2), so a wrapped
-// line can start with a lonely "—". A word joiner in front keeps the dash bound
-// to the preceding text while still allowing a break after it. The lookbehind
-// skips dashes that are line-leading (preceded by whitespace or start of string)
-// or already glued (preceded by a word joiner); an element-boundary marker
-// counts as preceding text.
-const emDashWordJoinerRegex = new RegExp(`(?<=[^\\s${WORD_JOINER}])—`, "gu")
-
-/**
- * Glue a word joiner before em dashes so they can never be the first glyph on a
- * wrapped line.
- */
-export function preventEmDashLineStart(text: string): string {
-  return text.replace(emDashWordJoinerRegex, `${WORD_JOINER}—`)
-}
+// Glue a word joiner before em dashes so they can never be the first glyph on a
+// wrapped line (U+2014 has line-break class B2, allowing a break on either side).
+// Marker-aware so it respects element boundaries.
+const emDashWordJoinerWrapper = (text: string) => emDashWordJoiner(text, { separator: markerChar })
 
 /**
  * Strip whitespace adjacent to the inside boundary of an inline element.
@@ -835,7 +830,7 @@ export const improveFormatting = (
         }
 
         // Runs after dash conversion; marker-aware so it sees element boundaries.
-        transformElement(elt, preventEmDashLineStart, toSkip, markerChar, false)
+        transformElement(elt, emDashWordJoinerWrapper, toSkip, markerChar, false)
 
         // Don't replace slashes in fractions, but give breathing room
         // to others

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -141,26 +141,20 @@ export function spacesAroundSlashes(text: string): string {
   return text.replace(htPlaceholderRegex, "h/t")
 }
 
-const EM_DASH = "—"
-
-// U+2014 has Unicode line-break class B2 (break opportunity before AND after),
-// so an unspaced "word—word" can wrap to leave "—word" at the start of a line.
-// A word joiner glued in front of the dash removes the break-before opportunity
-// while preserving the break-after. The lookbehind fires when the dash is
-// immediately preceded by anything other than whitespace or an existing word
-// joiner — that includes the element-boundary marker, so a dash glued to a
-// preceding inline element (including skipped ones like <code>) is still
-// protected. A dash with nothing (or only whitespace) before it — a genuine
-// line-leading "— Author" attribution — is left untouched, and already-glued
-// dashes are skipped, keeping the transform idempotent.
-const emDashWordJoinerRegex = new RegExp(`(?<=[^\\s${WORD_JOINER}])${EM_DASH}`, "gu")
+// U+2014 can break before or after (Unicode line-break class B2), so a wrapped
+// line can start with a lonely "—". A word joiner in front keeps the dash bound
+// to the preceding text while still allowing a break after it. The lookbehind
+// skips dashes that are line-leading (preceded by whitespace or start of string)
+// or already glued (preceded by a word joiner); an element-boundary marker
+// counts as preceding text.
+const emDashWordJoinerRegex = new RegExp(`(?<=[^\\s${WORD_JOINER}])—`, "gu")
 
 /**
  * Glue a word joiner before em dashes so they can never be the first glyph on a
  * wrapped line.
  */
 export function preventEmDashLineStart(text: string): string {
-  return text.replace(emDashWordJoinerRegex, `${WORD_JOINER}${EM_DASH}`)
+  return text.replace(emDashWordJoinerRegex, `${WORD_JOINER}—`)
 }
 
 /**
@@ -840,9 +834,7 @@ export const improveFormatting = (
           transformElement(elt, transform, toSkip, markerChar, false)
         }
 
-        // Marker-aware so it runs after dash conversion and sees element
-        // boundaries — keeps it out of meta descriptions / TOC text, which
-        // don't need invisible joiners.
+        // Runs after dash conversion; marker-aware so it sees element boundaries.
         transformElement(elt, preventEmDashLineStart, toSkip, markerChar, false)
 
         // Don't replace slashes in fractions, but give breathing room

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -22,6 +22,7 @@ import {
   NBSP,
   RIGHT_SINGLE_QUOTE,
   STRIP_BOUNDARY_TAGS,
+  WORD_JOINER,
 } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
 import { isHeading } from "./favicons"
@@ -138,6 +139,28 @@ export function spacesAroundSlashes(text: string): string {
 
   // Restore the h/t occurrences
   return text.replace(htPlaceholderRegex, "h/t")
+}
+
+const EM_DASH = "—"
+
+// U+2014 has Unicode line-break class B2 (break opportunity before AND after),
+// so an unspaced "word—word" can wrap to leave "—word" at the start of a line.
+// A word joiner glued in front of the dash removes the break-before opportunity
+// while preserving the break-after. The lookbehind fires when the dash is
+// immediately preceded by anything other than whitespace or an existing word
+// joiner — that includes the element-boundary marker, so a dash glued to a
+// preceding inline element (including skipped ones like <code>) is still
+// protected. A dash with nothing (or only whitespace) before it — a genuine
+// line-leading "— Author" attribution — is left untouched, and already-glued
+// dashes are skipped, keeping the transform idempotent.
+const emDashWordJoinerRegex = new RegExp(`(?<=[^\\s${WORD_JOINER}])${EM_DASH}`, "gu")
+
+/**
+ * Glue a word joiner before em dashes so they can never be the first glyph on a
+ * wrapped line.
+ */
+export function preventEmDashLineStart(text: string): string {
+  return text.replace(emDashWordJoinerRegex, `${WORD_JOINER}${EM_DASH}`)
 }
 
 /**
@@ -816,6 +839,11 @@ export const improveFormatting = (
         for (const transform of activeUncheckedTransformers) {
           transformElement(elt, transform, toSkip, markerChar, false)
         }
+
+        // Marker-aware so it runs after dash conversion and sees element
+        // boundaries — keeps it out of meta descriptions / TOC text, which
+        // don't need invisible joiners.
+        transformElement(elt, preventEmDashLineStart, toSkip, markerChar, false)
 
         // Don't replace slashes in fractions, but give breathing room
         // to others

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -2,7 +2,7 @@ import type { Element, ElementContent, Parent, Root, Text } from "hast"
 
 import { h } from "hastscript"
 import {
-  emDashWordJoiner,
+  dashWordJoiner,
   hyphenReplace,
   nbspTransform,
   niceQuotes,
@@ -146,11 +146,6 @@ export function spacesAroundSlashes(text: string): string {
   // Restore the h/t occurrences
   return text.replace(htPlaceholderRegex, "h/t")
 }
-
-// Glue a word joiner before em dashes so they can never be the first glyph on a
-// wrapped line (U+2014 has line-break class B2, allowing a break on either side).
-// Marker-aware so it respects element boundaries.
-const emDashWordJoinerWrapper = (text: string) => emDashWordJoiner(text, { separator: markerChar })
 
 /**
  * Strip whitespace adjacent to the inside boundary of an inline element.
@@ -829,8 +824,10 @@ export const improveFormatting = (
           transformElement(elt, transform, toSkip, markerChar, false)
         }
 
-        // Runs after dash conversion; marker-aware so it sees element boundaries.
-        transformElement(elt, emDashWordJoinerWrapper, toSkip, markerChar, false)
+        // Glue a word joiner before em/en dashes so they can never be the first
+        // glyph on a wrapped line. Runs after dash conversion; the marker char
+        // counts as preceding content, so element boundaries are respected.
+        transformElement(elt, dashWordJoiner, toSkip, markerChar, false)
 
         // Don't replace slashes in fractions, but give breathing room
         // to others

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -34,6 +34,7 @@ import {
   l_pRegex,
   massTransformText,
   moveQuotesBeforeLink,
+  preventEmDashLineStart,
   rearrangeLinkPunctuation,
   replaceFractions,
   spacesAroundSlashes,
@@ -747,36 +748,34 @@ describe("HTMLFormattingImprovement", () => {
       expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(expected)
     })
 
-    describe("em dashes cannot start a wrapped line", () => {
-      const WJ = WORD_JOINER
-
+    describe("preventEmDashLineStart", () => {
       it.each([
-        // Glue a word joiner before an em dash that has preceding content.
-        ["<p>plan -- result</p>", `<p>plan${WJ}—result</p>`],
-        // Boundary case: the em dash starts a text node after a sibling element.
-        // The joiner still lands immediately before the dash.
-        ["<p>not simply <em>accept</em> -- but</p>", `<p>not simply <em>accept</em>${WJ}—but</p>`],
-        ["<p>Hi <code>ABC</code> -- file</p>", `<p>Hi <code>ABC</code>${WJ}—file</p>`],
-      ])("inserts a word joiner: %s", (input: string, expected: string) => {
-        expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+        ["plan—result", `plan${WORD_JOINER}—result`], // preceded by a letter
+        ["a—b—c", `a${WORD_JOINER}—b${WORD_JOINER}—c`], // every interior dash
+        [`x${markerChar}—y`, `x${markerChar}${WORD_JOINER}—y`], // element boundary counts as text
+        ["—Author", "—Author"], // start of string: untouched
+        ["foo — bar", "foo — bar"], // whitespace before: untouched
+        [`plan${WORD_JOINER}—result`, `plan${WORD_JOINER}—result`], // already glued: idempotent
+      ])("%s", (input: string, expected: string) => {
+        expect(preventEmDashLineStart(input)).toBe(expected)
       })
+    })
 
-      it.each([
-        // Attribution dash at the start of a paragraph has no preceding glyph,
-        // so it must stay free of a joiner.
-        ["<blockquote><p>-- Orwell</p></blockquote>", "<blockquote><p>— Orwell</p></blockquote>"],
-      ])("leaves line-leading dashes untouched: %s", (input: string, expected: string) => {
-        const out = normalizeNbsp(testHtmlFormattingImprovement(input))
-        expect(out).not.toContain(WJ)
-        expect(out).toBe(expected)
-      })
-
-      it("is idempotent", () => {
-        const once = testHtmlFormattingImprovement("<p>plan -- result</p>")
-        const twice = testHtmlFormattingImprovement(once)
-        expect(twice).toBe(once)
-        expect((twice.match(new RegExp(WJ, "gu")) ?? []).length).toBe(1)
-      })
+    it.each([
+      ["<p>plan -- result</p>", `<p>plan${WORD_JOINER}—result</p>`],
+      // The em dash starts a text node after a sibling element; the joiner still
+      // lands immediately before the dash.
+      [
+        "<p>not simply <em>accept</em> -- but</p>",
+        `<p>not simply <em>accept</em>${WORD_JOINER}—but</p>`,
+      ],
+      ["<p>Hi <code>ABC</code> -- file</p>", `<p>Hi <code>ABC</code>${WORD_JOINER}—file</p>`],
+      // The dash leads an inner element but trails outer content.
+      ["<p>a<em>—b</em></p>", `<p>a<em>${WORD_JOINER}—b</em></p>`],
+      // Attribution dash at paragraph start has no preceding glyph: untouched.
+      ["<blockquote><p>-- Orwell</p></blockquote>", "<blockquote><p>— Orwell</p></blockquote>"],
+    ])("em dashes never start a wrapped line: %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
     })
   })
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -858,7 +858,7 @@ describe("HTMLFormattingImprovement", () => {
       "should replace hyphens with en dashes in number ranges: %s (end-to-end)",
       (input, expected) => {
         const processedHtml = testHtmlFormattingImprovement(`<p>${input}</p>`)
-        expect(normalizeNbsp(processedHtml)).toBe(`<p>${expected}</p>`)
+        expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(`<p>${expected}</p>`)
       },
     )
   })
@@ -1623,7 +1623,7 @@ describe("Date Range", () => {
     const input = "<p>Revenue from Jan-Mar exceeded Apr-Jun.</p>"
     const expected = "<p>Revenue from Jan–Mar exceeded Apr–Jun.</p>"
     const processedHtml = testHtmlFormattingImprovement(input)
-    expect(normalizeNbsp(processedHtml)).toBe(expected)
+    expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(expected)
   })
 })
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -34,7 +34,6 @@ import {
   l_pRegex,
   massTransformText,
   moveQuotesBeforeLink,
-  preventEmDashLineStart,
   rearrangeLinkPunctuation,
   replaceFractions,
   spacesAroundSlashes,
@@ -746,19 +745,6 @@ describe("HTMLFormattingImprovement", () => {
     ])("handling hyphenation in the DOM", (input: string, expected: string) => {
       const processedHtml = testHtmlFormattingImprovement(input)
       expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(expected)
-    })
-
-    describe("preventEmDashLineStart", () => {
-      it.each([
-        ["plan—result", `plan${WORD_JOINER}—result`], // preceded by a letter
-        ["a—b—c", `a${WORD_JOINER}—b${WORD_JOINER}—c`], // every interior dash
-        [`x${markerChar}—y`, `x${markerChar}${WORD_JOINER}—y`], // element boundary counts as text
-        ["—Author", "—Author"], // start of string: untouched
-        ["foo — bar", "foo — bar"], // whitespace before: untouched
-        [`plan${WORD_JOINER}—result`, `plan${WORD_JOINER}—result`], // already glued: idempotent
-      ])("%s", (input: string, expected: string) => {
-        expect(preventEmDashLineStart(input)).toBe(expected)
-      })
     })
 
     it.each([

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -23,6 +23,7 @@ import {
   normalizeNbsp,
   RIGHT_DOUBLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
+  WORD_JOINER,
 } from "../../../components/constants"
 import {
   applyTextTransforms,
@@ -43,6 +44,10 @@ import {
 import { FRACTION_SKIP_TAGS, SKIP_CLASSES, SKIP_TAGS, toSkip } from "../formatting_improvement_html"
 
 const MULTIPLICATION = "\u00D7" // ×
+
+// Drop the invisible word joiner that `preventEmDashLineStart` glues before
+// em dashes, so assertions can compare against human-readable expected output.
+const stripWordJoiner = (s: string) => s.replaceAll(WORD_JOINER, "")
 
 function testHtmlFormattingImprovement(
   inputHTML: string,
@@ -119,7 +124,7 @@ describe("HTMLFormattingImprovement", () => {
       ],
     ])("should handle HTML inputs", (input, expected) => {
       const processedHtml = testHtmlFormattingImprovement(input)
-      expect(normalizeNbsp(processedHtml)).toBe(expected)
+      expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(expected)
     })
 
     it.each([['<p><br>"Unicorn"<br></p>', "<p><br>“Unicorn”<br></p>"]])(
@@ -739,7 +744,39 @@ describe("HTMLFormattingImprovement", () => {
       ],
     ])("handling hyphenation in the DOM", (input: string, expected: string) => {
       const processedHtml = testHtmlFormattingImprovement(input)
-      expect(normalizeNbsp(processedHtml)).toBe(expected)
+      expect(stripWordJoiner(normalizeNbsp(processedHtml))).toBe(expected)
+    })
+
+    describe("em dashes cannot start a wrapped line", () => {
+      const WJ = WORD_JOINER
+
+      it.each([
+        // Glue a word joiner before an em dash that has preceding content.
+        ["<p>plan -- result</p>", `<p>plan${WJ}—result</p>`],
+        // Boundary case: the em dash starts a text node after a sibling element.
+        // The joiner still lands immediately before the dash.
+        ["<p>not simply <em>accept</em> -- but</p>", `<p>not simply <em>accept</em>${WJ}—but</p>`],
+        ["<p>Hi <code>ABC</code> -- file</p>", `<p>Hi <code>ABC</code>${WJ}—file</p>`],
+      ])("inserts a word joiner: %s", (input: string, expected: string) => {
+        expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+      })
+
+      it.each([
+        // Attribution dash at the start of a paragraph has no preceding glyph,
+        // so it must stay free of a joiner.
+        ["<blockquote><p>-- Orwell</p></blockquote>", "<blockquote><p>— Orwell</p></blockquote>"],
+      ])("leaves line-leading dashes untouched: %s", (input: string, expected: string) => {
+        const out = normalizeNbsp(testHtmlFormattingImprovement(input))
+        expect(out).not.toContain(WJ)
+        expect(out).toBe(expected)
+      })
+
+      it("is idempotent", () => {
+        const once = testHtmlFormattingImprovement("<p>plan -- result</p>")
+        const twice = testHtmlFormattingImprovement(once)
+        expect(twice).toBe(once)
+        expect((twice.match(new RegExp(WJ, "gu")) ?? []).length).toBe(1)
+      })
     })
   })
 
@@ -782,7 +819,7 @@ describe("HTMLFormattingImprovement", () => {
       // After stripInlineBoundaryWhitespace runs first, the <em> has no leading
       // space, so em-dash conversion produces the unspaced "—despite" form.
       const out = testHtmlFormattingImprovement("<p>I think that -<em> despite</em></p>")
-      expect(normalizeNbsp(out)).toBe("<p>I think that—<em>despite</em></p>")
+      expect(stripWordJoiner(normalizeNbsp(out))).toBe("<p>I think that—<em>despite</em></p>")
     })
   })
 

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -225,6 +225,16 @@ def _should_skip_paragraph(p: Tag) -> bool:
     )
 
 
+_INVISIBLE_CHARS = (ZERO_WIDTH_SPACE, ZERO_WIDTH_NBSP, WORD_JOINER)
+
+
+def strip_invisible_chars(text: str) -> str:
+    """Remove zero-width / joiner characters that carry no visible spacing."""
+    for char in _INVISIBLE_CHARS:
+        text = text.replace(char, "")
+    return text
+
+
 def _get_paragraph_text_for_punctuation_check(p: Tag) -> str:
     """
     Get cleaned text from a paragraph for punctuation checking.
@@ -246,10 +256,7 @@ def _get_paragraph_text_for_punctuation_check(p: Tag) -> str:
         TRIM_CHARACTERS_FROM_END_OF_PARAGRAPH
     )
     # Strip zero-width spaces and other invisible characters
-    text = text.replace(ZERO_WIDTH_SPACE, "")
-    text = text.replace(ZERO_WIDTH_NBSP, "")
-    text = text.replace(WORD_JOINER, "")
-    return text.strip()
+    return strip_invisible_chars(text).strip()
 
 
 def check_top_level_paragraphs_end_with_punctuation(
@@ -2260,7 +2267,13 @@ def check_spacing(
     sibling = (
         element.previous_sibling if prefix == "before" else element.next_sibling
     )
-    if not isinstance(sibling, NavigableString) or not sibling.strip():
+    if not isinstance(sibling, NavigableString):
+        return []
+    # Ignore zero-width joiners (e.g. the word joiner glued before em dashes):
+    # they carry no visible spacing, so the check must look past them to the
+    # real adjacent glyph.
+    sibling_text = strip_invisible_chars(str(sibling))
+    if not sibling_text.strip():
         return []
 
     # Properly escape characters for regex pattern
@@ -2272,7 +2285,7 @@ def check_spacing(
         else rf"^{ok_regex_chars}.*$"
     )
 
-    if not re.search(ok_regex_expr, sibling, flags=re.MULTILINE):
+    if not re.search(ok_regex_expr, sibling_text, flags=re.MULTILINE):
         preview = f"<{element.name}>{element.get_text()}</{element.name}>"
         if prefix == "before":
             preview = f"{sibling.get_text()}{preview}"

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -1946,6 +1946,33 @@ def test_check_spacing_after_branch():
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (f"{WORD_JOINER}—x", "—x"),
+        (f"a{ZERO_WIDTH_SPACE}{ZERO_WIDTH_NBSP}b", "ab"),
+        ("no invisibles", "no invisibles"),
+    ],
+)
+def test_strip_invisible_chars(text, expected):
+    assert built_site_checks.strip_invisible_chars(text) == expected
+
+
+def test_check_spacing_ignores_word_joiner_before_em_dash():
+    """A word joiner glued before an em dash must not read as a missing
+    space."""
+    soup = BeautifulSoup(
+        f"<p><em>values</em>{WORD_JOINER}—it is</p>", "html.parser"
+    )
+    em_element = soup.find("em")
+    assert isinstance(em_element, Tag)
+
+    result = built_site_checks.check_spacing(
+        em_element, built_site_checks.ALLOWED_ELT_FOLLOWING_CHARS, "after"
+    )
+    assert result == []
+
+
 _MAX_DESCRIPTION_LENGTH = built_site_checks.MAX_DESCRIPTION_LENGTH
 _MIN_DESCRIPTION_LENGTH = built_site_checks.MIN_DESCRIPTION_LENGTH
 

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -536,6 +536,9 @@ No hyphenated text wrapping
 Balanced text wrapping
 : I use [`text-wrap: balance`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) to balance line lengths in headings, captions, and subtitles. I use `text-wrap: pretty` for body text, which lets the browser optimize line-break positions to reduce orphans. `punctilio`'s non-breaking spaces set hard constraints on which words must stay together, while `text-wrap` optimizes the remaining break points.
 
+No line-leading em dashes
+: An em dash can break onto a new line from _either_ side, so a wrapped line could start with a lonely "—". I glue a [word joiner](https://en.wikipedia.org/wiki/Word_joiner) in front of every em dash, which keeps the dash bound to the text before it while still letting the line break _after_ the dash.
+
 Fractions
 : I chose slanted fractions in order to slightly increase the height of the numerals in the numerator and denominator. People are 2/3 water, but "01/01/2000" should not be rendered as a fraction.
 

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -536,8 +536,8 @@ No hyphenated text wrapping
 Balanced text wrapping
 : I use [`text-wrap: balance`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) to balance line lengths in headings, captions, and subtitles. I use `text-wrap: pretty` for body text, which lets the browser optimize line-break positions to reduce orphans. `punctilio`'s non-breaking spaces set hard constraints on which words must stay together, while `text-wrap` optimizes the remaining break points.
 
-No line-leading em dashes
-: An em dash can break onto a new line from _either_ side, so a wrapped line could start with a lonely "—". I glue a [word joiner](https://en.wikipedia.org/wiki/Word_joiner) in front of every em dash, which keeps the dash bound to the text before it while still letting the line break _after_ the dash.
+No line-leading em or en dashes
+: An em dash (—) or en dash (–) can break onto a new line from _either_ side, so a wrapped line could start with a lonely dash. `punctilio` glues a [word joiner](https://en.wikipedia.org/wiki/Word_joiner) in front of every such dash, which keeps the dash bound to the text before it while still letting the line break _after_ the dash.
 
 Fractions
 : I chose slanted fractions in order to slightly increase the height of the numerals in the numerator and denominator. People are 2/3 water, but "01/01/2000" should not be rendered as a fraction.


### PR DESCRIPTION
## Summary

- Em dashes (U+2014) and en dashes (U+2013) have Unicode line-break class **B2** — a break is allowed *before and after* — so an unspaced `word—word` or `1–5` can wrap to leave the dash stranded at the start of a line.
- This glues an invisible **word joiner (U+2060)** in front of each such dash that has preceding content, killing the break-*before* opportunity while preserving the break-*after*. Genuine line-leading dashes (e.g. `— Author` attributions) are left untouched.
- The logic lives in **punctilio** (`dashWordJoiner`, shipped in 3.13.0), alongside the existing dash/nbsp typography. The site consumes it marker-aware in the HTML pipeline.

## Changes

- **`formatting_improvement_html.ts`**: import `dashWordJoiner` from punctilio and apply it in the per-element HTML transform loop, after dash conversion. The element-boundary marker char counts as preceding content, so dashes glued across element boundaries (`<em>`/`<code>`/etc.) are still protected. Removed the local `preventEmDashLineStart`. Kept out of `applyTextTransforms`, so meta descriptions and the TOC don't get invisible joiners.
- **`package.json` / lockfile**: `punctilio` 3.11.2 → 3.13.0.
- **Tests**: dropped the local-function unit tests; kept the end-to-end DOM tests (cross-element boundaries, dash-leading inner elements, line-leading attribution left alone). Reconciled the affected em- and en-dash assertions via a `stripWordJoiner` helper so they keep asserting visible dash-conversion output (the expected strings are unchanged; only the invisible joiner is normalized away).
- **`built_site_checks.py`**: the word joiner sits between an inline element and the dash, so `check_spacing` read it as the following glyph and raised false "Missing space after" errors. Fix: strip zero-width/joiner chars before evaluating the adjacent glyph (shared `strip_invisible_chars` helper, reused by the paragraph-punctuation check). Regression test added. Char-agnostic, so it covers en dashes too.
- **`design.md`**: documented under "Other display tweaks".

## Testing

- `pnpm check` clean (tsc + prettier + stylelint); full TS suite **4004 passing**, 100% coverage on the modified transformer.
- Python: ruff/mypy/pylint clean; `built_site_checks` suite green with the regression test.

## Note on visual baselines

The feature deliberately changes where em/en-dash lines wrap, so the visual-testing run will produce expected snapshot diffs. Those need baseline approval via the diff gallery once CI is green.

## Lessons learned

- **What**: When a transform injects an invisible control character (word joiner, zero-width space) into rendered HTML, downstream structural checks that inspect the *adjacent character* (spacing/punctuation validators) must strip those chars before evaluating. **Where**: spacing/whitespace checks like `scripts/built_site_checks.py:check_spacing`. **Why**: the joiner inserted before em/en dashes was read as the "following glyph", producing false "missing space" failures across many pages.