### PR TITLE
feat: add no_dropcap_color opt-out for colored dropcaps

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -65,6 +65,7 @@ export default (() => {
     )
     const exposedFrontmatter = {
       no_dropcap: fileData.frontmatter?.no_dropcap,
+      no_dropcap_color: fileData.frontmatter?.no_dropcap_color,
     }
 
     const frontmatterScript = (

--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -68,6 +68,9 @@ const rewardPostWarning = (
 const Content: QuartzComponent = ({ fileData, tree }: QuartzComponentProps) => {
   const useDropcap =
     fileData?.frontmatter?.no_dropcap !== true && fileData?.frontmatter?.no_dropcap !== "true"
+  const noDropcapColor =
+    fileData?.frontmatter?.no_dropcap_color === true ||
+    fileData?.frontmatter?.no_dropcap_color === "true"
   const showWarning = fileData.frontmatter?.["lw-reward-post-warning"] === "true"
   const isQuestion = fileData?.frontmatter?.["lw-is-question"] === "true"
   const originalURL = fileData?.frontmatter?.["original_url"]
@@ -78,7 +81,12 @@ const Content: QuartzComponent = ({ fileData, tree }: QuartzComponentProps) => {
   const classString = [PREVIEWABLE_CLASS, ...classes].join(" ")
   const toc = renderTableOfContents(fileData)
   return (
-    <article id="top" className={classString} data-use-dropcap={useDropcap}>
+    <article
+      id="top"
+      className={classString}
+      data-use-dropcap={useDropcap}
+      data-no-dropcap-color={noDropcapColor}
+    >
       <span className="mobile-only">{toc}</span>
       {isQuestion && originalURL && lessWrongQuestion(originalURL as string)}
       {showWarning && rewardPostWarning}

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -99,6 +99,7 @@ function createSearchIndex(): InstanceType<typeof documentType> {
 
 interface Frontmatter {
   no_dropcap?: boolean | string
+  no_dropcap_color?: boolean | string
 }
 
 /**
@@ -109,6 +110,15 @@ interface Frontmatter {
  */
 export function shouldUseDropcap(frontmatter: Frontmatter): boolean {
   return frontmatter.no_dropcap !== true && frontmatter.no_dropcap !== "true"
+}
+
+/**
+ * Whether a page's dropcap opts out of the random color flourish. Returns true
+ * only when `no_dropcap_color` is explicitly truthy (boolean `true` or string
+ * `"true"`). Mirrors the canonical interpretation in `Content.tsx`.
+ */
+export function noDropcapColor(frontmatter: Frontmatter): boolean {
+  return frontmatter.no_dropcap_color === true || frontmatter.no_dropcap_color === "true"
 }
 
 interface FetchResult {
@@ -424,6 +434,7 @@ export class PreviewManager {
 
       const useDropcap: boolean = shouldUseDropcap(frontmatter)
       this.inner.setAttribute("data-use-dropcap", useDropcap.toString())
+      this.inner.setAttribute("data-no-dropcap-color", noDropcapColor(frontmatter).toString())
 
       // Create a document fragment to build content off-screen
       const fragment = document.createDocumentFragment()

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -19,6 +19,7 @@ import {
   matchHTML,
   matchTextNodes,
   navigateWithSearchTerm,
+  noDropcapColor,
   PreviewManager,
   resetSearchStateForTesting,
   scoreDocByMatchDegree,
@@ -1093,5 +1094,17 @@ describe("shouldUseDropcap", () => {
     ['string "true" suppresses dropcap', { no_dropcap: "true" }, false],
   ])("%s", (_name, frontmatter, expected) => {
     expect(shouldUseDropcap(frontmatter)).toBe(expected)
+  })
+})
+
+describe("noDropcapColor", () => {
+  it.each([
+    ["boolean true opts out of color", { no_dropcap_color: true }, true],
+    ['string "true" opts out of color', { no_dropcap_color: "true" }, true],
+    ["boolean false keeps color", { no_dropcap_color: false }, false],
+    ['string "false" keeps color', { no_dropcap_color: "false" }, false],
+    ["absence keeps color", {}, false],
+  ])("%s", (_name, frontmatter, expected) => {
+    expect(noDropcapColor(frontmatter)).toBe(expected)
   })
 })

--- a/quartz/components/tests/Content.test.tsx
+++ b/quartz/components/tests/Content.test.tsx
@@ -215,6 +215,26 @@ describe("Content component - mobile ToC rendering", () => {
   })
 })
 
+describe("Content component - dropcap attributes", () => {
+  it.each([
+    ["absent frontmatter enables dropcap and keeps color", {}, true, false],
+    ["no_dropcap true disables the dropcap", { no_dropcap: true }, false, false],
+    ['no_dropcap "true" disables the dropcap', { no_dropcap: "true" }, false, false],
+    ["no_dropcap_color true opts out of color", { no_dropcap_color: true }, true, true],
+    ['no_dropcap_color "true" opts out of color', { no_dropcap_color: "true" }, true, true],
+    ["no_dropcap_color false keeps color", { no_dropcap_color: false }, true, false],
+  ])("%s", (_name, extraFrontmatter, expectedUseDropcap, expectedNoColor) => {
+    const props = createQuartzProps({
+      frontmatter: { title: "Test Page", ...extraFrontmatter },
+    })
+    const result = Content()(props)
+
+    assertJSXElement(result)
+    expect(result.props["data-use-dropcap"]).toBe(expectedUseDropcap)
+    expect(result.props["data-no-dropcap-color"]).toBe(expectedNoColor)
+  })
+})
+
 describe("createLinkWithFavicon", () => {
   it("should create a link with favicon using default props", () => {
     const result = createLinkWithFavicon("Test Link", "/test-page", specialFaviconPaths.turntrout)

--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -1,8 +1,12 @@
+import type { Locator } from "@playwright/test"
+
 import { colorDropcapProbability, DROPCAP_COLORS } from "../constants"
 import { expect, test } from "./fixtures"
 import { gotoPage, triggerAndWaitForSPANav } from "./visual_utils"
 
 const DROPCAP_URL = "http://localhost:8080/test-page"
+// A solemn post that opts out of the random color via `no_dropcap_color`.
+const OPTED_OUT_URL = "http://localhost:8080/bruce-wayne-and-the-cost-of-inaction"
 
 /** Mock Math.random so sequential calls return the given values (then 0.5).
  *  Must accept values as a parameter (not closure) because addInitScript serializes the function. */
@@ -10,6 +14,24 @@ const mockRandom = (vals: number[]) => {
   let i = 0
   Math.random = () => vals[i++] ?? 0.5
 }
+
+/** Resolved color of the dropcap embellishment (the `::before` pseudo-element). */
+const embellishmentColor = (paragraph: Locator) =>
+  paragraph.evaluate((el) => getComputedStyle(el, "::before").color)
+
+/** Resolve --midground-faint to an rgb() string via a throwaway probe element. */
+const midgroundFaintColor = (paragraph: Locator) =>
+  paragraph.evaluate((el) => {
+    const probe = document.createElement("span")
+    probe.style.color = "var(--midground-faint)"
+    el.appendChild(probe)
+    const resolved = getComputedStyle(probe).color
+    probe.remove()
+    return resolved
+  })
+
+const firstDropcapParagraph = (root: Locator) =>
+  root.locator("> p:not(.subtitle):first-of-type").first()
 
 test.describe("Random dropcap color", () => {
   test(`no color applied when Math.random >= ${colorDropcapProbability}`, async ({ page }) => {
@@ -69,33 +91,36 @@ test.describe("Random dropcap color", () => {
     await page.addInitScript(mockRandom, [0.01, 0.0])
     await gotoPage(page, DROPCAP_URL)
 
-    const dropcapParagraph = page
-      .locator('article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type')
-      .first()
+    const dropcapParagraph = firstDropcapParagraph(
+      page.locator('article[data-use-dropcap="true"]').first(),
+    )
     await dropcapParagraph.scrollIntoViewIfNeeded()
 
-    const beforeColor = () =>
-      dropcapParagraph.evaluate((el) => getComputedStyle(el, "::before").color)
-
-    const coloredEmbellishment = await beforeColor()
+    const coloredEmbellishment = await embellishmentColor(dropcapParagraph)
 
     // Opting out reverts the embellishment to the monochrome --midground-faint.
     await dropcapParagraph.evaluate((el) =>
       el.closest("article")?.setAttribute("data-no-dropcap-color", "true"),
     )
-    const monochromeEmbellishment = await beforeColor()
+    const monochromeEmbellishment = await embellishmentColor(dropcapParagraph)
 
     expect(monochromeEmbellishment).not.toBe(coloredEmbellishment)
+    expect(monochromeEmbellishment).toBe(await midgroundFaintColor(dropcapParagraph))
+  })
 
-    const midgroundFaint = await dropcapParagraph.evaluate((el) => {
-      const probe = document.createElement("span")
-      probe.style.color = "var(--midground-faint)"
-      el.appendChild(probe)
-      const resolved = getComputedStyle(probe).color
-      probe.remove()
-      return resolved
-    })
-    expect(monochromeEmbellishment).toBe(midgroundFaint)
+  test("opted-out page renders monochrome end-to-end even when a color rolls", async ({ page }) => {
+    // Force a colored roll; the frontmatter→attribute→CSS chain must still win.
+    await page.addInitScript(mockRandom, [0.01, 0.0])
+    await gotoPage(page, OPTED_OUT_URL)
+
+    const article = page.locator('article[data-use-dropcap="true"]').first()
+    await expect(article).toHaveAttribute("data-no-dropcap-color", "true")
+
+    const dropcapParagraph = firstDropcapParagraph(article)
+    await dropcapParagraph.scrollIntoViewIfNeeded()
+    expect(await embellishmentColor(dropcapParagraph)).toBe(
+      await midgroundFaintColor(dropcapParagraph),
+    )
   })
 
   test("color re-rolls on SPA navigation", async ({ page }) => {

--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -64,6 +64,40 @@ test.describe("Random dropcap color", () => {
     await page2.close()
   })
 
+  test('data-no-dropcap-color="true" suppresses the rolled color', async ({ page }) => {
+    // Force a colored roll (red) so the opt-out has something to suppress.
+    await page.addInitScript(mockRandom, [0.01, 0.0])
+    await gotoPage(page, DROPCAP_URL)
+
+    const dropcapParagraph = page
+      .locator('article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type')
+      .first()
+    await dropcapParagraph.scrollIntoViewIfNeeded()
+
+    const beforeColor = () =>
+      dropcapParagraph.evaluate((el) => getComputedStyle(el, "::before").color)
+
+    const coloredEmbellishment = await beforeColor()
+
+    // Opting out reverts the embellishment to the monochrome --midground-faint.
+    await dropcapParagraph.evaluate((el) =>
+      el.closest("article")?.setAttribute("data-no-dropcap-color", "true"),
+    )
+    const monochromeEmbellishment = await beforeColor()
+
+    expect(monochromeEmbellishment).not.toBe(coloredEmbellishment)
+
+    const midgroundFaint = await dropcapParagraph.evaluate((el) => {
+      const probe = document.createElement("span")
+      probe.style.color = "var(--midground-faint)"
+      el.appendChild(probe)
+      const resolved = getComputedStyle(probe).color
+      probe.remove()
+      return resolved
+    })
+    expect(monochromeEmbellishment).toBe(midgroundFaint)
+  })
+
   test("color re-rolls on SPA navigation", async ({ page }) => {
     // IIFE roll: colored (0.01 < probability → pick red), SPA nav roll: no color (0.5 >= probability)
     await page.addInitScript(mockRandom, [0.01, 0.0, 0.5])

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -423,6 +423,13 @@ article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
   }
 }
 
+// Opt out of the random color flourish (e.g. solemn posts) while keeping the
+// dropcap. The extra attribute outranks the colored rule above, so the
+// embellishment always falls back to the monochrome --midground-faint.
+article[data-use-dropcap="true"][data-no-dropcap-color="true"] > p:not(.subtitle):first-of-type {
+  --before-color: var(--midground-faint);
+}
+
 // EG 1st, 2nd, 3rd
 .ordinal-suffix {
   vertical-align: calc(0.5 * $base-margin);

--- a/quartz/styles/generate-critical.ts
+++ b/quartz/styles/generate-critical.ts
@@ -61,6 +61,10 @@ article[data-use-dropcap="true"] {
   --font-dropcap-background: "EBGaramondInitialsF1__subset", "EBGaramondInitialsF1";
 }
 
+article[data-use-dropcap="true"][data-no-dropcap-color="true"] {
+  --before-color: var(--midground-faint);
+}
+
 article[data-use-dropcap="true"] > p:first-of-type {
   position: relative;
   min-height: #{$dropcap-min-height};

--- a/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
+++ b/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
@@ -43,6 +43,10 @@ article[data-use-dropcap="true"] {
   --font-dropcap-background: "EBGaramondInitialsF1__subset", "EBGaramondInitialsF1";
 }
 
+article[data-use-dropcap="true"][data-no-dropcap-color="true"] {
+  --before-color: var(--midground-faint);
+}
+
 article[data-use-dropcap="true"] > p:first-of-type {
   position: relative;
   min-height: #{$dropcap-min-height};

--- a/website_content/bruce-wayne-and-the-cost-of-inaction.md
+++ b/website_content/bruce-wayne-and-the-cost-of-inaction.md
@@ -1,5 +1,6 @@
 ---
 permalink: bruce-wayne-and-the-cost-of-inaction
+no_dropcap_color: true
 lw-was-draft-post: "false"
 lw-is-af: "false"
 lw-is-debate: "false"

--- a/website_content/emotionally-confronting-a-probably-doomed-world-against.md
+++ b/website_content/emotionally-confronting-a-probably-doomed-world-against.md
@@ -1,5 +1,6 @@
 ---
 permalink: emotionally-confronting-doom
+no_dropcap_color: true
 lw-was-draft-post: "false"
 lw-is-af: "false"
 lw-is-debate: "false"

--- a/website_content/lightness-and-unease.md
+++ b/website_content/lightness-and-unease.md
@@ -1,5 +1,6 @@
 ---
 permalink: lightness-and-unease
+no_dropcap_color: true
 lw-was-draft-post: "false"
 lw-is-af: "false"
 lw-is-debate: "false"


### PR DESCRIPTION
## Summary

- Dropcaps occasionally get a random color flourish (~6.7% of page loads). On solemn posts that playfulness clashes with the tone, so this adds a `no_dropcap_color` frontmatter flag that keeps the dropcap but always renders it monochrome.
- Applied to the Bruce Wayne story and two other emotionally heavy posts (confirmed with the author): `emotionally-confronting-doom` and `lightness-and-unease`.

## Changes

- **`Content.tsx`**: emit `data-no-dropcap-color` on the article when `no_dropcap_color` is truthy (`true` / `"true"`), mirroring the existing `no_dropcap` interpretation.
- **`fonts.scss`** & **`generate-critical.ts`**: a higher-specificity rule resets `--before-color` to `--midground-faint` for opted-out articles. The override lives at the same DOM level as the colored declaration in each stylesheet (`p:first-of-type` in the main sheet, `article` in critical CSS), so it wins in both — and because the critical CSS carries it, there's no color flash above the fold.
- **`search.ts`** + **`Head.tsx`**: expose `no_dropcap_color` in the page-frontmatter JSON and mirror the attribute onto the search-preview popover so previews match the page.
- **Frontmatter**: `no_dropcap_color: true` added to the three posts.

## Testing

- `search.test.ts`: parametrized `noDropcapColor` over `true`/`"true"`/`false`/`"false"`/absent.
- `Content.test.tsx`: parametrized assertions that the article carries the correct `data-use-dropcap` / `data-no-dropcap-color` for each frontmatter combination.
- `dropcap.spec.ts`: a Playwright test that loads an actual opted-out page with a forced color roll and asserts the dropcap embellishment resolves to `--midground-faint` (proving the frontmatter→attribute→CSS chain end-to-end), plus a unit-level toggle test. Shared probe helpers factored out.
- `generate-critical.test.ts` snapshot regenerated to include the new critical-CSS rule.
- `pnpm` type-check, prettier, stylelint, and eslint pass on the changed files; affected Jest suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5b839583dwRAQnLy6Fmr2)_