### PR TITLE
perf(hooks): make commit-time OpenTimestamps stamping asynchronous

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -160,6 +160,12 @@ For PR runs the workflow pushes an empty commit to the PR branch so visual-
 
 **Shard status vs. overall status.** Individual `visual-testing-(linux|macos)` shards stay green when the only failures are new or updated screenshots—those are expected outcomes that the diff-gallery + approve button is designed for, and red shards turn into noise. Each shard runs `scripts/classify_visual_failures.py` over its blob report and only exits non-zero for real failures (timeouts, page errors, exceptions before the screenshot assertion). The `aggregate-visual-results` job collects per-shard status artifacts and the overall `visual-testing` status + `publish-visual-report` deploy carry the snapshot-diff signal forward.
 
+## Commit timestamping (OpenTimestamps, async)
+
+`git commit` enqueues the commit hash and hands off to a **detached** background worker (`.hooks/post-commit` → `.hooks/timestamp-worker.sh`), so the commit returns immediately instead of blocking ~3s on network I/O. The worker holds a single `mkdir` lock (portable; `flock` is absent on macOS), drains every queued hash, creates each OpenTimestamps proof (`ots stamp`), commits it into the `.timestamps` repo, then pushes the whole batch in **one** pull/push.
+
+State lives under `$(git rev-parse --git-dir)/ots-timestamps/`: `queue` (pending hashes), `lock.d/` (worker lock), `worker.log` (errors only—a clean success writes nothing). Best-effort by design: a failed stamp re-queues its hash, a failed push leaves the proof committed-but-unpushed, and the next commit's worker retries via `has_unpushed`. A commit is never rolled back, so no commit loses its eventual proof. Skipped entirely when `CI=true`. If proofs are missing, check `worker.log`; re-trigger by committing, or run the worker directly with `OTS_GIT_ROOT`/`OTS_STATE_DIR` set.
+
 ## Pre-push validation pipeline
 
 When pushing to main, `scripts/run_push_checks.py` runs:

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -384,7 +384,17 @@ if [ -f "$PROJECT_DIR/package.json" ]; then
 	if command -v pnpm &>/dev/null; then
 		# Skip Puppeteer browser download — sandboxed environments can't reach
 		# storage.googleapis.com and Playwright browsers are used instead.
-		PUPPETEER_SKIP_DOWNLOAD=true pnpm install --silent || warn "Failed to install Node dependencies"
+		#
+		# --config.confirm-modules-purge=false: the container's pre-provisioned
+		# node_modules can be inconsistent with the lockfile, so pnpm wants to
+		# purge and reinstall it. Without this flag that prompt aborts under no
+		# TTY (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY), leaving node_modules
+		# stale — which then makes every later `pnpm exec` (e.g. the pre-push
+		# checks) fail the same way. Letting the purge proceed here leaves a
+		# consistent tree so subsequent `pnpm exec` runs skip the reinstall.
+		PUPPETEER_SKIP_DOWNLOAD=true pnpm install --silent \
+			--config.confirm-modules-purge=false ||
+			warn "Failed to install Node dependencies"
 	elif command -v npm &>/dev/null; then
 		npm install --silent || warn "Failed to install Node dependencies"
 	fi

--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -1,71 +1,41 @@
 #!/bin/bash
+# Enqueue this commit for OpenTimestamps stamping and hand off to a detached
+# worker. The network-heavy work (ots stamp + pull/push to the .timestamps
+# repo) runs in the background so `git commit` returns immediately. See
+# .hooks/timestamp-worker.sh for the queue/lock/retry logic.
 
-commit_hash="$(git rev-parse HEAD)"
+set -uo pipefail
+
+# In CI, .timestamps and ots are not available — skip entirely.
+[ "${CI:-}" = "true" ] && exit 0
+
 git_root="$(git rev-parse --show-toplevel)"
-timestamps_repo="$git_root/.timestamps"
-timestamps_dir="$timestamps_repo/files"
+commit_hash="$(git rev-parse HEAD)"
 
-rollback() {
-  echo "ERROR: $1"
-  echo "Undoing commit..."
-  cd "$git_root" && git reset --soft HEAD~1
-  exit 1
-}
-
-# In CI, .timestamps and ots are not available — skip entirely
-if [ "${CI:-}" = "true" ]; then
+if [ ! -d "$git_root/.timestamps/.git" ]; then
+  echo "Warning: .timestamps repo not set up; skipping OpenTimestamp proof." >&2
+  echo "  Set it up with: git clone <timestamps-repo-url> .timestamps" >&2
   exit 0
 fi
 
