### PR TITLE
fix(utils): harden frontmatter detection and cache shared constants

### DIFF
--- a/scripts/tests/test_script_utils.py
+++ b/scripts/tests/test_script_utils.py
@@ -1281,57 +1281,36 @@ def test_error_exit_prints_to_stderr_and_exits(capsys):
     assert "boom" in captured.err
 
 
-def test_split_yaml_ignores_body_horizontal_rules(tmp_path: Path):
-    """
-    A frontmatter-less file with `---` body rules must not be truncated.
-
-    Without a leading fence the file has no frontmatter, so the interior `---`
-    rules must not be mistaken for delimiters that drop the body before them.
-    """
-    file_path = tmp_path / "rules.md"
-    file_path.write_text(
+@pytest.mark.parametrize(
+    "text",
+    [
+        # `---` rules in the body of a frontmatter-less file
         "# Title\n\nIntro.\n\n---\n\nMiddle.\n\n---\n\nEnd.\n",
-        encoding="utf-8",
-    )
+        # leading rule longer than three dashes (not an opening fence)
+        "----------\n\nBody after a horizontal rule.\n",
+        # opening fence with no closing fence
+        "---\ntitle: x\n",
+    ],
+)
+def test_split_yaml_without_valid_frontmatter(tmp_path: Path, text: str):
+    """Files lacking a leading `---` fence yield empty metadata and content."""
+    file_path = tmp_path / "file.md"
+    file_path.write_text(text, encoding="utf-8")
 
-    metadata, content = script_utils.split_yaml(file_path)
-    assert metadata == {}
-    assert content == ""
-
-
-def test_split_yaml_ignores_leading_horizontal_rule(tmp_path: Path):
-    """A leading rule longer than three dashes is not a frontmatter fence."""
-    file_path = tmp_path / "leading_rule.md"
-    file_path.write_text(
-        "----------\n\nBody after a horizontal rule.\n", encoding="utf-8"
-    )
-
-    metadata, content = script_utils.split_yaml(file_path)
-    assert metadata == {}
-    assert content == ""
-
-
-def test_split_yaml_requires_closing_fence(tmp_path: Path):
-    """A leading fence with no closing `---` is not valid frontmatter."""
-    file_path = tmp_path / "unclosed.md"
-    file_path.write_text("---\ntitle: x\n", encoding="utf-8")
-
-    metadata, content = script_utils.split_yaml(file_path)
-    assert metadata == {}
-    assert content == ""
+    assert script_utils.split_yaml(file_path) == ({}, "")
 
 
 def test_split_yaml_parses_leading_frontmatter(tmp_path: Path):
-    """A well-formed leading frontmatter block is parsed and body preserved."""
+    """Leading frontmatter parses; a `---` rule in the body is preserved."""
     file_path = create_markdown_file(
         tmp_path / "valid.md",
         frontmatter={"title": "Hello"},
-        content="Body text.",
+        content="Before.\n\n---\n\nAfter.",
     )
 
     metadata, content = script_utils.split_yaml(file_path)
-    assert metadata["title"] == "Hello"
-    assert content == "\nBody text."
+    assert metadata == {"title": "Hello"}
+    assert content == "\nBefore.\n\n---\n\nAfter."
 
 
 def test_load_shared_constants_returns_independent_copy():

--- a/scripts/tests/test_script_utils.py
+++ b/scripts/tests/test_script_utils.py
@@ -1279,3 +1279,71 @@ def test_error_exit_prints_to_stderr_and_exits(capsys):
     assert excinfo.value.code == 2
     captured = capsys.readouterr()
     assert "boom" in captured.err
