### PR TITLE
fix(ci): restore actions:read so the Deploy workflow stops failing at startup

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,11 @@ on:
 
 # Read-only default; each job below elevates only to the writes it needs
 # (Cloudflare OIDC/Pages deploys, PR preview comments, check-run reads).
+# `actions: read` is required by the reusable build-site.yaml workflow (its
+# jobs declare it); a reusable workflow's permissions cannot exceed the
+# caller's, so omitting it here makes the whole run fail at startup.
 permissions:
+  actions: read
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

The **Deploy to Cloudflare** workflow (`deploy.yaml`) has ended in `startup_failure` on **every** run — pushes to `main`/`dev` and every PR — since its permissions were hardened (commit `18cdcaf`). Because a `startup_failure` run never starts any jobs, it creates **no check-runs**, so it silently disappears from the PR checks list and never gates anything; it only shows as a red run in the Actions tab. As a side effect, the `pr-<N>.turntrout.pages.dev` preview is never published.

## Root cause

`18cdcaf` reduced `deploy.yaml`'s top-level permissions to just `contents: read`, dropping the `actions` scope entirely. The `deploy-build` job calls the reusable workflow `build-site.yaml`, whose jobs declare:

```yaml
permissions:
  actions: read
  contents: read
```

A reusable workflow's permissions **cannot exceed the caller's**. With the caller granting only `contents: read`, the `actions: read` request is unsatisfiable, so GitHub rejects the workflow before any job runs — `startup_failure`.

Every other caller of `build-site.yaml` (`site-build-checks`, `preview-audits`, `playwright-tests`, `visual-testing`, …) grants top-level `actions: read` + `contents: read`, which is why only `deploy.yaml` was affected. (The `deploy: pass` check seen on PRs is the unrelated `deploy` job in `preview-audits.yaml` — a job-name collision.)

## Fix

Restore `actions: read` at `deploy.yaml`'s top level, matching every other `build-site.yaml` caller. The hardening intent is preserved: write scopes (`id-token`, `pages`, `pull-requests`) remain scoped to the individual jobs that declare them, and those job-level blocks override this default.

## Testing

- `actionlint` on all workflows — exit 0, no findings.
- `zizmor --offline --persona regular --min-confidence=medium` on `deploy.yaml` — no findings.
- Confirmed `deploy.yaml` was the only workflow in `startup_failure` on `main`.

## Lessons learned

- A reusable workflow's declared `permissions` are an **upper bound capped by the caller**; if the caller omits a scope the callee requests, the run fails at **startup**, not at job time.
- `startup_failure` runs produce **no check-runs**, so they never appear in a PR's checks list and never block merges — they're only visible in the Actions tab. A workflow can be broken on `main` indefinitely without any PR going red. When hardening (scoping down) workflow permissions, diff the granted scopes against what every called reusable workflow and action declares.