-if [ ! -d "$timestamps_repo/.git" ]; then
-  rollback ".timestamps repo not set up! Run: git clone <timestamps-repo-url> .timestamps"
+git_dir="$(git rev-parse --absolute-git-dir)"
+state_dir="$git_dir/ots-timestamps"
+mkdir -p "$state_dir"
+
+# A single-line append under PIPE_BUF is atomic, so concurrent commits can
+# enqueue without a lock.
+printf '%s\n' "$commit_hash" >>"$state_dir/queue"
+
+worker="$git_root/.hooks/timestamp-worker.sh"
+if [ -x "$worker" ]; then
+  if command -v setsid >/dev/null 2>&1; then
+    OTS_GIT_ROOT="$git_root" OTS_STATE_DIR="$state_dir" \
+      setsid "$worker" >/dev/null 2>&1 </dev/null &
+  else
+    OTS_GIT_ROOT="$git_root" OTS_STATE_DIR="$state_dir" \
+      nohup "$worker" >/dev/null 2>&1 </dev/null &
+  fi
+  disown 2>/dev/null || true
 fi
 
-# Find ots binary
-OTS_BIN=""
-if command -v ots >/dev/null 2>&1; then
-  OTS_BIN="$(command -v ots)"
-fi
-
-if [ -z "$OTS_BIN" ]; then
-  rollback "ots not found! Install opentimestamps-client."
-fi
-
-mkdir -p "$timestamps_dir"
-txt_file="$timestamps_dir/$commit_hash.txt"
-printf '%s' "$commit_hash" >"$txt_file"
-
-# Try to create timestamp with relaxed requirements (accept 1 calendar response, 30s timeout)
-ots_output=$(ots stamp -m 1 --timeout 30 "$txt_file" 2>&1)
-ots_exit=$?
-
-if [ $ots_exit -ne 0 ]; then
-  echo "OpenTimestamp output: $ots_output" >&2
-  rollback "Failed to create OpenTimestamp proof! This may be due to network issues or insufficient calendar server responses."
-fi
-
-# Wait for .ots file to be created (up to 5 seconds)
-ots_file="$txt_file.ots"
-count=0
-while [ $count -lt 50 ]; do
-  [ -f "$ots_file" ] && break
-  sleep 0.1
-  count=$((count + 1))
-done
-[ -f "$ots_file" ] || rollback "OpenTimestamp .ots file was not created!"
-
-cd "$timestamps_repo" || rollback "Failed to change to timestamps directory!"
-git add "files/$commit_hash.txt" "files/$commit_hash.txt.ots" || rollback "Failed to add timestamp files!"
-git commit -m "Add OpenTimestamp proof for commit $commit_hash" --quiet || rollback "Failed to commit timestamp files!"
-
-# Pull and rebase before pushing to handle divergent branches
-if ! git pull --rebase --quiet origin master 2>/dev/null; then
-  rollback "Could not pull from .timestamps repo."
-fi
-
-# Push to timestamps repo
-if ! git push --quiet 2>/dev/null; then
-  rollback "Could not push to .timestamps repo (no credentials?). Check session-setup.sh."
-fi
-
-cd "$git_root" || exit 1
+exit 0

--- a/.hooks/timestamp-worker.sh
+++ b/.hooks/timestamp-worker.sh
@@ -124,8 +124,8 @@ sync_repo() {
 }
 
 # Drain the queue: snapshot it, stamp each hash, re-queue any failures. Returns
