### PR TITLE
fix(ci): never cache an incomplete site build

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -37,9 +37,13 @@ jobs:
       # Cache keyed on commit SHA + fixture flag. Test builds and deploy
       # builds end up at different keys so fixtures can't leak from one to
       # the other.
+      # Restore-only here; the cache is saved by a later completeness-gated step.
+      # The all-in-one cache action saves in its post-step regardless of whether
+      # the build succeeded, so a failed or cancelled build poisons the key with a
+      # partial/empty public/ that every consumer then restores as an empty site.
       - name: Restore build cache
         id: cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: public/
           key: site-build-${{ github.sha }}-fixtures-${{ inputs.include-fixtures }}
@@ -57,3 +61,24 @@ jobs:
       - name: Build site
         if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm build
+
+      # Fail loudly on a partial build or a poisoned cache hit instead of letting
+      # consumers restore an empty public/ and time out their webServer minutes later.
+      - name: Verify built site is complete
+        run: |
+          count=$(find public -name '*.html' | wc -l)
+          echo "public/ contains ${count} HTML files"
+          if [ ! -f public/index.html ] || [ "${count}" -lt 100 ]; then
+            echo "::error::Built site is incomplete (${count} HTML files); refusing to use or cache it."
+            exit 1
+          fi
+
+      # Save only after the build is verified complete, so an incomplete public/
+      # can never be cached. Concurrent builds for the same key race harmlessly:
+      # the first writer wins and the rest no-op on the existing key.
+      - name: Save build cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: public/
+          key: site-build-${{ github.sha }}-fixtures-${{ inputs.include-fixtures }}

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -119,11 +119,7 @@ export default defineConfig({
         command: process.env.CI
           ? "pnpm serve public -l 8080 > /tmp/webserver.log 2>&1"
           : "INCLUDE_FIXTURES=true pnpm start",
-        // Probe a concrete, always-built page rather than the bare site root.
-        // The homepage is published under a permalink, so the CI static server
-        // answers `/` with 404; a 404 never satisfies the readiness check, so
-        // probing `/` stalls startup until the 7-minute timeout fires.
-        url: `${baseURL}/test-page`,
+        url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 7 * 60 * 1000, // 7 minutes
       },

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -119,7 +119,11 @@ export default defineConfig({
         command: process.env.CI
           ? "pnpm serve public -l 8080 > /tmp/webserver.log 2>&1"
           : "INCLUDE_FIXTURES=true pnpm start",
-        url: baseURL,
+        // Probe a concrete, always-built page rather than the bare site root.
+        // The homepage is published under a permalink, so the CI static server
+        // answers `/` with 404; a 404 never satisfies the readiness check, so
+        // probing `/` stalls startup until the 7-minute timeout fires.
+        url: `${baseURL}/test-page`,
         reuseExistingServer: !process.env.CI,
         timeout: 7 * 60 * 1000, // 7 minutes
       },


### PR DESCRIPTION
## Summary

- `playwright-tests` and `visual-testing` have failed on **every** shard since ~2026-06-25 with `Error: Timed out waiting 420000ms from config.webServer`.
- Root cause: `build-site.yaml` used the all-in-one `actions/cache`, which **saves `public/` in its post-step regardless of whether `pnpm build` succeeded**. A failed or cancelled build writes a partial/empty `public/` to the `site-build-<sha>-fixtures-*` key; since cache keys are immutable, every consumer then restores that empty site. `serve public` 404s every page, so Playwright's readiness probe never succeeds and times out after 7 minutes on all shards.
- This is a pre-existing `main` breakage (independent of any one PR) that blocks merges across the repo.

## Changes

- `.github/workflows/build-site.yaml`: split the cache into **restore-only** up front + a gated **save** at the end:
  - `actions/cache/restore` to consume an existing complete cache.
  - A `Verify built site is complete` step (`public/index.html` present and ≥100 HTML files) that fails loudly on a partial build or a poisoned cache hit.
  - `actions/cache/save` that runs only after verification passes, so an incomplete `public/` can never be cached. Concurrent builds for the same key race harmlessly — first writer wins, the rest no-op.

## Testing

- Diagnosed from CI artifacts: the build job logs `Done processing 173 files` (build OK) but the cache post-step logs `Failed to save … tar … Exiting with failure status` / `Unable to reserve cache … another job may be creating this cache`; the consumer `webserver.log` shows `serve` returning 404 for `/`, `/index`, and `/test-page` alike — i.e. an empty restored `public/`.
- Can't be validated locally (site build doesn't run in this sandbox); verification is via CI on this PR — `playwright-tests` / `visual-testing` should now get a complete `public/` and run.

## Lessons Learned

- **What**: When caching a build output across jobs, never use the all-in-one `actions/cache` (it saves in the post-step even when the build step failed/was cancelled, poisoning an immutable key). Use `actions/cache/restore` + a completeness check + `actions/cache/save` gated on success.
- **Where**: `.github/workflows/build-site.yaml`; applies to any workflow caching a generated artifact under a content-addressed key.
- **Why**: A partial/empty cached `public/` is restored by every consumer and surfaces only as an opaque 7-minute `webServer` timeout, not as a build error — extremely hard to diagnose downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)