### PR TITLE
Remove Palform dark mode filter styling

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -951,11 +951,6 @@ iframe {
   border-radius: $border-radius;
   margin-top: calc(2 * $base-margin);
   margin-bottom: calc(2 * $base-margin);
-
-  // Palform looks out of place in dark mode, so we invert it
-  :root[data-theme="dark"] &[src*="palform.app"] {
-    filter: url("#accurate-invert") grayscale(50%) brightness(95%);
-  }
 }
 
 .right-arrow,


### PR DESCRIPTION
## Summary
Removes the dark mode filter styling that was applied to embedded Palform iframes. This styling inverted colors and adjusted brightness/grayscale to make the embedded content more readable in dark mode.

## Changes
- Deleted the dark mode-specific CSS rule that applied `filter: url("#accurate-invert") grayscale(50%) brightness(95%)` to Palform iframe embeds
- The rule was scoped to `[src*="palform.app"]` elements within dark mode contexts

## Rationale
The filter styling is no longer needed, likely because:
- Palform's styling has been updated to work better in dark mode natively
- The filter approach was a workaround that is no longer necessary
- Removing it simplifies the stylesheet and reduces unnecessary DOM manipulation

https://claude.ai/code/session_01QBq6E4hgQMKNqEAZxc8bD7