-# 0 if the queue was fully drained, 1 if it stopped early on a failure (those
-# hashes stay queued for the next commit rather than hammering the network).
+# 0 if the queue was fully drained, 1 if any hash failed — failed hashes stay
+# queued for the next commit rather than being re-polled in a tight loop.
 process_queue() {
   local work="$state_dir/queue.work"
   local failed="$state_dir/queue.failed"

--- a/.hooks/timestamp-worker.sh
+++ b/.hooks/timestamp-worker.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Background OpenTimestamps worker.
+#
+# Launched detached by .hooks/post-commit so `git commit` never blocks on
+# network I/O. Drains a queue of commit hashes: for each, creates an OTS proof
+# and commits it into the .timestamps repo, then pushes the whole batch in a
+# single pull/push. A single mkdir lock keeps concurrent commits from racing;
+# whichever worker holds the lock drains every queued hash, so newer commits
+# piggyback on the running worker instead of spawning redundant network work.
+#
+# Best-effort by design: a failed stamp or push is logged and the hash is left
+# pending so the next commit retries it. The commit it belongs to is never
+# rolled back.
+
+set -uo pipefail
+
+git_root="${OTS_GIT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -n "$git_root" ] || exit 0
+
+# Git hooks don't inherit the interactive PATH; make ots (uv venv) and any
+# user-installed tooling resolvable for the detached process.
+[ -d "$git_root/.venv/bin" ] && export PATH="$git_root/.venv/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
+
+git_dir="$(git -C "$git_root" rev-parse --absolute-git-dir 2>/dev/null)" || exit 0
+state_dir="${OTS_STATE_DIR:-$git_dir/ots-timestamps}"
+queue="$state_dir/queue"
+lockdir="$state_dir/lock.d"
+log_file="$state_dir/worker.log"
+
+timestamps_repo="$git_root/.timestamps"
+timestamps_dir="$timestamps_repo/files"
+
+mkdir -p "$state_dir"
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$1" >>"$log_file"
+}
+
+# Keep the log from growing without bound across many commits.
+rotate_log() {
+  if [ -f "$log_file" ] && [ "$(wc -c <"$log_file" 2>/dev/null || echo 0)" -gt 1048576 ]; then
+    mv -f "$log_file" "$log_file.1" 2>/dev/null || true
+  fi
+}
+
+# Atomic, portable lock (flock is absent on macOS). Steal a stale lock whose
+# owning process is gone so a killed worker can't wedge the queue forever.
+acquire_lock() {
+  if mkdir "$lockdir" 2>/dev/null; then
+    echo $$ >"$lockdir/pid"
+    return 0
+  fi
+  oldpid="$(cat "$lockdir/pid" 2>/dev/null || echo "")"
+  if [ -n "$oldpid" ] && ! kill -0 "$oldpid" 2>/dev/null; then
+    rm -rf "$lockdir"
+    if mkdir "$lockdir" 2>/dev/null; then
+      echo $$ >"$lockdir/pid"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# shellcheck disable=SC2317  # invoked indirectly via trap
+cleanup() {
+  rm -rf "$lockdir" 2>/dev/null || true
+}
+
+has_unpushed() {
+  local n
+  n="$(git -C "$timestamps_repo" rev-list --count origin/master..HEAD 2>/dev/null || echo 0)"
+  [ "${n:-0}" -gt 0 ]
+}
+
+# Create and locally commit the OTS proof for a single commit hash.
+stamp_one() {
+  local hash="$1"
+  local txt_file="$timestamps_dir/$hash.txt"
+  local ots_file="$txt_file.ots"
+
+  [ -f "$ots_file" ] && return 0 # already stamped
+
+  printf '%s' "$hash" >"$txt_file"
+
+  local out
+  if ! out="$(ots stamp -m 1 --timeout 30 "$txt_file" 2>&1)"; then
+    log "ots stamp failed for $hash: $out"
+    return 1
+  fi
+  if [ ! -f "$ots_file" ]; then
+    log "ots produced no .ots file for $hash"
+    return 1
+  fi
+
+  if ! git -C "$timestamps_repo" add "files/$hash.txt" "files/$hash.txt.ots" 2>>"$log_file" ||
+    ! git -C "$timestamps_repo" commit --quiet -m "Add OpenTimestamp proof for commit $hash" 2>>"$log_file"; then
+    log "failed to commit proof for $hash"
+    return 1
+  fi
+  return 0
+}
+
+# Push every locally committed proof in one pull/push round-trip.
+sync_repo() {
+  if ! git -C "$timestamps_repo" pull --rebase --quiet origin master 2>>"$log_file"; then
+    log "could not pull .timestamps repo"
+    return 1
+  fi
+  if ! git -C "$timestamps_repo" push --quiet 2>>"$log_file"; then
+    log "could not push .timestamps repo (no credentials?)"
+    return 1
+  fi
+  return 0
+}
+
+stamped_any=0
+
+# Drain the queue: snapshot it, stamp each hash, re-queue any failures and stop
+# (they retry on the next commit rather than hammering the network in a loop).
+process_queue() {
+  local work="$state_dir/queue.work"
+  local failed="$state_dir/queue.failed"
+  while [ -s "$queue" ]; do
+    mv "$queue" "$work" 2>/dev/null || break
+    : >"$failed"
+    local hash
+    while IFS= read -r hash; do
+      [ -n "$hash" ] || continue
+      if stamp_one "$hash"; then
+        stamped_any=1
+      else
+        printf '%s\n' "$hash" >>"$failed"
+      fi
+    done <"$work"
+    rm -f "$work"
+    if [ -s "$failed" ]; then
+      cat "$failed" >>"$queue"
+      rm -f "$failed"
+      break
+    fi
+    rm -f "$failed"
+  done
+}
+
+if [ ! -d "$timestamps_repo/.git" ]; then
+  log ".timestamps repo not set up; skipping"
+  exit 0
+fi
+
+if ! command -v ots >/dev/null 2>&1; then
+  log "ots not found; install opentimestamps-client"
+  exit 0
+fi
+
+acquire_lock || exit 0
+trap cleanup EXIT
+rotate_log
+
+process_queue
+
+if [ "$stamped_any" -eq 1 ] || has_unpushed; then
+  sync_repo || log "sync deferred; will retry on next commit"
+fi
+
+exit 0

--- a/.hooks/timestamp-worker.sh
+++ b/.hooks/timestamp-worker.sh
@@ -62,11 +62,6 @@ acquire_lock() {
   return 1
 }
 
-# shellcheck disable=SC2317  # invoked indirectly via trap
-cleanup() {
-  rm -rf "$lockdir" 2>/dev/null || true
-}
-
 has_unpushed() {
   local n
   n="$(git -C "$timestamps_repo" rev-list --count origin/master..HEAD 2>/dev/null || echo 0)"
@@ -159,7 +154,7 @@ if ! command -v ots >/dev/null 2>&1; then
 fi
 
 acquire_lock || exit 0
-trap cleanup EXIT
+trap 'rm -rf "$lockdir" 2>/dev/null || true' EXIT
 rotate_log
 
 # Drain, push, then re-poll so hashes enqueued while we were working get handled

--- a/.hooks/timestamp-worker.sh
+++ b/.hooks/timestamp-worker.sh
@@ -4,9 +4,9 @@
 # Launched detached by .hooks/post-commit so `git commit` never blocks on
 # network I/O. Drains a queue of commit hashes: for each, creates an OTS proof
 # and commits it into the .timestamps repo, then pushes the whole batch in a
-# single pull/push. A single mkdir lock keeps concurrent commits from racing;
-# whichever worker holds the lock drains every queued hash, so newer commits
-# piggyback on the running worker instead of spawning redundant network work.
+# single pull/push. A single mkdir lock serializes workers; the lock holder
+# keeps draining and re-polls the queue, so commits enqueued while it runs are
+# handled in the same run instead of spawning redundant network work.
 #
 # Best-effort by design: a failed stamp or push is logged and the hash is left
 # pending so the next commit retries it. The commit it belongs to is never
@@ -73,28 +73,37 @@ has_unpushed() {
   [ "${n:-0}" -gt 0 ]
 }
 
-# Create and locally commit the OTS proof for a single commit hash.
+# Create (if needed) and commit the OTS proof for a single commit hash. Both
+# steps are idempotent: an existing .ots is reused instead of re-stamped, and an
+# already-committed proof is a no-op. So a proof whose commit failed on an
+# earlier run is still committed on retry rather than skipped as "done".
 stamp_one() {
   local hash="$1"
   local txt_file="$timestamps_dir/$hash.txt"
   local ots_file="$txt_file.ots"
 
-  [ -f "$ots_file" ] && return 0 # already stamped
-
-  printf '%s' "$hash" >"$txt_file"
-
-  local out
-  if ! out="$(ots stamp -m 1 --timeout 30 "$txt_file" 2>&1)"; then
-    log "ots stamp failed for $hash: $out"
-    return 1
-  fi
   if [ ! -f "$ots_file" ]; then
-    log "ots produced no .ots file for $hash"
-    return 1
+    printf '%s' "$hash" >"$txt_file"
+    local out
+    if ! out="$(ots stamp -m 1 --timeout 30 "$txt_file" 2>&1)"; then
+      log "ots stamp failed for $hash: $out"
+      return 1
+    fi
+    if [ ! -f "$ots_file" ]; then
+      log "ots produced no .ots file for $hash"
+      return 1
+    fi
   fi
 
-  if ! git -C "$timestamps_repo" add "files/$hash.txt" "files/$hash.txt.ots" 2>>"$log_file" ||
-    ! git -C "$timestamps_repo" commit --quiet -m "Add OpenTimestamp proof for commit $hash" 2>>"$log_file"; then
+  if ! git -C "$timestamps_repo" add "files/$hash.txt" "files/$hash.txt.ots" 2>>"$log_file"; then
+    log "failed to stage proof for $hash"
+    return 1
+  fi
+  # Nothing staged means the proof is already committed — done.
+  if git -C "$timestamps_repo" diff --cached --quiet -- "files/$hash.txt" "files/$hash.txt.ots"; then
+    return 0
+  fi
+  if ! git -C "$timestamps_repo" commit --quiet -m "Add OpenTimestamp proof for commit $hash" 2>>"$log_file"; then
     log "failed to commit proof for $hash"
     return 1
   fi
@@ -114,33 +123,29 @@ sync_repo() {
   return 0
 }
 
-stamped_any=0
-
-# Drain the queue: snapshot it, stamp each hash, re-queue any failures and stop
-# (they retry on the next commit rather than hammering the network in a loop).
+# Drain the queue: snapshot it, stamp each hash, re-queue any failures. Returns
+# 0 if the queue was fully drained, 1 if it stopped early on a failure (those
+# hashes stay queued for the next commit rather than hammering the network).
 process_queue() {
   local work="$state_dir/queue.work"
   local failed="$state_dir/queue.failed"
   while [ -s "$queue" ]; do
-    mv "$queue" "$work" 2>/dev/null || break
+    mv "$queue" "$work" 2>/dev/null || return 0
     : >"$failed"
     local hash
     while IFS= read -r hash; do
       [ -n "$hash" ] || continue
-      if stamp_one "$hash"; then
-        stamped_any=1
-      else
-        printf '%s\n' "$hash" >>"$failed"
-      fi
+      stamp_one "$hash" || printf '%s\n' "$hash" >>"$failed"
     done <"$work"
     rm -f "$work"
     if [ -s "$failed" ]; then
       cat "$failed" >>"$queue"
       rm -f "$failed"
-      break
+      return 1
     fi
     rm -f "$failed"
   done
+  return 0
 }
 
 if [ ! -d "$timestamps_repo/.git" ]; then
@@ -157,10 +162,16 @@ acquire_lock || exit 0
 trap cleanup EXIT
 rotate_log
 
-process_queue
-
-if [ "$stamped_any" -eq 1 ] || has_unpushed; then
-  sync_repo || log "sync deferred; will retry on next commit"
-fi
+# Drain, push, then re-poll so hashes enqueued while we were working get handled
+# in this run instead of waiting for the next commit. Stop re-polling once a
+# stamp fails — those hashes retry on the next commit.
+while :; do
+  process_queue
+  drained=$?
+  if has_unpushed; then
+    sync_repo || log "sync deferred; will retry on next commit"
+  fi
+  { [ "$drained" -eq 0 ] && [ -s "$queue" ]; } || break
+done
 
 exit 0

--- a/scripts/tests/test_timestamp_worker.py
+++ b/scripts/tests/test_timestamp_worker.py
@@ -1,4 +1,5 @@
-"""Integration tests for the async OpenTimestamps hooks.
+"""
+Integration tests for the async OpenTimestamps hooks.
 
 These drive the real bash scripts (``.hooks/timestamp-worker.sh`` and
 ``.hooks/post-commit``) via subprocess against a throwaway git sandbox. A fake,
@@ -75,7 +76,8 @@ def _proof_pushed(origin_repo: Path, commit_hash: str) -> bool:
 
 
 class _Sandbox:
-    """A throwaway main repo + cloned .timestamps repo wired to a bare origin."""
+    """A throwaway main repo + cloned .timestamps repo wired to a bare
+    origin."""
 
     def __init__(self, tmp_path: Path) -> None:
         self.home = tmp_path / "home"
@@ -121,7 +123,8 @@ class _Sandbox:
         self.log = self.state / "worker.log"
 
     def _write_fake_ots(self) -> None:
-        """Install an offline ``ots`` that writes a stub .ots next to its input.
+        """
+        Install an offline ``ots`` that writes a stub .ots next to its input.
 
         Honours ``FAKE_OTS_FAIL=1`` to simulate a stamping failure.
         """
@@ -376,7 +379,8 @@ class TestPostCommit:
         assert not sandbox.queue.exists()
 
     def test_enqueues_commit_hash(self, sandbox: _Sandbox) -> None:
-        """post-commit appends the commit hash to the queue.
+        """
+        Post-commit appends the commit hash to the queue.
 
         A held lock (live pid) stops the detached worker from draining the
         queue, so the enqueued hash is observable regardless of worker timing.

--- a/scripts/tests/test_timestamp_worker.py
+++ b/scripts/tests/test_timestamp_worker.py
@@ -1,0 +1,392 @@
+"""Integration tests for the async OpenTimestamps hooks.
+
+These drive the real bash scripts (``.hooks/timestamp-worker.sh`` and
+``.hooks/post-commit``) via subprocess against a throwaway git sandbox. A fake,
+offline ``ots`` binary is injected on ``PATH`` so the tests never touch the
+network or the real ``.timestamps`` repo.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKER = REPO_ROOT / ".hooks" / "timestamp-worker.sh"
+POST_COMMIT = REPO_ROOT / ".hooks" / "post-commit"
+
+# Mark every test in this module: they run real git against a sandbox repo.
+pytestmark = pytest.mark.allow_git_operations
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in *repo* and return stripped stdout."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str, filename: str = "file.txt") -> str:
+    """Create a commit in *repo* and return its hash."""
+    (repo / filename).write_text(f"{message}\n", encoding="utf-8")
+    _git(repo, "add", filename)
+    _git(repo, "commit", "--quiet", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _proof_committed(timestamps_repo: Path, commit_hash: str) -> bool:
+    """True if the proof for *commit_hash* is committed in the local repo."""
+    return (
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(timestamps_repo),
+                "cat-file",
+                "-e",
+                f"HEAD:files/{commit_hash}.txt.ots",
+            ],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _proof_pushed(origin_repo: Path, commit_hash: str) -> bool:
+    """True if the proof for *commit_hash* exists on origin's master."""
+    return (
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(origin_repo),
+                "cat-file",
+                "-e",
+                f"master:files/{commit_hash}.txt.ots",
+            ],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+class _Sandbox:
+    """A throwaway main repo + cloned .timestamps repo wired to a bare origin."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.home = tmp_path / "home"
+        (self.home / ".local" / "bin").mkdir(parents=True)
+        self._write_fake_ots()
+
+        self.origin = tmp_path / "ts-origin.git"
+        subprocess.run(
+            ["git", "init", "--quiet", "--bare", str(self.origin)], check=True
+        )
+
+        self.main = tmp_path / "main"
+        self.main.mkdir()
+        _git(self.main, "init", "--quiet")
+        _git(self.main, "config", "user.email", "t@t.com")
+        _git(self.main, "config", "user.name", "t")
+        _commit(self.main, "init")
+
+        self.timestamps = self.main / ".timestamps"
+        subprocess.run(
+            ["git", "clone", "--quiet", str(self.origin), str(self.timestamps)],
+            check=True,
+            capture_output=True,
+        )
+        _git(self.timestamps, "config", "user.email", "t@t.com")
+        _git(self.timestamps, "config", "user.name", "t")
+        (self.timestamps / "files").mkdir()
+        (self.timestamps / "files" / ".keep").touch()
+        _git(self.timestamps, "add", "files/.keep")
+        _git(self.timestamps, "commit", "--quiet", "-m", "seed")
+        _git(self.timestamps, "push", "--quiet", "origin", "master")
+        _git(
+            self.timestamps,
+            "branch",
+            "--set-upstream-to=origin/master",
+            "master",
+        )
+
+        self.git_dir = Path(_git(self.main, "rev-parse", "--absolute-git-dir"))
+        self.state = self.git_dir / "ots-timestamps"
+        self.state.mkdir(parents=True)
+        self.queue = self.state / "queue"
+        self.log = self.state / "worker.log"
+
+    def _write_fake_ots(self) -> None:
+        """Install an offline ``ots`` that writes a stub .ots next to its input.
+
+        Honours ``FAKE_OTS_FAIL=1`` to simulate a stamping failure.
+        """
+        ots = self.home / ".local" / "bin" / "ots"
+        ots.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -eu\n"
+            'if [ "${FAKE_OTS_FAIL:-0}" = "1" ]; then\n'
+            '  echo "fake ots: forced failure" >&2\n'
+            "  exit 1\n"
+            "fi\n"
+            'target="${*: -1}"\n'
+            'printf "fake-ots-proof" > "$target.ots"\n',
+            encoding="utf-8",
+        )
+        ots.chmod(0o755)
+
+    def env(self, **overrides: str) -> dict[str, str]:
+        env = {
+            **os.environ,
+            "HOME": str(self.home),
+            "PATH": f"{self.home / '.local' / 'bin'}:{os.environ['PATH']}",
+            "OTS_GIT_ROOT": str(self.main),
+            "OTS_STATE_DIR": str(self.state),
+        }
+        env.update(overrides)
+        return env
+
+    def enqueue(self, *hashes: str) -> None:
+        with self.queue.open("a", encoding="utf-8") as fh:
+            for h in hashes:
+                fh.write(f"{h}\n")
+
+    def run_worker(
+        self, timeout: float = 30, **env_overrides: str
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(WORKER)],
+            env=self.env(**env_overrides),
+            cwd=str(self.main),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def queued_hashes(self) -> list[str]:
+        if not self.queue.exists():
+            return []
+        return [
+            line
+            for line in self.queue.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+
+@pytest.fixture()
+def sandbox(tmp_path: Path) -> _Sandbox:
+    return _Sandbox(tmp_path)
+
+
+class TestWorker:
+    def test_stamps_commits_and_pushes(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+
+        result = sandbox.run_worker()
+
+        assert result.returncode == 0
+        assert sandbox.queued_hashes() == []
+        assert _proof_committed(sandbox.timestamps, commit)
+        assert _proof_pushed(sandbox.origin, commit)
+
+    def test_batches_multiple_commits(self, sandbox: _Sandbox) -> None:
+        first = _commit(sandbox.main, "r1")
+        second = _commit(sandbox.main, "r2")
+        sandbox.enqueue(first, second)
+
+        sandbox.run_worker()
+
+        assert sandbox.queued_hashes() == []
+        for commit in (first, second):
+            assert _proof_pushed(sandbox.origin, commit)
+
+    def test_recovers_orphaned_proof(self, sandbox: _Sandbox) -> None:
+        """An .ots on disk but never committed is committed and pushed."""
+        commit = _commit(sandbox.main, "orphan")
+        files = sandbox.timestamps / "files"
+        (files / f"{commit}.txt").write_text(commit, encoding="utf-8")
+        (files / f"{commit}.txt.ots").write_text("stub", encoding="utf-8")
+        assert not _proof_committed(sandbox.timestamps, commit)
+        sandbox.enqueue(commit)
+
+        sandbox.run_worker()
+
+        assert _proof_committed(sandbox.timestamps, commit)
+        assert _proof_pushed(sandbox.origin, commit)
+
+    def test_rerun_already_committed_is_clean_noop(
+        self, sandbox: _Sandbox
+    ) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+        sandbox.run_worker()
+        commits_before = _git(sandbox.timestamps, "rev-list", "--count", "HEAD")
+
+        sandbox.enqueue(commit)  # same hash again
+        result = sandbox.run_worker(
+            timeout=20
+        )  # guards against an infinite loop
+
+        assert result.returncode == 0
+        assert sandbox.queued_hashes() == []
+        commits_after = _git(sandbox.timestamps, "rev-list", "--count", "HEAD")
+        assert commits_after == commits_before
+
+    def test_push_failure_keeps_proof_then_retries(
+        self, sandbox: _Sandbox
+    ) -> None:
+        commit = _commit(sandbox.main, "real")
+        _git(
+            sandbox.timestamps,
+            "remote",
+            "set-url",
+            "origin",
+            str(sandbox.main / "does-not-exist.git"),
+        )
+        sandbox.enqueue(commit)
+
+        sandbox.run_worker()
+
+        # Stamp succeeded so the hash drains; the proof is committed locally but
+        # could not be pushed.
+        assert sandbox.queued_hashes() == []
+        assert _proof_committed(sandbox.timestamps, commit)
+        assert not _proof_pushed(sandbox.origin, commit)
+        assert "could not" in sandbox.log.read_text(encoding="utf-8").lower()
+
+        # Next run with an empty queue retries the unpushed proof.
+        _git(
+            sandbox.timestamps,
+            "remote",
+            "set-url",
+            "origin",
+            str(sandbox.origin),
+        )
+        sandbox.run_worker()
+        assert _proof_pushed(sandbox.origin, commit)
+
+    def test_stamp_failure_requeues_hash(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+
+        result = sandbox.run_worker(FAKE_OTS_FAIL="1")
+
+        assert result.returncode == 0
+        assert sandbox.queued_hashes() == [commit]
+        assert not _proof_committed(sandbox.timestamps, commit)
+        assert "ots stamp failed" in sandbox.log.read_text(encoding="utf-8")
+
+    def test_concurrent_worker_skips_when_locked(
+        self, sandbox: _Sandbox
+    ) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+        lockdir = sandbox.state / "lock.d"
+        lockdir.mkdir()
+        (lockdir / "pid").write_text(str(os.getpid()), encoding="utf-8")
+
+        result = sandbox.run_worker()
+
+        assert result.returncode == 0
+        assert sandbox.queued_hashes() == [commit]  # untouched
+        assert not _proof_committed(sandbox.timestamps, commit)
+
+    def test_steals_stale_lock(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+        # A pid that has already exited and been reaped is a stale lock.
+        dead = subprocess.Popen(["true"])  # noqa: S607 - resolved on PATH
+        dead.wait()
+        lockdir = sandbox.state / "lock.d"
+        lockdir.mkdir()
+        (lockdir / "pid").write_text(str(dead.pid), encoding="utf-8")
+
+        sandbox.run_worker()
+
+        assert sandbox.queued_hashes() == []
+        assert _proof_committed(sandbox.timestamps, commit)
+
+    def test_removes_lock_on_exit(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+
+        sandbox.run_worker()
+
+        assert not (sandbox.state / "lock.d").exists()
+
+    def test_skips_when_timestamps_repo_absent(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+        import shutil
+
+        shutil.rmtree(sandbox.timestamps)
+
+        result = sandbox.run_worker()
+
+        assert result.returncode == 0
+        assert "not set up" in sandbox.log.read_text(encoding="utf-8")
+
+    def test_skips_when_ots_missing(self, sandbox: _Sandbox) -> None:
+        commit = _commit(sandbox.main, "real")
+        sandbox.enqueue(commit)
+        (sandbox.home / ".local" / "bin" / "ots").unlink()
+
+        result = sandbox.run_worker(PATH="/usr/bin:/bin")
+
+        assert result.returncode == 0
+        assert "ots not found" in sandbox.log.read_text(encoding="utf-8")
+        assert not _proof_committed(sandbox.timestamps, commit)
+
+
+class TestPostCommit:
+    def _run(
+        self, sandbox: _Sandbox, **env_overrides: str
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(POST_COMMIT)],
+            env=sandbox.env(**env_overrides),
+            cwd=str(sandbox.main),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_skips_in_ci(self, sandbox: _Sandbox) -> None:
+        _commit(sandbox.main, "real")
+        result = self._run(sandbox, CI="true")
+
+        assert result.returncode == 0
+        assert not sandbox.queue.exists()
+
+    def test_warns_when_timestamps_absent(self, sandbox: _Sandbox) -> None:
+        _commit(sandbox.main, "real")
+        import shutil
+
+        shutil.rmtree(sandbox.timestamps)
+
+        result = self._run(sandbox)
+
+        assert result.returncode == 0
+        assert "not set up" in result.stderr
+        assert not sandbox.queue.exists()
+
+    def test_enqueues_commit_hash(self, sandbox: _Sandbox) -> None:
+        """post-commit appends the commit hash to the queue.
+
+        A held lock (live pid) stops the detached worker from draining the
+        queue, so the enqueued hash is observable regardless of worker timing.
+        """
+        commit = _commit(sandbox.main, "real")
+        lockdir = sandbox.state / "lock.d"
+        lockdir.mkdir()
+        (lockdir / "pid").write_text(str(os.getpid()), encoding="utf-8")
+
+        result = self._run(sandbox)
+
+        assert result.returncode == 0
+        assert sandbox.queued_hashes() == [commit]

--- a/scripts/tests/test_timestamp_worker.py
+++ b/scripts/tests/test_timestamp_worker.py
@@ -149,6 +149,9 @@ class _Sandbox:
             "PATH": f"{self.home / '.local' / 'bin'}:{os.environ['PATH']}",
             "OTS_GIT_ROOT": str(self.main),
             "OTS_STATE_DIR": str(self.state),
+            # post-commit skips entirely when CI=true; the GitHub Actions runner
+            # sets CI=true, so default it off here. test_skips_in_ci overrides.
+            "CI": "",
         }
         env.update(overrides)
         return env


### PR DESCRIPTION
## Summary

- `git commit` blocked ~3s on every commit because the `post-commit` OpenTimestamps hook ran three serial network operations inline (`ots stamp` against 4 calendar servers, then `git pull` + `git push` to the `.timestamps` repo), and rolled back the commit on any failure.
- Move all of that network work to a **detached background worker** so the commit returns in ~15ms (measured) and stamping happens asynchronously, best-effort, with retry.
- Also fixes the web/remote session setup so the pre-push checks stop aborting on a pnpm no-TTY prompt.

## Changes

**Async timestamp stamping** (`.hooks/post-commit`, `.hooks/timestamp-worker.sh`)
- `post-commit` now just appends the commit hash to a queue and launches `timestamp-worker.sh` detached (`setsid`/`nohup`), returning immediately. No more rollback of the user's commit on a network blip.
- The worker holds a portable `mkdir` lock (`flock` is absent on macOS), drains the queue, creates each proof, commits it into the `.timestamps` repo, and pushes the **whole batch in one** pull/push.
- **Retry guarantee**: a failed stamp re-queues its hash; a failed push leaves the proof committed-but-unpushed and the next worker retries it via `has_unpushed`. A commit is never rolled back, so no commit loses its eventual proof. Skipped entirely under `CI=true`. Errors (only) are logged to `$(git rev-parse --git-dir)/ots-timestamps/worker.log`.
- Self-review fixes: `stamp_one` no longer conflates "`.ots` exists on disk" with "committed+pushed" (a proof whose commit failed once is now recovered on retry via a staged-diff check); the main loop re-polls the queue after each drain to catch hashes enqueued mid-run, stopping on stamp failure to avoid hammering. The lock cleanup is inlined into the `trap` (resolves DeepSource SH-2329 / shellcheck SC2317 at the root).

**Pre-push fix** (`.claude/hooks/session-setup.sh`)
- The container's pre-provisioned `node_modules` can be inconsistent with the lockfile, so pnpm wants to purge+reinstall. Under no TTY that prompt aborts (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`); because the setup install is guarded by `|| warn`, it left `node_modules` stale and every later `pnpm exec` (including the pre-push checks) failed the same way. Pass `--config.confirm-modules-purge=false` so the purge proceeds non-interactively, leaving a consistent tree.

**Tests** (`scripts/tests/test_timestamp_worker.py`)
- New integration tests that drive the real bash hooks via subprocess against a throwaway git sandbox (main repo + cloned `.timestamps` repo wired to a bare origin), with a fake offline `ots` injected on `PATH` so they're hermetic — no network, no real `.timestamps` repo.
- Worker: stamp+commit+push, batching, orphaned-proof recovery, idempotent re-run (guards against an infinite loop), push-failure retry via `has_unpushed`, stamp-failure re-queue, lock contention + stale-lock steal, lock cleanup on exit, and the `ots`-missing / `.timestamps`-absent skips. post-commit: `CI` skip, absent-repo warning, hash enqueue.

**Docs** (`.claude/dev-notes.md`)
- New "Commit timestamping (OpenTimestamps, async)" section documenting the queue/lock/retry model and where to look (`worker.log`) when a proof is missing.

## Testing

- `shellcheck` + `shfmt -i 2` clean on both `.hooks/*` files; `shellcheck` clean on `session-setup.sh` (its tab style is by convention, not subject to `shfmt -i 2`).
- `scripts/tests/test_timestamp_worker.py` (14 tests) + existing `scripts/tests/test_timestamps.py` (8) — 22 passed under `-n auto`. `ruff check`/`ruff format`/`pyright` clean on the new file.
- End-to-end sandbox runs with real `ots stamp` + real git push to a local bare origin confirmed: `post-commit` returns in ~15ms; the detached worker batches two commits into a single push; retry, orphan-recovery, and idempotent-rerun all behave.
- pnpm fix: after a non-interactive install `pnpm exec prettier --version` → `3.8.3`, exit 0 (no purge prompt).

## Lessons Learned

- **What**: When a git hook does network I/O that isn't required for the commit object's validity (e.g. pushing an auxiliary proof to a separate repo), enqueue + detach a background worker instead of blocking the commit; make it best-effort with a retry queue rather than rolling back the user's commit on a network failure.
- **Where**: `.hooks/post-commit` / `.hooks/timestamp-worker.sh` pattern.
- **Why**: A synchronous, rollback-on-failure hook added ~3s to every commit and could undo a commit because a calendar server was slow.

- **What**: In headless/no-TTY environments, make `pnpm install` non-interactive with `--config.confirm-modules-purge=false` (do not set `CI=true` globally — it changes unrelated behavior). A setup install guarded by `|| warn` that silently aborts leaves `node_modules` stale and breaks every later `pnpm exec`.
- **Where**: `session-setup.sh` (web/remote session SessionStart hook).
- **Why**: The pre-push pipeline aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` and the failure was non-obvious because the root cause was an earlier, silently-warned setup install.

- **What**: To test a hook that detaches a background worker, test the worker script directly via subprocess (inject a fake offline binary on `PATH`) rather than asserting on the detached hand-off — a `setsid`-detached process does not reliably survive a subprocess that exits in sandboxed CI, so end-to-end detachment assertions are flaky.
- **Where**: `scripts/tests/test_timestamp_worker.py`.
- **Why**: The detached worker is reaped when the launching subprocess's process group is torn down in CI, so an end-to-end "post-commit → worker pushed" assertion times out even though the mechanism works in real interactive use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)