### PR TITLE
fix: harden Python build/validation scripts against three correctness bugs

### DIFF
--- a/scripts/run_push_checks.py
+++ b/scripts/run_push_checks.py
@@ -236,9 +236,9 @@ def _run_parallel_group(
             if first_failure is None:
                 first_failure = (step.name, result)
 
-    # Advance resume state only when every check in the group passed; if any
-    # failed, leave state untouched so --resume re-runs the whole group.
-    if first_failure is None:
+    # Advance resume state unless a failure is about to halt the run; a halted
+    # group must re-run in full on --resume rather than be skipped.
+    if first_failure is None or continue_on_failure:
         save_state(group[-1].name)
 
     if first_failure is not None and not continue_on_failure:

--- a/scripts/run_push_checks.py
+++ b/scripts/run_push_checks.py
@@ -236,8 +236,10 @@ def _run_parallel_group(
             if first_failure is None:
                 first_failure = (step.name, result)
 
-    # Save state at the last step so resume picks up after the whole group.
-    save_state(group[-1].name)
+    # Advance resume state only when every check in the group passed; if any
+    # failed, leave state untouched so --resume re-runs the whole group.
+    if first_failure is None:
+        save_state(group[-1].name)
 
     if first_failure is not None and not continue_on_failure:
         name, result = first_failure

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -66,8 +66,8 @@ def check_cover_image_alt(metadata: dict) -> list[str]:
         return errors
 
     # Check if there's a custom card_image
-    card_image_alt = metadata.get("card_image_alt", "")
-    if not card_image_alt.strip():
+    card_image_alt = metadata.get("card_image_alt") or ""
+    if not str(card_image_alt).strip():
         errors.append(f"Custom card_image ({card_url}) requires card_image_alt")
 
     return errors
@@ -550,7 +550,7 @@ def check_no_forbidden_patterns(text: str) -> list[str]:
             processed_text = remove_math(processed_text, mark_boundaries=True)
 
         for match in re.finditer(config["pattern"], processed_text):
-            line_num = text[: match.start()].count("\n") + 1
+            line_num = processed_text[: match.start()].count("\n") + 1
             errors.append(
                 f"Forbidden pattern found: {match.group()} on line {line_num}"
             )

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -1334,6 +1334,42 @@ def test_run_parallel_group_raises_on_failure(temp_state_dir):
     assert exc_info.value.stdout == "boom"
 
 
+def test_run_parallel_group_does_not_save_state_on_partial_failure(
+    temp_state_dir,
+):
+    """When a step fails, resume state must not advance past the group, even if
+    a later step in the same group succeeded; otherwise --resume would skip the
+    failed check."""
+    group = [
+        run_push_checks.CheckStep(
+            name="Bad", command=["bad"], parallel_group="verify"
+        ),
+        run_push_checks.CheckStep(
+            name="OK", command=["ok"], parallel_group="verify"
+        ),
+    ]
+    results_by_name = {
+        "Bad": run_push_checks.CommandResult(
+            success=False, stdout="boom", stderr="kaboom"
+        ),
+        "OK": run_push_checks.CommandResult(success=True, stdout="", stderr=""),
+    }
+    with (
+        patch("scripts.run_push_checks._execute_step") as mock_exec,
+        patch("scripts.run_push_checks.commit_step_changes"),
+        patch("scripts.run_push_checks.save_state") as mock_save,
+        pytest.raises(run_push_checks.CheckFailedError),
+    ):
+        mock_exec.side_effect = lambda step, _p: results_by_name[step.name]
+        run_push_checks._run_parallel_group(
+            group,
+            MagicMock(),
+            auto_commit=False,
+            continue_on_failure=False,
+        )
+    mock_save.assert_not_called()
+
+
 def test_run_parallel_group_continues_past_failure(temp_state_dir):
     """continue_on_failure swallows the failure (used by CI autofix)."""
     group = [

--- a/scripts/tests/test_run_push_checks.py
+++ b/scripts/tests/test_run_push_checks.py
@@ -1334,12 +1334,13 @@ def test_run_parallel_group_raises_on_failure(temp_state_dir):
     assert exc_info.value.stdout == "boom"
 
 
-def test_run_parallel_group_does_not_save_state_on_partial_failure(
-    temp_state_dir,
+@pytest.mark.parametrize("continue_on_failure", [False, True])
+def test_run_parallel_group_save_state_on_failure(
+    continue_on_failure, temp_state_dir
 ):
-    """When a step fails, resume state must not advance past the group, even if
-    a later step in the same group succeeded; otherwise --resume would skip the
-    failed check."""
+    """A failed check halts resume progress (state untouched) unless
+    continue_on_failure lets the run proceed past it; otherwise --resume would
+    skip the failed check."""
     group = [
         run_push_checks.CheckStep(
             name="Bad", command=["bad"], parallel_group="verify"
@@ -1358,16 +1359,22 @@ def test_run_parallel_group_does_not_save_state_on_partial_failure(
         patch("scripts.run_push_checks._execute_step") as mock_exec,
         patch("scripts.run_push_checks.commit_step_changes"),
         patch("scripts.run_push_checks.save_state") as mock_save,
-        pytest.raises(run_push_checks.CheckFailedError),
     ):
         mock_exec.side_effect = lambda step, _p: results_by_name[step.name]
-        run_push_checks._run_parallel_group(
-            group,
-            MagicMock(),
-            auto_commit=False,
-            continue_on_failure=False,
-        )
-    mock_save.assert_not_called()
+        if continue_on_failure:
+            run_push_checks._run_parallel_group(
+                group, MagicMock(), auto_commit=False, continue_on_failure=True
+            )
+            mock_save.assert_called_once_with("OK")
+        else:
+            with pytest.raises(run_push_checks.CheckFailedError):
+                run_push_checks._run_parallel_group(
+                    group,
+                    MagicMock(),
+                    auto_commit=False,
+                    continue_on_failure=False,
+                )
+            mock_save.assert_not_called()
 
 
 def test_run_parallel_group_continues_past_failure(temp_state_dir):

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -145,6 +145,17 @@ def test_check_required_fields(
             {},
             [],
         ),
+        # Test case 7: card_image_alt present but null (YAML `card_image_alt:`)
+        # parses as None - should fail cleanly, not raise AttributeError.
+        (
+            {
+                "title": "Test",
+                "description": "Test Description",
+                "card_image": "/custom-image.png",
+                "card_image_alt": None,
+            },
+            ["Custom card_image (/custom-image.png) requires card_image_alt"],
+        ),
     ],
 )
 def test_check_cover_image_alt(
@@ -2047,6 +2058,12 @@ def test_check_filename_lowercase(filename: str, should_error: bool):
         # Shouldn't ignore boundaries of code/math blocks
         ("Test `code`)", []),
         ("Test $math$)", []),
+        # Line number is computed against the code-stripped text, so inline
+        # code on an earlier line must not shift the reported line.
+        (
+            "`inline code spanning many chars`\nSentence. )",
+            ["Forbidden pattern found:  ) on line 2"],
+        ),
     ],
 )
 def test_check_no_forbidden_patterns(text: str, expected_errors: list[str]):


### PR DESCRIPTION
## Summary

A thorough adversarial audit of the repo (Python scripts, Quartz/TypeScript, docs/config/CI) surfaced a number of issues. This PR lands the cluster of **verified, surgical, clearly-correct Python bug fixes** that don't change rendered output and don't alter any existing test expectations — each gets an additive regression test. The remaining findings are catalogued below as a roadmap for follow-up PRs (kept separate to keep this diff reviewable and low-risk).

All three fixes serve the repo's stated values: zero flakiness, fail loudly / report clean issues, correct diagnostics.

## Changes

1. **`run_push_checks.py` — `--resume` could skip a failed check.** `_run_parallel_group` called `save_state(group[-1].name)` unconditionally, so when a check failed but the run halted, a later `RESUME=true git push` advanced past the whole group and silently skipped the failed check. Now state advances only when `first_failure is None or continue_on_failure` — i.e. when the run proceeds past the group — matching the sequential path's semantics and leaving the CI-autofix (`continue_on_failure=True`) behavior unchanged.

2. **`source_file_checks.py::check_cover_image_alt` — crash on null `card_image_alt`.** A bare `card_image_alt:` in YAML parses to `None`, so `.strip()` raised `AttributeError` instead of reporting a clean check failure. Now coerces via `metadata.get(...) or ""` + `str(...)`, which also defends against non-string scalars.

3. **`source_file_checks.py::check_no_forbidden_patterns` — wrong reported line numbers.** `line_num` was counted in the original `text` using an offset (`match.start()`) into the code/math-*stripped* `processed_text`; any inline code/math before the match shifted the count, mis-reporting the line. Now counts in `processed_text` — the same string the match came from — matching the already-correct pattern in `check_html_with_braces`.

## Testing

- `uv run pytest scripts/tests/test_run_push_checks.py scripts/tests/test_source_file_checks.py` — 393 passed.
- New tests are purely additive (new `pytest.mark.parametrize` rows / one parametrized test); no existing expectations changed. The forbidden-pattern test asserts `on line 2`, which fails against the old code and passes against the fix.
- `mypy`, `ruff check`, `ruff format --check`, `pylint` all clean on the changed files.
- Branch coverage of the new `or continue_on_failure` condition is covered by both parametrized cases.

## Audit roadmap (follow-up, not in this PR)

Verified findings deliberately left out of this PR. Several were rejected on inspection — noting them so they aren't re-flagged.

**Python (follow-up):**
- `built_site_checks.py` reads + BeautifulSoup-parses each HTML file 3–4× per page (`meta_tags_early`, citation collection, spellcheck collection) — parse once and thread `soup` through. (perf refactor)
- `check_no_forbidden_patterns` line numbers are still relative to stripped text; fenced code blocks preserve newline counts so this is correct today, but worth a note.
- `source_file_checks` footnote reference/definition detection compares counts derived from two differently-processed strings — can yield false "defined but never referenced".

**TypeScript (follow-up — several change rendered output, so need owner sign-off per CLAUDE.md "don't change test expectations / output"):**
- `formatting_improvement_html.ts:884` — `.test()` on a global (`/g`) regex (`urlRegex`) carries `lastIndex` across calls → order-dependent fraction/URL detection. Reset `lastIndex` or use a non-global copy.
- `ofm.ts:896-897` — non-global `.replace("#"/"\|")` escapes only the first occurrence in table wikilinks.
- `search.ts:409` — boolean `no_dropcap: false` incorrectly suppresses the dropcap (only the string `"false"` is handled).
- `handlers.ts:448` — naive `replaceAll("$"+key, …)` corrupts prefix-overlapping SCSS vars (`$color` inside `$color-light`).
- `handlers.ts:382` — critical-CSS injection failure is swallowed (warn + continue), shipping FOUC silently; should fail loudly.
- `populateContainers.ts` — `countJsTests()` runs the full Jest suite via `execSync` inside the production build emitter just to compute a stat badge.
- `search.ts:208,1282` — regexes recompiled per-token in hot scoring loops.

**Docs/config (follow-up):**
- `config/python/pyproject.toml` `[project]` block has drifted badly from the root manifest but is never installed (only its `[tool.*]` is read) — delete the stale block; also missing `norecursedirs` so a `mutants/` tree could leak into CI collection.
- `.claude/dev-notes.md` references a non-existent `lint.yaml` and a wrong required-check name (`Node.js CI / build` vs `Node tests / build`).
- README's Python "Passing" badges are hardcoded static images, not live CI status.

### Rejected on inspection (intentional behavior — do not "fix")
- `check_metadata_matches` raising `KeyError` on missing `title`/`description` is **intentional and explicitly tested** (`test_check_metadata_matches_missing_md_keys` asserts `pytest.raises(KeyError)`).
- `rich.Progress` mutation from worker threads — `rich.Progress` guards task ops with an internal `RLock`, so not the flakiness source the audit suspected.
- `built_site_checks.py:717` asset-domain `split("/")[2]` is guarded by a `"//" in str_src` check, so no `IndexError` in practice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGyPefUXF4i5ndgLF4gWaL)_