### PR TITLE
chore: linting/CI improvements and fail-loud cleanups from a code review

### DIFF
--- a/.github/actions/restore-site-build/action.yml
+++ b/.github/actions/restore-site-build/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Restore built site from cache
-      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: public/
         key: site-build-${{ github.sha }}

--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -55,7 +55,7 @@ runs:
 
     - name: Restore pnpm cache
       if: inputs.install-node-deps == 'true'
-      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -70,7 +70,7 @@ runs:
     - name: Cache node_modules
       if: inputs.install-node-deps == 'true'
       id: cache-node-modules
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: node_modules
         key: node-modules-${{ runner.os }}-sharp-${{ inputs.install-sharp }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -112,7 +112,7 @@ runs:
     - name: Cache .venv
       if: inputs.install-python == 'true'
       id: cache-venv
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}
@@ -125,7 +125,7 @@ runs:
     # ── Browsers ──────────────────────────────────────────────────────────────
     - name: Cache Playwright browsers
       if: inputs.cache-playwright == 'true'
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
         key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -134,7 +134,7 @@ runs:
 
     - name: Cache Puppeteer browsers
       if: inputs.cache-puppeteer == 'true' || inputs.install-puppeteer-chrome == 'true'
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -148,7 +148,7 @@ runs:
     # the gate matches `install-system-deps`.
     - name: Restore apt package cache
       if: inputs.install-system-deps == 'true' && runner.os == 'Linux'
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/apt-cache
         key: apt-cache-${{ runner.os }}-${{ hashFiles('.github/actions/setup-site/action.yaml') }}

--- a/.github/workflows/auto-merge-deepsource.yml
+++ b/.github/workflows/auto-merge-deepsource.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     # Check if PR is from DeepSource and is a style fix
-    if: |
-      (github.actor == 'deepsource-autofix[bot]' || github.actor == 'deepsource-io') &&
-      startsWith(github.event.pull_request.title, 'style:')
+    # Gated on a plain `pull_request` trigger with read-only checkout; the job
+    # only enables auto-merge on style PRs and runs no PR code, so a spoofed
+    # actor cannot escalate.
+    if: (github.actor == 'deepsource-autofix[bot]' || github.actor == 'deepsource-io') && startsWith(github.event.pull_request.title, 'style:') # zizmor: ignore[bot-conditions]
     steps:
       - name: Enable auto-merge for DeepSource style PRs
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -3,6 +3,9 @@ name: Auto-merge Dependabot PRs
 # fork-like context and need write permissions. This is safe as long as
 # no step checks out or executes PR code.
 on:
+  # zizmor: ignore[dangerous-triggers] pull_request_target is required so
+  # Dependabot PRs (fork-like context) get write permissions; safe because no
+  # step checks out or executes PR code — only metadata + gh pr commands run.
   pull_request_target:
     types: [opened]
 
@@ -14,7 +17,10 @@ jobs:
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    if: github.actor == 'dependabot[bot]'
+    # On pull_request_target the actor is the PR author; dependabot[bot] cannot
+    # be spoofed by an external contributor, and the job only enables auto-merge
+    # (no PR code is run).
+    if: github.actor == 'dependabot[bot]' # zizmor: ignore[bot-conditions]
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,12 +23,10 @@ on:
       - ".github/actions/**"
   workflow_dispatch:
 
+# Read-only default; each job below elevates only to the writes it needs
+# (Cloudflare OIDC/Pages deploys, PR preview comments, check-run reads).
 permissions:
-  actions: write
   contents: read
-  id-token: write
-  pages: write
-  pull-requests: write
 
 jobs:
   deploy-build:
@@ -40,6 +38,12 @@ jobs:
     needs: deploy-build
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    # Cloudflare Pages deploy (OIDC + Pages) plus PR preview comments.
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
@@ -156,6 +160,10 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    # Reads check-run conclusions on the commit via the GitHub API.
+    permissions:
+      contents: read
+      checks: read
     steps:
       - name: Wait for test workflows to succeed
         env:
@@ -165,13 +173,23 @@ jobs:
           # specific workflow runs. This handles cancelled/replaced runs
           # gracefully — sort_by(.started_at)|last always picks the most
           # recent check run for each name.
+          # Per-check wall-clock deadline. The 90-min job timeout is the outer
+          # bound; this inner deadline fails a single check fast (with a clear
+          # message) if it never even produces a check-run, instead of burning
+          # the whole job budget polling a check that will never appear.
+          CHECK_DEADLINE_SECONDS=2700  # ~45 min per check
           for CHECK_NAME in visual-testing playwright-tests; do
             echo "Waiting for $CHECK_NAME..."
             CANCEL_RETRIES=0
             MAX_CANCEL_RETRIES=10  # Wait up to ~5 min for a replacement run
             POLL_INTERVAL=30
             MAX_POLL_INTERVAL=120
+            CHECK_START=$(date +%s)
             while true; do
+              if [ $(( $(date +%s) - CHECK_START )) -ge "$CHECK_DEADLINE_SECONDS" ]; then
+                echo "::error::$CHECK_NAME did not conclude within $((CHECK_DEADLINE_SECONDS / 60)) min (no successful check-run observed). Failing fast."
+                exit 1
+              fi
               RESULT=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
                 --jq "[.check_runs[] | select(.name == \"$CHECK_NAME\")] | sort_by(.started_at) | last | .conclusion // empty" \
                 2>/dev/null || echo "")
@@ -216,6 +234,11 @@ jobs:
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # Cloudflare Pages production deploy (OIDC + Pages).
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -231,6 +231,53 @@ jobs:
           fi
           echo "All action references are SHA-pinned"
 
+  # Static analysis of the workflows themselves: actionlint (syntax, shell,
+  # expression checks) and zizmor (security audit). Gates the PR — both must
+  # pass. zizmor runs at medium confidence so the Medium/High-confidence
+  # findings we fixed stay enforced, while the Low-confidence categories
+  # (artipacked on read-only checkouts, template-injection on internal
+  # needs/steps outputs that are not attacker-controllable) don't block. Any
+  # genuinely-intentional High-confidence finding is suppressed inline with a
+  # `# zizmor: ignore[<audit>]` comment plus a rationale at the call site.
+  workflow-lint:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.workflows == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        timeout-minutes: 5
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${TARBALL}"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum --check
+          tar -xzf "${TARBALL}" actionlint
+          sudo mv actionlint /usr/local/bin/
+
+      - name: Run actionlint
+        run: actionlint -color .github/workflows/*.yml .github/workflows/*.yaml
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7
+
+      - name: Run zizmor
+        env:
+          # No GH token, so no online (network) audits; --persona regular keeps
+          # the default low-confidence noise filtered the same way locally.
+          ZIZMOR_VERSION: "1.25.2"
+        run: |
+          uvx "zizmor@${ZIZMOR_VERSION}" \
+            --offline \
+            --persona regular \
+            --min-confidence=medium \
+            .github/workflows/
+
   lint:
     needs: [update-dates, detect-changes, autofix]
     # Run if detect-changes found changes, and not a deepsource PR.
@@ -305,7 +352,7 @@ jobs:
         id: eslint
         if: needs.detect-changes.outputs.code == 'true'
         continue-on-error: true
-        run: pnpm eslint . --config config/javascript/eslint.config.js
+        run: pnpm eslint . --config config/javascript/eslint.config.js --max-warnings 0
 
       - name: Run Stylelint
         id: stylelint

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -93,9 +93,10 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
+      # Critical log: surface upload failures (don't swallow with
+      # continue-on-error) so a missing log is visible on the shard.
       - name: Upload flake check logs
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: flake-check-log-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -201,9 +202,10 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
+      # Critical log: surface upload failures (don't swallow with
+      # continue-on-error) so a missing log is visible on the shard.
       - name: Upload flake check logs
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: flake-check-log-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -108,9 +108,10 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
+      # Critical log: surface upload failures (don't swallow with
+      # continue-on-error) so a missing log is visible on the shard.
       - name: Upload Playwright logs
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-log-linux-shard-${{ env.SANITIZED_SHARD }}
@@ -215,9 +216,10 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
+      # Critical log: surface upload failures (don't swallow with
+      # continue-on-error) so a missing log is visible on the shard.
       - name: Upload Playwright logs
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-log-macos-shard-${{ env.SANITIZED_SHARD }}

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -10,11 +10,11 @@ on:
     branches: ["main", "dev"]
   pull_request:
 
+# Minimal default at the workflow level; the `deploy` job below elevates to
+# the id-token/pages writes that only the Cloudflare Pages deploy needs.
 permissions:
   actions: read
   contents: read
-  id-token: write
-  pages: write
 
 jobs:
   should-run:
@@ -64,6 +64,12 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 12
+    # Cloudflare Pages deploy needs OIDC + Pages writes; scoped here rather
+    # than at the workflow level so the audit jobs stay read-only.
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     outputs:
       deploy_url: ${{ steps.deploy_cf_pages.outputs.DEPLOY_URL }}
     steps:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -58,12 +58,14 @@ jobs:
             --config-file config/python/mypy.ini \
             scripts/*.py
 
-      - name: Run docformatter check
-        run: |
-          uv run python -m docformatter \
-            --check \
-            --config config/python/pyproject.toml \
-            scripts/*.py
+      # Ruff is the formatter/linter authority (config in pyproject.toml's
+      # [tool.ruff]). Run via `uvx` (ephemeral, version-pinned) since it isn't
+      # a locked project dependency.
+      - name: Run ruff format check
+        run: uvx ruff@0.15.8 format --check --config pyproject.toml scripts/
+
+      - name: Run ruff check
+        run: uvx ruff@0.15.8 check --config pyproject.toml scripts/
 
       - name: Run pylint
         run: |

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -41,6 +41,7 @@ jobs:
         id: existing-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Check if there's an open PR with the security-scan label
           EXISTING_BRANCH=$(gh pr list --label "security-scan" --state open --json headRefName --jq '.[0].headRefName // empty')
@@ -48,7 +49,7 @@ jobs:
             echo "Found existing security PR branch: $EXISTING_BRANCH"
             git fetch origin "$EXISTING_BRANCH"
             git checkout "$EXISTING_BRANCH"
-            if ! git merge origin/${{ github.event.repository.default_branch }} --no-edit; then
+            if ! git merge "origin/${DEFAULT_BRANCH}" --no-edit; then
               echo "::error::Merge conflict with default branch. Aborting merge."
               git merge --abort
               exit 1

--- a/.github/workflows/subfont-bisect.yaml
+++ b/.github/workflows/subfont-bisect.yaml
@@ -56,7 +56,9 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install subfont fork at ${{ inputs.fork_ref }}
-        run: pnpm add -g github:alexander-turner/subfont#${{ inputs.fork_ref }}
+        env:
+          FORK_REF: ${{ inputs.fork_ref }}
+        run: pnpm add -g "github:alexander-turner/subfont#${FORK_REF}"
 
       - name: Record installed subfont SHA
         run: |
@@ -89,17 +91,23 @@ jobs:
 
       - name: Write summary
         if: always()
+        env:
+          FORK_REF: ${{ inputs.fork_ref }}
+          INSTALLED: ${{ steps.record.outputs.installed }}
+          SUBFONT_OUTCOME: ${{ steps.subfont.outcome }}
+          ELAPSED_SECONDS: ${{ steps.subfont.outputs.elapsed_seconds || 'n/a (step did not complete)' }}
+          SITE_COMMIT: ${{ github.sha }}
         run: |
           {
-            echo "## Subfont bisect — \`${{ inputs.fork_ref }}\`"
+            echo "## Subfont bisect — \`${FORK_REF}\`"
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Fork ref (input) | \`${{ inputs.fork_ref }}\` |"
-            echo "| Installed | \`${{ steps.record.outputs.installed }}\` |"
-            echo "| Subfont step result | ${{ steps.subfont.outcome }} |"
-            echo "| Elapsed (seconds) | ${{ steps.subfont.outputs.elapsed_seconds || 'n/a (step did not complete)' }} |"
-            echo "| Site commit | \`${{ github.sha }}\` |"
+            echo "| Fork ref (input) | \`${FORK_REF}\` |"
+            echo "| Installed | \`${INSTALLED}\` |"
+            echo "| Subfont step result | ${SUBFONT_OUTCOME} |"
+            echo "| Elapsed (seconds) | ${ELAPSED_SECONDS} |"
+            echo "| Site commit | \`${SITE_COMMIT}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload subfont log

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -60,6 +60,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout child repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -237,24 +237,29 @@ jobs:
       - name: Comment success on PR
         if: success() && steps.resolve.outputs.pr_number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number('${{ steps.resolve.outputs.pr_number }}'),
-              body: `Approved baselines from run ${{ github.event.inputs.run_id }} and pushed an empty commit to retrigger visual-testing.`,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: `Approved baselines from run ${process.env.RUN_ID} and pushed an empty commit to retrigger visual-testing.`,
             });
 
       - name: Comment failure on PR
         if: failure() && steps.resolve.outputs.pr_number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number('${{ steps.resolve.outputs.pr_number }}'),
+              issue_number: Number(process.env.PR_NUMBER),
               body: `Approve-baselines failed: ${runUrl}`,
             });

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -10,11 +10,11 @@ on:
     branches: ["main"]
   pull_request:
 
+# Read-only default; only `publish-visual-report` elevates to the PR-comment
+# and commit-status writes it needs.
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   # Gate: skip expensive tests for bot actors (dependabot, renovate, etc.).
@@ -298,6 +298,12 @@ jobs:
   # individual shards green) need the report too, so the user can approve
   # the new baselines.
   publish-visual-report:
+    # Posts the PR comment with report links and the visual-diff commit status.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      statuses: write
     needs:
       [
         should-run,

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -53,8 +53,28 @@ stash_and_exit() {
 
 cd "$GIT_ROOT"
 
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: 'uv' was not found on PATH." >&2
+  echo "The pre-push checks run via 'uv'. Install it (https://docs.astral.sh/uv/)" >&2
+  echo "or add it to PATH, then retry the push. To bypass once: 'git push --no-verify'." >&2
+  exit 1
+fi
+
 if [ "$RESUME" != "true" ]; then
   PUSHED_CHANGES=$(stash_and_exit)
 fi
 
+# Temporarily disable `set -e` so we can capture the exact exit status and
+# print the resume hint before propagating the failure.
+set +e
 uv run python "$GIT_ROOT/scripts/run_push_checks.py" $RESUME_FLAG
+_checks_status=$?
+set -e
+
+if [ "$_checks_status" -ne 0 ]; then
+  echo "" >&2
+  echo "Pre-push checks failed. After fixing the issue, resume from the failed" >&2
+  echo "step (skipping the checks that already passed) with:" >&2
+  echo "    RESUME=true git push" >&2
+  exit "$_checks_status"
+fi

--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -8,7 +8,16 @@ import pluginReact from "eslint-plugin-react"
 import reactHooks from "eslint-plugin-react-hooks"
 import regexpPlugin from "eslint-plugin-regexp"
 import globals from "globals"
-import { configs as tseslintConfigs } from "typescript-eslint"
+import { configs as tseslintConfigs, parser as tseslintParser } from "typescript-eslint"
+
+// Backward-compat re-exports (`export ... from`) are banned project-wide to
+// keep call sites importing from the canonical module, EXCEPT for the three
+// plugin barrel files, which legitimately use the pattern as a registry.
+const noReexportSyntax = {
+  selector: "ExportNamedDeclaration[source]",
+  message:
+    "Do not add backward-compat re-exports (`export ... from`); import from the canonical module at the call site.",
+}
 
 export default [
   // Global rules and plugins
@@ -75,6 +84,46 @@ export default [
     },
   },
 
+  // Ban backward-compat re-exports everywhere.
+  {
+    rules: {
+      "no-restricted-syntax": ["error", noReexportSyntax],
+    },
+  },
+
+  // Plugin barrel files use `export ... from` as a legitimate registry pattern.
+  {
+    files: [
+      "quartz/plugins/transformers/index.ts",
+      "quartz/plugins/filters/index.ts",
+      "quartz/plugins/emitters/index.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
+
+  // Type-aware rules for our TypeScript sources. Requires the parser to load
+  // the project so type information is available.
+  {
+    files: ["quartz/**/*.ts", "quartz/**/*.tsx"],
+    ignores: ["**/*.min.ts", "**/*.min.d.ts"],
+    languageOptions: {
+      parser: tseslintParser,
+      parserOptions: {
+        project: "./config/typescript/tsconfig.json",
+        // This config lives in config/javascript/; the tsconfig project path is
+        // relative to the repo root, two levels up.
+        tsconfigRootDir: `${import.meta.dirname}/../..`,
+      },
+    },
+    rules: {
+      "@typescript-eslint/prefer-readonly": "error",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+    },
+  },
+
   // Disable rules for test/spec files:
   // - react-hooks: Playwright's `use()` triggers false positives
   // - require-await: mock methods often need async signatures
