### PR TITLE
Load VOYAGE_API_KEY from envchain in pre-push hook

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -11,6 +11,16 @@ if [ -d "$GIT_ROOT/node_modules/.bin" ]; then
   export PATH="$GIT_ROOT/node_modules/.bin:$PATH"
 fi
 
+# Source VOYAGE_API_KEY from the `ai` envchain namespace when it isn't already
+# in the environment, so the related-posts step can run without the key being
+# exported globally. If envchain or the key is unavailable, VOYAGE_API_KEY stays
+# empty and run_push_checks.py skips that step with a warning.
+if [ -z "${VOYAGE_API_KEY:-}" ] && command -v envchain >/dev/null 2>&1; then
+  # shellcheck disable=SC2016  # $VOYAGE_API_KEY must expand in envchain's shell.
+  VOYAGE_API_KEY=$(envchain ai sh -c 'printf %s "$VOYAGE_API_KEY"' 2>/dev/null) || VOYAGE_API_KEY=""
+  export VOYAGE_API_KEY
+fi
+
 RESUME_FLAG=""
 if [ "$RESUME" = "true" ]; then
   echo "Resuming from last failed step."

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -11,14 +11,15 @@ if [ -d "$GIT_ROOT/node_modules/.bin" ]; then
   export PATH="$GIT_ROOT/node_modules/.bin:$PATH"
 fi
 
-# Source VOYAGE_API_KEY from the `ai` envchain namespace when it isn't already
-# in the environment, so the related-posts step can run without the key being
-# exported globally. If envchain or the key is unavailable, VOYAGE_API_KEY stays
-# empty and run_push_checks.py skips that step with a warning.
-if [ -z "${VOYAGE_API_KEY:-}" ] && command -v envchain >/dev/null 2>&1; then
+# Fetch VOYAGE_API_KEY from the `ai` envchain namespace when it isn't already
+# available, so the related-posts step can run. The key is passed only to the
+# checks command below rather than exported into the hook's environment. If
+# envchain or the key is unavailable, VOYAGE_API_KEY stays empty and
+# run_push_checks.py skips that step with a warning.
+VOYAGE_API_KEY="${VOYAGE_API_KEY:-}"
+if [ -z "$VOYAGE_API_KEY" ] && command -v envchain >/dev/null 2>&1; then
   # shellcheck disable=SC2016  # $VOYAGE_API_KEY must expand in envchain's shell.
   VOYAGE_API_KEY=$(envchain ai sh -c 'printf %s "$VOYAGE_API_KEY"' 2>/dev/null) || VOYAGE_API_KEY=""
-  export VOYAGE_API_KEY
 fi
 
 RESUME_FLAG=""
@@ -77,7 +78,7 @@ fi
 # Temporarily disable `set -e` so we can capture the exact exit status and
 # print the resume hint before propagating the failure.
 set +e
-uv run python "$GIT_ROOT/scripts/run_push_checks.py" $RESUME_FLAG
+VOYAGE_API_KEY="$VOYAGE_API_KEY" uv run python "$GIT_ROOT/scripts/run_push_checks.py" $RESUME_FLAG
 _checks_status=$?
 set -e
 


### PR DESCRIPTION
## Summary
Adds support for sourcing the `VOYAGE_API_KEY` environment variable from the `ai` envchain namespace during the pre-push hook, allowing the related-posts step to run without requiring the key to be exported globally.

## Changes
- Modified `.hooks/pre-push` to check for and load `VOYAGE_API_KEY` from envchain when:
  - The variable is not already set in the environment
  - The `envchain` command is available
- If envchain or the key is unavailable, the variable remains empty and `run_push_checks.py` skips the related-posts step with a warning
- Added appropriate shell linting directives to handle variable expansion in envchain's subshell

## Implementation details
- Uses `command -v` to safely check for envchain availability
- Gracefully degrades if envchain is missing or the key lookup fails (sets `VOYAGE_API_KEY=""`)
- Exports the variable so it's available to downstream scripts in the push workflow
- Includes a shellcheck disable comment to allow `$VOYAGE_API_KEY` to expand within the envchain command string

https://claude.ai/code/session_01VoPzFXcU1c1NuijJKdfiqx