### PR TITLE
fix(toc): highlight correct entry on fresh load scrolled mid-page

### DIFF
--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -121,6 +121,13 @@ export const specialDomainMappings: ReadonlyArray<{ pattern: RegExp; to: string 
   })),
 ]
 
+// Desktop ToC active-heading detection: a heading counts as the current
+// section while it sits within the top `TOC_DETECTION_BAND_FRACTION` of the
+// viewport. `TOC_DETECTION_ROOT_MARGIN` derives the IntersectionObserver
+// margin from the same fraction so the two never drift apart.
+export const TOC_DETECTION_BAND_FRACTION = 0.3
+export const TOC_DETECTION_ROOT_MARGIN = `0px 0px -${(1 - TOC_DETECTION_BAND_FRACTION) * 100}% 0px`
+
 // External link attributes
 export const EXTERNAL_LINK_REL = "noopener noreferrer"
 

--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -1,3 +1,5 @@
+import { TOC_DETECTION_BAND_FRACTION, TOC_DETECTION_ROOT_MARGIN } from "../constants"
+
 let tocAbortController: AbortController | null = null
 
 function setupMobileTocClickDelegation(signal: AbortSignal): void {
@@ -66,14 +68,12 @@ function setupTocActiveHighlighting(): void {
 
   const visibleSections = new Set<string>()
 
-  // Detection band is the top 30% of the viewport (matches rootMargin below).
-  const DETECTION_BAND_FRACTION = 0.3
   const firstSectionId = sections[0]?.id
 
   // When no heading sits in the detection band (e.g. on a fresh load scrolled
   // partway down), fall back to the last heading scrolled above the band.
   function getActiveSectionByScroll(): string {
-    const boundary = window.innerHeight * DETECTION_BAND_FRACTION
+    const boundary = window.innerHeight * TOC_DETECTION_BAND_FRACTION
     let active = ""
     for (const section of sections) {
       if (section.getBoundingClientRect().top > boundary) break
@@ -92,7 +92,7 @@ function setupTocActiveHighlighting(): void {
   }
 
   const observerOptions: IntersectionObserverInit = {
-    rootMargin: "0px 0px -70% 0px",
+    rootMargin: TOC_DETECTION_ROOT_MARGIN,
     threshold: 0,
   }
 

--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -66,6 +66,31 @@ function setupTocActiveHighlighting(): void {
 
   const visibleSections = new Set<string>()
 
+  // Detection band is the top 30% of the viewport (matches rootMargin below).
+  const DETECTION_BAND_FRACTION = 0.3
+  const firstSectionId = sections[0]?.id
+
+  // When no heading sits in the detection band (e.g. on a fresh load scrolled
+  // partway down), fall back to the last heading scrolled above the band.
+  function getActiveSectionByScroll(): string {
+    const boundary = window.innerHeight * DETECTION_BAND_FRACTION
+    let active = ""
+    for (const section of sections) {
+      if (section.getBoundingClientRect().top > boundary) break
+      active = section.id
+    }
+    return active
+  }
+
+  function resolveActiveSection(): string {
+    if (visibleSections.size > 0) {
+      for (let i = sections.length - 1; i >= 0; i--) {
+        if (visibleSections.has(sections[i].id)) return sections[i].id
+      }
+    }
+    return getActiveSectionByScroll() || firstSectionId
+  }
+
   const observerOptions: IntersectionObserverInit = {
     rootMargin: "0px 0px -70% 0px",
     threshold: 0,
@@ -80,23 +105,17 @@ function setupTocActiveHighlighting(): void {
       }
     })
 
-    if (visibleSections.size > 0) {
-      for (let i = sections.length - 1; i >= 0; i--) {
-        if (visibleSections.has(sections[i].id)) {
-          updateActiveLink(sections[i].id)
-          return
-        }
-      }
-    }
+    updateActiveLink(resolveActiveSection())
   }, observerOptions)
   window.tocObserver = observer
 
   sections.forEach((section) => observer.observe(section))
 
   const hash = window.location.hash.slice(1)
-  const firstSectionId = sections[0]?.id
-  if (hash || firstSectionId) {
-    updateActiveLink(hash || firstSectionId)
+  if (hash) {
+    updateActiveLink(hash)
+  } else if (firstSectionId) {
+    updateActiveLink(resolveActiveSection())
   }
 }
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -461,7 +461,7 @@ test.describe("Table of contents", () => {
     await expect(highlightText).not.toHaveText(initialHighlightText)
   })
 
-  test("Re-initializing while scrolled partway down highlights the passed heading", async ({
+  test("Re-initializing while scrolled past the detection band highlights the passed heading", async ({
     page,
   }) => {
     test.skip(!isDesktopViewport(page))
@@ -471,9 +471,11 @@ test.describe("Table of contents", () => {
       { timeout: 15_000 },
     )
 
-    // Simulate a hard refresh that lands mid-page: scroll down past several
-    // headings, then re-run the TOC setup the way a fresh `nav` dispatch would.
-    const { expectedSlug, firstSlug } = await page.evaluate(() => {
+    // Reproduce a fresh load that lands below every heading: scroll past the
+    // detection band so no heading intersects it, then re-run the TOC setup
+    // the way a `nav` dispatch would. This exercises the scroll fallback, not
+    // the IntersectionObserver's visible-section branch.
+    const { expectedSlug, firstSlug, headingsInBand } = await page.evaluate(() => {
       const navLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>("#toc-content a"))
       const navSlugs = new Set(navLinks.map((l) => l.getAttribute("href")?.split("#")[1]))
       const sections = Array.from(
@@ -484,8 +486,14 @@ test.describe("Table of contents", () => {
 
       window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" })
 
-      // Mirror getActiveSectionByScroll: last heading scrolled above the band.
+      // Must match DETECTION_BAND_FRACTION in toc.inline.ts (rootMargin -70%).
       const boundary = window.innerHeight * 0.3
+      const headingsInBand = sections.filter((s) => {
+        const rect = s.getBoundingClientRect()
+        return rect.top < boundary && rect.bottom > 0
+      }).length
+
+      // Mirror getActiveSectionByScroll: last heading scrolled above the band.
       let expected = ""
       for (const s of sections) {
         if (s.getBoundingClientRect().top > boundary) break
@@ -493,11 +501,13 @@ test.describe("Table of contents", () => {
       }
 
       document.dispatchEvent(new CustomEvent("nav", { detail: { url: window.location.pathname } }))
-      return { expectedSlug: expected, firstSlug: sections[0]?.id ?? "" }
+      return { expectedSlug: expected, firstSlug: sections[0]?.id ?? "", headingsInBand }
     })
 
-    // The bug symptom: the first entry stays highlighted instead of the
-    // heading we've scrolled past. Guard that this case is meaningful.
+    // Guard that the scenario is meaningful: the fallback (not the observer)
+    // must drive the result, and the answer must differ from the first entry
+    // that the buggy code left stuck.
+    expect(headingsInBand).toBe(0)
     expect(expectedSlug).not.toBe(firstSlug)
 
     await page.waitForFunction(

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -460,6 +460,55 @@ test.describe("Table of contents", () => {
     const highlightText = page.locator("#table-of-contents .active").first()
     await expect(highlightText).not.toHaveText(initialHighlightText)
   })
+
+  test("Re-initializing while scrolled partway down highlights the passed heading", async ({
+    page,
+  }) => {
+    test.skip(!isDesktopViewport(page))
+
+    await page.waitForFunction(
+      () => document.querySelector("#table-of-contents .active") !== null,
+      { timeout: 15_000 },
+    )
+
+    // Simulate a hard refresh that lands mid-page: scroll down past several
+    // headings, then re-run the TOC setup the way a fresh `nav` dispatch would.
+    const { expectedSlug, firstSlug } = await page.evaluate(() => {
+      const navLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>("#toc-content a"))
+      const navSlugs = new Set(navLinks.map((l) => l.getAttribute("href")?.split("#")[1]))
+      const sections = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "#center-content article h1, #center-content article h2",
+        ),
+      ).filter((s) => s.id && navSlugs.has(s.id))
+
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" })
+
+      // Mirror getActiveSectionByScroll: last heading scrolled above the band.
+      const boundary = window.innerHeight * 0.3
+      let expected = ""
+      for (const s of sections) {
+        if (s.getBoundingClientRect().top > boundary) break
+        expected = s.id
+      }
+
+      document.dispatchEvent(new CustomEvent("nav", { detail: { url: window.location.pathname } }))
+      return { expectedSlug: expected, firstSlug: sections[0]?.id ?? "" }
+    })
+
+    // The bug symptom: the first entry stays highlighted instead of the
+    // heading we've scrolled past. Guard that this case is meaningful.
+    expect(expectedSlug).not.toBe(firstSlug)
+
+    await page.waitForFunction(
+      (slug) => {
+        const active = document.querySelector("#table-of-contents .active")
+        return active?.getAttribute("href")?.split("#")[1] === slug
+      },
+      expectedSlug,
+      { timeout: 15_000 },
+    )
+  })
 })
 
 test.describe("Layout Breakpoints", () => {

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -2,7 +2,12 @@ import { type TestInfo } from "@playwright/test"
 import { type Page } from "playwright"
 
 import { maxMobileWidth, minDesktopWidth } from "../../styles/variables"
-import { forceHslInvertClass, listTolerance, tightScrollTolerance } from "../constants"
+import {
+  forceHslInvertClass,
+  listTolerance,
+  tightScrollTolerance,
+  TOC_DETECTION_BAND_FRACTION,
+} from "../constants"
 import { expect, test } from "./fixtures"
 import {
   getH1Screenshots,
@@ -475,7 +480,7 @@ test.describe("Table of contents", () => {
     // detection band so no heading intersects it, then re-run the TOC setup
     // the way a `nav` dispatch would. This exercises the scroll fallback, not
     // the IntersectionObserver's visible-section branch.
-    const { expectedSlug, firstSlug, headingsInBand } = await page.evaluate(() => {
+    const { expectedSlug, firstSlug, headingsInBand } = await page.evaluate((bandFraction) => {
       const navLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>("#toc-content a"))
       const navSlugs = new Set(navLinks.map((l) => l.getAttribute("href")?.split("#")[1]))
       const sections = Array.from(
@@ -486,8 +491,7 @@ test.describe("Table of contents", () => {
 
       window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" })
 
-      // Must match DETECTION_BAND_FRACTION in toc.inline.ts (rootMargin -70%).
-      const boundary = window.innerHeight * 0.3
+      const boundary = window.innerHeight * bandFraction
       const headingsInBand = sections.filter((s) => {
         const rect = s.getBoundingClientRect()
         return rect.top < boundary && rect.bottom > 0
@@ -502,7 +506,7 @@ test.describe("Table of contents", () => {
 
       document.dispatchEvent(new CustomEvent("nav", { detail: { url: window.location.pathname } }))
       return { expectedSlug: expected, firstSlug: sections[0]?.id ?? "", headingsInBand }
-    })
+    }, TOC_DETECTION_BAND_FRACTION)
 
     // Guard that the scenario is meaningful: the fallback (not the observer)
     // must drive the result, and the answer must differ from the first entry


### PR DESCRIPTION
## Problem

Hard-refreshing `turntrout.com/design` (or any long page) while scrolled partway down caused the desktop ToC to highlight the **first** entry instead of the section you were actually at.

## Root cause

The `IntersectionObserver` uses `rootMargin: "0px 0px -70% 0px"`, so a heading only counts as "active" while sitting in the **top 30%** of the viewport. On a fresh load that lands mid-page, no heading is inside that narrow band. The observer callback was gated behind `visibleSections.size > 0`, so it did nothing — leaving the active link stuck on the `firstSectionId` seed value set at init.

## Fix

`quartz/components/scripts/toc.inline.ts`

- Added `getActiveSectionByScroll()`: when the detection band is empty, resolves to the **last heading scrolled above the band** (the section you're reading).
- Added `resolveActiveSection()`: uses the observer's `visibleSections` when populated, otherwise falls back to `getActiveSectionByScroll()`.
- Both the observer callback and the init path now call `resolveActiveSection()`.

## Tests

Added a Playwright regression test (`Re-initializing while scrolled past the detection band highlights the passed heading`) that:

1. Scrolls to page bottom so all headings are above the detection band.
2. Asserts `headingsInBand === 0` — proving the fallback, not the observer, drives the result.
3. Fires a `nav` event (simulating a fresh load) and waits for the active link to match the heading we scrolled past.
4. Guards that `expectedSlug !== firstSlug` so the test is only meaningful when the page actually has multiple headings.

Verified the test **fails** against the pre-fix bundle and **passes** with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MknomvpK9u9aBJ886aj4yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MknomvpK9u9aBJ886aj4yY)_