### PR TITLE
Honor .gitignore in strip_for_spellcheck

### DIFF
--- a/scripts/strip_for_spellcheck.py
+++ b/scripts/strip_for_spellcheck.py
@@ -203,7 +203,21 @@ def create_stripped_directory(
     if output_dir is None:
         output_dir = Path(tempfile.mkdtemp(prefix="stripped_for_spellcheck_"))
 
-    for md_file in source_dir.rglob("*.md"):
+    # Resolve to an absolute path so git-ignore filtering (which compares
+    # against the repo root) and the `relative_to` below both work whether
+    # the caller passed a relative or absolute source directory.
+    source_dir = source_dir.resolve()
+
+    # Honor .gitignore so gitignored content (e.g. website_content/drafts,
+    # *test.md) is excluded from spellcheck and vale, matching the rest of
+    # the pre-push checks.
+    md_files = script_utils.get_files(
+        dir_to_search=source_dir,
+        filetypes_to_match=(".md",),
+        use_git_ignore=True,
+    )
+
+    for md_file in md_files:
         relative = md_file.relative_to(source_dir)
         output_file = output_dir / relative
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tests/test_strip_for_spellcheck.py
+++ b/scripts/tests/test_strip_for_spellcheck.py
@@ -380,6 +380,29 @@ class TestCreateStrippedDirectory:
         assert nested_out.endswith(" world")
         assert not (output / "ignored.txt").exists()
 
+    def test_excludes_gitignored_content(
+        self, git_initialized_dir: dict[str, object]
+    ):
+        root = git_initialized_dir["root"]
+        assert isinstance(root, Path)
+        source = root / "website_content"
+        (source / "drafts").mkdir(parents=True)
+        (root / ".gitignore").write_text(
+            "website_content/drafts\n*test.md\n", encoding="utf-8"
+        )
+        (source / "published.md").write_text("Hello", encoding="utf-8")
+        (source / "drafts" / "secret.md").write_text(
+            "Draft text", encoding="utf-8"
+        )
+        (source / "scratch.test.md").write_text("Scratch", encoding="utf-8")
+
+        output = root / "output"
+        strip_for_spellcheck.create_stripped_directory(source, output)
+
+        assert (output / "published.md").exists()
+        assert not (output / "drafts" / "secret.md").exists()
+        assert not (output / "scratch.test.md").exists()
+
     def test_creates_temp_dir_when_no_output(self, tmp_path: Path):
         source = tmp_path / "source"
         source.mkdir()


### PR DESCRIPTION
## Summary
Update `strip_for_spellcheck.create_stripped_directory()` to respect `.gitignore` rules when selecting files for processing, ensuring that gitignored content (e.g., draft directories, test files) is excluded from spellcheck and vale checks, matching the behavior of other pre-push checks.

## Changes
- **Modified `create_stripped_directory()`** to use `script_utils.get_files()` with `use_git_ignore=True` instead of directly globbing all `.md` files
- **Resolved source directory to absolute path** to ensure git-ignore filtering works correctly regardless of whether a relative or absolute path was passed
- **Added test case** `test_excludes_gitignored_content()` to verify that files matching `.gitignore` patterns are properly excluded from the output directory

## Implementation details
- The source directory is now resolved to an absolute path before processing, which is necessary for both git-ignore filtering (which compares against the repo root) and the subsequent `relative_to()` call
- Uses the existing `script_utils.get_files()` utility which already handles git-ignore logic, avoiding duplication
- This change aligns the spellcheck preprocessing with the rest of the pre-push validation pipeline

https://claude.ai/code/session_0116e7cWY3yEeuuRGiHZmn84