### PR TITLE
Normalize tag names: replace ampersand with "and"

### DIFF
--- a/website_content/a-kernel-of-truth-insights-from-a-friendly-approach-to.md
+++ b/website_content/a-kernel-of-truth-insights-from-a-friendly-approach-to.md
@@ -20,7 +20,7 @@ title: "A Kernel of Truth: Insights from 'A Friendly Approach to Functional Anal
 lw-latest-edit: 2020-04-04T13:18:43.104000Z
 lw-is-linkpost: 'false'
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - understanding-the-world
   - mathematics
 aliases:

--- a/website_content/confounded-no-longer-insights-from-all-of-statistics.md
+++ b/website_content/confounded-no-longer-insights-from-all-of-statistics.md
@@ -21,7 +21,7 @@ lw-latest-edit: 2018-05-03T22:56:27.057000Z
 lw-is-linkpost: 'false'
 tags:
   - summaries
-  - scholarship-&-learning
+  - scholarship-and-learning
   - mathematics
 aliases:
   - confounded-no-longer-insights-from-all-of-statistics

--- a/website_content/how-i-do-research.md
+++ b/website_content/how-i-do-research.md
@@ -21,7 +21,7 @@ lw-latest-edit: 2019-11-20T21:28:11.835000Z
 lw-is-linkpost: 'false'
 tags:
   - rationality
-  - scholarship-&-learning
+  - scholarship-and-learning
 aliases:
   - how-i-do-research
 lw-reward-post-warning: 'false'

--- a/website_content/insights-from-euclid-s-elements.md
+++ b/website_content/insights-from-euclid-s-elements.md
@@ -20,7 +20,7 @@ title: Insights from Euclid's 'Elements'
 lw-latest-edit: 2021-02-15T03:50:14.043000Z
 lw-is-linkpost: "false"
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - understanding-the-world
   - mathematics
 aliases:

--- a/website_content/judgment-day-insights-from-judgment-in-managerial-decision.md
+++ b/website_content/judgment-day-insights-from-judgment-in-managerial-decision.md
@@ -21,7 +21,7 @@ lw-latest-edit: 2019-12-30T00:31:36.289000Z
 lw-is-linkpost: 'false'
 tags:
   - understanding-the-world
-  - scholarship-&-learning
+  - scholarship-and-learning
 aliases:
   - judgment-day-insights-from-judgment-in-managerial-decision
 lw-sequence-title: Becoming Stronger

--- a/website_content/lessons-i-ve-learned-from-self-teaching.md
+++ b/website_content/lessons-i-ve-learned-from-self-teaching.md
@@ -20,7 +20,7 @@ title: Lessons I've Learned from Self-Teaching
 lw-latest-edit: 2021-12-05T17:56:31.967000Z
 lw-is-linkpost: "false"
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - practical
   - rationality
 aliases:

--- a/website_content/ode-to-joy-insights-from-a-first-course-in-ordinary.md
+++ b/website_content/ode-to-joy-insights-from-a-first-course-in-ordinary.md
@@ -20,7 +20,7 @@ title: "ODE to Joy: Insights from 'A First Course in Ordinary Differential Equat
 lw-latest-edit: 2020-03-25T22:12:25.494000Z
 lw-is-linkpost: "false"
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - understanding-the-world
   - mathematics
 aliases:

--- a/website_content/set-up-for-success-insights-from-naive-set-theory.md
+++ b/website_content/set-up-for-success-insights-from-naive-set-theory.md
@@ -20,7 +20,7 @@ title: "Set Up for Success: Insights from 'Naïve Set Theory'"
 lw-latest-edit: 2018-02-28T02:01:43.790000Z
 lw-is-linkpost: 'false'
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - mathematics
 aliases:
   - set-up-for-success-insights-from-naive-set-theory

--- a/website_content/the-art-of-the-artificial-insights-from-artificial.md
+++ b/website_content/the-art-of-the-artificial-insights-from-artificial.md
@@ -21,7 +21,7 @@ lw-latest-edit: 2018-03-25T06:55:46.204000Z
 lw-is-linkpost: "false"
 tags:
   - AI
-  - scholarship-&-learning
+  - scholarship-and-learning
 aliases:
   - the-art-of-the-artificial-insights-from-artificial
 lw-sequence-title: Becoming Stronger

--- a/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
+++ b/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
@@ -20,7 +20,7 @@ title: "The First Rung: Insights from 'Linear Algebra Done Right'"
 lw-latest-edit: 2018-04-22T05:23:49.024000Z
 lw-is-linkpost: 'false'
 tags:
-  - scholarship-&-learning
+  - scholarship-and-learning
   - mathematics
 aliases:
   - the-first-rung-insights-from-linear-algebra-done-right


### PR DESCRIPTION
## Summary
Standardize the `scholarship-&-learning` tag to `scholarship-and-learning` across all content files for consistency and improved readability.

## Changes
- Updated tag name in 10 content files from `scholarship-&-learning` to `scholarship-and-learning`:
  - a-kernel-of-truth-insights-from-a-friendly-approach-to.md
  - confounded-no-longer-insights-from-all-of-statistics.md
  - how-i-do-research.md
  - insights-from-euclid-s-elements.md
  - judgment-day-insights-from-judgment-in-managerial-decision.md
  - lessons-i-ve-learned-from-self-teaching.md
  - ode-to-joy-insights-from-a-first-course-in-ordinary.md
  - set-up-for-success-insights-from-naive-set-theory.md
  - the-art-of-the-artificial-insights-from-artificial.md
  - the-first-rung-insights-from-linear-algebra-done-right.md

## Details
This change improves tag consistency by replacing the ampersand character (`&`) with the word "and" in the tag name. This makes the tag more readable and follows a more conventional naming pattern for multi-word tags.

https://claude.ai/code/session_019GT8NdddTja98Dx7ooN63H