### PR TITLE
Broaden ESLint ignore pattern for img-comparison-slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Dependencies & Environments
 node_modules
 .venv/
+.worktrees/
 
 # Build Output & Caches
 public

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ private/
 scripts/*.json
 
 # Python Tools
+.dmypy.json
 
 # AI Tools
 .aider*

--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -188,6 +188,7 @@ export default [
       "**/*.min.ts",
       "quartz/i18n/",
       "**/img-comparison-slider.js",
+      "**/.worktrees/",
       ".venv/",
       ".stryker-tmp/",
       "mutants/",

--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -187,7 +187,7 @@ export default [
       "**/*.min.js",
       "**/*.min.ts",
       "quartz/i18n/",
-      "quartz/static/scripts/img-comparison-slider.js",
+      "**/img-comparison-slider.js",
       ".venv/",
       ".stryker-tmp/",
       "mutants/",


### PR DESCRIPTION
## Summary
Updated ESLint configuration to use a glob pattern that matches `img-comparison-slider.js` regardless of its location in the project, and added `.dmypy.json` to `.gitignore` for Python type-checking artifacts.

## Changes
- **ESLint config**: Changed `quartz/static/scripts/img-comparison-slider.js` to `**/img-comparison-slider.js` to ignore the minified slider script from any directory, improving flexibility if the file is moved or duplicated elsewhere in the codebase
- **`.gitignore`**: Added `.dmypy.json` under the Python Tools section to exclude daemon mode cache files generated by `dmypy` (mypy daemon)

## Details
The ESLint pattern change makes the ignore rule location-agnostic, reducing maintenance burden if the slider script is reorganized. The `.gitignore` addition prevents committing mypy daemon state files that are regenerated locally during type-checking.

https://claude.ai/code/session_01DeQu85pX8duQNmG8SEtrkB