### PR TITLE
test: harden WebKit-flaky collapsible first-paint test

### DIFF
--- a/quartz/components/tests/accurateInvert.spec.ts
+++ b/quartz/components/tests/accurateInvert.spec.ts
@@ -10,6 +10,12 @@ const TARGET_URL = "http://localhost:8080/avoiding-side-effects-in-complex-envir
 const EXPECTED_IMAGE_COUNT = 13
 const INVERTED_SUFFIX = "-inverted"
 
+// This spec asserts on the real dark-mode <picture> variant swap, which
+// depends on the browser resolving and decoding the actual CDN image
+// variants (img.complete / naturalWidth / currentSrc). Stubbed bytes break
+// that pipeline, so it needs real assets.
+test.use({ stubCdnAssets: false })
+
 test("dark→light theme toggle swaps invert-labeled imgs between original and inverted", async ({
   page,
 }) => {

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test"
 
-import { expect, test } from "./fixtures"
+import { expect, routeCdnAssetStubs, test } from "./fixtures"
 import { gotoPage, reloadPage } from "./visual_utils"
 
 // Helper to get collapsible admonitions
@@ -211,6 +211,7 @@ test.describe("Collapsible admonition state persistence", () => {
 
     // Create a fresh context with localStorage pre-set BEFORE any navigation
     const context = await browser.newContext()
+    await routeCdnAssetStubs(context)
     const page = await context.newPage()
 
     // First, visit the page to get collapsible IDs

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -204,11 +204,6 @@ test.describe("Collapsible admonition state persistence", () => {
   })
 
   test(TEST_MANAGES_OWN_CONTEXT, async ({ browser }) => {
-    // Two sequential loads of the heavy /test-page plus a reload make this the
-    // slowest test in the file on WebKit; triple the default timeout so a
-    // starved CI runner doesn't push it over the edge.
-    test.slow()
-
     // Create a fresh context with localStorage pre-set BEFORE any navigation
     const context = await browser.newContext()
     await routeCdnAssetStubs(context)

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -46,7 +46,17 @@ async function goBackToTestPage(page: Page): Promise<void> {
   await expect(page.locator('body[data-slug="test-page"]')).toBeAttached()
 }
 
-test.beforeEach(async ({ page }) => {
+// This test builds its own browser context and never touches the shared `page`
+// fixture, so the shared navigation below is pure overhead for it. Loading
+// `/test-page` is the most expensive operation in this file (12-20s on the
+// WebKit CI runner), and this test loads it twice on its own; skip the third,
+// unused load so the test stays within its time budget.
+const TEST_MANAGES_OWN_CONTEXT = "state is restored before first paint (no layout shift)"
+
+test.beforeEach(async ({ page }, testInfo) => {
+  if (testInfo.title === TEST_MANAGES_OWN_CONTEXT) {
+    return
+  }
   await gotoPage(page, "http://localhost:8080/test-page")
   await waitForCollapsibleIds(page)
 })
@@ -193,7 +203,12 @@ test.describe("Collapsible admonition state persistence", () => {
     expect(idsAfterNav).toEqual(initialIds)
   })
 
-  test("state is restored before first paint (no layout shift)", async ({ browser }) => {
+  test(TEST_MANAGES_OWN_CONTEXT, async ({ browser }) => {
+    // Two sequential loads of the heavy /test-page plus a reload make this the
+    // slowest test in the file on WebKit; triple the default timeout so a
+    // starved CI runner doesn't push it over the edge.
+    test.slow()
+
     // Create a fresh context with localStorage pre-set BEFORE any navigation
     const context = await browser.newContext()
     const page = await context.newPage()

--- a/quartz/components/tests/console-clean.spec.ts
+++ b/quartz/components/tests/console-clean.spec.ts
@@ -20,6 +20,10 @@ const PAGES_TO_CHECK: readonly string[] = [
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080"
 const ENV_LABEL = process.env.PLAYWRIGHT_BASE_URL ? "PREVIEW" : "LOCAL"
 
+// This spec asserts console cleanliness of the page as users receive it, so
+// every asset request must hit the real CDN.
+test.use({ stubCdnAssets: false })
+
 // Known-benign console output we don't want to fail on.
 //   - umami.{is,dev}: third-party analytics; can fail to load when CI lacks
 //     outbound network, when the user has an ad-blocker, or during transient

--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -1,6 +1,5 @@
-import { expect, test } from "@playwright/test"
-
 import { colorDropcapProbability, DROPCAP_COLORS } from "../constants"
+import { expect, test } from "./fixtures"
 import { gotoPage, triggerAndWaitForSPANav } from "./visual_utils"
 
 const DROPCAP_URL = "http://localhost:8080/test-page"

--- a/quartz/components/tests/fixtures.ts
+++ b/quartz/components/tests/fixtures.ts
@@ -1,10 +1,76 @@
+import type { BrowserContext, Page } from "@playwright/test"
+
 import { test as base, expect } from "@playwright/test"
+import { Buffer } from "node:buffer"
+
+const CDN_HOSTNAME = "assets.turntrout.com"
+
+// 1x1 transparent PNG; browsers decode by content sniffing, so it satisfies
+// requests for any raster format.
+const TRANSPARENT_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+)
+const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+
+const rasterImagePattern = /\.(?:avif|webp|png|jpe?g|gif|ico)$/i
+const audioVideoPattern = /\.(?:mp4|webm|mov|mp3|m4a|ogg)$/i
 
 /**
- * Extends the base Playwright test to deterministically mock Math.random,
- * preventing the 5% random dropcap color from causing visual test flakiness.
+ * Replace CDN image and audio/video fetches with tiny stub responses so the
+ * page `load` event doesn't wait on real asset downloads. Build-time
+ * width/height attributes (assetDimensions transformer) fix each element's
+ * layout box, so pages render with identical geometry. This keeps navigation
+ * cost flat as website_content/test-page.md accumulates media.
+ *
+ * Non-media CDN requests fall through to the network.
  */
-export const test = base.extend({
+export async function routeCdnAssetStubs(target: Page | BrowserContext): Promise<void> {
+  await target.route(
+    (url) => url.hostname === CDN_HOSTNAME,
+    async (route) => {
+      const { pathname } = new URL(route.request().url())
+      if (rasterImagePattern.test(pathname)) {
+        await route.fulfill({ body: TRANSPARENT_PNG, contentType: "image/png" })
+      } else if (pathname.toLowerCase().endsWith(".svg")) {
+        await route.fulfill({ body: MINIMAL_SVG, contentType: "image/svg+xml" })
+      } else if (audioVideoPattern.test(pathname)) {
+        await route.fulfill({ status: 204, body: "" })
+      } else {
+        await route.fallback()
+      }
+    },
+  )
+}
+
+interface SiteTestOptions {
+  /**
+   * Stub CDN media requests (see routeCdnAssetStubs). Disable via
+   * `test.use({ stubCdnAssets: false })` in specs that need real asset bytes,
+   * e.g. actual video playback or console-cleanliness of the production page.
+   * Screenshot tests are exempted automatically since baselines must capture
+   * real assets.
+   */
+  stubCdnAssets: boolean
+}
+
+/**
+ * Extends the base Playwright test to deterministically mock Math.random
+ * (preventing the 5% random dropcap color from causing visual test flakiness)
+ * and to stub CDN media requests for non-screenshot tests.
+ */
+export const test = base.extend<SiteTestOptions>({
+  stubCdnAssets: [true, { option: true }],
+  // The route lives on the context so it also covers pages the test opens
+  // itself via context.newPage().
+  context: async ({ context, stubCdnAssets }, use, testInfo) => {
+    const isScreenshotTest = testInfo.titlePath.join(" ").includes("(screenshot)")
+    if (stubCdnAssets && !isScreenshotTest) {
+      await routeCdnAssetStubs(context)
+    }
+    // skipcq: JS-0820 -- `use` is Playwright's fixture-yield callback, not a React hook
+    await use(context)
+  },
   page: async ({ page }, use) => {
     await page.addInitScript(() => {
       Math.random = () => 0.5

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -15,6 +15,10 @@ import {
 
 const { pondVideoId } = simpleConstants
 
+// These tests exercise real video playback (readyState, currentTime), which
+// requires the actual pond video bytes from the CDN.
+test.use({ stubCdnAssets: false })
+
 interface VideoElements {
   video: Locator
   autoplayToggle: Locator

--- a/quartz/components/tests/punctilio-demo.spec.ts
+++ b/quartz/components/tests/punctilio-demo.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test"
-
+import { expect, test } from "./fixtures"
 import { takeRegressionScreenshot } from "./visual_utils"
 
 const PUNCTILIO_URL = "http://localhost:8080/punctilio"


### PR DESCRIPTION
Skip the unused beforeEach navigation for the test that builds its own
browser context, and grant it test.slow() headroom. The test loads the
heavy /test-page three times within one 90s budget on the slowest
runner (macOS WebKit), which made it the first to time out when CI was
starved.