### PR TITLE
fix(ci): serve built site from repo root in Playwright webServer

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -1,5 +1,12 @@
 // Playwright configuration for cross-browser testing
 import { defineConfig, devices } from "@playwright/test"
+import { fileURLToPath } from "url"
+import { dirname, resolve } from "path"
+
+// Playwright resolves a relative `webServer.command` path against
+// `webServer.cwd`, which defaults to this config file's directory. The built
+// site lives at the repo root (`public/`), so pin the server's cwd there.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
 
 interface DeviceConfig {
   name: string
@@ -119,6 +126,7 @@ export default defineConfig({
         command: process.env.CI
           ? "pnpm serve public -l 8080 > /tmp/webserver.log 2>&1"
           : "INCLUDE_FIXTURES=true pnpm start",
+        cwd: repoRoot,
         url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 7 * 60 * 1000, // 7 minutes


### PR DESCRIPTION
## Summary

- `visual-testing` has been **red on `main` and every PR** (all shards, both platforms) with `Error: Timed out waiting 420000ms from config.webServer`. This fixes the root cause.
- One-line fix: pin the Playwright `webServer.cwd` to the repo root so the CI command `serve public` resolves to the built site.

## Root cause

Playwright's `webServer.cwd` **defaults to the config file's directory** (`config/playwright/`). The CI webServer command is `pnpm serve public -l 8080` — a **relative** path, resolved by the shell against that cwd. So in CI it served `config/playwright/public`, which **does not exist**.

I reproduced the failure chain locally:

- `serve <nonexistent-dir>` returns **404** for every path (`/`, `/test-page`, …); `serve <existing-dir>` returns **200** for `/` (index or directory listing) even when empty.
- Playwright 1.60 webServer readiness accepts only **2xx, 3xx, 400, 401, 402, 403** — a **404 never satisfies it** (confirmed in `playwright/types/test.d.ts`).

So `serve config/playwright/public` → 404 on `/` → readiness never succeeds → 7-minute timeout on every shard. Local dev was unaffected because the dev command is `pnpm start`, a package script that pnpm runs from the repo root.

This also explains the two earlier attempts: `eb9d856` (probe `/test-page`) couldn't help — `/test-page` 404s too when the served dir is missing — and `2ad54af` (cache-completeness) addressed a real but separate concern and left this bug in place.

## Changes

- `config/playwright/playwright.config.ts`: compute `repoRoot` via `resolve(dirname(fileURLToPath(import.meta.url)), "../..")` (the same idiom already used in `config/javascript/jest.config.js`) and set `webServer.cwd: repoRoot`. Now `serve public` resolves to `./public` (the built site) → `/` returns 200 → readiness passes.

## Testing

- Verified the config loads cleanly under Playwright's loader (`playwright test --list`), and `prettier` reports the file unchanged (formatting matches).
- The definitive verification is this PR's own **`visual-testing` workflow going green** — it exercises exactly this webServer path. Playwright configs are intentionally outside Jest's unit-coverage scope (like the repo's other CLI/config entrypoints), so a Jest unit test isn't the right guard here.

## Lessons learned

- **What**: When a Playwright config lives in a subdirectory, never use a bare relative path in `webServer.command` (e.g. `serve public`) — set `webServer.cwd` explicitly (or use an absolute path). `webServer.cwd` defaults to the *config file's directory*, not the repo root.
- **Where**: `config/playwright/playwright.config.ts` (and any Playwright config not at the repo root).
- **Why**: A relative serve path resolved against the config dir served a nonexistent directory; `serve` returns 404 for missing dirs and Playwright's readiness check rejects 404, so every shard hung until the 7-minute webServer timeout — silently breaking visual CI repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEn3AWrUd1pLcRKD5AvLGa)_