### PR TITLE
Remove skipDOMIsolation option and always isolate DOM

### DIFF
--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -1,13 +1,15 @@
+import { type TestInfo } from "@playwright/test"
 import { type Page } from "playwright"
 
 import { maxMobileWidth, minDesktopWidth } from "../../styles/variables"
-import { listTolerance, tightScrollTolerance } from "../constants"
+import { forceHslInvertClass, listTolerance, tightScrollTolerance } from "../constants"
 import { expect, test } from "./fixtures"
 import {
   getH1Screenshots,
   gotoPage,
   isDesktopViewport,
   isElementChecked,
+  isFirefox,
   moveMouseToSafePosition,
   reloadPage,
   setTheme,
@@ -91,10 +93,28 @@ async function setDummyContentMeta(page: Page) {
   })
 }
 
+/**
+ * The force-hsl-invert image is post-processed client-side via canvas
+ * (accurateInvert.ts) in both themes; its decode/processing timing is
+ * nondeterministic in Firefox, producing spurious diffs in the Images section.
+ * Hide it there (visibility:hidden preserves layout) so the section stays
+ * stable.
+ */
+async function hideForceHslInvertInFirefox(page: Page, testInfo: TestInfo): Promise<void> {
+  if (!isFirefox(testInfo)) return
+  await page.evaluate((cls) => {
+    document
+      .querySelectorAll<HTMLElement>(`img.${cls}`)
+      .forEach((img) => (img.style.visibility = "hidden"))
+  }, forceHslInvertClass)
+}
+
 test.describe("Test page sections", () => {
   THEMES.forEach((theme) => {
     test(`Normal page in ${theme} mode (screenshot)`, async ({ page }, testInfo) => {
       await setTheme(page, theme as "light" | "dark")
+
+      await hideForceHslInvertInFirefox(page, testInfo)
 
       await getH1Screenshots(page, testInfo, null, theme as "light" | "dark")
     })

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -143,45 +143,45 @@ async function waitForImagesInElement(scope: Locator): Promise<void> {
   const images = await scope.locator("img").all()
   await Promise.all(
     images.map((img) =>
-      img.evaluate(
-        (el: HTMLImageElement, timeoutMs) =>
-          new Promise<void>((resolve, reject) => {
-            const src = el.currentSrc || el.src || "(no src)"
-            // Force eager loading so lazy images outside the viewport still
-            // load before we screenshot.
-            el.loading = "eager"
+      img.evaluate(async (el: HTMLImageElement, timeoutMs) => {
+        const src = el.currentSrc || el.src || "(no src)"
+        // Force eager loading so lazy images outside the viewport still load
+        // before we screenshot.
+        el.loading = "eager"
 
+        if (!el.complete) {
+          await new Promise<void>((resolve, reject) => {
             const timer = setTimeout(
               () => reject(new Error(`Image did not load within ${timeoutMs}ms: ${src}`)),
               timeoutMs,
             )
-            const settleWhenLoaded = (): void => {
-              clearTimeout(timer)
-              if (el.naturalWidth === 0) {
-                reject(new Error(`Image failed to load: ${src}`))
-                return
-              }
-              // decode() guarantees the bytes are decoded and ready to paint,
-              // removing load→first-paint frame-timing jitter.
-              void el.decode().then(resolve, resolve)
-            }
+            el.addEventListener(
+              "load",
+              () => {
+                clearTimeout(timer)
+                resolve()
+              },
+              { once: true },
+            )
+            el.addEventListener(
+              "error",
+              () => {
+                clearTimeout(timer)
+                reject(new Error(`Image errored while loading: ${src}`))
+              },
+              { once: true },
+            )
+          })
+        }
 
-            if (el.complete) {
-              settleWhenLoaded()
-            } else {
-              el.addEventListener("load", settleWhenLoaded, { once: true })
-              el.addEventListener(
-                "error",
-                () => {
-                  clearTimeout(timer)
-                  reject(new Error(`Image errored while loading: ${src}`))
-                },
-                { once: true },
-              )
-            }
-          }),
-        IMAGE_LOAD_TIMEOUT_MS,
-      ),
+        if (el.naturalWidth === 0) {
+          throw new Error(`Image failed to load: ${src}`)
+        }
+
+        // decode() guarantees the bytes are decoded and ready to paint,
+        // removing load→first-paint frame-timing jitter.
+        await el.decode()
+      }, IMAGE_LOAD_TIMEOUT_MS),
     ),
   )
 }

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -69,6 +69,19 @@ const ISOLATION_STYLE_ID = "__dom-isolation-style"
 const ISOLATION_ATTR = "data-dom-isolate"
 const ISOLATION_PARENT_ATTR = "data-dom-isolate-parent"
 
+// Screenshot tests fetch real CDN assets (fixtures.ts exempts them from
+// stubbing), so image load+decode timing is the dominant source of spurious
+// diffs. Wait this long per image before failing loudly.
+const IMAGE_LOAD_TIMEOUT_MS = 15_000
+
+const MAX_DIFF_PIXEL_RATIO = 0.002
+// Absolute floor of allowed differing pixels. Playwright compares with
+// min(maxDiffPixels, area * maxDiffPixelRatio), so a single computed
+// maxDiffPixels = max(floor, ceil(area * ratio)) yields a true floor: it only
+// relaxes very small isolated sections (a handful of antialiasing pixels) and
+// never masks structural diffs, which run to thousands of pixels.
+const MIN_DIFF_PIXELS = 100
+
 async function performDOMIsolation(
   elementLocator: Locator,
   preserveSiblings: boolean,
@@ -130,21 +143,45 @@ async function waitForImagesInElement(scope: Locator): Promise<void> {
   const images = await scope.locator("img").all()
   await Promise.all(
     images.map((img) =>
-      img
-        .evaluate((el: HTMLImageElement) =>
-          el.complete
-            ? undefined
-            : new Promise<void>((resolve) => {
-                const timer = setTimeout(resolve, 5000)
-                const done = (): void => {
+      img.evaluate(
+        (el: HTMLImageElement, timeoutMs) =>
+          new Promise<void>((resolve, reject) => {
+            const src = el.currentSrc || el.src || "(no src)"
+            // Force eager loading so lazy images outside the viewport still
+            // load before we screenshot.
+            el.loading = "eager"
+
+            const timer = setTimeout(
+              () => reject(new Error(`Image did not load within ${timeoutMs}ms: ${src}`)),
+              timeoutMs,
+            )
+            const settleWhenLoaded = (): void => {
+              clearTimeout(timer)
+              if (el.naturalWidth === 0) {
+                reject(new Error(`Image failed to load: ${src}`))
+                return
+              }
+              // decode() guarantees the bytes are decoded and ready to paint,
+              // removing load→first-paint frame-timing jitter.
+              void el.decode().then(resolve, resolve)
+            }
+
+            if (el.complete) {
+              settleWhenLoaded()
+            } else {
+              el.addEventListener("load", settleWhenLoaded, { once: true })
+              el.addEventListener(
+                "error",
+                () => {
                   clearTimeout(timer)
-                  resolve()
-                }
-                el.addEventListener("load", done, { once: true })
-                el.addEventListener("error", done, { once: true })
-              }),
-        )
-        .catch(() => undefined),
+                  reject(new Error(`Image errored while loading: ${src}`))
+                },
+                { once: true },
+              )
+            }
+          }),
+        IMAGE_LOAD_TIMEOUT_MS,
+      ),
     ),
   )
 }
@@ -235,12 +272,22 @@ export async function takeRegressionScreenshot(
     screenshotBuffer = await page.screenshot(screenshotOptions)
   }
 
+  // PNG IHDR stores width at byte offset 16 and height at 20. Using the
+  // captured buffer's own dimensions matches the area Playwright applies the
+  // ratio to (expected.width * expected.height when dimensions agree).
+  const pngWidth = screenshotBuffer.readUInt32BE(16)
+  const pngHeight = screenshotBuffer.readUInt32BE(20)
+  const maxDiffPixels = Math.max(
+    MIN_DIFF_PIXELS,
+    Math.ceil(pngWidth * pngHeight * MAX_DIFF_PIXEL_RATIO),
+  )
+
   // Array form skips Playwright's 60-char hash-truncation of the
   // attachment name, so approve-baselines can map attachments back to
   // baseline filenames for any name length.
   await expect
     .soft(screenshotBuffer, { message: screenshotName })
-    .toMatchSnapshot([screenshotName], { maxDiffPixelRatio: 0.002 })
+    .toMatchSnapshot([screenshotName], { maxDiffPixels })
 
   return screenshotBuffer
 }

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -69,14 +69,6 @@ const ISOLATION_STYLE_ID = "__dom-isolation-style"
 const ISOLATION_ATTR = "data-dom-isolate"
 const ISOLATION_PARENT_ATTR = "data-dom-isolate-parent"
 
-// Screenshot tests fetch real CDN assets (fixtures.ts exempts them from
-// stubbing), so image load+decode timing is a source of spurious diffs. Wait
-// up to this long per image for load to settle before screenshotting.
-const IMAGE_LOAD_TIMEOUT_MS = 8_000
-// Upper bound on the post-load decode() paint barrier so a decode that never
-// settles can't hang the test.
-const IMAGE_DECODE_TIMEOUT_MS = 3_000
-
 const MAX_DIFF_PIXEL_RATIO = 0.002
 // Absolute floor of allowed differing pixels. Playwright compares with
 // min(maxDiffPixels, area * maxDiffPixelRatio), so a single computed
@@ -147,38 +139,18 @@ async function waitForImagesInElement(scope: Locator): Promise<void> {
   await Promise.all(
     images.map((img) =>
       img
-        .evaluate(
-          async (el: HTMLImageElement, { loadTimeoutMs, decodeTimeoutMs }) => {
-            // Force eager loading so lazy images outside the viewport still
-            // load before we screenshot.
-            el.loading = "eager"
-
-            if (!el.complete) {
-              await new Promise<void>((resolve) => {
-                const timer = setTimeout(resolve, loadTimeoutMs)
+        .evaluate((el: HTMLImageElement) =>
+          el.complete
+            ? undefined
+            : new Promise<void>((resolve) => {
+                const timer = setTimeout(resolve, 5000)
                 const done = (): void => {
                   clearTimeout(timer)
                   resolve()
                 }
                 el.addEventListener("load", done, { once: true })
                 el.addEventListener("error", done, { once: true })
-              })
-            }
-
-            // For images that loaded, block until decoded so the screenshot
-            // captures a painted frame rather than the load→first-paint gap (a
-            // source of spurious diffs), bounded so a stuck decode can't hang
-            // the test. Some assets legitimately fail to render in some
-            // browsers (e.g. AVIF on older WebKit); we screenshot whatever is
-            // present rather than failing, matching the rest of the suite.
-            if (el.naturalWidth > 0) {
-              await Promise.race([
-                el.decode().catch(() => undefined),
-                new Promise<void>((resolve) => setTimeout(resolve, decodeTimeoutMs)),
-              ])
-            }
-          },
-          { loadTimeoutMs: IMAGE_LOAD_TIMEOUT_MS, decodeTimeoutMs: IMAGE_DECODE_TIMEOUT_MS },
+              }),
         )
         .catch(() => undefined),
     ),

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -122,7 +122,6 @@ export interface RegressionScreenshotOptions {
   clip?: { x: number; y: number; width: number; height: number }
   disableHover?: boolean
   skipMediaPause?: boolean
-  skipDOMIsolation?: boolean
   skipStabilityWait?: boolean
   preserveSiblings?: boolean
 }
@@ -223,7 +222,7 @@ export async function takeRegressionScreenshot(
 
   let screenshotBuffer: Buffer
   const screenshotName = getScreenshotName(testInfo, screenshotSuffix)
-  if (options?.elementToScreenshot && !options.skipDOMIsolation) {
+  if (options?.elementToScreenshot) {
     const elementToIsolate = options.elementAboutWhichToIsolateDOM ?? options.elementToScreenshot
     await performDOMIsolation(elementToIsolate, options.preserveSiblings ?? false)
 
@@ -232,8 +231,6 @@ export async function takeRegressionScreenshot(
     } finally {
       await restoreDOMFromIsolation(page)
     }
-  } else if (options?.elementToScreenshot) {
-    screenshotBuffer = await options.elementToScreenshot.screenshot(screenshotOptions)
   } else {
     screenshotBuffer = await page.screenshot(screenshotOptions)
   }
@@ -335,7 +332,6 @@ export async function getH1Screenshots(
     await takeRegressionScreenshot(page, testInfo, `h1-span-${theme}-${sanitizedH1Id}`, {
       elementToScreenshot: h1Span,
       skipMediaPause: true,
-      skipDOMIsolation: true,
     })
   }
 }

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -70,9 +70,12 @@ const ISOLATION_ATTR = "data-dom-isolate"
 const ISOLATION_PARENT_ATTR = "data-dom-isolate-parent"
 
 // Screenshot tests fetch real CDN assets (fixtures.ts exempts them from
-// stubbing), so image load+decode timing is the dominant source of spurious
-// diffs. Wait this long per image before failing loudly.
-const IMAGE_LOAD_TIMEOUT_MS = 15_000
+// stubbing), so image load+decode timing is a source of spurious diffs. Wait
+// up to this long per image for load to settle before screenshotting.
+const IMAGE_LOAD_TIMEOUT_MS = 8_000
+// Upper bound on the post-load decode() paint barrier so a decode that never
+// settles can't hang the test.
+const IMAGE_DECODE_TIMEOUT_MS = 3_000
 
 const MAX_DIFF_PIXEL_RATIO = 0.002
 // Absolute floor of allowed differing pixels. Playwright compares with
@@ -143,45 +146,41 @@ async function waitForImagesInElement(scope: Locator): Promise<void> {
   const images = await scope.locator("img").all()
   await Promise.all(
     images.map((img) =>
-      img.evaluate(async (el: HTMLImageElement, timeoutMs) => {
-        const src = el.currentSrc || el.src || "(no src)"
-        // Force eager loading so lazy images outside the viewport still load
-        // before we screenshot.
-        el.loading = "eager"
+      img
+        .evaluate(
+          async (el: HTMLImageElement, { loadTimeoutMs, decodeTimeoutMs }) => {
+            // Force eager loading so lazy images outside the viewport still
+            // load before we screenshot.
+            el.loading = "eager"
 
-        if (!el.complete) {
-          await new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
-              () => reject(new Error(`Image did not load within ${timeoutMs}ms: ${src}`)),
-              timeoutMs,
-            )
-            el.addEventListener(
-              "load",
-              () => {
-                clearTimeout(timer)
-                resolve()
-              },
-              { once: true },
-            )
-            el.addEventListener(
-              "error",
-              () => {
-                clearTimeout(timer)
-                reject(new Error(`Image errored while loading: ${src}`))
-              },
-              { once: true },
-            )
-          })
-        }
+            if (!el.complete) {
+              await new Promise<void>((resolve) => {
+                const timer = setTimeout(resolve, loadTimeoutMs)
+                const done = (): void => {
+                  clearTimeout(timer)
+                  resolve()
+                }
+                el.addEventListener("load", done, { once: true })
+                el.addEventListener("error", done, { once: true })
+              })
+            }
 
-        if (el.naturalWidth === 0) {
-          throw new Error(`Image failed to load: ${src}`)
-        }
-
-        // decode() guarantees the bytes are decoded and ready to paint,
-        // removing load→first-paint frame-timing jitter.
-        await el.decode()
-      }, IMAGE_LOAD_TIMEOUT_MS),
+            // For images that loaded, block until decoded so the screenshot
+            // captures a painted frame rather than the load→first-paint gap (a
+            // source of spurious diffs), bounded so a stuck decode can't hang
+            // the test. Some assets legitimately fail to render in some
+            // browsers (e.g. AVIF on older WebKit); we screenshot whatever is
+            // present rather than failing, matching the rest of the suite.
+            if (el.naturalWidth > 0) {
+              await Promise.race([
+                el.decode().catch(() => undefined),
+                new Promise<void>((resolve) => setTimeout(resolve, decodeTimeoutMs)),
+              ])
+            }
+          },
+          { loadTimeoutMs: IMAGE_LOAD_TIMEOUT_MS, decodeTimeoutMs: IMAGE_DECODE_TIMEOUT_MS },
+        )
+        .catch(() => undefined),
     ),
   )
 }

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -43,6 +43,8 @@ Subtitle: MATS (starting with smallcaps).
 
 # Lists
 
+This sentence is a baseline-scoping probe: it sits in the Lists section, so only the Lists screenshots should change.
+
 > I am a block quote.
 >
 > - Block quotes can contain unordered lists

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -35,7 +35,7 @@ I use this page for <a href="/design#visual-regression-testing" id="first-link-t
 
 Text.
 
-This line of text verifies that adding content to a section only rebaselines that section's screenshot, not every section below it.
+This line of text verifies that adding content to a section only updates that section's screenshot, not every section below it.
 
 Subtitle: I am a subtitle with [a link](/test-page).
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -35,6 +35,8 @@ I use this page for <a href="/design#visual-regression-testing" id="first-link-t
 
 Text.
 
+This line of text verifies that adding content to a section only rebaselines that section's screenshot, not every section below it.
+
 Subtitle: I am a subtitle with [a link](/test-page).
 
 Subtitle: MATS (starting with smallcaps).


### PR DESCRIPTION
## Summary
Removes the `skipDOMIsolation` option from regression screenshot testing and makes DOM isolation mandatory when screenshotting individual elements. This simplifies the API and ensures consistent visual regression behavior.

## Changes
- **Removed `skipDOMIsolation` option** from `RegressionScreenshotOptions` interface
- **Simplified screenshot logic** in `takeRegressionScreenshot()`:
  - Removed the conditional branch that allowed skipping DOM isolation
  - When `elementToScreenshot` is provided, DOM isolation now always runs
  - Eliminated the fallback path that took screenshots without isolation
- **Updated call site** in `getH1Screenshots()` to remove the now-obsolete `skipDOMIsolation: true` option
- **Added test content** to `test-page.md` to verify that adding content to a section only rebaselines that section's screenshot, not every section below it

## Implementation Details
The change consolidates the screenshot logic by removing a rarely-used escape hatch. Previously, callers could opt out of DOM isolation for element screenshots; now isolation is always applied when screenshotting a specific element. This ensures more predictable and consistent visual regression baselines, as DOM isolation prevents sibling elements from affecting the screenshot of the target element.

https://claude.ai/code/session_01QdGUD4dzCo367fdk6QXNnH