### PR TITLE
Fix search match color override in admonition titles

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -350,6 +350,15 @@ $match-color: var(--green);
   }
 }
 
+// Inside the preview, force the match color to win over high-specificity
+// `color: ... !important` rules on descendants (e.g. admonition titles, which
+// set `color: inherit !important` on every child). The leading ID outweighs
+// those declarations. Scoped to the preview so the on-page fade animation,
+// which animates `color` back to `inherit`, is left untouched.
+#search-container .search-match {
+  color: $match-color !important;
+}
+
 @media all and (max-width: $tablet-breakpoint) {
   .search > #search-icon > p {
     padding: 0;

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -299,6 +299,31 @@ test("search matches in headers have correct color styling", async ({ page }) =>
   expect(matchColor).not.toBe(foregroundColor)
 })
 
+test("search matches keep one highlight color across every element type", async ({ page }) => {
+  // The fixture's unique title deterministically lands on the search fixture,
+  // whose "fixture" token appears in headers, body text, and a custom
+  // admonition title ("Quote fixture"). The highlight color must win
+  // everywhere — a high-specificity `color: ... !important` rule on
+  // descendants (admonition titles force `color: inherit !important` on every
+  // child) would otherwise clobber the match inside the title, leaving its
+  // color diverging from the others. Asserting all matches share one color
+  // catches that regression for any clobbering selector, not just admonitions.
+  await search(page, "Search preview fixture")
+
+  const preview = await waitForArticlePreview(page)
+
+  // The admonition-title match is the case that regressed; make sure it renders
+  // so the shared-color assertion below actually exercises it.
+  const admonitionMatch = preview.locator(".admonition-title .search-match")
+  await expect(admonitionMatch.first()).toBeAttached({ timeout: 10_000 })
+
+  const colors = await preview
+    .locator(".search-match")
+    .evaluateAll((els) => els.map((el) => window.getComputedStyle(el).color))
+  expect(colors.length).toBeGreaterThan(1)
+  expect(new Set(colors).size).toBe(1)
+})
+
 test("Search results are case-insensitive", async ({ page }, testInfo) => {
   // Two sequential searches can exceed default timeouts on Firefox
   test.slow(testInfo.project.name.includes("Firefox"), "Firefox is slow in CI")

--- a/website_content/fixtures/search-fixture.md
+++ b/website_content/fixtures/search-fixture.md
@@ -19,7 +19,7 @@ The fixture lives outside the live site (see `RemoveFixtures` filter), so no use
 > [!note]
 > A short note admonition for the focused mobile-card-preview screenshot.
 
-> [!quote]
+> [!quote] Quote fixture
 > A second admonition.
 
 # Checkboxes fixture


### PR DESCRIPTION
## Summary
Force the search match highlight color to take precedence over high-specificity `color: ... !important` rules applied to descendants within the search preview, particularly in admonition titles.

## Changes
- Added a scoped CSS rule (`#search-container .search-match`) with `!important` to override descendant color declarations that use `color: inherit !important`
- Scoped to the search preview container to preserve the on-page fade animation, which animates `color` back to `inherit`

## Implementation details
The fix uses a leading ID selector (`#search-container`) to achieve sufficient specificity to outweigh the `!important` declarations on child elements (e.g., admonition titles that set `color: inherit !important`). By scoping this rule to the preview, the on-page fade animation remains unaffected and can properly animate the color back to `inherit`.

https://claude.ai/code/session_01Xw8bN8hU4J448ExC9eLpWX