### PR TITLE
ci(setup-site): unpin apt packages, rely on apt's GPG verification

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -180,8 +180,10 @@ runs:
     # All apt packages in one step so every workflow populates the same
     # cache. With caching active, repeat installs unpack from disk in
     # seconds instead of downloading from slow mirrors.
-    # All versions pinned for deterministic builds. Bump when Ubuntu
-    # pushes security updates that remove the old version.
+    # Versions are intentionally unpinned: these are build-time-only tools,
+    # apt still verifies every package against Ubuntu's GPG-signed archive,
+    # and exact pins broke constantly as Ubuntu garbage-collected superseded
+    # patch versions from the mirror.
     # GitHub-hosted runners ship with `azure.archive.ubuntu.com` as the
     # priority-1 mirror in /etc/apt/apt-mirrors.txt. That mirror
     # periodically throttles to ~100 kB/s, which made install steps
@@ -206,12 +208,12 @@ runs:
         command: |
           sudo apt-get update && \
           sudo apt-get install -y --no-install-recommends \
-            libxml2-utils=2.9.14+dfsg-1.3ubuntu3.8 \
-            dos2unix=7.5.1-1 \
-            ffmpeg=7:6.1.1-3ubuntu5 \
-            libimage-exiftool-perl=12.76+dfsg-1 \
-            inkscape=1.2.2-2ubuntu12 \
-            fish=3.7.0-1
+            libxml2-utils \
+            dos2unix \
+            ffmpeg \
+            libimage-exiftool-perl \
+            inkscape \
+            fish
 
     - name: Install rclone
       if: inputs.install-system-deps == 'true' && runner.os == 'Linux'

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -382,19 +382,6 @@ jobs:
         continue-on-error: true
         run: uv run python scripts/source_file_checks.py ${{ steps.pub-date-flag.outputs.flag }}
 
-      - name: Verify apt packages are version-pinned
-        run: |
-          # Find package-like lines between apt-get install and shell: that lack =version
-          # shellcheck disable=SC1003  # the regex needs a literal backslash, not an escaped single quote
-          awk '/apt-get install/,/shell:/' .github/actions/setup-site/action.yaml \
-            | grep -E '^\s+[a-z][a-z0-9._+-]+\s*\\?\s*$' \
-            | while read -r line; do
-                pkg=$(echo "$line" | tr -d ' \\')
-                echo "::error::Unpinned apt package in setup-site: '$pkg' (add =version suffix)"
-                exit 1
-              done
-          echo "All apt packages are version-pinned"
-
       - name: Check results
         run: |
           failed=""


### PR DESCRIPTION
## Summary

The exact apt version pins in `setup-site` broke CI repeatedly: Ubuntu garbage-collects superseded patch versions from the archive mirror, so a pinned version (e.g. `libxml2-utils=…ubuntu3.7`) disappears and `apt-get install pkg=ver` fails with `Version '…' not found`. Chasing each bump is recurring toil.

This unpins the packages. The key reframe: **apt already cryptographically verifies every package against Ubuntu's GPG-signed `Release` files**, so unpinning does *not* lose authenticity/integrity — it only gives up byte-for-byte reproducibility. These are all build-time-only tools (`libxml2-utils`, `dos2unix`, `ffmpeg`, `libimage-exiftool-perl`, `inkscape`, `fish`) that never ship to users, so "latest signed patch from the official archive" is a sound posture — and it's resilient to mirror GC.

## Changes

- `.github/actions/setup-site/action.yaml` — drop the `=version` suffixes from the six apt packages; update the rationale comment.
- `.github/workflows/lint-and-validate.yaml` — remove the "Verify apt packages are version-pinned" step, which enforced the now-reversed policy.

## Lessons learned

- Exact apt version pins on Ubuntu are a recurring CI fragility: the `-security`/`-updates` pockets garbage-collect superseded patch versions, so a pinned version eventually vanishes from the mirror and the install fails. For build-time-only tooling, unpinning and relying on apt's built-in GPG signature verification keeps supply-chain authenticity while removing the breakage; reserve exact pinning (or an immutable archive snapshot) for cases that genuinely need byte-for-byte reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyiiTv8hfQ23XD1e7Fu1KV)_