@@ -119,6 +168,8 @@ export default [
     },
     rules: {
       ...jestPlugin.configs["flat/recommended"].rules,
+      // Custom assertion helpers that wrap `expect` internally.
+      "jest/expect-expect": ["warn", { assertFunctionNames: ["expect", "expectRevealed"] }],
     },
   },
 
@@ -127,6 +178,7 @@ export default [
     ignores: [
       "website_content/",
       "**/htmlcov/",
+      "**/coverage/",
       "public/",
       "backstop/",
       "**/*!*",

--- a/config/javascript/jest.config.js
+++ b/config/javascript/jest.config.js
@@ -19,16 +19,43 @@ const config = {
   coverageDirectory: "coverage",
 
   coveragePathIgnorePatterns: [
+    // Third-party packages — not our code to cover
     "/node_modules/",
+    // CLI entrypoints (build/dev/serve/create); exercised via the full Quartz
+    // build pipeline, not in the Jest unit-test environment
     "quartz/cli/",
+    // Tested by depgraph.test.ts but excluded here because it relies on
+    // Node-only data structures that report misleading branch counts under Jest's
+    // JSDOM environment
     "quartz/depgraph\\.ts",
+    // Thin file-copy emitter; all meaningful branches require a live FS + full
+    // build context (esbuild, globby over real static assets) that the Jest
+    // environment cannot provide
     "quartz/plugins/emitters/static\\.ts",
+    // glob: thin async wrapper around globby — requires a real filesystem walk
+    // ctx: type-only (interfaces + zero runtime branches)
+    // escape: tested by escape.test.ts (excluded from threshold to avoid noise from a single trivial file)
+    // log: winston logger setup with file rotation — side-effects at module load time make it hostile to coverage
+    // path: tested by path.test.ts (excluded to avoid JSDOM/Node path-module conflicts with the isomorphic slug logic)
+    // perf: PerfTimer wraps process.hrtime; wall-clock calls produce non-deterministic output
+    // sourcemap: thin source-map-support config hook; exercised only when the built bundle runs
+    // trace: calls process.exit(1) — untestable without crashing the Jest worker
     "quartz/util/(glob|ctx|escape|log|path|perf|sourcemap|trace)\\.ts",
+    // jsx: hast-to-JSX runtime renderer — rendering fidelity is verified by
+    //   Playwright visual tests, not unit tests
+    // resources: JSX helpers for <script>/<link> injection; no pure-logic branches
     "quartz/util/(jsx|resources)\\.tsx",
+    // Vendored minified third-party code (e.g. twemoji); not our logic to cover
     "quartz/.*\\.min\\.ts",
+    // Pure constant re-exports from constants.json — zero runtime branches
     "quartz/components/constants\\.ts",
+    // Thin presentational component; rendering correctness covered by Playwright,
+    // not Jest unit tests
     "quartz/components/Authors\\.tsx",
+    // Spawns child processes and reads from the filesystem to fetch image
+    // dimensions; requires a fully-built site and real assets to exercise
     "quartz/plugins/transformers/assetDimensions\\.ts",
+    // Test files themselves are not subject to coverage
     "\\.test\\.(ts|tsx|js|jsx)$",
     "/__tests__/",
   ],

--- a/config/markdownlint/.markdownlint-cli2.jsonc
+++ b/config/markdownlint/.markdownlint-cli2.jsonc
@@ -1,5 +1,0 @@
-{
-  "config": {
-    "extends": ".markdownlint.jsonc",
-  },
-}

--- a/package.json
+++ b/package.json
@@ -44,11 +44,8 @@
       "shellcheck"
     ],
     "*.py": [
-      "autoflake --in-place",
-      "isort",
-      "autopep8 --in-place",
-      "black",
-      "ruff check --fix"
+      "ruff check --fix",
+      "ruff format"
     ],
     "{*.md,.claude/**/*.md}": [
       "prettier --write --config config/prettier/.prettierrc --ignore-path config/prettier/.prettierignore",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,26 +77,17 @@ line-length = 80
 target-version = "py311"
 
 [tool.ruff.lint]
-# Default E + F, plus pyupgrade (UP) and return-statement (RET) — both are
-# largely autofixable and surface real modernization / dead-code issues.
-select = ["E", "F", "UP", "RET"]
-# Black is the authority on line length; it tolerates unsplittable long
-# lines (URLs, strings) that E501 would otherwise flag.
+# E + F (pycodestyle/pyflakes, incl. F401 unused-import removal), I (import
+# sorting, replacing isort), plus pyupgrade (UP) and return-statement (RET) —
+# all largely autofixable and surface real modernization / dead-code issues.
+select = ["E", "F", "I", "UP", "RET"]
+# The formatter is the authority on line length; it tolerates unsplittable
+# long lines (URLs, strings) that E501 would otherwise flag.
 ignore = ["E501"]
 
-[tool.black]
-line-length = 80
-target-version = ['py311']
-include = '\.pyw?$'
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 80
+[tool.ruff.format]
+# Match the previous black configuration exactly (80-column lines).
+line-ending = "lf"
 
 [tool.pytest.ini_options]
 addopts = "--cov=scripts --cov-report=html -n auto"
@@ -112,15 +103,6 @@ wrap-descriptions = 80
 pre-summary-newline = true
 make-summary-multi-line = false
 black = true
-
-[tool.autoflake]
-exclude = ["node_modules/*"]
-remove-all-unused-imports = true
-remove-unused-variables = true
-
-[tool.autopep8]
-ignore = ["E402"]
-max_line_length = 80
 
 [tool.coverage.run]
 omit = ["scripts/tests/*", "scripts/__init__.py"]

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -183,9 +183,9 @@ async function startServing(
 
   const buildFromEntry = argv.fastRebuild ? partialRebuildFromEntrypoint : rebuildFromEntrypoint
   watcher
-    .on("add", (fp) => buildFromEntry(fp, "add", clientRefresh, buildData))
-    .on("change", (fp) => buildFromEntry(fp, "change", clientRefresh, buildData))
-    .on("unlink", (fp) => buildFromEntry(fp, "delete", clientRefresh, buildData))
+    .on("add", (fp) => void buildFromEntry(fp, "add", clientRefresh, buildData))
+    .on("change", (fp) => void buildFromEntry(fp, "change", clientRefresh, buildData))
+    .on("unlink", (fp) => void buildFromEntry(fp, "delete", clientRefresh, buildData))
 
   return async () => {
     await watcher.close()
@@ -358,22 +358,26 @@ async function partialRebuildFromEntrypoint(
 
     // CLEANUP
     const destinationsToDelete = new Set<FilePath>()
+    // remove from cache
     for (const file of toRemove) {
-      // remove from cache
       contentMap.delete(file)
-      Object.values(dependencies).forEach((depGraph) => {
-        // remove the node from dependency graphs
-        depGraph?.removeNode(file)
-        // remove any orphan nodes. eg if a.md is deleted, a.html is orphaned and should be removed
-        const orphanNodes = depGraph?.removeOrphanNodes()
-        orphanNodes?.forEach((node) => {
-          // only delete files that are in the output directory
-          if (node.startsWith(argv.output)) {
-            destinationsToDelete.add(node)
-          }
-        })
-      })
     }
+    // Iterate each dependency graph once, removing every deleted file's node,
+    // then collecting orphans. eg if a.md is deleted, a.html is orphaned and
+    // should be removed.
+    Object.values(dependencies).forEach((depGraph) => {
+      if (!depGraph) return
+      for (const file of toRemove) {
+        depGraph.removeNode(file)
+      }
+      const orphanNodes = depGraph.removeOrphanNodes()
+      orphanNodes.forEach((node) => {
+        // only delete files that are in the output directory
+        if (node.startsWith(argv.output)) {
+          destinationsToDelete.add(node)
+        }
+      })
+    })
     await rimraf([...destinationsToDelete])
 
     console.log(chalk.green(`Done rebuilding in ${perf.timeSince()} 🔔`))

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -183,8 +183,11 @@ async function startServing(
 
   const buildFromEntry = argv.fastRebuild ? partialRebuildFromEntrypoint : rebuildFromEntrypoint
   watcher
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     .on("add", (fp) => void buildFromEntry(fp, "add", clientRefresh, buildData))
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     .on("change", (fp) => void buildFromEntry(fp, "change", clientRefresh, buildData))
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     .on("unlink", (fp) => void buildFromEntry(fp, "delete", clientRefresh, buildData))
 
   return async () => {

--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -270,7 +270,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       const indexFp: string = path.posix.join(filepath, "index.html")
       if (fs.existsSync(path.posix.join(argv.output, indexFp))) {
         req.url = filepath
-        serve()
+        void serve()
         return
       }
 
@@ -290,7 +290,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       }
       if (fs.existsSync(path.posix.join(argv.output, base))) {
         req.url = filepath
-        serve()
+        void serve()
         return
       }
 
@@ -301,7 +301,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       }
     }
 
-    serve()
+    void serve()
   })
 
   server.listen(argv.port)
@@ -328,12 +328,12 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       "**/*.spec.ts",
       "**/*.spec.tsx",
     ],
-  }).on("all", async (_event, fp) => {
+  }).on("all", (_event, fp) => {
     if (fp.endsWith(".scss")) {
       cachedCriticalCSS = ""
       console.log(chalk.yellow("SCSS change detected, invalidating critical CSS cache."))
     }
-    await build(clientRefresh)
+    void build(clientRefresh)
   })
 }
 

--- a/quartz/cli/handlers.ts
+++ b/quartz/cli/handlers.ts
@@ -270,6 +270,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       const indexFp: string = path.posix.join(filepath, "index.html")
       if (fs.existsSync(path.posix.join(argv.output, indexFp))) {
         req.url = filepath
+        // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
         void serve()
         return
       }
@@ -290,6 +291,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       }
       if (fs.existsSync(path.posix.join(argv.output, base))) {
         req.url = filepath
+        // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
         void serve()
         return
       }
@@ -301,6 +303,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       }
     }
 
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void serve()
   })
 
@@ -333,6 +336,7 @@ export async function handleBuild(argv: BuildArguments): Promise<void> {
       cachedCriticalCSS = ""
       console.log(chalk.yellow("SCSS change detected, invalidating critical CSS cache."))
     }
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void build(clientRefresh)
   })
 }

--- a/quartz/components/PageShell.tsx
+++ b/quartz/components/PageShell.tsx
@@ -19,6 +19,9 @@ import scrollIndicatorScript from "./scripts/scroll-indicator.inline"
 // @ts-expect-error Not a module but a script
 // skipcq: JS-W1028
 import smallCapsCopyScript from "./scripts/smallcaps-copy.inline"
+// @ts-expect-error Not a module but a script
+// skipcq: JS-W1028
+import spoilerScript from "./scripts/spoiler.inline"
 import clipboardStyle from "./styles/clipboard.scss"
 import {
   type QuartzComponent,
@@ -108,6 +111,7 @@ PageShell.afterDOMLoaded = [
   smallCapsCopyScript,
   scrollIndicatorScript,
   punctilioDemoScript,
+  spoilerScript,
 ]
 // Runs synchronously in `<head>` before any `<img>` is parsed — required so
 // the capture-phase `load` listener catches every img load before first paint.

--- a/quartz/components/scripts/accurateInvert.test.ts
+++ b/quartz/components/scripts/accurateInvert.test.ts
@@ -273,8 +273,10 @@ describe("handleLoadEvent", () => {
   })
 
   it("ignores non-eligible targets", () => {
-    handleLoadEvent({ target: document.createElement("div") } as unknown as Event)
-    handleLoadEvent({ target: null } as unknown as Event)
+    expect(() => {
+      handleLoadEvent({ target: document.createElement("div") } as unknown as Event)
+      handleLoadEvent({ target: null } as unknown as Event)
+    }).not.toThrow()
   })
 })
 
@@ -479,7 +481,7 @@ describe("prepareForThemeChange", () => {
 
   it("is a no-op when no images need swapping", async () => {
     await prepareForThemeChange(true)
-    await prepareForThemeChange(false)
+    await expect(prepareForThemeChange(false)).resolves.toBeUndefined()
   })
 })
 

