### PR TITLE
Handle punctuation in favicon-spans from footnote plugin

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -659,13 +659,14 @@ export const rearrangeLinkPunctuation = (
 
   if (sibling && "type" in sibling) {
     const hasAttrs = "tagName" in sibling && "children" in sibling
+    // A favicon-span wraps trailing text + an icon/back-arrow (created for
+    // footnote back-arrows before this pass runs). Its leading punctuation
+    // should move into the link just like a bare text sibling's would.
+    const looksTextLike =
+      hasAttrs && (TEXT_LIKE_TAGS.includes(sibling.tagName) || hasClass(sibling, "favicon-span"))
     if (sibling.type === "text") {
       textNode = sibling
-    } else if (
-      hasAttrs &&
-      TEXT_LIKE_TAGS.includes(sibling.tagName) &&
-      sibling.children.length > 0
-    ) {
+    } else if (looksTextLike && sibling.children.length > 0) {
       textNode = sibling.children[0]
     }
   }

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -923,6 +923,18 @@ describe("rearrangeLinkPunctuation", () => {
       const processedHtml = testHtmlFormattingImprovement(input)
       expect(normalizeNbsp(processedHtml)).toBe(expected)
     })
+
+    // The footnote back-arrow plugin runs first, splicing trailing text + arrow
+    // into a favicon-span. Punctuation left at the span's head must still move
+    // into the preceding link, otherwise the "." renders after the favicon.
+    it("should move punctuation from a favicon-span into the preceding link", () => {
+      const input =
+        '<p>I even self-host <a href="/alignment-tier-list">AI presidents discuss AI alignment agendas</a><span class="favicon-span">. <a class="data-footnote-backref">⤴</a></span></p>'
+      const expected =
+        '<p>I even self-host <a href="/alignment-tier-list">AI presidents discuss AI alignment agendas.</a><span class="favicon-span"> <a class="data-footnote-backref">⤴</a></span></p>'
+      const processedHtml = testHtmlFormattingImprovement(input)
+      expect(normalizeNbsp(processedHtml)).toBe(expected)
+    })
   })
 
   describe("End-to-end HTML formatting improvement", () => {


### PR DESCRIPTION
## Summary
Fixes punctuation placement when the footnote back-arrow plugin creates a `favicon-span` that wraps trailing text and an icon. The `rearrangeLinkPunctuation` transformer now correctly moves leading punctuation from these spans into the preceding link, preventing periods from rendering after the favicon.

## Changes
- **Test case added**: New test in `rearrangeLinkPunctuation` suite verifies that punctuation (`.`) moves from a `favicon-span` into the preceding link, with the space and back-arrow remaining in the span.
- **Logic updated**: Modified the punctuation rearrangement logic to recognize `favicon-span` elements as "text-like" containers, treating them the same way as other text-containing siblings when extracting leading punctuation.

## Implementation details
The footnote back-arrow plugin runs before this transformer and splices trailing text + arrow into a `favicon-span`. Previously, the `rearrangeLinkPunctuation` logic only checked for `TEXT_LIKE_TAGS` when deciding whether to extract punctuation from a sibling element. Now it also checks for the `favicon-span` class, allowing the transformer to correctly identify and move punctuation that should belong inside the link.

The fix extracts the condition into a `looksTextLike` variable for clarity and reuses it in both branches of the punctuation extraction logic.

https://claude.ai/code/session_01J7d2W2PFA9mqCpntgWfqVs