### PR TITLE
test(search): isolate highlight-color test from shared visual fixtures

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -3297,4 +3297,3 @@ SDF
 Sohaib
 Tice
 Weems
-Matchcolor

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -300,16 +300,17 @@ test("search matches in headers have correct color styling", async ({ page }) =>
 })
 
 test("search matches keep one highlight color across every element type", async ({ page }) => {
-  // Searches a dedicated, never-screenshotted fixture whose unique word
-  // "Matchcolor" appears in a heading, body text, and an admonition title.
-  // Using a private fixture keeps this test independent: editing it can never
-  // churn another test's visual baseline. The highlight color must win
-  // everywhere — a high-specificity `color: ... !important` rule on
-  // descendants (admonition titles force `color: inherit !important` on every
-  // child) would otherwise clobber the match inside the title, leaving its
-  // color diverging from the others. Asserting all matches share one color
-  // catches that regression for any clobbering selector, not just admonitions.
-  await search(page, "Matchcolor")
+  // Searches a dedicated, never-screenshotted fixture whose unique title
+  // phrase deterministically returns it. The word "quotation" appears in a
+  // heading, body text, and an admonition title. Using a private fixture keeps
+  // this test independent: editing it can never churn another test's visual
+  // baseline. The highlight color must win everywhere — a high-specificity
+  // `color: ... !important` rule on descendants (admonition titles force
+  // `color: inherit !important` on every child) would otherwise clobber the
+  // match inside the title, leaving its color diverging from the others.
+  // Asserting all matches share one color catches that regression for any
+  // clobbering selector, not just admonitions.
+  await search(page, "Highlighted quotation fixture")
 
   const preview = await waitForArticlePreview(page)
 

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -314,6 +314,10 @@ test("search matches keep one highlight color across every element type", async 
 
   const preview = await waitForArticlePreview(page)
 
+  // Confirm the preview is this fixture, so a ranking change can't silently
+  // make the color assertion run against the wrong page.
+  await expect(preview).toContainText("Quotation heading")
+
   // The admonition-title match is the case that regressed; make sure it renders
   // so the shared-color assertion below actually exercises it.
   const admonitionMatch = preview.locator(".admonition-title .search-match")

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -300,15 +300,16 @@ test("search matches in headers have correct color styling", async ({ page }) =>
 })
 
 test("search matches keep one highlight color across every element type", async ({ page }) => {
-  // The fixture's unique title deterministically lands on the search fixture,
-  // whose "fixture" token appears in headers, body text, and a custom
-  // admonition title ("Quote fixture"). The highlight color must win
+  // Searches a dedicated, never-screenshotted fixture whose unique word
+  // "Matchcolor" appears in a heading, body text, and an admonition title.
+  // Using a private fixture keeps this test independent: editing it can never
+  // churn another test's visual baseline. The highlight color must win
   // everywhere — a high-specificity `color: ... !important` rule on
   // descendants (admonition titles force `color: inherit !important` on every
   // child) would otherwise clobber the match inside the title, leaving its
   // color diverging from the others. Asserting all matches share one color
   // catches that regression for any clobbering selector, not just admonitions.
-  await search(page, "Search preview fixture")
+  await search(page, "Matchcolor")
 
   const preview = await waitForArticlePreview(page)
 

--- a/website_content/fixtures/search-color-fixture.md
+++ b/website_content/fixtures/search-color-fixture.md
@@ -1,5 +1,5 @@
 ---
-title: Matchcolor fixture
+title: Highlighted quotation fixture
 permalink: search-color-fixture
 no_dropcap: "true"
 tags:
@@ -10,10 +10,10 @@ date_published: 2024-12-04
 date_updated: 2024-12-04
 ---
 
-This page exists only so `search.spec.ts` can assert that highlighted search matches keep one color across every element type. The coined word "Matchcolor" is unique in the corpus, so searching it deterministically returns this page and highlights the word in the body, a heading, and an admonition title.
+This page exists only so `search.spec.ts` can assert that highlighted search matches keep one color across every element type. Its unique title phrase deterministically returns this page, and the word "quotation" appears in the body, a heading, and an admonition title so the search highlights all three.
 
-# Matchcolor heading
+# Quotation heading
 
-> [!quote] Matchcolor quote
+> [!quote] Quotation title
 > A quote admonition whose title contains the searched word, exercising the
 > admonition-title case that previously clobbered the highlight color.

--- a/website_content/fixtures/search-color-fixture.md
+++ b/website_content/fixtures/search-color-fixture.md
@@ -4,13 +4,13 @@ permalink: search-color-fixture
 no_dropcap: "true"
 tags:
   - website
-description: Stable fixture for the search-highlight color-invariant test in `search.spec.ts`. No screenshot test targets this page, so editing it never churns visual baselines.
+description: Dedicated fixture for the search-highlight color-invariant test in `search.spec.ts`.
 hideSubscriptionLinks: true
 date_published: 2024-12-04
 date_updated: 2024-12-04
 ---
 
-This page exists only so `search.spec.ts` can assert that highlighted search matches keep one color across every element type. Its unique title phrase deterministically returns this page, and the word "quotation" appears in the body, a heading, and an admonition title so the search highlights all three.
+The word "quotation" recurs in the body, a heading, and an admonition title so a search for it highlights matches in every element type.
 
 # Quotation heading
 

--- a/website_content/fixtures/search-color-fixture.md
+++ b/website_content/fixtures/search-color-fixture.md
@@ -1,0 +1,19 @@
+---
+title: Matchcolor fixture
+permalink: search-color-fixture
+no_dropcap: "true"
+tags:
+  - website
+description: Stable fixture for the search-highlight color-invariant test in `search.spec.ts`. No screenshot test targets this page, so editing it never churns visual baselines.
+hideSubscriptionLinks: true
+date_published: 2024-12-04
+date_updated: 2024-12-04
+---
+
+This page exists only so `search.spec.ts` can assert that highlighted search matches keep one color across every element type. The coined word "Matchcolor" is unique in the corpus, so searching it deterministically returns this page and highlights the word in the body, a heading, and an admonition title.
+
+# Matchcolor heading
+
+> [!quote] Matchcolor quote
+> A quote admonition whose title contains the searched word, exercising the
+> admonition-title case that previously clobbered the highlight color.

--- a/website_content/fixtures/search-fixture.md
+++ b/website_content/fixtures/search-fixture.md
@@ -19,7 +19,7 @@ The fixture lives outside the live site (see `RemoveFixtures` filter), so no use
 > [!note]
 > A short note admonition for the focused mobile-card-preview screenshot.
 
-> [!quote] Quote fixture
+> [!quote]
 > A second admonition.
 
 # Checkboxes fixture


### PR DESCRIPTION
## Summary

- The search highlight-color regression test (added in #1457) borrowed the shared `search-fixture.md`, whose preview is captured *whole* by other screenshot tests (`Search-checkboxes`, `mobile-card-preview-admonition`). Adding a quote-admonition title there rippled into those baselines across every browser/viewport — so one logical change churned many baseline images.
- This PR makes the test independent: it now uses its own never-screenshotted fixture, so editing it can never touch another test's visual baseline.

## Changes

- **New fixture** `website_content/fixtures/search-color-fixture.md` (title *"Highlighted quotation fixture"*), used only by the color test. The word "quotation" recurs in a heading, the body, and an admonition title, so a search highlights matches in every element type. No screenshot test targets this page.
- **Repointed** the `search matches keep one highlight color across every element type` test in `quartz/components/tests/search.spec.ts` to search the new fixture, and added an exact-text guard (`toContainText("Quotation heading")`) so a ranking change can't silently run the color assertion on the wrong page.
- **Reverted** the `Quote fixture` title previously added to the shared `search-fixture.md`, decoupling it and restoring its original screenshots.

## Testing

- The test asserts every `.search-match` in the preview shares one computed color, guarded by `colors.length > 1` and an attached `.admonition-title .search-match` so it can't pass vacuously.
- Real, spellcheck-clean words throughout (no dictionary entry needed); the unique title phrase deterministically returns the fixture.
- Reverting the shared fixture produces an expected, net-restorative visual diff bringing `Search-checkboxes` / `mobile-card-preview-admonition` back to their pre-#1457 appearance (approve in the diff gallery).

## Lessons Learned

- **What**: Never put test-specific content into a fixture that other tests screenshot wholesale; give each visual-sensitive test its own fixture, or have screenshots target the smallest element they assert on.
- **Where**: `website_content/fixtures/`, `quartz/components/tests/*.spec.ts`, and the testing-rules section of `CLAUDE.md`.
- **Why**: A one-line edit to a shared fixture rippled into multiple unrelated screenshot tests' baselines (× every browser/viewport), making a tiny change look like a large, surprising baseline update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw8bN8hU4J448ExC9eLpWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xw8bN8hU4J448ExC9eLpWX)_