--- a/quartz/components/scripts/darkmode.ts
+++ b/quartz/components/scripts/darkmode.ts
@@ -92,6 +92,7 @@ export const rotateTheme = () => {
 function setupDarkMode() {
   const savedTheme = localStorage.getItem(savedThemeKey)
   const theme = savedTheme || "auto"
+  // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
   void handleThemeUpdate(theme as Theme)
 
   const toggle = document.querySelector("#theme-toggle") as HTMLButtonElement

--- a/quartz/components/scripts/darkmode.ts
+++ b/quartz/components/scripts/darkmode.ts
@@ -92,7 +92,7 @@ export const rotateTheme = () => {
 function setupDarkMode() {
   const savedTheme = localStorage.getItem(savedThemeKey)
   const theme = savedTheme || "auto"
-  handleThemeUpdate(theme as Theme)
+  void handleThemeUpdate(theme as Theme)
 
   const toggle = document.querySelector("#theme-toggle") as HTMLButtonElement
   if (toggle) {

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -272,6 +272,7 @@ document.addEventListener("nav", () => {
           if (activePopoverRemover) {
             activePopoverRemover()
           }
+          // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
           void mouseEnterHandler.call(link) // Show the new popover
           pendingPopoverTimer = null
         }, popoverRemovalDelayMs)
@@ -314,6 +315,7 @@ document.addEventListener("nav", () => {
             activePopoverRemover()
           }
           nextPopoverPinned = true
+          // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
           void mouseEnterHandler.call(link)
         },
         { signal },

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -25,10 +25,11 @@ let linkListenerController: AbortController | null = null
 // When true, the next popover created by mouseEnterHandler will be pinned
 // (persist until explicitly closed via X or Escape). Set by click handlers.
 let nextPopoverPinned = false
-// Generation counter to detect stale async calls to mouseEnterHandler.
-// Incremented synchronously at call start; checked after await to bail
-// out if a newer call has started.
-let popoverGeneration = 0
+// Aborted to cancel in-flight async popover creation. A fresh controller is
+// installed synchronously at the start of each mouseEnterHandler call (and on
+// nav), so a stale call's signal is already aborted by the time its fetch
+// resolves and it discards its result.
+let popoverFetchController: AbortController | null = null
 
 /**
  * Handles the mouse enter event for link elements
@@ -43,7 +44,11 @@ async function mouseEnterHandler(this: HTMLLinkElement) {
   // don't share or leak the pinned flag across popovers.
   const shouldPin = nextPopoverPinned
   nextPopoverPinned = false
-  const thisGeneration = ++popoverGeneration
+  // Abort any previous in-flight creation so its stale result is discarded,
+  // then install a fresh controller for this call.
+  popoverFetchController?.abort()
+  popoverFetchController = new AbortController()
+  const { signal } = popoverFetchController
 
   const thisUrl = new URL(document.location.href)
   thisUrl.hash = ""
@@ -63,7 +68,7 @@ async function mouseEnterHandler(this: HTMLLinkElement) {
 
   // A newer call to mouseEnterHandler started while we were fetching —
   // discard this stale popover so we don't end up with duplicates.
-  if (thisGeneration !== popoverGeneration) {
+  if (signal.aborted) {
     return
   }
 
@@ -175,7 +180,7 @@ document.addEventListener("nav", () => {
   }
   // Invalidate any in-flight async mouseEnterHandler calls so they
   // discard their result instead of creating an orphaned popover.
-  popoverGeneration++
+  popoverFetchController?.abort()
 
   // Mark that the mouse hasn't moved yet since this navigation.
   // Safari fires spurious mouseenter events after DOM morphing under a
@@ -267,7 +272,7 @@ document.addEventListener("nav", () => {
           if (activePopoverRemover) {
             activePopoverRemover()
           }
-          mouseEnterHandler.call(link) // Show the new popover
+          void mouseEnterHandler.call(link) // Show the new popover
           pendingPopoverTimer = null
         }, popoverRemovalDelayMs)
       }
@@ -309,7 +314,7 @@ document.addEventListener("nav", () => {
             activePopoverRemover()
           }
           nextPopoverPinned = true
-          mouseEnterHandler.call(link)
+          void mouseEnterHandler.call(link)
         },
         { signal },
       )

--- a/quartz/components/scripts/randomPost.ts
+++ b/quartz/components/scripts/randomPost.ts
@@ -31,6 +31,7 @@ async function handleRandomPostClick(e: MouseEvent): Promise<void> {
   const slug = candidates[Math.floor(Math.random() * candidates.length)]
   const url = new URL(`/${slug}`, location.origin)
   if (window.spaNavigate) {
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void window.spaNavigate(url)
   } else {
     location.assign(url)
@@ -39,6 +40,7 @@ async function handleRandomPostClick(e: MouseEvent): Promise<void> {
 
 export function setupRandomPostLink(): void {
   document.addEventListener("click", (e: MouseEvent) => {
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void handleRandomPostClick(e)
   })
 }

--- a/quartz/components/scripts/randomPost.ts
+++ b/quartz/components/scripts/randomPost.ts
@@ -15,26 +15,30 @@ export function isPost(slug: string): boolean {
   return !EXCLUDED_SLUG_PREFIXES.some((prefix) => slug.startsWith(prefix))
 }
 
+async function handleRandomPostClick(e: MouseEvent): Promise<void> {
+  const btn = (e.target as HTMLElement).closest("#random-post-link")
+  if (!btn) return
+  e.preventDefault()
+  const data = await getContentIndex()
+  if (!data) return
+  const posts = Object.keys(data).filter(isPost)
+  if (posts.length <= 1) {
+    console.error("[randomPost] Not enough posts:", posts.length)
+    return
+  }
+  const current = document.body.dataset.slug ?? ""
+  const candidates = posts.filter((s) => s !== current)
+  const slug = candidates[Math.floor(Math.random() * candidates.length)]
+  const url = new URL(`/${slug}`, location.origin)
+  if (window.spaNavigate) {
+    void window.spaNavigate(url)
+  } else {
+    location.assign(url)
+  }
+}
+
 export function setupRandomPostLink(): void {
-  document.addEventListener("click", async (e: MouseEvent) => {
-    const btn = (e.target as HTMLElement).closest("#random-post-link")
-    if (!btn) return
-    e.preventDefault()
-    const data = await getContentIndex()
-    if (!data) return
-    const posts = Object.keys(data).filter(isPost)
-    if (posts.length <= 1) {
-      console.error("[randomPost] Not enough posts:", posts.length)
-      return
-    }
-    const current = document.body.dataset.slug ?? ""
-    const candidates = posts.filter((s) => s !== current)
-    const slug = candidates[Math.floor(Math.random() * candidates.length)]
-    const url = new URL(`/${slug}`, location.origin)
-    if (window.spaNavigate) {
-      window.spaNavigate(url)
-    } else {
-      location.assign(url)
-    }
+  document.addEventListener("click", (e: MouseEvent) => {
+    void handleRandomPostClick(e)
   })
 }

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -857,6 +857,7 @@ function onNav(e: CustomEventMap["nav"]) {
   // Start fetching content index in the background (cached for later use
   // by initializeSearch). Don't block handler registration on the fetch —
   // data is only needed when the user actually performs a search.
+  // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
   void getContentIndex()
 
   results = document.createElement("div")
@@ -886,6 +887,7 @@ function onNav(e: CustomEventMap["nav"]) {
     document,
     "keydown",
     (e: Event) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void shortcutHandler(e as KeyboardEvent, container, searchBar)
     },
     listeners,
@@ -1242,6 +1244,7 @@ export function navigateWithSearchTerm(href: string, searchTerm: string) {
   }
 
   hideSearch(null)
+  // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
   void window.spaNavigate(new URL(href), { searchTerm })
 }
 

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -347,8 +347,8 @@ export const matchTextNodes = (node: Node, term: string) => {
  * matching, and handles show/hide/clear operations.
  */
 export class PreviewManager {
-  private container: HTMLDivElement
-  private inner: HTMLElement
+  private readonly container: HTMLDivElement
+  private readonly inner: HTMLElement
   private currentSlug: FullSlug | null = null
 
   constructor(container: HTMLDivElement) {
@@ -857,7 +857,7 @@ function onNav(e: CustomEventMap["nav"]) {
   // Start fetching content index in the background (cached for later use
   // by initializeSearch). Don't block handler registration on the fetch —
   // data is only needed when the user actually performs a search.
-  getContentIndex()
+  void getContentIndex()
 
   results = document.createElement("div")
   const container = document.getElementById("search-container")
@@ -885,7 +885,9 @@ function onNav(e: CustomEventMap["nav"]) {
   addListener(
     document,
     "keydown",
-    (e: Event) => shortcutHandler(e as KeyboardEvent, container, searchBar),
+    (e: Event) => {
+      void shortcutHandler(e as KeyboardEvent, container, searchBar)
+    },
     listeners,
   )
   addListener(
@@ -1240,7 +1242,7 @@ export function navigateWithSearchTerm(href: string, searchTerm: string) {
   }
 
   hideSearch(null)
-  window.spaNavigate(new URL(href), { searchTerm })
+  void window.spaNavigate(new URL(href), { searchTerm })
 }
 
 /**

--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -791,14 +791,14 @@ test.describe("Fetch & Redirect Handling", () => {
     const targetContent = "Redirect Target Content"
 
     await page.route(`**${sourcePath}`, (route) => {
-      route.fulfill({
+      void route.fulfill({
         status: 200,
         contentType: "text/html",
         body: `<html><head><meta http-equiv="refresh" content="0; url=${targetPath}"></head><body>Redirecting...</body></html>`,
       })
     })
     await page.route(`**${targetPath}`, (route) => {
-      route.fulfill({
+      void route.fulfill({
         status: 200,
         contentType: "text/html",
         body: `<html><head><title>Target Page</title></head><body><h1>${targetContent}</h1></body></html>`,
@@ -856,7 +856,7 @@ test.describe("Network Behavior", () => {
     // Intercept requests for the same page.
     await page.route(`**/${testingPageSlug}`, (route) => {
       requestMade = true
-      route.continue()
+      void route.continue()
     })
 
     // Create an anchor and a link pointing to it

--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -791,6 +791,7 @@ test.describe("Fetch & Redirect Handling", () => {
     const targetContent = "Redirect Target Content"
 
     await page.route(`**${sourcePath}`, (route) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.fulfill({
         status: 200,
         contentType: "text/html",
@@ -798,6 +799,7 @@ test.describe("Fetch & Redirect Handling", () => {
       })
     })
     await page.route(`**${targetPath}`, (route) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.fulfill({
         status: 200,
         contentType: "text/html",
@@ -856,6 +858,7 @@ test.describe("Network Behavior", () => {
     // Intercept requests for the same page.
     await page.route(`**/${testingPageSlug}`, (route) => {
       requestMade = true
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.continue()
     })
 

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -485,11 +485,13 @@ function createRouter() {
     )
 
     document.addEventListener("click", (event) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void handleClickNavigation(event)
     })
 
     // Listener for back/forward navigation
     window.addEventListener("popstate", (event) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void handlePopstate(event)
     })
 

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -433,6 +433,40 @@ async function handlePopstate(event: PopStateEvent): Promise<void> {
 }
 
 /**
+ * Intercepts in-app link clicks and performs SPA navigation, falling back to a
+ * full page load if navigation fails.
+ */
+async function handleClickNavigation(event: Event): Promise<void> {
+  // Use getNavigationOpts to check for valid local links ignoring modifiers/targets
+  const opts = getNavigationOpts(event)
+  if (
+    !opts ||
+    !opts.url ||
+    event.defaultPrevented ||
+    (event as MouseEvent).ctrlKey ||
+    (event as MouseEvent).metaKey
+  ) {
+    return // Let browser handle normal links, external links, or modified clicks
+  }
+
+  event.preventDefault() // Prevent default link behavior
+
+  const targetUrl = opts.url
+  const currentUrl = new URL(window.location.toString())
+  const shouldFetch =
+    targetUrl.pathname !== currentUrl.pathname || targetUrl.search !== currentUrl.search
+
+  try {
+    console.debug(`[Router] Click navigation to ${opts.url.toString()}`)
+    await navigate(opts.url, { scroll: opts.scroll, fetch: shouldFetch })
+  } catch (e) {
+    console.error("Click navigation error:", e)
+    // Fallback to standard navigation if spa navigation fails
+    window.location.assign(opts.url)
+  }
+}
+
+/**
  * Creates and configures the router instance
  * - Sets up click event listeners for link interception
  * - Handles browser back/forward navigation (popstate)
@@ -450,38 +484,14 @@ function createRouter() {
       { passive: true },
     )
 
-    document.addEventListener("click", async (event) => {
-      // Use getNavigationOpts to check for valid local links ignoring modifiers/targets
-      const opts = getNavigationOpts(event)
-      if (
-        !opts ||
-        !opts.url ||
-        event.defaultPrevented ||
-        (event as MouseEvent).ctrlKey ||
-        (event as MouseEvent).metaKey
-      ) {
-        return // Let browser handle normal links, external links, or modified clicks
-      }
-
-      event.preventDefault() // Prevent default link behavior
-
-      const targetUrl = opts.url
-      const currentUrl = new URL(window.location.toString())
-      const shouldFetch =
-        targetUrl.pathname !== currentUrl.pathname || targetUrl.search !== currentUrl.search
-
-      try {
-        console.debug(`[Router] Click navigation to ${opts.url.toString()}`)
-        await navigate(opts.url, { scroll: opts.scroll, fetch: shouldFetch })
-      } catch (e) {
-        console.error("Click navigation error:", e)
-        // Fallback to standard navigation if spa navigation fails
-        window.location.assign(opts.url)
-      }
+    document.addEventListener("click", (event) => {
+      void handleClickNavigation(event)
     })
 
     // Listener for back/forward navigation
-    window.addEventListener("popstate", handlePopstate)
+    window.addEventListener("popstate", (event) => {
+      void handlePopstate(event)
+    })
 
     window.__routerInitialized = true
   }

--- a/quartz/components/scripts/spoiler.inline.ts
+++ b/quartz/components/scripts/spoiler.inline.ts
@@ -1,0 +1,12 @@
+import { handleSpoilerClick, handleSpoilerKeydown } from "./spoiler"
+
+let spoilerAbortController: AbortController | null = null
+
+document.addEventListener("nav", () => {
+  spoilerAbortController?.abort()
+  spoilerAbortController = new AbortController()
+  const { signal } = spoilerAbortController
+
+  document.addEventListener("click", handleSpoilerClick, { signal })
+  document.addEventListener("keydown", handleSpoilerKeydown, { signal })
+})

--- a/quartz/components/scripts/spoiler.test.ts
+++ b/quartz/components/scripts/spoiler.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals"
+
+import { handleSpoilerClick, handleSpoilerKeydown, toggleSpoiler } from "./spoiler"
+
+function createSpoiler(): HTMLElement {
+  const container = document.createElement("div")
+  container.className = "spoiler-container"
+
+  const overlay = document.createElement("span")
+  overlay.className = "spoiler-overlay"
+  overlay.setAttribute("role", "button")
+  overlay.setAttribute("tabindex", "0")
+  overlay.setAttribute("aria-expanded", "false")
+  overlay.setAttribute("aria-hidden", "false")
+
+  const content = document.createElement("span")
+  content.className = "spoiler-content"
+  content.setAttribute("aria-hidden", "true")
+  content.textContent = "secret"
+
+  container.append(overlay, content)
+  document.body.appendChild(container)
+  return container
+}
+
+function expectRevealed(container: HTMLElement, revealed: boolean): void {
+  const overlay = container.querySelector(".spoiler-overlay")
+  const content = container.querySelector(".spoiler-content")
+  expect(container.classList.contains("revealed")).toBe(revealed)
+  expect(overlay?.getAttribute("aria-expanded")).toBe(String(revealed))
+  expect(overlay?.getAttribute("aria-hidden")).toBe(String(revealed))
+  expect(content?.getAttribute("aria-hidden")).toBe(String(!revealed))
+}
+
+describe("spoiler", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    document.addEventListener("click", handleSpoilerClick)
+    document.addEventListener("keydown", handleSpoilerKeydown)
+  })
+
+  afterEach(() => {
+    document.removeEventListener("click", handleSpoilerClick)
+    document.removeEventListener("keydown", handleSpoilerKeydown)
+    document.body.innerHTML = ""
+  })
+
+  describe("toggleSpoiler", () => {
+    it("toggles revealed state and syncs aria attributes", () => {
+      const container = createSpoiler()
+
+      toggleSpoiler(container)
+      expectRevealed(container, true)
+
+      toggleSpoiler(container)
+      expectRevealed(container, false)
+    })
+
+    it("does not throw when overlay and content are missing", () => {
+      const container = document.createElement("div")
+      container.className = "spoiler-container"
+      document.body.appendChild(container)
+
+      expect(() => toggleSpoiler(container)).not.toThrow()
+      expect(container.classList.contains("revealed")).toBe(true)
+    })
+  })
+
+  describe("handleSpoilerClick", () => {
+    it("reveals when clicking inside the container", () => {
+      const container = createSpoiler()
+      const overlay = container.querySelector(".spoiler-overlay") as HTMLElement
+
+      overlay.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      expectRevealed(container, true)
+    })
+
+    it("ignores clicks outside any spoiler container", () => {
+      createSpoiler()
+      const outside = document.createElement("div")
+      document.body.appendChild(outside)
+
+      const handled = handleSpoilerClickReturns(outside)
+      expect(handled).toBe(false)
+    })
+  })
+
+  describe("handleSpoilerKeydown", () => {
+    it.each(["Enter", " "])("toggles on %s when overlay focused", (key) => {
+      const container = createSpoiler()
+      const overlay = container.querySelector(".spoiler-overlay") as HTMLElement
+
+      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true })
+      overlay.dispatchEvent(event)
+
+      expectRevealed(container, true)
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it("ignores non-toggle keys", () => {
+      const container = createSpoiler()
+      const overlay = container.querySelector(".spoiler-overlay") as HTMLElement
+
+      overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }))
+      expectRevealed(container, false)
+    })
+
+    it("ignores toggle keys fired outside an overlay", () => {
+      const container = createSpoiler()
+      const content = container.querySelector(".spoiler-content") as HTMLElement
+
+      content.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+      expectRevealed(container, false)
+    })
+
+    it("does nothing when overlay has no container ancestor", () => {
+      const overlay = document.createElement("span")
+      overlay.className = "spoiler-overlay"
+      document.body.appendChild(overlay)
+
+      const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      expect(() => handleSpoilerKeydown(event)).not.toThrow()
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
+})
+
+/**
+ * Invokes `handleSpoilerClick` for a target and reports whether any spoiler was
+ * revealed, exercising the no-container branch directly.
+ */
+function handleSpoilerClickReturns(target: HTMLElement): boolean {
+  const before = document.querySelectorAll(".spoiler-container.revealed").length
+  const event = new MouseEvent("click", { bubbles: true })
+  Object.defineProperty(event, "target", { value: target })
+  handleSpoilerClick(event)
+  const after = document.querySelectorAll(".spoiler-container.revealed").length
+  return after !== before
+}

--- a/quartz/components/scripts/spoiler.ts
+++ b/quartz/components/scripts/spoiler.ts
@@ -1,0 +1,58 @@
+/**
+ * Spoiler toggle functionality - reveals/hides spoiler content on click.
+ * Uses event delegation so a single document-level listener handles every
+ * `.spoiler-container`, including ones morphed in after SPA navigation.
+ */
+
+const REVEALED_CLASS = "revealed"
+
+/**
+ * Toggle the revealed state of a spoiler container and sync the
+ * aria-expanded / aria-hidden attributes on its overlay and content.
+ * @param container - The `.spoiler-container` element to toggle
+ */
+export function toggleSpoiler(container: HTMLElement): void {
+  const revealed = container.classList.toggle(REVEALED_CLASS)
+
+  const overlay = container.querySelector(".spoiler-overlay")
+  if (overlay) {
+    overlay.setAttribute("aria-expanded", String(revealed))
+    overlay.setAttribute("aria-hidden", String(revealed))
+  }
+
+  const content = container.querySelector(".spoiler-content")
+  if (content) {
+    content.setAttribute("aria-hidden", String(!revealed))
+  }
+}
+
+/**
+ * Document-level click handler that toggles the nearest spoiler container.
+ * @param e - The click event
+ */
+export function handleSpoilerClick(e: MouseEvent): void {
+  const target = e.target as HTMLElement | null
+  const container = target?.closest<HTMLElement>(".spoiler-container")
+  if (container) {
+    toggleSpoiler(container)
+  }
+}
+
+/**
+ * Document-level keydown handler that toggles a spoiler when its overlay is
+ * focused and the user presses Enter or Space.
+ * @param e - The keydown event
+ */
+export function handleSpoilerKeydown(e: KeyboardEvent): void {
+  if (e.key !== "Enter" && e.key !== " ") return
+
+  const target = e.target as HTMLElement | null
+  const overlay = target?.closest<HTMLElement>(".spoiler-overlay")
+  if (!overlay) return
+
+  const container = overlay.closest<HTMLElement>(".spoiler-container")
+  if (container) {
+    e.preventDefault()
+    toggleSpoiler(container)
+  }
+}

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -513,18 +513,21 @@ describe("showSearch", () => {
   })
 
   it("should make the search container active and focus the search bar", () => {
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void showSearch(container, searchBar)
     expect(container.classList.contains("active")).toBe(true)
     expect(document.activeElement).toBe(searchBar)
   })
 
   it("should set the z-index of the navbar", () => {
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void showSearch(container, searchBar)
     expect(navbar.style.zIndex).toBe("1")
   })
 
   it("should lock body scroll by setting overflow hidden", () => {
     expect(document.body.style.overflow).toBe("")
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void showSearch(container, searchBar)
     expect(document.body.style.overflow).toBe("hidden")
   })

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -513,19 +513,19 @@ describe("showSearch", () => {
   })
 
   it("should make the search container active and focus the search bar", () => {
-    showSearch(container, searchBar)
+    void showSearch(container, searchBar)
     expect(container.classList.contains("active")).toBe(true)
     expect(document.activeElement).toBe(searchBar)
   })
 
   it("should set the z-index of the navbar", () => {
-    showSearch(container, searchBar)
+    void showSearch(container, searchBar)
     expect(navbar.style.zIndex).toBe("1")
   })
 
   it("should lock body scroll by setting overflow hidden", () => {
     expect(document.body.style.overflow).toBe("")
-    showSearch(container, searchBar)
+    void showSearch(container, searchBar)
     expect(document.body.style.overflow).toBe("hidden")
   })
 

--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -25,7 +25,7 @@ function setupTocTitleScrollToTop(signal: AbortSignal): void {
     "click",
     () => {
       const url = new URL(window.location.pathname, window.location.origin)
-      window.spaNavigate(url)
+      void window.spaNavigate(url)
       window.scrollTo({ top: 0, behavior: "instant" })
     },
     { signal },

--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -25,6 +25,7 @@ function setupTocTitleScrollToTop(signal: AbortSignal): void {
     "click",
     () => {
       const url = new URL(window.location.pathname, window.location.origin)
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void window.spaNavigate(url)
       window.scrollTo({ top: 0, behavior: "instant" })
     },

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -386,7 +386,7 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
       releasePopoverFetch = release
     })
     let firstRequest = true
-    page.route("**/popover-fixture", async (route) => {
+    void page.route("**/popover-fixture", async (route) => {
       if (firstRequest) {
         firstRequest = false
         resolve() // signal that the popover fetch has started
@@ -755,11 +755,11 @@ test.describe("Popover checkbox state preservation", () => {
   test("Popover preserves checkbox state", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/design")
 
-    const linkToTestPage = page.locator('a[href*="test-page"]').last()
-    await linkToTestPage.scrollIntoViewIfNeeded()
-    await expect(linkToTestPage).toBeVisible()
+    const testPageLink = page.locator('a[href*="test-page"]').last()
+    await testPageLink.scrollIntoViewIfNeeded()
+    await expect(testPageLink).toBeVisible()
 
-    await linkToTestPage.hover()
+    await testPageLink.hover()
     const popover = page.locator(".popover")
     await expect(popover).toBeVisible()
 

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -386,6 +386,7 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
       releasePopoverFetch = release
     })
     let firstRequest = true
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void page.route("**/popover-fixture", async (route) => {
       if (firstRequest) {
         firstRequest = false

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -576,7 +576,7 @@ test.describe("pauseMediaElements", () => {
     `)
     // Mock media sources to prevent actual loading/errors
     await page.route("**/*.{mp4,mp3}", (route) => {
-      route.fulfill({ status: 200, contentType: "video/mp4", body: Buffer.from("") })
+      void route.fulfill({ status: 200, contentType: "video/mp4", body: Buffer.from("") })
     })
   })
 
@@ -616,7 +616,7 @@ test.describe("pauseMediaElements", () => {
 
     // Mock the audio file
     await page.route("**/test.mp3", (route) => {
-      route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
+      void route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
     })
 
     const audio = page.locator("#audio-with-duration")
@@ -651,7 +651,7 @@ test.describe("pauseMediaElements", () => {
 
     // Mock the audio file
     await page.route("**/loading.mp3", (route) => {
-      route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
+      void route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
     })
 
     const audio = page.locator("#audio-loading")

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -576,6 +576,7 @@ test.describe("pauseMediaElements", () => {
     `)
     // Mock media sources to prevent actual loading/errors
     await page.route("**/*.{mp4,mp3}", (route) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.fulfill({ status: 200, contentType: "video/mp4", body: Buffer.from("") })
     })
   })
@@ -616,6 +617,7 @@ test.describe("pauseMediaElements", () => {
 
     // Mock the audio file
     await page.route("**/test.mp3", (route) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
     })
 
@@ -651,6 +653,7 @@ test.describe("pauseMediaElements", () => {
 
     // Mock the audio file
     await page.route("**/loading.mp3", (route) => {
+      // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
       void route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from("") })
     })
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -504,7 +504,7 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
               () => {
                 const time = target === "start" ? 0 : media.duration
                 if (Number.isFinite(time)) {
-                  seekAndWait(time).then(resolve)
+                  void seekAndWait(time).then(resolve)
                 } else {
                   resolve()
                 }

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -504,6 +504,7 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
               () => {
                 const time = target === "start" ? 0 : media.duration
                 if (Number.isFinite(time)) {
+                  // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
                   void seekAndWait(time).then(resolve)
                 } else {
                   resolve()

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -7,7 +7,7 @@ import { toHtml } from "hast-util-to-html"
 import { h } from "hastscript"
 import { render } from "preact-render-to-string"
 import { quote } from "shell-quote"
-import { CONTINUE, EXIT, visit } from "unist-util-visit"
+import { visit } from "unist-util-visit"
 
 import { simpleConstants, specialFaviconPaths } from "../../components/constants"
 import { renderPostStatistics } from "../../components/ContentMeta"
@@ -36,19 +36,30 @@ const {
 const logger = createWinstonLogger("populateContainers")
 
 /**
+ * Collects every element in the HAST tree matching a predicate.
+ * @param tree - The root HAST node to search
+ * @param predicate - Returns true for elements that should be collected
+ * @returns Array of matching elements in document order
+ */
+export const findElements = (tree: Root, predicate: (node: Element) => boolean): Element[] => {
+  const found: Element[] = []
+  visit(tree, "element", (node) => {
+    if (predicate(node)) {
+      found.push(node)
+    }
+  })
+  return found
+}
+
+/**
  * Finds an element in the HAST tree by its ID attribute.
  * @param root - The root HAST node to search
  * @param id - The ID to search for
  * @returns The element with the matching ID, or null if not found
  */
 export const findElementById = (root: Root, id: string): Element | null => {
-  let found: Element | null = null
-  visit(root, "element", (node) => {
-    if (node.properties?.id !== id) return CONTINUE
-    found = node
-    return EXIT
-  })
-  return found
+  const matches = findElements(root, (node) => node.properties?.id === id)
+  return matches[0] ?? null
 }
 
 /**
@@ -58,13 +69,7 @@ export const findElementById = (root: Root, id: string): Element | null => {
  * @returns Array of elements with the matching class name
  */
 export const findElementsByClass = (root: Root, className: string): Element[] => {
-  const found: Element[] = []
-  visit(root, "element", (node) => {
-    if (hasClass(node, className)) {
-      found.push(node)
-    }
-  })
-  return found
+  return findElements(root, (node) => hasClass(node, className))
 }
 
 /**

--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -274,7 +274,7 @@ class AssetProcessor {
           !isSvgRemote &&
           (contentType?.startsWith("video/") || contentType?.startsWith("image/"))
         ) {
-          response.body?.cancel()
+          void response.body?.cancel()
           return await AssetProcessor.getAssetDimensionsFfprobe(assetSrc)
         }
 

--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -274,6 +274,7 @@ class AssetProcessor {
           !isSvgRemote &&
           (contentType?.startsWith("video/") || contentType?.startsWith("image/"))
         ) {
+          // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
           void response.body?.cancel()
           return await AssetProcessor.getAssetDimensionsFfprobe(assetSrc)
         }

--- a/quartz/plugins/transformers/countFavicons.test.ts
+++ b/quartz/plugins/transformers/countFavicons.test.ts
@@ -420,38 +420,30 @@ describe("getFaviconCounts", () => {
     expect(counts.get("mail")).toBe(5)
   })
 
-  it("should return empty map when file does not exist", async () => {
-    jest.spyOn(fs.promises, "access").mockRejectedValue(new Error("ENOENT"))
+  it("should return empty map when file does not exist (ENOENT)", async () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    jest.spyOn(fs.promises, "readFile").mockRejectedValue(err)
 
     const counts = await getFaviconCounts()
 
     expect(counts.size).toBe(0)
   })
 
-  it("should handle invalid JSON content gracefully", async () => {
-    jest.spyOn(fs.promises, "access").mockImplementation(() => Promise.resolve())
+  it("should throw on invalid JSON content (fail loudly on corruption)", async () => {
     jest.spyOn(fs.promises, "readFile").mockResolvedValue("invalid json {]")
 
-    const counts = await getFaviconCounts()
-
-    expect(counts.size).toBe(0)
+    await expect(getFaviconCounts()).rejects.toThrow()
   })
 
-  it("should handle read errors gracefully", async () => {
-    jest.spyOn(fs.promises, "access").mockImplementation(() => Promise.resolve())
+  it("should throw on non-ENOENT read errors", async () => {
     jest.spyOn(fs.promises, "readFile").mockRejectedValue(new Error("Read error"))
 
-    const counts = await getFaviconCounts()
-
-    expect(counts.size).toBe(0)
+    await expect(getFaviconCounts()).rejects.toThrow("Read error")
   })
 
-  it("should return empty map when file is empty", async () => {
-    jest.spyOn(fs.promises, "access").mockImplementation(() => Promise.resolve())
+  it("should throw when the file is empty (malformed JSON)", async () => {
     jest.spyOn(fs.promises, "readFile").mockResolvedValue("")
 
-    const counts = await getFaviconCounts()
-
-    expect(counts.size).toBe(0)
+    await expect(getFaviconCounts()).rejects.toThrow()
   })
 })

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -242,12 +242,18 @@ describe("findFaviconPath", () => {
 })
 
 describe("readFaviconCounts", () => {
-  it.each(["ENOENT", "EACCES"])("returns empty Map when access fails with %s", async (code) => {
-    const err: NodeJS.ErrnoException = Object.assign(new Error(code), { code })
-    jest.spyOn(fs.promises, "access").mockRejectedValue(err)
+  it("returns empty Map when the file is missing (ENOENT)", async () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    jest.spyOn(fs.promises, "readFile").mockRejectedValue(err)
     const result = await favicons.readFaviconCounts()
     expect(result).toBeInstanceOf(Map)
     expect(result.size).toBe(0)
+  })
+
+  it("throws when the file cannot be accessed for a non-ENOENT reason", async () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error("EACCES"), { code: "EACCES" })
+    jest.spyOn(fs.promises, "readFile").mockRejectedValue(err)
+    await expect(favicons.readFaviconCounts()).rejects.toThrow("EACCES")
   })
 
   it.each([
@@ -276,7 +282,6 @@ describe("readFaviconCounts", () => {
       "JSON with invalid entries (skipped)",
     ],
   ])("parses %s", async (fileContent, expectedMap) => {
-    jest.spyOn(fs.promises, "access").mockResolvedValue()
     jest.spyOn(fs.promises, "readFile").mockResolvedValue(fileContent)
     const result = await favicons.readFaviconCounts()
     expect(result.size).toBe(expectedMap.size)
@@ -285,18 +290,14 @@ describe("readFaviconCounts", () => {
     })
   })
 
-  it("returns empty Map when JSON parsing fails", async () => {
-    jest.spyOn(fs.promises, "access").mockResolvedValue()
+  it("throws when the file is malformed (JSON parse fails)", async () => {
     jest.spyOn(fs.promises, "readFile").mockResolvedValue("not json")
-    const result = await favicons.readFaviconCounts()
-    expect(result.size).toBe(0)
+    await expect(favicons.readFaviconCounts()).rejects.toThrow()
   })
 
-  it("returns empty Map when file read fails", async () => {
-    jest.spyOn(fs.promises, "access").mockResolvedValue()
+  it("throws when file read fails for a non-ENOENT reason", async () => {
     jest.spyOn(fs.promises, "readFile").mockRejectedValue(new Error("read failed"))
-    const result = await favicons.readFaviconCounts()
-    expect(result.size).toBe(0)
+    await expect(favicons.readFaviconCounts()).rejects.toThrow("read failed")
   })
 })
 

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -58,34 +58,31 @@ export function normalizePathForCounting(faviconPath: string): string {
 /**
  * Reads favicon counts from the faviconCountsFile and returns them as a ReadonlyMap.
  *
- * @returns A ReadonlyMap of favicon path to count, or empty Map if file doesn't exist or can't be read.
+ * A missing file (ENOENT) is a normal, expected state and yields an empty Map.
+ * A malformed/corrupt file throws so the corruption fails loudly rather than
+ * silently degrading to an empty count map.
+ *
+ * @returns A ReadonlyMap of favicon path to count, or empty Map if the file doesn't exist.
  */
 export async function readFaviconCounts(): Promise<ReadonlyMap<string, number>> {
+  let data: string
   try {
-    await fs.promises.access(faviconCountsFile, fs.constants.F_OK)
+    data = await fs.promises.readFile(faviconCountsFile, "utf8")
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
     if (code === "ENOENT") {
       logger.warn(`Favicon counts file not found at ${faviconCountsFile}`)
-    } else {
-      logger.error(`Cannot access favicon counts file at ${faviconCountsFile}: ${error}`)
+      return new Map<string, number>()
     }
-    return new Map<string, number>()
+    throw error
   }
 
   const countMap = new Map<string, number>()
-
-  try {
-    const data = await fs.promises.readFile(faviconCountsFile, "utf8")
-    const countsArray = JSON.parse(data) as Array<[string, number]>
-    for (const [faviconPath, count] of countsArray) {
-      if (faviconPath && typeof count === "number" && !isNaN(count)) {
-        countMap.set(faviconPath, count)
-      }
+  const countsArray = JSON.parse(data) as Array<[string, number]>
+  for (const [faviconPath, count] of countsArray) {
+    if (faviconPath && typeof count === "number" && !isNaN(count)) {
+      countMap.set(faviconPath, count)
     }
-  } catch (error) {
-    logger.error(`Error reading or parsing favicon counts file: ${error}`)
-    return new Map<string, number>()
   }
 
   return countMap

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -31,10 +31,10 @@ const improveFootnoteFormatting = (text: string) => {
 
 // Regular expression for edit/note patterns
 const editPattern =
-  /^\s*(?<emph1>[*_]*)(?:edit|eta|note),?\s*\(?(?<date>\d{1,2}[-/]\d{1,2}[-/]\d{2,4})\)?(?<emph2>[*_]*:[*_]*) (?<text>.*)/gim
+  /^\s*[*_]*(?:edit|eta|note),?\s*\(?(?<date>\d{1,2}[-/]\d{1,2}[-/]\d{2,4})\)?[*_]*:[*_]* (?<text>.*)/gim
 const editAdmonitionPattern = "\n> [!info] Edited on $<date>\n>\n> $<text>"
 
-const editPatternNoDate = /^\s*(?<emph1>[*_]*)(?:edit|eta)(?<emph2>[*_]*:[*_]*) (?<text>.*)/gim
+const editPatternNoDate = /^\s*[*_]*(?:edit|eta)[*_]*:[*_]* (?<text>.*)/gim
 const editAdmonitionPatternNoDate = "\n> [!info] Edited after posting\n>\n> $<text>"
 
 /**
@@ -136,7 +136,7 @@ const concentrateEmphasisAroundLinks = (text: string): string => {
  * @returns The text with all formatting improvements applied.
  */
 export const formattingImprovement = (text: string) => {
-  const yamlHeaderMatch = text.match(/^\s*---\n(?<yaml>.*?)\n---\n/s)
+  const yamlHeaderMatch = text.match(/^\s*---\n.*?\n---\n/s)
   let yamlHeader = ""
   let content = text
 

--- a/quartz/plugins/transformers/spoiler.ts
+++ b/quartz/plugins/transformers/spoiler.ts
@@ -10,16 +10,6 @@ type InlineNode = Text | Element
 const SPOILER_REGEX = /^!\s*(?<spoilerText>.*)/
 
 /**
- * Generate inline JavaScript to toggle a spoiler from the container element.
- * Toggles class on the container and updates aria-expanded on the overlay child.
- * @param className - The CSS class name to toggle on the container
- * @returns JavaScript code as a string for the onclick handler
- */
-function toggleSpoilerJs(className: string): string {
-  return `this.classList.toggle('${className}');var r=this.classList.contains('${className}');this.querySelector('.spoiler-overlay').setAttribute('aria-expanded',r);this.querySelector('.spoiler-overlay').setAttribute('aria-hidden',r);this.querySelector('.spoiler-content').setAttribute('aria-hidden',!r)`
-}
-
-/**
  * Extract spoiler text from a string.
  */
 export function matchSpoilerText(text: string): string | null {
@@ -29,18 +19,17 @@ export function matchSpoilerText(text: string): string | null {
 
 /**
  * Create a spoiler container element with overlay and content.
- * The container has onclick for toggling (works even after overlay becomes pointer-events:none).
- * The overlay has role="button" and keyboard handlers for accessibility, but no onclick
- * (clicks on the overlay bubble to the container's onclick handler).
+ * Toggling is handled by the delegated listeners in `spoiler.inline.ts`,
+ * which react to clicks anywhere in the container and to Enter/Space on the
+ * overlay; no inline event handlers are emitted.
  * @param content - The content to hide behind the spoiler (string or array of elements)
- * @returns A div element with spoiler-container class and click handler
+ * @returns A div element with spoiler-container class
  */
 export function createSpoilerNode(content: string | Element[]): Element {
   return h(
     "div",
     {
       className: ["spoiler-container"],
-      onclick: toggleSpoilerJs("revealed"),
     },
     [
       h("span", {
@@ -49,8 +38,6 @@ export function createSpoilerNode(content: string | Element[]): Element {
         tabindex: 0,
         ariaExpanded: "false",
         ariaLabel: "Spoiler (click or press Enter to reveal)",
-        onkeydown:
-          "if(event.key==='Enter'||event.key===' '){event.preventDefault();this.parentElement.click()}",
       }),
       h("span", { className: ["spoiler-content"], ariaHidden: "true" }, content),
     ],

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2138,7 +2138,7 @@ describe("improveFormatting function with options", () => {
     mockFile.data = {}
 
     // Transform should work with default options (including first letter processing)
-    transformer(tree, mockFile, () => {
+    void transformer(tree, mockFile, () => {
       /* noop */
     })
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2138,6 +2138,7 @@ describe("improveFormatting function with options", () => {
     mockFile.data = {}
 
     // Transform should work with default options (including first letter processing)
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void transformer(tree, mockFile, () => {
       /* noop */
     })

--- a/quartz/plugins/transformers/tests/spoiler.test.ts
+++ b/quartz/plugins/transformers/tests/spoiler.test.ts
@@ -33,7 +33,7 @@ describe("rehype-custom-spoiler", () => {
     expect(output).toMatch(/<span class="spoiler-content" aria-hidden="true">/)
     expect(output).toMatch(/<span class="spoiler-overlay"[^>]*><\/span>/)
     expect(output).not.toContain("<blockquote>")
-    expect(output).toMatch(/onclick="[^"]*"/)
+    expect(output).not.toContain("onclick=")
     expect(output).toContain('role="button"')
   })
 
@@ -63,7 +63,8 @@ describe("rehype-custom-spoiler", () => {
 
     expect(node.tagName).toBe("div")
     expect(node.properties?.className).toContain("spoiler-container")
-    expect(node.properties?.onClick).toBeDefined() // container has click handler
+    // Toggling is handled by delegated listeners, not inline handlers.
+    expect(node.properties?.onClick).toBeUndefined()
     expect(node.children).toHaveLength(2)
     expect((node.children[0] as Element).tagName).toBe("span")
     expect((node.children[0] as Element).properties?.className).toContain("spoiler-overlay")
@@ -71,19 +72,14 @@ describe("rehype-custom-spoiler", () => {
     expect((node.children[1] as Element).properties?.className).toContain("spoiler-content")
     expect((node.children[1] as Element).properties?.ariaHidden).toBe("true")
 
-    // Accessibility attributes are on the overlay (role, aria-*), click handler on container
+    // Accessibility attributes are on the overlay (role, aria-*); no inline handlers.
     const overlay = node.children[0] as Element
     expect(overlay.properties?.role).toBe("button")
     expect(overlay.properties?.tabIndex).toBe(0)
     expect(overlay.properties?.ariaExpanded).toBe("false")
     expect(overlay.properties?.ariaLabel).toContain("Spoiler")
-    expect(overlay.properties?.onKeyDown).toBeDefined()
-    expect(overlay.properties?.onClick).toBeUndefined() // onclick is on container, not overlay
-
-    // Container onclick toggles aria-hidden on spoiler-content
-    const containerOnClick = node.properties?.onClick as string
-    expect(containerOnClick).toContain("spoiler-content")
-    expect(containerOnClick).toContain("aria-hidden")
+    expect(overlay.properties?.onKeyDown).toBeUndefined()
+    expect(overlay.properties?.onClick).toBeUndefined()
   })
 
   describe("processParagraph function", () => {

--- a/quartz/plugins/transformers/twemoji.ts
+++ b/quartz/plugins/transformers/twemoji.ts
@@ -73,7 +73,7 @@ export function replaceEmoji(content: string): string {
  */
 export function createNodes(twemojiContent: string): (Text | Element)[] {
   const newNodes: (Text | Element)[] = []
-  const parts = twemojiContent.split(/<img.*?>/g)
+  const parts = twemojiContent.split(/<img.*?>/)
   const imgRegex = /<img.*?>/g
   const matches: string[] = []
   let match: RegExpExecArray | null

--- a/scripts/compress.py
+++ b/scripts/compress.py
@@ -64,6 +64,58 @@ _FFMPEG_COMMON_OUTPUT_ARGS: Final[list[str]] = [
     "error",
 ]
 
+# Even-dimension downscale + 8-bit planar pixel format, shared by the HEVC and
+# WebM encoders so both honor the same scaling/pixel-format contract.
+_FFMPEG_SCALE_PIX_FMT_ARGS: Final[list[str]] = [
+    "-vf",
+    "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+    "-pix_fmt",
+    _PIXEL_FORMAT_YUV420P,
+]
+
+# Stream-mapping for HEVC: copy the source audio track through untouched.
+_HEVC_AUDIO_ARGS: Final[list[str]] = [
+    "-map",
+    "0:v:0",
+    "-map",
+    "0:a?",
+    "-c:a",
+    "copy",
+]
+
+
+def _ffmpeg_audio_loop_args(is_gif: bool, audio_args: list[str]) -> list[str]:
+    """
+    Build the audio + GIF-loop suffix shared by both encoders.
+
+    GIF inputs have no audio and must loop forever (``-loop 0``); other
+    sources carry ``audio_args`` through and don't loop.
+    """
+    return [
+        *(["-an"] if is_gif else audio_args),
+        *(["-loop", "0"] if is_gif else []),
+    ]
+
+
+def _run_ffmpeg(
+    ffmpeg_cmd: list[str],
+    input_video_path: Path,
+    output_path: Path,
+) -> None:
+    """Run an ffmpeg command via a tempfile, then move it into place."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path: Path = Path(temp_dir) / output_path.name
+        subprocess.run(
+            ffmpeg_cmd + [str(temp_path)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        shutil.move(temp_path, output_path)
+    print(
+        f"Successfully converted {input_video_path.name} to {output_path.name}"
+    )
+
 
 def _check_dependencies() -> None:  # pragma: no cover
     """Check if required command-line tools are installed."""
@@ -161,15 +213,6 @@ def _run_ffmpeg_hevc(
         return
 
     is_gif: bool = input_video_path.suffix.lower() == ".gif"
-    audio_args = [
-        "-map",
-        "0:v:0",
-        "-map",
-        "0:a?",
-        "-c:a",
-        "copy",
-    ]
-
     ffmpeg_cmd: list[str] = [
         "ffmpeg",
         "-i",
@@ -182,29 +225,14 @@ def _run_ffmpeg_hevc(
         "log-level=warning",  # Keep logging minimal for x265
         "-preset",
         "slower",
-        "-vf",
-        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-        "-pix_fmt",
-        _PIXEL_FORMAT_YUV420P,
+        *_FFMPEG_SCALE_PIX_FMT_ARGS,
         "-tag:v",
         _TAG_APPLE_COMPATIBILITY,
-        *(["-an"] if is_gif else audio_args),  # No audio for GIF output
-        *(["-loop", "0"] if is_gif else []),
+        *_ffmpeg_audio_loop_args(is_gif, _HEVC_AUDIO_ARGS),
         *_FFMPEG_COMMON_OUTPUT_ARGS,
     ]
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path: Path = Path(temp_dir) / output_path.name
-        subprocess.run(
-            ffmpeg_cmd + [str(temp_path)],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
-        shutil.move(temp_path, output_path)
-    print(
-        f"Successfully converted {input_video_path.name} to {output_path.name}"
-    )
+    _run_ffmpeg(ffmpeg_cmd, input_video_path, output_path)
 
 
 _WEBM_AUDIO_ARGS: Final[list[str]] = [
@@ -244,10 +272,7 @@ def _run_ffmpeg_webm(
         str(quality),
         "-b:v",
         "0",
-        "-vf",
-        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-        "-pix_fmt",
-        _PIXEL_FORMAT_YUV420P,
+        *_FFMPEG_SCALE_PIX_FMT_ARGS,
         "-deadline",
         "good",
         "-cpu-used",
@@ -256,21 +281,11 @@ def _run_ffmpeg_webm(
         "1",
         "-auto-alt-ref",
         "1",
-        *(["-an"] if is_gif else _WEBM_AUDIO_ARGS),
-        *(["-loop", "0"] if is_gif else []),
+        *_ffmpeg_audio_loop_args(is_gif, _WEBM_AUDIO_ARGS),
         *_FFMPEG_COMMON_OUTPUT_ARGS,
     ]
 
-    subprocess.run(
-        ffmpeg_cmd + [str(output_path)],
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-    )
-
-    print(
-        f"Successfully converted {input_video_path.name} to {output_path.name}"
-    )
+    _run_ffmpeg(ffmpeg_cmd, input_video_path, output_path)
 
 
 _CMD_TO_CHECK_CODEC: tuple[str, ...] = (
@@ -289,10 +304,15 @@ _CMD_TO_CHECK_CODEC: tuple[str, ...] = (
 def _check_if_hevc_codec(video_path: Path) -> bool:
     """Checks if the video is already HEVC encoded."""
     args: tuple[str, ...] = _CMD_TO_CHECK_CODEC + (str(video_path),)
-    codec: str = subprocess.check_output(
-        args, universal_newlines=True, stderr=subprocess.PIPE
-    ).strip()
-    return codec == "hevc"
+    # subprocess.run with check=True surfaces ffprobe's stderr in the raised
+    # CalledProcessError; check_output discards it.
+    result = subprocess.run(
+        args,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "hevc"
 
 
 def _parse_args() -> argparse.Namespace:  # pragma: no cover

--- a/scripts/notebooks/bisect_axe_hang.py
+++ b/scripts/notebooks/bisect_axe_hang.py
@@ -223,7 +223,7 @@ def _select_sections(
     outer = _sections(src, (args.anchor,))
     if args.drill >= len(outer):
         print(
-            f"section {args.drill} out of range (0..{len(outer)-1})",
+            f"section {args.drill} out of range (0..{len(outer) - 1})",
             file=sys.stderr,
         )
         return None
@@ -247,7 +247,7 @@ def _bisect_dom(args: argparse.Namespace, src: str, base_url: str) -> int:
     for i, (s, e) in enumerate(sections):
         out_path = args.serve_dir / f"{variant_prefix}_cut_{i}.html"
         out_path.write_text(
-            src[:s] + f"<!--cut [{i}] {e-s}B-->" + src[e:], encoding="utf-8"
+            src[:s] + f"<!--cut [{i}] {e - s}B-->" + src[e:], encoding="utf-8"
         )
         passes, times = _passes(
             f"{base_url}/{out_path.name}",
@@ -259,7 +259,7 @@ def _bisect_dom(args: argparse.Namespace, src: str, base_url: str) -> int:
         label = _label_for_cut(src, s, args.drill, args.anchor)
         print(
             f"  cut [{i:2d}] {label!r:50s} "
-            f"{passes}/{args.trials} pass, times={[round(t,1) for t in times]}{marker}"
+            f"{passes}/{args.trials} pass, times={[round(t, 1) for t in times]}{marker}"
         )
         out_path.unlink(missing_ok=True)
     return 0
@@ -288,7 +288,7 @@ def main() -> int:
         args.url, args.pa11y_config, args.timeout, args.trials
     )
     print(
-        f"baseline: {passes}/{args.trials} passes; times={[round(t,1) for t in times]}"
+        f"baseline: {passes}/{args.trials} passes; times={[round(t, 1) for t in times]}"
     )
 
     if args.bisect_css:
@@ -332,9 +332,9 @@ def _css_drop_variant(ctx: _CssBisectCtx, label: str, lo: int, hi: int) -> None:
             " ← drop unbreaks" if passes >= ctx.args.trials // 2 + 1 else ""
         )
         print(
-            f"  drop rules[{lo:4d}..{hi:4d}) ({hi-lo:4d}): "
+            f"  drop rules[{lo:4d}..{hi:4d}) ({hi - lo:4d}): "
             f"{passes}/{ctx.args.trials} pass, "
-            f"times={[round(t,1) for t in times]}{marker}"
+            f"times={[round(t, 1) for t in times]}{marker}"
         )
     finally:
         html_out.unlink(missing_ok=True)

--- a/scripts/notebooks/create_html_descriptions.py
+++ b/scripts/notebooks/create_html_descriptions.py
@@ -22,8 +22,10 @@ from io import StringIO
 from pathlib import Path
 
 import google.generativeai as genai  # type: ignore
-from google.generativeai.types import HarmBlockThreshold  # type: ignore
-from google.generativeai.types import HarmCategory
+from google.generativeai.types import (
+    HarmBlockThreshold,  # type: ignore
+    HarmCategory,
+)
 from ruamel.yaml import YAML
 
 try:

--- a/scripts/notebooks/fix_video_source_order_and_type.py
+++ b/scripts/notebooks/fix_video_source_order_and_type.py
@@ -33,7 +33,7 @@ DESIRED_MP4_TYPE = "video/mp4; codecs=hvc1"
 # skipcq: PY-R1000 (one-off script)
 def _process_video_content(
     video_content: str,
-) -> tuple[str, bool]:  # noqa: PY-R1000
+) -> tuple[str, bool]:
     """
     Processes the inner content of a video tag.
 

--- a/scripts/run_push_checks.py
+++ b/scripts/run_push_checks.py
@@ -515,11 +515,6 @@ def get_formatter_steps(git_root_path: Path) -> list[CheckStep]:
         str(git_root_path / "scripts"),
         str(git_root_path / ".github" / "scripts"),
     ]
-    # NB: no `ruff format` step. The pre-commit lint-staged pipeline runs
-    # `black` on Python files (see package.json) and ruff's formatter
-    # produces subtly different output. Running both creates an infinite
-    # loop of empty autofix commits as each reformat fights the other.
-    # `ruff check --fix` only touches lint issues, not layout.
     return [
         CheckStep(
             name="Linting Python",
@@ -551,6 +546,11 @@ def get_formatter_steps(git_root_path: Path) -> list[CheckStep]:
                 f"{git_root_path}/quartz/**/*.scss",
             ],
             parallel_group="autofix-lint",
+        ),
+        CheckStep(
+            name="Formatting Python",
+            command=["uv", "run", "ruff", "format", *py_targets],
+            parallel_group="autofix-format",
         ),
         CheckStep(
             name="Formatting Python docstrings",

--- a/scripts/spellcheck_triage.py
+++ b/scripts/spellcheck_triage.py
@@ -27,6 +27,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 from scripts import built_site_checks
 
@@ -110,21 +111,46 @@ def collect_unknown_words(public_dir: Path) -> list[UnknownWord]:
     return list(out.values())
 
 
+_VALID_ACTIONS: Final[frozenset[str]] = frozenset({"add", "defer"})
+
+
 def _parse_decisions(text: str) -> list[Decision]:
-    """Extract decisions from the model's JSON response."""
+    """
+    Extract decisions from the model's JSON response.
+
+    Validates the response shape explicitly: a malformed payload (missing
+    ``decisions`` list, an item that isn't an object, or one lacking the
+    required ``word``/``action`` keys or carrying an unknown ``action``)
+    raises ``ValueError`` rather than silently dropping entries.
+    """
     match = re.search(r"\{[\s\S]*\}", text)
     if not match:
         raise ValueError(f"No JSON object in model response: {text!r}")
     data = json.loads(match.group(0))
-    return [
-        Decision(
-            word=item["word"],
-            action=item["action"],
-            reason=item.get("reason", ""),
+    decisions = data.get("decisions")
+    if not isinstance(decisions, list):
+        raise ValueError(f"Model response missing a 'decisions' list: {text!r}")
+
+    parsed: list[Decision] = []
+    for item in decisions:
+        if not isinstance(item, dict) or "word" not in item:
+            raise ValueError(
+                f"Malformed decision item (needs 'word'): {item!r}"
+            )
+        action = item.get("action")
+        if action not in _VALID_ACTIONS:
+            raise ValueError(
+                f"Decision for {item['word']!r} has invalid action "
+                f"{action!r}; expected one of {sorted(_VALID_ACTIONS)}"
+            )
+        parsed.append(
+            Decision(
+                word=item["word"],
+                action=action,
+                reason=item.get("reason", ""),
+            )
         )
-        for item in data.get("decisions", [])
-        if item.get("action") in ("add", "defer")
-    ]
+    return parsed
 
 
 def classify(

--- a/scripts/tests/test_build_fonts.py
+++ b/scripts/tests/test_build_fonts.py
@@ -111,9 +111,9 @@ class TestHarmonizeBrackets:
         for name in _SQUARE_BRACKET_GLYPHS:
             glyph = glyf[name]
             assert glyph.yMax == paren.yMax, f"{name} yMax"
-            assert (
-                glyph.yMin == original_y_mins[name]
-            ), f"{name} yMin should stay at original"
+            assert glyph.yMin == original_y_mins[name], (
+                f"{name} yMin should stay at original"
+            )
 
     @pytest.mark.parametrize(
         "font_fixture,expected_paren_y_max",
@@ -243,9 +243,9 @@ class TestKerning:
                 continue
             for pvr in subtable.PairSet[i].PairValueRecord:
                 if pvr.SecondGlyph in desc_set:
-                    assert (
-                        pvr.Value1.XAdvance == _OPEN_DESCENDER_KERN
-                    ), f"{src}->{pvr.SecondGlyph}"
+                    assert pvr.Value1.XAdvance == _OPEN_DESCENDER_KERN, (
+                        f"{src}->{pvr.SecondGlyph}"
+                    )
 
     def test_close_descender_kern_values(self, upstream_08: TTFont) -> None:
         _add_kerning(upstream_08, _get_f_glyphs(upstream_08))
@@ -257,9 +257,9 @@ class TestKerning:
                 continue
             for pvr in subtable.PairSet[i].PairValueRecord:
                 if pvr.SecondGlyph in close_set:
-                    assert (
-                        pvr.Value1.XAdvance == _CLOSE_DESCENDER_KERN[src]
-                    ), f"{src}->{pvr.SecondGlyph}"
+                    assert pvr.Value1.XAdvance == _CLOSE_DESCENDER_KERN[src], (
+                        f"{src}->{pvr.SecondGlyph}"
+                    )
 
     def test_kern_feature_in_all_scripts(self, upstream_08: TTFont) -> None:
         _add_kerning(upstream_08, _get_f_glyphs(upstream_08))
@@ -303,9 +303,9 @@ class TestTableEquivalence:
         committed = TTFont(_FONT_DIR / filename)
 
         for tag in self._table_tags(built) | self._table_tags(committed):
-            assert built.getTableData(tag) == committed.getTableData(
-                tag
-            ), f"Table {tag} differs"
+            assert built.getTableData(tag) == committed.getTableData(tag), (
+                f"Table {tag} differs"
+            )
 
 
 class TestBuildAll:
@@ -389,7 +389,7 @@ def _assert_no_nonzero_kern(
                 if pvr.SecondGlyph in targets:
                     xadv = pvr.Value1.XAdvance if pvr.Value1 else 0
                     assert xadv == 0, (
-                        f"Existing kern {glyph}+{pvr.SecondGlyph}" f" = {xadv}"
+                        f"Existing kern {glyph}+{pvr.SecondGlyph} = {xadv}"
                     )
     elif subtable.Format == 2:
         cd1 = subtable.ClassDef1.classDefs
@@ -402,5 +402,5 @@ def _assert_no_nonzero_kern(
                 if rec.Value1:
                     xadv = rec.Value1.XAdvance
                     assert xadv == 0, (
-                        f"Existing kern {f_name}+{t_name}" f" = {xadv}"
+                        f"Existing kern {f_name}+{t_name} = {xadv}"
                     )

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -6096,9 +6096,9 @@ def test_check_html_tags_in_text(html, expected):
 
     # Check that each expected substring is in the results
     for expected_msg in expected:
-        assert any(
-            expected_msg in issue for issue in result
-        ), f"Expected '{expected_msg}' not found in results: {result}"
+        assert any(expected_msg in issue for issue in result), (
+            f"Expected '{expected_msg}' not found in results: {result}"
+        )
 
 
 def test_check_html_tags_in_text_real_world_katex():
@@ -6244,9 +6244,9 @@ def test_check_top_level_paragraphs_end_with_punctuation_valid_chars(
     issues = built_site_checks.check_top_level_paragraphs_end_with_punctuation(
         soup
     )
-    assert (
-        issues == []
-    ), f"Character {char} should be valid but got issues: {issues}"
+    assert issues == [], (
+        f"Character {char} should be valid but got issues: {issues}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -6261,9 +6261,9 @@ def test_check_top_level_paragraphs_trim_chars(char: str):
     issues = built_site_checks.check_top_level_paragraphs_end_with_punctuation(
         soup
     )
-    assert (
-        issues == []
-    ), f"Character {char} should be trimmed, allowing valid punctuation before it"
+    assert issues == [], (
+        f"Character {char} should be trimmed, allowing valid punctuation before it"
+    )
 
 
 @pytest.mark.parametrize(
@@ -6846,9 +6846,7 @@ def test_check_invert_labels_inverted_variants(
         ),
         # Reviewed invert=True on one source but class absent on the <video>.
         (
-            "<video autoplay loop muted>"
-            '<source src="https://x/a.mp4">'
-            "</video>",
+            '<video autoplay loop muted><source src="https://x/a.mp4"></video>',
             {"https://x/a.mp4": _reviewed(True)},
             [
                 _class_mismatch_msg(

--- a/scripts/tests/test_classify_visual_failures.py
+++ b/scripts/tests/test_classify_visual_failures.py
@@ -362,7 +362,7 @@ def test_script_runs_as_subprocess_from_repo_root(tmp_path: Path) -> None:
         text=True,
         check=False,
     )
-    assert (
-        result.returncode == 0
-    ), f"Script crashed (stdout={result.stdout!r}, stderr={result.stderr!r})"
+    assert result.returncode == 0, (
+        f"Script crashed (stdout={result.stdout!r}, stderr={result.stderr!r})"
+    )
     assert "has_any_failures=false" in result.stdout

--- a/scripts/tests/test_compress.py
+++ b/scripts/tests/test_compress.py
@@ -49,9 +49,9 @@ def test_avif_size_reduction(temp_dir: Path, image_ext: str):
     avif_file = input_file.with_suffix(".avif")
     avif_size = avif_file.stat().st_size
 
-    assert (
-        avif_size < original_size
-    ), f"AVIF ({avif_file}) size ({avif_size}) not less than original {image_ext.upper()} ({original_size} {input_file})"
+    assert avif_size < original_size, (
+        f"AVIF ({avif_file}) size ({avif_size}) not less than original {image_ext.upper()} ({original_size} {input_file})"
+    )
 
 
 def test_convert_avif_fails_with_non_existent_file(temp_dir: Path):
@@ -242,9 +242,9 @@ def test_convert_gif_mp4_codec_is_hevc(temp_dir: Path):
             text=True,
             check=True,
         )
-        assert (
-            result.stdout.strip() == "hevc"
-        ), f"Output video codec is not HEVC, got: {result.stdout.strip()}"
+        assert result.stdout.strip() == "hevc", (
+            f"Output video codec is not HEVC, got: {result.stdout.strip()}"
+        )
     except subprocess.CalledProcessError as e:
         pytest.fail(f"Error checking MP4 file codec: {e.stderr}")
 
@@ -308,9 +308,9 @@ def test_convert_gif_output_has_no_audio(temp_dir: Path):
     for suffix in [".mp4", ".webm"]:
         output_file = input_file.with_suffix(suffix)
         assert output_file.exists(), f"{suffix} file not created from GIF"
-        assert not _has_audio_stream(
-            output_file
-        ), f"{suffix} output from GIF should not have audio"
+        assert not _has_audio_stream(output_file), (
+            f"{suffix} output from GIF should not have audio"
+        )
 
 
 @requires_ffmpeg
@@ -324,9 +324,9 @@ def test_convert_video_output_has_audio(temp_dir: Path):
     for suffix in [".mp4", ".webm"]:
         output_file = input_file.with_suffix(suffix)
         assert output_file.exists(), f"{suffix} file not created from video"
-        assert _has_audio_stream(
-            output_file
-        ), f"{suffix} output from video should have audio"
+        assert _has_audio_stream(output_file), (
+            f"{suffix} output from video should have audio"
+        )
 
 
 def _get_frame_rate(file_path: Path) -> float:
@@ -373,9 +373,9 @@ def test_avif_preserves_color_profile(temp_dir: Path, input_file_ext: str):
         check=True,
     )
 
-    assert (
-        "Colorspace: sRGB" in result.stdout
-    ), "AVIF file should have sRGB colorspace"
+    assert "Colorspace: sRGB" in result.stdout, (
+        "AVIF file should have sRGB colorspace"
+    )
 
 
 def test_png_input_has_transparency(temp_dir: Path):
@@ -394,9 +394,9 @@ def test_png_input_has_transparency(temp_dir: Path):
         text=True,
         check=True,
     )
-    assert (
-        "alpha: 8-bit" in pre_result.stdout.lower()
-    ), "Input PNG file should have transparency before conversion"
+    assert "alpha: 8-bit" in pre_result.stdout.lower(), (
+        "Input PNG file should have transparency before conversion"
+    )
 
 
 def test_avif_output_preserves_transparency(temp_dir: Path):
@@ -420,9 +420,9 @@ def test_avif_output_preserves_transparency(temp_dir: Path):
         text=True,
         check=True,
     )
-    assert (
-        "alpha: 8-bit" in post_result.stdout.lower()
-    ), "AVIF file should preserve transparency"
+    assert "alpha: 8-bit" in post_result.stdout.lower(), (
+        "AVIF file should preserve transparency"
+    )
 
 
 @pytest.mark.parametrize("input_file_ext", compress.ALLOWED_IMAGE_EXTENSIONS)
@@ -444,9 +444,9 @@ def test_avif_quality_affects_file_size(temp_dir: Path, input_file_ext: str):
     compress.image(input_file, quality=10)
     low_quality_size = input_file.with_suffix(".avif").stat().st_size
 
-    assert (
-        high_quality_size > low_quality_size
-    ), f"Higher quality ({high_quality_size}B) should be larger than lower quality ({low_quality_size}B)"
+    assert high_quality_size > low_quality_size, (
+        f"Higher quality ({high_quality_size}B) should be larger than lower quality ({low_quality_size}B)"
+    )
 
 
 @requires_exiftool
@@ -465,9 +465,9 @@ def test_avif_format_chroma(temp_dir: Path):
         text=True,
         check=True,
     )
-    assert re.search(
-        r"Chroma Format\s*:\s*YUV 4:2:0", result.stdout
-    ), "AVIF should use YUV 4:2:0"
+    assert re.search(r"Chroma Format\s*:\s*YUV 4:2:0", result.stdout), (
+        "AVIF should use YUV 4:2:0"
+    )
 
 
 def test_avif_format_pixel_depth(temp_dir: Path):
@@ -487,9 +487,9 @@ def test_avif_format_pixel_depth(temp_dir: Path):
         text=True,
         check=True,
     )
-    assert (
-        result.stdout.strip() == "8"
-    ), f"AVIF should have 8-bit depth, got {result.stdout.strip()!r}"
+    assert result.stdout.strip() == "8", (
+        f"AVIF should have 8-bit depth, got {result.stdout.strip()!r}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -591,10 +591,14 @@ def test_check_if_hevc_codec(
     input_file = temp_dir / f"test_{test_id}.mp4"
     input_file.touch()
 
-    def mock_check_output(*args: object, **kwargs: object) -> str:
-        return mock_output
+    def mock_run(
+        *args: object, **kwargs: object
+    ) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            args=args[0], returncode=0, stdout=mock_output, stderr=""
+        )
 
-    monkeypatch.setattr(subprocess, "check_output", mock_check_output)
+    monkeypatch.setattr(subprocess, "run", mock_run)
     assert compress._check_if_hevc_codec(input_file) is expected_result
 
 
@@ -603,14 +607,14 @@ def test_check_if_hevc_codec_ffprobe_error(temp_dir: Path, monkeypatch):
     input_file = temp_dir / "test_error.mp4"
     input_file.touch()
 
-    def mock_check_output(*args: object, **kwargs: object) -> None:
+    def mock_run(*args: object, **kwargs: object) -> None:
         raise subprocess.CalledProcessError(
             cmd=list(args[0]),  # type: ignore[call-overload]
             returncode=1,
             stderr="ffprobe error",
         )
 
-    monkeypatch.setattr(subprocess, "check_output", mock_check_output)
+    monkeypatch.setattr(subprocess, "run", mock_run)
     with pytest.raises(subprocess.CalledProcessError):
         compress._check_if_hevc_codec(input_file)
 
@@ -631,14 +635,14 @@ def test_video_preserves_framerate(
 
     # TODO `create_test_video` framerate isn't reliable for GIFs
     if input_video_ext != ".gif":
-        assert input_fps == pytest.approx(
-            framerate, rel=0.05
-        ), f"Input FPS {input_fps} does not match expected FPS {framerate}"
+        assert input_fps == pytest.approx(framerate, rel=0.05), (
+            f"Input FPS {input_fps} does not match expected FPS {framerate}"
+        )
 
     for output_video_ext in [".webm", ".mp4"]:
         output_file = input_file.with_suffix(output_video_ext)
         output_fps = _get_frame_rate(output_file)
 
-        assert output_fps == pytest.approx(
-            input_fps, rel=0.05
-        ), f"Output FPS {output_fps} does not match expected FPS {input_fps}"
+        assert output_fps == pytest.approx(input_fps, rel=0.05), (
+            f"Output FPS {output_fps} does not match expected FPS {input_fps}"
+        )

--- a/scripts/tests/test_convert_assets.py
+++ b/scripts/tests/test_convert_assets.py
@@ -444,13 +444,13 @@ def test_video_figure_caption_formatting(setup_test_env, initial_content):
         converted_content = f.read()
 
     expected_pattern = r"</video>\n\nFigure: This is a caption"
-    assert re.search(
-        expected_pattern, converted_content
-    ), f"Expected pattern not found in:\n{converted_content}"
+    assert re.search(expected_pattern, converted_content), (
+        f"Expected pattern not found in:\n{converted_content}"
+    )
 
-    assert (
-        "<br/>" not in converted_content
-    ), f"<br/> tag still present in:\n{converted_content}"
+    assert "<br/>" not in converted_content, (
+        f"<br/> tag still present in:\n{converted_content}"
+    )
 
 
 def test_asset_staging_path_conversion(setup_test_env):
@@ -769,9 +769,9 @@ def test_video_pattern_matching(
     # Check that each group captured exactly what we expect
     for group_name, expected_value in expected_groups.items():
         actual_value = match.group(group_name)
-        assert (
-            actual_value == expected_value
-        ), f"For {input_str}, group {group_name} captured '{actual_value}' but expected '{expected_value}'\npattern: {original_pattern}"
+        assert actual_value == expected_value, (
+            f"For {input_str}, group {group_name} captured '{actual_value}' but expected '{expected_value}'\npattern: {original_pattern}"
+        )
 
 
 @pytest.mark.parametrize("ext", compress.ALLOWED_VIDEO_EXTENSIONS)

--- a/scripts/tests/test_convert_markdown.py
+++ b/scripts/tests/test_convert_markdown.py
@@ -351,9 +351,9 @@ def test_convert_to_jpeg_resizes_to_height_1200(
 
     assert "-resize" in args
     resize_idx = args.index("-resize")
-    assert (
-        args[resize_idx + 1] == "x1200"
-    ), f"Expected resize parameter 'x1200', got '{args[resize_idx + 1]}'"
+    assert args[resize_idx + 1] == "x1200", (
+        f"Expected resize parameter 'x1200', got '{args[resize_idx + 1]}'"
+    )
 
 
 def test_convert_to_jpeg_iterative_compression(jpeg_conversion_setup):

--- a/scripts/tests/test_linkchecker.py
+++ b/scripts/tests/test_linkchecker.py
@@ -154,21 +154,21 @@ def html_linkchecker_result(test_server_and_files) -> object:
 
 
 def test_invalid_port_error(html_linkchecker_result):
-    assert (
-        "Internal linkchecker: 1" in html_linkchecker_result.stderr
-    ), "URL error not found in output"
-    assert (
-        html_linkchecker_result.returncode != 0
-    ), "Linkchecker script should have failed"
+    assert "Internal linkchecker: 1" in html_linkchecker_result.stderr, (
+        "URL error not found in output"
+    )
+    assert html_linkchecker_result.returncode != 0, (
+        "Linkchecker script should have failed"
+    )
 
 
 def test_invalid_asset_error(html_linkchecker_result):
-    assert (
-        "External linkchecker: 1" in html_linkchecker_result.stderr
-    ), "Invalid asset error not found in output"
-    assert (
-        html_linkchecker_result.returncode != 0
-    ), "Linkchecker script should have failed"
+    assert "External linkchecker: 1" in html_linkchecker_result.stderr, (
+        "Invalid asset error not found in output"
+    )
+    assert html_linkchecker_result.returncode != 0, (
+        "Linkchecker script should have failed"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_r2_upload.py
+++ b/scripts/tests/test_r2_upload.py
@@ -82,9 +82,12 @@ def test_media_setup(
     mock_repo.ignored = MagicMock(return_value=False)
     monkeypatch.setattr("git.Repo", lambda *args, **kwargs: mock_repo)
 
-    yield tmp_path, dirs["static"] / "test.jpg", dirs[
-        "website_content"
-    ], md_files
+    yield (
+        tmp_path,
+        dirs["static"] / "test.jpg",
+        dirs["website_content"],
+        md_files,
+    )
 
     shutil.rmtree(tmp_path)
 
@@ -294,9 +297,9 @@ def test_upload_and_move(
     # Check if the file is moved to the correct location with preserved structure
     expected_moved_path = move_to_dir / test_image.relative_to(mock_git_root)
 
-    assert (
-        expected_moved_path.exists()
-    ), f"Expected moved file does not exist: {expected_moved_path}"
+    assert expected_moved_path.exists(), (
+        f"Expected moved file does not exist: {expected_moved_path}"
+    )
     assert not test_image.exists(), f"Original file still exists: {test_image}"
 
     # Check if rclone was called with the correct arguments
@@ -394,9 +397,9 @@ def test_main_upload_all_custom_filetypes(
             for call in mock_rclone.call_args_list
             if call[0][0][1] == "copyto"
         )
-        assert (
-            copyto_count == 2
-        ), f"Expected 2 'copyto' calls, but got {copyto_count}"
+        assert copyto_count == 2, (
+            f"Expected 2 'copyto' calls, but got {copyto_count}"
+        )
 
 
 def test_preserve_path_structure(mock_git_root: Path, tmp_path: Path):

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -610,15 +610,14 @@ def test_get_formatter_steps():
     test_root = Path("/test/root")
     steps = run_push_checks.get_formatter_steps(test_root)
 
-    # Ruff check has --fix so the step is an autofixer, not a blocking
-    # check. We deliberately do NOT run `ruff format` here — black runs
-    # via lint-staged in the pre-commit hook and the two formatters fight.
+    # Ruff check has --fix so the step is an autofixer, not a blocking check.
     ruff_lint = _step_by_name(steps, "Linting Python")
     assert "--fix" in ruff_lint.command
     assert "format" not in ruff_lint.command
-    assert not any(
-        s.command[:4] == ["uv", "run", "ruff", "format"] for s in steps
-    )
+
+    # `ruff format` is the sole Python formatter (it replaced the
+    # autoflake/isort/autopep8/black stack).
+    assert any(s.command[:4] == ["uv", "run", "ruff", "format"] for s in steps)
 
     eslint_step = _step_by_name(steps, "Linting TypeScript")
     assert "--fix" in eslint_step.command
@@ -668,6 +667,7 @@ _AUTOFIX_LINT_NAMES = frozenset(
 )
 _AUTOFIX_FORMAT_NAMES = frozenset(
     {
+        "Formatting Python",
         "Formatting Python docstrings",
         "Formatting SCSS",
         "Formatting TypeScript",

--- a/scripts/tests/test_script_utils.py
+++ b/scripts/tests/test_script_utils.py
@@ -285,11 +285,13 @@ def test_get_files_ignore_dirs(tmp_path):
     [
         # Basic permalink
         (
-            {"test1.md": """---
+            {
+                "test1.md": """---
 permalink: /test-page
 title: Test Page
 ---
-# Content"""},
+# Content"""
+            },
             {"test-page": "test1.md"},
         ),
         # Multiple files with permalinks
@@ -310,10 +312,12 @@ title: Other Page
         ),
         # File without permalink should be skipped
         (
-            {"test3.md": """---
+            {
+                "test3.md": """---
 title: No Permalink
 ---
-# Content"""},
+# Content"""
+            },
             {},
         ),
         # Files in drafts directory
@@ -335,18 +339,22 @@ permalink: /draft
         ),
         # Invalid YAML should be skipped
         (
-            {"invalid.md": """---
+            {
+                "invalid.md": """---
 permalink: /test
 title: "Unclosed quote
 ---
-# Content"""},
+# Content"""
+            },
             {},
         ),
         # Empty front matter should be skipped
         (
-            {"empty.md": """---
+            {
+                "empty.md": """---
 ---
-# Content"""},
+# Content"""
+            },
             {},
         ),
         # Mixed valid and invalid files
@@ -362,32 +370,38 @@ permalink: /valid-page
         ),
         # Test permalink appearing in aliases
         (
-            {"test1.md": """---
+            {
+                "test1.md": """---
 permalink: /test-page
 aliases: [/test-page, /other-alias]
 title: Test Page
 ---
-# Content"""},
+# Content"""
+            },
             {"test-page": "test1.md"},
         ),
         # Test permalink as only alias
         (
-            {"test2.md": """---
+            {
+                "test2.md": """---
 permalink: /test-page
 aliases: /test-page
 title: Test Page
 ---
-# Content"""},
+# Content"""
+            },
             {"test-page": "test2.md"},
         ),
         # Test permalink in list of aliases
         (
-            {"test3.md": """---
+            {
+                "test3.md": """---
 permalink: /test-page
 aliases: [/first-alias, /test-page, /last-alias]
 title: Test Page
 ---
-# Content"""},
+# Content"""
+            },
             {"test-page": "test3.md"},
         ),
     ],
@@ -718,9 +732,9 @@ def test_md_for_html_error_handling(
     test_file.write_text(html_content)
 
     # Should handle all error cases gracefully by returning True
-    assert (
-        script_utils.should_have_md(test_file) is True
-    ), f"Failed to handle {description}"
+    assert script_utils.should_have_md(test_file) is True, (
+        f"Failed to handle {description}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -895,12 +909,14 @@ def test_get_non_code_text_with_placeholder(
     [
         # Basic cases
         (
-            {"test.md": """---
+            {
+                "test.md": """---
 title: Test
 aliases: [/alias1, /alias2]
 ---
 # Content
-"""},
+"""
+            },
             {"/alias1", "/alias2"},
         ),
         (
@@ -922,32 +938,38 @@ aliases: [/alias3, /alias4]
         ),
         # No aliases
         (
-            {"test.md": """---
+            {
+                "test.md": """---
 title: Test
 ---
 # Content
-"""},
+"""
+            },
             set(),
         ),
         # Permalink removal
         (
-            {"test.md": """---
+            {
+                "test.md": """---
 title: Test
 permalink: /test
 aliases: [/alias1, /test, /alias2]
 ---
 # Content
-"""},
+"""
+            },
             {"/alias1", "/alias2"},
         ),
         # String alias (ignored)
         (
-            {"test.md": """---
+            {
+                "test.md": """---
 title: Test
 aliases: /single-alias
 ---
 # Content
-"""},
+"""
+            },
             set(),
         ),
         # Mixed files
@@ -969,12 +991,14 @@ title: Without Aliases
         ),
         # Invalid YAML (skipped)
         (
-            {"invalid.md": """---
+            {
+                "invalid.md": """---
 title: "Unclosed quote
 aliases: [/alias1, /alias2]
 ---
 # Content
-"""},
+"""
+            },
             set(),
         ),
         # Nested directories
@@ -1002,16 +1026,20 @@ aliases: [/nested-alias1, /nested-alias2]
         ),
         # Empty front matter
         (
-            {"empty.md": """---
+            {
+                "empty.md": """---
 ---
 # Content
-"""},
+"""
+            },
             set(),
         ),
         # No front matter
         (
-            {"no_front_matter.md": """# Content without front matter
-"""},
+            {
+                "no_front_matter.md": """# Content without front matter
+"""
+            },
             set(),
         ),
     ],

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -1207,14 +1207,14 @@ def test_check_card_image(
 
         # Check that all expected error substrings are present
         for expected_error in expected_error_contains:
-            assert any(
-                expected_error in error for error in errors
-            ), f"Expected error containing '{expected_error}' not found in {errors}"
+            assert any(expected_error in error for error in errors), (
+                f"Expected error containing '{expected_error}' not found in {errors}"
+            )
 
         # Check that we have the right number of errors
-        assert len(errors) == len(
-            expected_error_contains
-        ), f"Expected {len(expected_error_contains)} errors, got {len(errors)}: {errors}"
+        assert len(errors) == len(expected_error_contains), (
+            f"Expected {len(expected_error_contains)} errors, got {len(errors)}: {errors}"
+        )
 
 
 def test_check_card_image_request_exception():
@@ -1879,9 +1879,9 @@ def test_slug_in_metadata(slug: str, metadata: dict, expected: bool):
         expected: Whether the slug is expected to be found in the metadata
     """
     result = source_file_checks._slug_in_metadata(slug, metadata)
-    assert (
-        result == expected
-    ), f"Expected {expected} but got {result} for slug '{slug}' in metadata {metadata}"
+    assert result == expected, (
+        f"Expected {expected} but got {result} for slug '{slug}' in metadata {metadata}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1921,9 +1921,9 @@ def test_validate_video_tag(video_tag: str, should_raise: bool):
         assert issues, f"Expected errors for tag: {video_tag}, but got none."
         assert "forbidden 'src' or 'type' attribute" in issues[0]
     else:
-        assert (
-            not issues
-        ), f"Expected no errors for tag: {video_tag}, but got: {issues}"
+        assert not issues, (
+            f"Expected no errors for tag: {video_tag}, but got: {issues}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/scripts/tests/test_spellcheck_triage.py
+++ b/scripts/tests/test_spellcheck_triage.py
@@ -65,13 +65,12 @@ def test_context_for_truncates_oversized_paragraph():
 # ---------- _parse_decisions ----------------------------------------------
 
 
-def test_parse_decisions_filters_invalid_actions():
+def test_parse_decisions_parses_valid_actions():
     text = json.dumps(
         {
             "decisions": [
                 {"word": "KaTeX", "action": "add", "reason": "Known."},
                 {"word": "xyzzy", "action": "defer", "reason": "Unclear."},
-                {"word": "bad", "action": "maybe"},  # filtered
             ]
         }
     )
@@ -91,6 +90,31 @@ def test_parse_decisions_tolerates_prose_around_json():
 def test_parse_decisions_raises_without_json():
     with pytest.raises(ValueError, match="No JSON object"):
         spellcheck_triage._parse_decisions("nothing json-shaped here")
+
+
+def test_parse_decisions_raises_on_invalid_action():
+    text = json.dumps({"decisions": [{"word": "bad", "action": "maybe"}]})
+    with pytest.raises(ValueError, match="invalid action"):
+        spellcheck_triage._parse_decisions(text)
+
+
+def test_parse_decisions_raises_on_missing_decisions_list():
+    text = json.dumps({"not_decisions": []})
+    with pytest.raises(ValueError, match="missing a 'decisions' list"):
+        spellcheck_triage._parse_decisions(text)
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"action": "add"},  # missing "word"
+        "not-an-object",
+    ],
+)
+def test_parse_decisions_raises_on_malformed_item(item: object):
+    text = json.dumps({"decisions": [item]})
+    with pytest.raises(ValueError, match="Malformed decision item"):
+        spellcheck_triage._parse_decisions(text)
 
 
 # ---------- classify -------------------------------------------------------

--- a/scripts/tests/test_strip_for_spellcheck.py
+++ b/scripts/tests/test_strip_for_spellcheck.py
@@ -153,9 +153,9 @@ def test_is_quote_callout_start(line: str, expected: bool):
 def test_strip_quote_blocks(text: str, expected: str):
     result = strip_for_spellcheck.strip_quote_blocks(text)
     assert result == expected
-    assert result.count("\n") == text.count(
-        "\n"
-    ), "Line count must be preserved"
+    assert result.count("\n") == text.count("\n"), (
+        "Line count must be preserved"
+    )
 
 
 def _blank_inner_spans(text: str, spans: list[tuple[int, int]]) -> str:
@@ -219,9 +219,9 @@ def test_strip_math(text: str, blanks: list[tuple[int, int]]):
     expected = _blank_inner_spans(text, blanks)
     result = strip_for_spellcheck.strip_math(text)
     assert result == expected
-    assert result.count("\n") == text.count(
-        "\n"
-    ), "Line count must be preserved"
+    assert result.count("\n") == text.count("\n"), (
+        "Line count must be preserved"
+    )
     assert len(result) == len(text), "Length must be preserved"
 
 
@@ -320,9 +320,9 @@ def test_strip_callout_markers(text: str, expected: str):
     result = strip_for_spellcheck.strip_callout_markers(text)
     assert result == expected
     assert len(result) == len(text), "Length must be preserved"
-    assert result.count("\n") == text.count(
-        "\n"
-    ), "Line count must be preserved"
+    assert result.count("\n") == text.count("\n"), (
+        "Line count must be preserved"
+    )
 
 
 def test_strip_for_lint_blanks_non_quote_callout_marker():

--- a/scripts/tests/test_update_date_on_publish.py
+++ b/scripts/tests/test_update_date_on_publish.py
@@ -377,7 +377,7 @@ def test_is_file_modified_git_error(test_file, mock_git_commands):
             "subprocess.check_output",
             side_effect=mock_git_commands(raise_error=True),
         ),
-        pytest.raises(subprocess.CalledProcessError),
+        pytest.raises(RuntimeError, match="Could not check git status"),
     ):
         update_lib.is_file_modified(test_file)
 

--- a/scripts/tests/test_update_date_on_publish.py
+++ b/scripts/tests/test_update_date_on_publish.py
@@ -371,12 +371,30 @@ def test_is_file_modified_no_changes(test_file, mock_git_commands):
 
 
 def test_is_file_modified_git_error(test_file, mock_git_commands):
-    """Test handling of git command errors."""
-    with patch(
-        "subprocess.check_output",
-        side_effect=mock_git_commands(raise_error=True),
+    """A failing git command surfaces loudly rather than degrading to False."""
+    with (
+        patch(
+            "subprocess.check_output",
+            side_effect=mock_git_commands(raise_error=True),
+        ),
+        pytest.raises(subprocess.CalledProcessError),
     ):
-        assert update_lib.is_file_modified(test_file) is False
+        update_lib.is_file_modified(test_file)
+
+
+def test_is_file_modified_diff_error_raises(test_file, mock_git_root):
+    """A failing `git diff` surfaces as RuntimeError, not a silent False."""
+
+    def _mock_git(*args, **kwargs) -> str:
+        if "rev-parse" in args[0]:
+            return f"{mock_git_root}\n"
+        raise subprocess.CalledProcessError(1, "git diff")
+
+    with (
+        patch("subprocess.check_output", side_effect=_mock_git),
+        pytest.raises(RuntimeError, match="Could not check git status"),
+    ):
+        update_lib.is_file_modified(test_file)
 
 
 def test_is_file_modified_invalid_path(mock_git_commands):
@@ -648,9 +666,9 @@ def test_main_default_content_dir(mock_datetime, mock_git):
     # Check that glob was called with the right path and pattern
     assert len(glob_calls) == 1, "Path.glob was not called"
     called_path, pattern = glob_calls[0]
-    assert (
-        str(called_path) == "website_content"
-    ), f"Expected path 'website_content', got '{called_path}'"
+    assert str(called_path) == "website_content", (
+        f"Expected path 'website_content', got '{called_path}'"
+    )
     assert pattern == "*.md", f"Expected pattern '*.md', got '{pattern}'"
 
 

--- a/scripts/update_date_on_publish.py
+++ b/scripts/update_date_on_publish.py
@@ -57,18 +57,22 @@ def is_file_modified(file_path: Path, commit_range: str | None = None) -> bool:
 
     Returns:
         bool: True if file was modified, False otherwise
+
+    Raises:
+        RuntimeError: If a git command fails — surfacing the failure rather
+            than silently treating the file as unmodified.
     """
+    # Get the relative path from git root
+    git_executable = script_utils.find_executable("git")
+    git_root = subprocess.check_output(
+        [git_executable, "rev-parse", "--show-toplevel"], text=True
+    ).strip()
+    rel_path = file_path.resolve().relative_to(Path(git_root))
+
+    # Determine commit range to check
+    range_to_check = _determine_commit_range(commit_range)
+
     try:
-        # Get the relative path from git root
-        git_executable = script_utils.find_executable("git")
-        git_root = subprocess.check_output(
-            [git_executable, "rev-parse", "--show-toplevel"], text=True
-        ).strip()
-        rel_path = file_path.resolve().relative_to(Path(git_root))
-
-        # Determine commit range to check
-        range_to_check = _determine_commit_range(commit_range)
-
         # Check if file changed in the range
         result = subprocess.check_output(
             [
@@ -80,11 +84,12 @@ def is_file_modified(file_path: Path, commit_range: str | None = None) -> bool:
             ],
             text=True,
         ).strip()
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Could not check git status for {file_path}: {exc}"
+        ) from exc
 
-        return bool(result)
-    except subprocess.CalledProcessError:
-        print(f"Warning: Could not check git status for {file_path}")
-        return False
+    return bool(result)
 
 
 def maybe_convert_to_date(

--- a/scripts/update_date_on_publish.py
+++ b/scripts/update_date_on_publish.py
@@ -62,18 +62,14 @@ def is_file_modified(file_path: Path, commit_range: str | None = None) -> bool:
         RuntimeError: If a git command fails — surfacing the failure rather
             than silently treating the file as unmodified.
     """
-    # Get the relative path from git root
     git_executable = script_utils.find_executable("git")
-    git_root = subprocess.check_output(
-        [git_executable, "rev-parse", "--show-toplevel"], text=True
-    ).strip()
-    rel_path = file_path.resolve().relative_to(Path(git_root))
-
-    # Determine commit range to check
     range_to_check = _determine_commit_range(commit_range)
 
     try:
-        # Check if file changed in the range
+        git_root = subprocess.check_output(
+            [git_executable, "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+        rel_path = file_path.resolve().relative_to(Path(git_root))
         result = subprocess.check_output(
             [
                 git_executable,


### PR DESCRIPTION
## Summary

This PR implements the actionable findings from a whole-repo code review, grouped into four areas. The throughline is **moving conventions into enforcement** (lint rules instead of "we don't do that") and **failing loudly** where code previously swallowed errors.

- Consolidate the Python formatter stack to Ruff and replace several silent-failure paths with loud ones.
- Enforce existing style rules via type-aware ESLint, and tidy a few Quartz internals the review flagged.
- Harden CI: add `actionlint` + `zizmor` as a gating job, scope down workflow permissions, and make a couple of jobs fail fast instead of hanging.
- Document the coverage carve-outs and drop a dead config file.

## Changes

### Python tooling (`build(python)`)
- Replace the `autoflake → isort → autopep8 → black → ruff` lint-staged chain with `ruff check --fix` + `ruff format` (config consolidated in `pyproject.toml`; `run_push_checks.py` updated to match). One-time `ruff format` reformat across `scripts/` (most of the test-file churn is this).
- Fail loudly instead of swallowing: `spellcheck_triage` validates the decision schema and raises on malformed LLM output; `is_file_modified` raises a contextual `RuntimeError` on any git failure instead of returning `False`; `compress.py` surfaces ffprobe stderr.
- De-duplicate the ffmpeg argument construction shared by the HEVC and WebM encoders.

### Lint strictness + Quartz cleanups (`feat(lint)`)
- Enable type-aware ESLint on `quartz/`: `prefer-readonly`, `no-floating-promises`, `no-misused-promises`, and a `no-restricted-syntax` ban on backward-compat re-exports (with an override for the three plugin barrel registries). All 39 resulting violations fixed.
- `favicons.readFaviconCounts` now throws on a corrupt counts file (missing file still yields an empty map); `build.ts` file-removal is no longer quadratic; `populateContainers` shares a `findElements` helper; `popover.inline` uses an `AbortController`; spoiler toggling moved out of an inline-JS template string into a delegated client script.
- Cleared the remaining ESLint warnings and gated CI at `--max-warnings 0`.

### CI hardening (`ci`)
- New `workflow-lint` job (actionlint + zizmor at medium confidence, SHA-pinned). Fixed the findings it surfaced: moved untrusted interpolations into `env:` and scoped workflow write-permissions down to the jobs that need them.
- `deploy` verify-test-results poll gets a per-check wall-clock deadline (fails fast instead of burning the 90-min job timeout); `continue-on-error` made selective so infra/critical-log failures still surface on Playwright shards; `template-sync` job timeout added; `python-lint` migrated to ruff (job name preserved); `actions/cache` SHA pins standardized; `pre-push` guards `uv` and prints the `RESUME=true` hint on failure.

### Config hygiene (`chore(config)`)
- Inline rationale on each `coveragePathIgnorePatterns` entry; removed the unreferenced `.markdownlint-cli2.jsonc`.

**Note:** `noUncheckedIndexedAccess` was evaluated but **not** included — it produces ~280 errors across ~50 files (including `config/` and `scripts/`) and is better handled as its own focused PR.

## Testing

- `pnpm check` (tsc + prettier + stylelint): clean
- `pnpm test`: 4013 passed, 100% coverage
- `pnpm eslint . --max-warnings 0`: clean
- Python suite (`uv run pytest scripts/`): 2086 passed, 100% coverage
- `actionlint` and `zizmor` (medium confidence): no findings
- Pre-push checks (pylint, mypy, source checks, asset upload, alt-text): all green

The test-expectation changes (favicon fail-loud, spellcheck-triage raise, ruff-format step, git-failure raise) were confirmed with the user before being applied, with new tests added for the new branches.

## Lessons Learned

- **What**: When farming a multi-area change out to parallel agents, partition by **disjoint file ownership** and have agents leave the working tree dirty for the orchestrator to verify/commit — never let parallel agents run `git commit` against a shared tree.
- **Where**: agent-orchestration workflow (applies to any repo using parallel sub-agents)
- **Why**: Concurrent commits race on the index; disjoint ownership lets independent edits coexist in one working tree, and a single verify-then-commit pass keeps the history coherent and the tests green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WtrhHhbXv8y7Jvopt9sS8v)_