### PR TITLE
Rewrite relative links to GitHub blob URLs in external markdown

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -30,10 +30,10 @@ import {
   RemoveDrafts,
   RemoveFixtures,
   RemovePartials,
+  rewriteRelativeLinksToGitHub,
   Static,
   stripBadges,
   StripInlineBoundaryWhitespace,
-  stripRelativeLinks,
   SyntaxHighlighting,
   TableDivider,
   TableOfContents,
@@ -72,7 +72,8 @@ const config: QuartzConfig = {
           punctilio: {
             owner: "alexander-turner",
             repo: "punctilio",
-            transform: (content: string) => stripRelativeLinks(stripBadges(content)),
+            transform: (content: string) =>
+              rewriteRelativeLinksToGitHub("alexander-turner", "punctilio")(stripBadges(content)),
           },
           "lint-staged": {
             filePath: "package.json",

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -23,6 +23,7 @@ export { ObsidianFlavoredMarkdown } from "./ofm"
 export { OxHugoFlavouredMarkdown } from "./oxhugofm"
 export {
   PopulateExternalMarkdown,
+  rewriteRelativeLinksToGitHub,
   stripBadges,
   stripRelativeLinks,
 } from "./populateExternalMarkdown"

--- a/quartz/plugins/transformers/populateExternalMarkdown.test.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.test.ts
@@ -12,6 +12,7 @@ import {
   isLocalSource,
   populateExternalContent,
   PopulateExternalMarkdown,
+  rewriteRelativeLinksToGitHub,
   stripBadges,
   stripRelativeLinks,
 } from "./populateExternalMarkdown"
@@ -70,6 +71,36 @@ describe("PopulateExternalMarkdown", () => {
       ],
     ])("%s", (_desc, input, expected) => {
       expect(stripRelativeLinks(input)).toBe(expected)
+    })
+  })
+
+  describe("rewriteRelativeLinksToGitHub", () => {
+    const rewrite = rewriteRelativeLinksToGitHub("owner", "repo")
+    const rewriteRef = rewriteRelativeLinksToGitHub("owner", "repo", "v2")
+
+    it.each([
+      [
+        "relative path link",
+        "[v5 migration guide](docs/migrating-to-v5.md)",
+        "[v5 migration guide](https://github.com/owner/repo/blob/main/docs/migrating-to-v5.md)",
+      ],
+      ["absolute https link", "[text](https://example.com)", "[text](https://example.com)"],
+      ["anchor link", "[issue](#anchor)", "[issue](#anchor)"],
+      ["absolute path link", "[root](/absolute/path)", "[root](/absolute/path)"],
+      ["mailto link", "[mail](mailto:a@b.com)", "[mail](mailto:a@b.com)"],
+      [
+        "multiple relative links",
+        "See [guide](docs/guide.md) and [ref](other.md) for details.",
+        "See [guide](https://github.com/owner/repo/blob/main/docs/guide.md) and [ref](https://github.com/owner/repo/blob/main/other.md) for details.",
+      ],
+    ])("%s", (_desc, input, expected) => {
+      expect(rewrite(input)).toBe(expected)
+    })
+
+    it("respects custom ref", () => {
+      expect(rewriteRef("[guide](docs/guide.md)")).toBe(
+        "[guide](https://github.com/owner/repo/blob/v2/docs/guide.md)",
+      )
     })
   })
 

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -108,6 +108,22 @@ export function stripRelativeLinks(content: string): string {
   return content.replace(/\[([^\]]+)\]\((?!https?:\/\/|mailto:|#|\/)[^)]+\)/g, "$1")
 }
 
+const RELATIVE_LINK_RE = /\[([^\]]+)\]\(((?!https?:\/\/|mailto:|#|\/)[^)]+)\)/g
+
+/**
+ * Returns a transform that rewrites relative markdown links to absolute
+ * GitHub blob URLs so CrawlLinks doesn't mangle them.
+ */
+export function rewriteRelativeLinksToGitHub(
+  owner: string,
+  repo: string,
+  ref = "main",
+): (content: string) => string {
+  const base = `https://github.com/${owner}/${repo}/blob/${ref}`
+  return (content) =>
+    content.replace(RELATIVE_LINK_RE, (_match, text, href) => `[${text}](${base}/${href})`)
+}
+
 function getContent(name: string, source: MarkdownSource): string {
   const local = isLocalSource(source)
   const cacheKey = local


### PR DESCRIPTION
## Summary
Adds a new `rewriteRelativeLinksToGitHub` function to transform relative markdown links into absolute GitHub blob URLs, preventing link mangling during external content population. Updates the punctilio configuration to use this new approach instead of stripping relative links entirely.

## Changes
- **New function `rewriteRelativeLinksToGitHub`**: Converts relative markdown links (e.g., `[text](docs/guide.md)`) to absolute GitHub URLs (e.g., `https://github.com/owner/repo/blob/main/docs/guide.md`). Supports custom git refs via optional parameter, defaults to `main`.
- **Regex pattern `RELATIVE_LINK_RE`**: Extracted shared pattern for matching relative links (excludes https, mailto, anchors, and absolute paths).
- **Updated punctilio config**: Changed from `stripRelativeLinks(stripBadges(content))` to `rewriteRelativeLinksToGitHub("alexander-turner", "punctilio")(stripBadges(content))` to preserve link targets as GitHub URLs.
- **Exports**: Added `rewriteRelativeLinksToGitHub` to transformer index for public API access.
- **Tests**: Comprehensive test suite covering relative paths, absolute URLs, anchors, mailto links, multiple links in one string, and custom ref parameter.

## Implementation details
- The function returns a closure that captures the GitHub base URL, allowing reuse across multiple content transformations.
- Regex uses negative lookahead to distinguish relative links from other URL types, matching the existing `stripRelativeLinks` pattern.
- Maintains backward compatibility by keeping `stripRelativeLinks` and `stripBadges` exports unchanged.

https://claude.ai/code/session_0129uqE1DgpJFy7i48kdtwFr