### PR TITLE
ci: run template sync weekly instead of daily

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -35,8 +35,8 @@ on:
         default: "false"
         type: boolean
   schedule:
-    # Run daily at 9am UTC
-    - cron: "0 9 * * *"
+    # Run weekly on Mondays at 9am UTC
+    - cron: "0 9 * * 1"
 
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"


### PR DESCRIPTION
## Summary
- The template-sync workflow ran on a daily cron, which is more frequent than needed for picking up upstream template changes.
- Switch the schedule to weekly (Mondays at 9am UTC) to cut redundant runs while still keeping the repo in sync.

## Changes
- `.github/workflows/template-sync.yaml`: change the `schedule:` cron from `0 9 * * *` (daily) to `0 9 * * 1` (weekly, Mondays), and update the adjacent comment.

## Testing
- No code change; cron-only edit. `workflow_dispatch` remains available for manual on-demand syncs.