+
+
+def test_split_yaml_ignores_body_horizontal_rules(tmp_path: Path):
+    """
+    A frontmatter-less file with `---` body rules must not be truncated.
+
+    Without a leading fence the file has no frontmatter, so the interior `---`
+    rules must not be mistaken for delimiters that drop the body before them.
+    """
+    file_path = tmp_path / "rules.md"
+    file_path.write_text(
+        "# Title\n\nIntro.\n\n---\n\nMiddle.\n\n---\n\nEnd.\n",
+        encoding="utf-8",
+    )
+
+    metadata, content = script_utils.split_yaml(file_path)
+    assert metadata == {}
+    assert content == ""
+
+
+def test_split_yaml_ignores_leading_horizontal_rule(tmp_path: Path):
+    """A leading rule longer than three dashes is not a frontmatter fence."""
+    file_path = tmp_path / "leading_rule.md"
+    file_path.write_text(
+        "----------\n\nBody after a horizontal rule.\n", encoding="utf-8"
+    )
+
+    metadata, content = script_utils.split_yaml(file_path)
+    assert metadata == {}
+    assert content == ""
+
+
+def test_split_yaml_requires_closing_fence(tmp_path: Path):
+    """A leading fence with no closing `---` is not valid frontmatter."""
+    file_path = tmp_path / "unclosed.md"
+    file_path.write_text("---\ntitle: x\n", encoding="utf-8")
+
+    metadata, content = script_utils.split_yaml(file_path)
+    assert metadata == {}
+    assert content == ""
+
+
+def test_split_yaml_parses_leading_frontmatter(tmp_path: Path):
+    """A well-formed leading frontmatter block is parsed and body preserved."""
+    file_path = create_markdown_file(
+        tmp_path / "valid.md",
+        frontmatter={"title": "Hello"},
+        content="Body text.",
+    )
+
+    metadata, content = script_utils.split_yaml(file_path)
+    assert metadata["title"] == "Hello"
+    assert content == "\nBody text."
+
+
+def test_load_shared_constants_returns_independent_copy():
+    """Each call returns an equal but independently mutable deep copy."""
+    first = script_utils.load_shared_constants()
+    second = script_utils.load_shared_constants()
+    assert first == second
+    assert first is not second
+
+    first["__injected_top_level__"] = 123
+    first["unicodeTypography"]["__injected_nested__"] = "x"
+
+    fresh = script_utils.load_shared_constants()
+    assert "__injected_top_level__" not in fresh
+    assert "__injected_nested__" not in fresh["unicodeTypography"]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for scripts/ directory."""
 
+import copy
 import functools
 import io
 import json
@@ -138,9 +139,13 @@ def http_session(
 
 
 def load_shared_constants() -> dict:
-    """Load shared constants from config/constants.json."""
-    with open(_CONSTANTS_JSON_PATH, encoding="utf-8") as f:
-        return json.load(f)
+    """
+    Return the shared constants from config/constants.json.
+
+    The file is read once at import into ``_CONSTANTS``; callers receive an
+    independent deep copy so mutating the result cannot corrupt the cache.
+    """
+    return copy.deepcopy(_CONSTANTS)
 
 
 _executable_cache: dict[str, str] = {}
@@ -392,9 +397,12 @@ def split_yaml(file_path: Path, verbose: bool = False) -> tuple[dict, str]:
     with file_path.open("r", encoding="utf-8") as f:
         content = f.read()
 
-    # Split frontmatter and content
+    # Frontmatter is a leading YAML block fenced by `---` lines. Require the
+    # opening fence at the very start of the file so a `---` horizontal rule in
+    # the body is never mistaken for a delimiter — which would otherwise drop
+    # everything before it.
     parts = content.split("---", 2)
-    if len(parts) < 3:
+    if not content.startswith("---\n") or len(parts) < 3:
         if verbose:
             print(f"Skipping {file_path}: No valid frontmatter found")
         return {}, ""

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -397,10 +397,9 @@ def split_yaml(file_path: Path, verbose: bool = False) -> tuple[dict, str]:
     with file_path.open("r", encoding="utf-8") as f:
         content = f.read()
 
-    # Frontmatter is a leading YAML block fenced by `---` lines. Require the
-    # opening fence at the very start of the file so a `---` horizontal rule in
-    # the body is never mistaken for a delimiter — which would otherwise drop
-    # everything before it.
+    # Frontmatter is a leading YAML block fenced by `---` lines: an opening
+    # `---\n` at the very start of the file and a closing `---` after it. A
+    # `---` rule elsewhere in the body is content, not a delimiter.
     parts = content.split("---", 2)
     if not content.startswith("---\n") or len(parts) < 3:
         if verbose:


### PR DESCRIPTION
## Summary

Two correctness/efficiency fixes to `scripts/utils.py`, the shared helper module used across the asset-processing and validation scripts. Both were found while auditing the `scripts/` tree for latent bugs.

- **`split_yaml` could truncate a file's body.** It treated the text between the first two `---` occurrences as YAML frontmatter even when the file had **no** leading fence. A markdown file without frontmatter but containing `---` horizontal rules was therefore misparsed, and everything before the second rule was silently dropped. The function now requires the opening `---\n` fence at the very start of the file, so a body rule is never mistaken for a delimiter. Behavior for well-formed files (the common case) is unchanged.
- **`load_shared_constants` re-read `config/constants.json` from disk on every call** even though the file is already loaded once at import into the module-level `_CONSTANTS`. It now returns a deep copy of that cached dict — callers still get an independent, freely mutable result, but the redundant per-call I/O and the second source of truth are gone.

## Changes

- `scripts/utils.py`
  - `split_yaml`: require a leading `---\n` fence before parsing frontmatter (`not content.startswith("---\n") or len(parts) < 3`). A `---` rule elsewhere in the body stays content.
  - `load_shared_constants`: `return copy.deepcopy(_CONSTANTS)` instead of re-opening/parsing the JSON file; added `import copy`.
- `scripts/tests/test_script_utils.py`
  - Parametrized regression test for the frontmatter-less cases (body `---` rules, a leading rule longer than three dashes, an opening fence with no close) — all yield `({}, "")`.
  - Positive test asserting full-dict metadata equality and that a `---` rule in the body of a properly fenced file is preserved.
  - Test that `load_shared_constants` returns equal-but-independent deep copies (top-level and nested mutation isolation).

## Testing

- `uv run pytest --cov=scripts -n auto`: **2086 passed**; `scripts/utils.py` at **100% line coverage** (209/209).
- `ruff`, `black`, `isort`, `mypy`, `pylint` (10.00/10) clean on both changed files.
- Pre-push checks (pylint, mypy, source-file checks, alt-text scan) all green.

## Lessons Learned

- **What**: When using exploration/critique sub-agents to hunt for bugs, independently verify each claimed defect against the source (trace the actual data/control flow) before fixing it.
- **Where**: the self-critique / code-audit workflow described in `CLAUDE.md` and the pr-creation skill.
- **Why**: In this audit, the two highest-ranked agent findings were false positives — a Python "loop-variable late-binding closure bug" where the captured values were actually loop-invariant, and a "regex recompiled every call" where the patterns were already memoized at module load. Acting on them unverified would have added churn and risked regressions; the real fixes came from cases the agents under-weighted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AYmevxtAdPiQumGsDATDTt)_