### PR TITLE
fix(assets): keep admonition directives out of converted video alt text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Configuration entry points: `config/quartz/quartz.config.ts`, `config/quartz/qua
 - **Hooks auto-configured** via `.claude/settings.json` SessionStart hook (also exports `GH_REPO` for proxy environments). Manual: `git config core.hooksPath .hooks`.
 - **Pre-commit**: lint-staged formatters/linters on changed files.
 - **Pre-push**: stashes uncommitted changes, runs auto-fix formatters, pylint, asset upload, alt-text scan. Resume from last failure with `RESUME=true git push`.
-- **Pull requests**: always follow `.claude/skills/pr-creation.md`.
+- **Pull requests**: always follow `.claude/skills/pr-creation.md`. Once a unit of work (a fix, feature, or refactor) is committed and pushed, open a PR for it without waiting to be asked—don't push to the branch and stop. This overrides any default "only open a PR when explicitly asked" behavior.
 - **Dev branch workflow**: when working on `dev`, first merge `main` into `dev`, push `dev`, then start the new feature branch from `dev`.
 - **Merging PRs**: never call `merge_pull_request` directly. Once checks are green, call `mcp__github__enable_pr_auto_merge` (squash by default). Required status checks gate the merge—the full suite (Linux Chromium + Firefox, macOS WebKit, visual, a11y, lighthouse, site-build-checks, python, lint, node) runs on every PR where the `paths:` filter matches. Do **not** force-merge with empty “run ALL CI” commits or a direct merge—auto-merge is the only sanctioned path to `main`.
 

--- a/scripts/convert_assets.py
+++ b/scripts/convert_assets.py
@@ -69,8 +69,11 @@ def _video_original_pattern(input_file: Path) -> str:
     input_file_pattern: str = rf"{input_file.stem}\{input_file.suffix}"
 
     # Pattern for markdown image syntax: ![alt text](link){attributes}
+    # Alt text must not span a `]`, or an admonition directive plus a following
+    # link (`[!quote] [text](video.mp4)`) collapses into one match whose alt
+    # swallows the directive.
     parens_pattern: str = (
-        rf"\!?\[(?P<markdown_alt_text>.*?)\]\({ASSET_STAGING_PATTERN}"
+        rf"\!?\[(?P<markdown_alt_text>[^\]]*?)\]\({ASSET_STAGING_PATTERN}"
         rf"{link_pattern_fn('parens')}{input_file_pattern}\)"
         r"(?P<attributes_parens>\{[^}]*\})?"
     )

--- a/scripts/tests/test_convert_assets.py
+++ b/scripts/tests/test_convert_assets.py
@@ -364,7 +364,7 @@ _ASSET_PATTERN = convert_assets.ASSET_STAGING_PATTERN
     [
         (
             Path("animation.gif"),
-            rf"\!?\[(?P<markdown_alt_text>.*?)\]\({_ASSET_PATTERN}(?P<link_parens>[^\)\]\"]*)"
+            rf"\!?\[(?P<markdown_alt_text>[^\]]*?)\]\({_ASSET_PATTERN}(?P<link_parens>[^\)\]\"]*)"
             rf"animation\.gif\)(?P<attributes_parens>\{{[^}}]*\}})?|"
             rf"\!?\[\[{_ASSET_PATTERN}(?P<link_brackets>[^\)\]\"]*)"
             rf"animation\.gif\]\](?P<attributes_brackets>\{{[^}}]*\}})?|"
@@ -380,7 +380,7 @@ _ASSET_PATTERN = convert_assets.ASSET_STAGING_PATTERN
     + [
         (
             Path(f"video{ext}"),
-            rf"\!?\[(?P<markdown_alt_text>.*?)\]\({_ASSET_PATTERN}(?P<link_parens>[^\)\]\"]*)"
+            rf"\!?\[(?P<markdown_alt_text>[^\]]*?)\]\({_ASSET_PATTERN}(?P<link_parens>[^\)\]\"]*)"
             rf"video\{ext}\)(?P<attributes_parens>\{{[^}}]*\}})?|"
             rf"\!?\[\[{_ASSET_PATTERN}(?P<link_brackets>[^\)\]\"]*)"
             rf"video\{ext}\]\](?P<attributes_brackets>\{{[^}}]*\}})?|"
@@ -799,6 +799,38 @@ def test_markdown_video_with_alt_text(ext: str, setup_test_env):
     tags_to_use = f" {convert_assets.GIF_ATTRIBUTES}" if ext == ".gif" else ""
     expected_html = (
         f'<video{tags_to_use} alt="{alt_text}">'
+        f'<source src="{asset_name}.mp4" type="video/mp4; codecs=hvc1">'
+        f'<source src="{asset_name}.webm" type="video/webm">'
+        "</video>"
+    )
+
+    assert converted_content.strip() == expected_html
+
+
+def test_admonition_directive_before_video_link_is_preserved(setup_test_env):
+    """A `[!quote]` directive before a video link must not be swallowed into the
+    converted video's alt text."""
+    test_dir = Path(setup_test_env)
+    content_dir = test_dir / "website_content"
+    asset_name = "prune_still-easy_trajectories"
+    asset_filename = f"{asset_name}.mp4"
+    dummy_video_path: Path = test_dir / "quartz" / "static" / asset_filename
+    test_md_path: Path = content_dir / "test_admonition.md"
+
+    alt_text = "Stuart Russell's final remarks"
+    input_markdown = f"> [!quote] [{alt_text}]({asset_filename})"
+
+    test_utils.create_test_video(dummy_video_path)
+    test_md_path.write_text(input_markdown)
+
+    convert_assets.convert_asset(
+        dummy_video_path, md_references_dir=content_dir
+    )
+
+    converted_content = test_md_path.read_text(encoding="utf-8")
+
+    expected_html = (
+        f'> [!quote] <video alt="{alt_text}">'
         f'<source src="{asset_name}.mp4" type="video/mp4; codecs=hvc1">'
         f'<source src="{asset_name}.webm" type="video/webm">'
         "</video>"


### PR DESCRIPTION
## Summary

- A markdown video link inside (or after) an admonition directive — `> [!quote] [text](video.mp4)` — was mis-converted into `<video alt="!quote] [text">…`, swallowing the `[!quote]` directive into the video's alt text.
- Root cause: the alt-text capture group in `_video_original_pattern` was `.*?`, which matched across `]`, so the regex opened at the `[` of `[!quote]` and consumed `!quote] [text` as one link.

## Changes

- `scripts/convert_assets.py`: restrict the markdown alt-text group to `[^\]]*?` so a match can't span a closing bracket. The directive is left intact and only the trailing link converts.
- `scripts/tests/test_convert_assets.py`: add `test_admonition_directive_before_video_link_is_preserved` (exact-output regression test for the reported case); update the two `test_video_patterns` mirror assertions to reflect the new regex.
- `CLAUDE.md`: encode the rule to open a PR whenever a unit of work is complete, rather than just pushing the branch.

## Testing

- `uv run pytest scripts/tests/test_convert_assets.py` → 90 passed.
- Verified the reported input now yields `> [!quote] <video alt="Stuart Russell's final remarks">…</video>`.

## Lessons Learned

- **What**: When a regex captures "link text" / alt text, bound the group with `[^\]]` instead of `.*?` so it can't cross a `]` into an adjacent bracketed construct (e.g. an Obsidian admonition directive).
- **Where**: `scripts/convert_assets.py` (and any similar markdown-link parsing).
- **Why**: `.*?` is only locally non-greedy; it still backtracks across `]`, letting `[!quote] [text](x.mp4)` collapse into a single match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw8bN8hU4J448ExC9eLpWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xw8bN8hU4J448ExC9eLpWX)_