### PR TITLE
fix: demote within-page links inside transcludes to internal links

### DIFF
--- a/quartz/components/tests/renderPage.test.tsx
+++ b/quartz/components/tests/renderPage.test.tsx
@@ -255,6 +255,68 @@ describe("renderPage", () => {
     expect(html).toContain("./source-page/nested#intro")
   })
 
+  it("demotes a transcluded same-page link to a normal internal link", () => {
+    const anchorFavicon: Element = {
+      type: "element",
+      tagName: "svg",
+      children: [],
+      properties: {
+        class: "favicon",
+        "data-domain": "anchor",
+        style:
+          "--mask-url: url(https://assets.turntrout.com/static/images/external-favicons/anchor.svg);",
+      },
+    }
+    const link = h("a", { href: "#intro", className: ["internal", "same-page-link"] }, [
+      h("span", { className: ["favicon-span"] }, ["Link", anchorFavicon]),
+    ])
+
+    const transcludedPage: QuartzPluginData = {
+      slug: "source-page/nested" as FullSlug,
+      frontmatter: { title: "Source Page" },
+      htmlAst: {
+        type: "root",
+        children: [h("p", [link]) as unknown as Element],
+      },
+    } as unknown as QuartzPluginData
+
+    const props = createMockProps(
+      {
+        tree: {
+          type: "root",
+          children: [
+            h("span", { className: ["transclude"], dataUrl: "source-page/nested", dataBlock: "" }),
+          ],
+        } as unknown as Root,
+      },
+      [transcludedPage],
+    )
+
+    const html = renderPage(
+      props.cfg,
+      "current-page" as FullSlug,
+      props,
+      {
+        ...components,
+        pageBody: ({ tree }: QuartzComponentProps) => (
+          <div id="page-body">{JSON.stringify(tree)}</div>
+        ),
+      } as typeof components,
+      pageResources,
+    )
+
+    // The transcluded link is serialized as escaped JSON inside #page-body; scope
+    // assertions to it so the page shell's own skip-to-content link is ignored.
+    const pageBody = html.slice(html.indexOf('id="page-body"'))
+    expect(pageBody).toContain("./source-page/nested#intro")
+    // Demoted: same-page-link dropped (className is internal-only), anchor favicon
+    // swapped for the turntrout favicon.
+    expect(pageBody).toContain("[&quot;internal&quot;]")
+    expect(pageBody).toContain("turntrout_com")
+    expect(pageBody).not.toContain("same-page-link")
+    expect(pageBody).not.toContain("&quot;anchor&quot;")
+  })
+
   it.each([
     {
       name: "intro transclusion with ![[page#]]",

--- a/quartz/components/tests/transclude.spec.ts
+++ b/quartz/components/tests/transclude.spec.ts
@@ -3,47 +3,34 @@ import { expect, test } from "./fixtures"
 const TEST_PAGE_URL = "http://localhost:8080/test-page"
 
 // The "Section to transclude" contains a within-page link to #admonitions. It is
-// rendered twice: once inline (a genuine same-page link, href "#admonitions") and
-// once inside the `[!quote]` transclude above it, where it is rebased to a
-// cross-page link back to this page (href ".../test-page#admonitions") and must be
-// demoted to a normal internal link. The transcluded block paragraph is hoisted
-// out of the inline `span.transclude` by the HTML parser, so target the links by
-// their distinct hrefs rather than by DOM ancestry.
-const TRANSCLUDED_LINK = 'a[href$="test-page#admonitions"]'
-const INLINE_LINK = 'a.same-page-link.can-trigger-popover[href="#admonitions"]'
+// rendered twice: once inline and once inside the `[!quote]` transclude above it.
+// Because that transclude is from the same page (`![[/test-page#...]]`), the link
+// still resolves on this page, so both copies must stay normal same-page links
+// (anchor favicon kept, not demoted to an internal turntrout link).
+const WITHIN_PAGE_LINKS = 'a.same-page-link.can-trigger-popover[href="#admonitions"]'
+const DEMOTED_LINK = 'a[href$="test-page#admonitions"]'
 
 test.beforeEach(async ({ page }) => {
   await page.goto(TEST_PAGE_URL, { waitUntil: "domcontentloaded" })
 })
 
-test.describe("Within-page links inside transcludes", () => {
-  test("are demoted from same-page links to internal links", async ({ page }) => {
-    const transcludedLink = page.locator(TRANSCLUDED_LINK)
-    await expect(transcludedLink).toHaveCount(1)
+test.describe("Within-page links inside same-page transcludes", () => {
+  test("keep their within-page (anchor) favicon", async ({ page }) => {
+    // Both the inline copy and the transcluded copy survive as same-page links.
+    await expect(page.locator(WITHIN_PAGE_LINKS)).toHaveCount(2)
+    await expect(
+      page.locator(`${WITHIN_PAGE_LINKS} svg.favicon[data-domain="anchor"]`),
+    ).toHaveCount(2)
 
-    // No longer a same-page link (so the SPA router navigates instead of trying
-    // to scroll to a non-existent host-page anchor), but still internal.
-    await expect(transcludedLink).not.toHaveClass(/same-page-link/)
-    await expect(transcludedLink).toHaveClass(/internal/)
-
-    // The same-page (anchor) favicon was swapped for the internal turntrout one.
-    await expect(transcludedLink.locator("svg.favicon")).toHaveAttribute(
-      "data-domain",
-      "turntrout_com",
-    )
-  })
-
-  test("leave the inline same-page link untouched", async ({ page }) => {
-    const inlineLink = page.locator(INLINE_LINK)
-    await expect(inlineLink).toHaveCount(1)
-    await expect(inlineLink.locator("svg.favicon")).toHaveAttribute("data-domain", "anchor")
+    // The link was not rebased to a cross-page link, so nothing was demoted.
+    await expect(page.locator(DEMOTED_LINK)).toHaveCount(0)
   })
 
   test("scroll to the target header when clicked", async ({ page }) => {
     const heading = page.locator("#admonitions")
     await expect(heading).toHaveCount(1)
 
-    await page.locator(TRANSCLUDED_LINK).click()
+    await page.locator(WITHIN_PAGE_LINKS).first().click()
 
     // The header should be scrolled into view near the top of the viewport.
     await expect

--- a/quartz/components/tests/transclude.spec.ts
+++ b/quartz/components/tests/transclude.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "./fixtures"
+
+const TEST_PAGE_URL = "http://localhost:8080/test-page"
+
+// The "Section to transclude" contains a within-page link to #admonitions. It is
+// rendered twice: once inline (a genuine same-page link) and once inside the
+// `[!quote]` transclude above it, where it is rebased to a cross-page link and
+// must be demoted to a normal internal link.
+const TRANSCLUDED_LINK = 'span.transclude a[href$="#admonitions"]'
+const INLINE_LINK = 'article > p a.same-page-link[href="#admonitions"]'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(TEST_PAGE_URL, { waitUntil: "domcontentloaded" })
+})
+
+test.describe("Within-page links inside transcludes", () => {
+  test("are demoted from same-page links to internal links", async ({ page }) => {
+    const transcludedLink = page.locator(TRANSCLUDED_LINK).first()
+    await expect(transcludedLink).toHaveCount(1)
+
+    // No longer a same-page link (so the SPA router navigates instead of trying
+    // to scroll to a non-existent host-page anchor), but still internal.
+    await expect(transcludedLink).not.toHaveClass(/same-page-link/)
+    await expect(transcludedLink).toHaveClass(/internal/)
+
+    // The same-page (anchor) favicon was swapped for the internal turntrout one.
+    await expect(transcludedLink.locator("svg.favicon")).toHaveAttribute(
+      "data-domain",
+      "turntrout_com",
+    )
+  })
+
+  test("leave the inline same-page link untouched", async ({ page }) => {
+    const inlineLink = page.locator(INLINE_LINK).first()
+    await expect(inlineLink).toHaveCount(1)
+    await expect(inlineLink.locator("svg.favicon")).toHaveAttribute("data-domain", "anchor")
+  })
+
+  test("scroll to the target header when clicked", async ({ page }) => {
+    const heading = page.locator("#admonitions")
+    await expect(heading).toHaveCount(1)
+
+    await page.locator(TRANSCLUDED_LINK).first().click()
+
+    // The header should be scrolled into view near the top of the viewport.
+    await expect
+      .poll(async () => {
+        const box = await heading.boundingBox()
+        return box ? box.y : Number.POSITIVE_INFINITY
+      })
+      .toBeLessThan(200)
+  })
+})

--- a/quartz/components/tests/transclude.spec.ts
+++ b/quartz/components/tests/transclude.spec.ts
@@ -3,11 +3,14 @@ import { expect, test } from "./fixtures"
 const TEST_PAGE_URL = "http://localhost:8080/test-page"
 
 // The "Section to transclude" contains a within-page link to #admonitions. It is
-// rendered twice: once inline (a genuine same-page link) and once inside the
-// `[!quote]` transclude above it, where it is rebased to a cross-page link and
-// must be demoted to a normal internal link.
-const TRANSCLUDED_LINK = 'span.transclude a[href$="#admonitions"]'
-const INLINE_LINK = 'article > p a.same-page-link[href="#admonitions"]'
+// rendered twice: once inline (a genuine same-page link, href "#admonitions") and
+// once inside the `[!quote]` transclude above it, where it is rebased to a
+// cross-page link back to this page (href ".../test-page#admonitions") and must be
+// demoted to a normal internal link. The transcluded block paragraph is hoisted
+// out of the inline `span.transclude` by the HTML parser, so target the links by
+// their distinct hrefs rather than by DOM ancestry.
+const TRANSCLUDED_LINK = 'a[href$="test-page#admonitions"]'
+const INLINE_LINK = 'a.same-page-link.can-trigger-popover[href="#admonitions"]'
 
 test.beforeEach(async ({ page }) => {
   await page.goto(TEST_PAGE_URL, { waitUntil: "domcontentloaded" })
@@ -15,7 +18,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("Within-page links inside transcludes", () => {
   test("are demoted from same-page links to internal links", async ({ page }) => {
-    const transcludedLink = page.locator(TRANSCLUDED_LINK).first()
+    const transcludedLink = page.locator(TRANSCLUDED_LINK)
     await expect(transcludedLink).toHaveCount(1)
 
     // No longer a same-page link (so the SPA router navigates instead of trying
@@ -31,7 +34,7 @@ test.describe("Within-page links inside transcludes", () => {
   })
 
   test("leave the inline same-page link untouched", async ({ page }) => {
-    const inlineLink = page.locator(INLINE_LINK).first()
+    const inlineLink = page.locator(INLINE_LINK)
     await expect(inlineLink).toHaveCount(1)
     await expect(inlineLink.locator("svg.favicon")).toHaveAttribute("data-domain", "anchor")
   })
@@ -40,7 +43,7 @@ test.describe("Within-page links inside transcludes", () => {
     const heading = page.locator("#admonitions")
     await expect(heading).toHaveCount(1)
 
-    await page.locator(TRANSCLUDED_LINK).first().click()
+    await page.locator(TRANSCLUDED_LINK).click()
 
     // The header should be scrolled into view near the top of the viewport.
     await expect

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -3,6 +3,7 @@ import type { Element, Text } from "hast"
 import { describe, expect, it } from "@jest/globals"
 import { h } from "hastscript"
 
+import { specialFaviconPaths } from "../components/constants"
 import { type FullSlug, normalizeHastElement } from "./path"
 
 describe("normalizeHastElement", () => {
@@ -125,5 +126,65 @@ describe("normalizeHastElement", () => {
     const result = normalizeHastElement(input, baseSlug, newSlug)
     const anchor = result.children[0] as Element
     expect(anchor.properties?.href).toBe("../other/page#footnote")
+  })
+
+  describe("demotes within-page links rebased to the source page", () => {
+    // Favicons are hand-constructed in createFaviconElement with a literal
+    // "data-domain" key (not via hastscript), so mirror that shape exactly.
+    const faviconNode = (domain: string, maskUrl: string): Element => ({
+      type: "element",
+      tagName: "svg",
+      children: [],
+      properties: {
+        class: "favicon",
+        "data-domain": domain,
+        style: `--mask-url: url(${maskUrl});`,
+      },
+    })
+    const anchorFavicon = () => faviconNode("anchor", specialFaviconPaths.anchor)
+
+    it("drops same-page-link and swaps the anchor favicon for the turntrout favicon", () => {
+      const link = h(
+        "a",
+        { href: "#section", className: ["internal", "same-page-link", "can-trigger-popover"] },
+        [h("span", { className: ["favicon-span"] }, ["Link", anchorFavicon()])],
+      )
+      const result = normalizeHastElement(h("p", [link]), baseSlug, newSlug)
+      const anchor = result.children[0] as Element
+
+      expect(anchor.properties?.href).toBe("../other/page#section")
+      expect(anchor.properties?.className).toEqual(["internal", "can-trigger-popover"])
+
+      const favicon = (anchor.children[0] as Element).children[1] as Element
+      expect(favicon.properties?.["data-domain"]).toBe("turntrout_com")
+      expect(favicon.properties?.style).toBe(`--mask-url: url(${specialFaviconPaths.turntrout});`)
+    })
+
+    it("removes same-page-link from a string-form className", () => {
+      const link = h("a", { href: "#section" }, "Link")
+      link.properties.className = "internal same-page-link"
+      const result = normalizeHastElement(h("p", [link]), baseSlug, newSlug)
+      const anchor = result.children[0] as Element
+      expect(anchor.properties?.className).toBe("internal")
+    })
+
+    it("leaves favicons for other domains untouched", () => {
+      const otherFavicon = faviconNode("wikipedia_org", "x")
+      const link = h("a", { href: "#section", className: ["same-page-link"] }, [
+        h("span", { className: ["favicon-span"] }, ["Link", otherFavicon]),
+      ])
+      const result = normalizeHastElement(h("p", [link]), baseSlug, newSlug)
+      const favicon = ((result.children[0] as Element).children[0] as Element)
+        .children[1] as Element
+      expect(favicon.properties?.["data-domain"]).toBe("wikipedia_org")
+    })
+
+    it("does not demote non-anchor elements that carry an anchor-only href", () => {
+      const div = h("div", { href: "#section", className: ["same-page-link"] }, "x")
+      const result = normalizeHastElement(h("section", [div]), baseSlug, newSlug)
+      const child = result.children[0] as Element
+      expect(child.properties?.href).toBe("../other/page#section")
+      expect(child.properties?.className).toEqual(["same-page-link"])
+    })
   })
 })

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -167,6 +167,15 @@ describe("normalizeHastElement", () => {
       expect(anchor.properties?.className).toEqual(["internal"])
     })
 
+    it("drops same-page-link from a string className (footnote backrefs)", () => {
+      // Footnote backrefs from rehype-gfm carry a space-separated string className.
+      const link = h("a", { href: "#user-content-fnref-1" }, "↩")
+      link.properties.className = "data-footnote-backref internal same-page-link"
+      const result = normalizeHastElement(h("p", [link]), baseSlug, newSlug)
+      const anchor = result.children[0] as Element
+      expect(anchor.properties?.className).toBe("data-footnote-backref internal")
+    })
+
     it("leaves favicons for other domains untouched", () => {
       const otherFavicon = faviconNode("wikipedia_org", "x")
       const link = h("a", { href: "#section", className: ["same-page-link"] }, [

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -160,12 +160,11 @@ describe("normalizeHastElement", () => {
       expect(favicon.properties?.style).toBe(`--mask-url: url(${specialFaviconPaths.turntrout});`)
     })
 
-    it("removes same-page-link from a string-form className", () => {
-      const link = h("a", { href: "#section" }, "Link")
-      link.properties.className = "internal same-page-link"
+    it("drops same-page-link even when the link carries no favicon", () => {
+      const link = h("a", { href: "#section", className: ["internal", "same-page-link"] }, "Link")
       const result = normalizeHastElement(h("p", [link]), baseSlug, newSlug)
       const anchor = result.children[0] as Element
-      expect(anchor.properties?.className).toBe("internal")
+      expect(anchor.properties?.className).toEqual(["internal"])
     })
 
     it("leaves favicons for other domains untouched", () => {

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -194,5 +194,20 @@ describe("normalizeHastElement", () => {
       expect(child.properties?.href).toBe("../other/page#section")
       expect(child.properties?.className).toEqual(["same-page-link"])
     })
+
+    it("keeps the within-page favicon for a same-page transclusion", () => {
+      // curBase === newBase: the anchor still resolves on the host page, so the
+      // link and its anchor favicon must be left untouched.
+      const link = h("a", { href: "#section", className: ["internal", "same-page-link"] }, [
+        h("span", { className: ["favicon-span"] }, ["Link", anchorFavicon()]),
+      ])
+      const result = normalizeHastElement(h("p", [link]), baseSlug, baseSlug)
+      const anchor = result.children[0] as Element
+
+      expect(anchor.properties?.href).toBe("#section")
+      expect(anchor.properties?.className).toEqual(["internal", "same-page-link"])
+      const favicon = (anchor.children[0] as Element).children[1] as Element
+      expect(favicon.properties?.["data-domain"]).toBe("anchor")
+    })
   })
 })

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -228,6 +228,11 @@ const _rebaseHastElement = (
 
     // Handle anchor-only links (e.g., #section)
     if (attrValue.startsWith("#")) {
+      // A same-page transclusion keeps the link on its own page, so the anchor
+      // still resolves there: leave it (and its within-page favicon) untouched.
+      if (curBase === newBase) {
+        return
+      }
       const relativeToOriginal = resolveRelative(curBase, newBase)
       el.properties[attr] = relativeToOriginal + attrValue
       demoteRebasedAnchorLink(el)

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -173,29 +173,10 @@ export function normalizeRelativeURLs(el: Element | Document, destination: strin
   )
 }
 
-// The `data-domain` a favicon carries identifies which icon it renders. The
-// same-page (anchor) favicon and the internal turntrout favicon are the two
-// relevant here.
-const ANCHOR_FAVICON_DOMAIN = "anchor"
-const TURNTROUT_FAVICON_DOMAIN = "turntrout_com"
-
-/** Removes a class from a HAST element's className, preserving its shape (string or array). */
-function removeClass(el: HastElement, className: string): void {
-  const existing = el.properties?.className
-  if (typeof existing === "string") {
-    el.properties.className = existing
-      .split(/\s+/)
-      .filter((c) => c && c !== className)
-      .join(" ")
-  } else if (Array.isArray(existing)) {
-    el.properties.className = existing.filter((c) => String(c) !== className)
-  }
-}
-
 /** Rewrites an anchor (same-page) favicon descendant in place to the internal turntrout favicon. */
 function retargetAnchorFaviconToInternal(el: HastElement): void {
-  if (el.tagName === "svg" && el.properties?.["data-domain"] === ANCHOR_FAVICON_DOMAIN) {
-    el.properties["data-domain"] = TURNTROUT_FAVICON_DOMAIN
+  if (el.tagName === "svg" && el.properties?.["data-domain"] === "anchor") {
+    el.properties["data-domain"] = "turntrout_com"
     el.properties.style = `--mask-url: url(${specialFaviconPaths.turntrout});`
   }
   for (const child of el.children) {
@@ -214,7 +195,10 @@ function retargetAnchorFaviconToInternal(el: HastElement): void {
  */
 function demoteRebasedAnchorLink(el: HastElement): void {
   if (el.tagName !== "a") return
-  removeClass(el, "same-page-link")
+  const classes = el.properties?.className
+  if (Array.isArray(classes)) {
+    el.properties.className = classes.filter((c) => String(c) !== "same-page-link")
+  }
   retargetAnchorFaviconToInternal(el)
 }
 

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -195,9 +195,16 @@ function retargetAnchorFaviconToInternal(el: HastElement): void {
  */
 function demoteRebasedAnchorLink(el: HastElement): void {
   if (el.tagName !== "a") return
+  // Same-page links carry their classes as an array (markdown links) or a
+  // space-separated string (footnote backrefs from rehype-gfm); handle both.
   const classes = el.properties?.className
   if (Array.isArray(classes)) {
     el.properties.className = classes.filter((c) => String(c) !== "same-page-link")
+  } else if (typeof classes === "string") {
+    el.properties.className = classes
+      .split(/\s+/)
+      .filter((c) => c && c !== "same-page-link")
+      .join(" ")
   }
   retargetAnchorFaviconToInternal(el)
 }

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -3,6 +3,8 @@ import type { Element as HastElement } from "hast"
 import { slug as slugAnchor } from "github-slugger"
 import rfdc from "rfdc"
 
+import { specialFaviconPaths } from "../components/constants"
+
 export const clone = rfdc()
 
 // this file must be isomorphic so it can't use node libs (e.g. path)
@@ -171,6 +173,51 @@ export function normalizeRelativeURLs(el: Element | Document, destination: strin
   )
 }
 
+// The `data-domain` a favicon carries identifies which icon it renders. The
+// same-page (anchor) favicon and the internal turntrout favicon are the two
+// relevant here.
+const ANCHOR_FAVICON_DOMAIN = "anchor"
+const TURNTROUT_FAVICON_DOMAIN = "turntrout_com"
+
+/** Removes a class from a HAST element's className, preserving its shape (string or array). */
+function removeClass(el: HastElement, className: string): void {
+  const existing = el.properties?.className
+  if (typeof existing === "string") {
+    el.properties.className = existing
+      .split(/\s+/)
+      .filter((c) => c && c !== className)
+      .join(" ")
+  } else if (Array.isArray(existing)) {
+    el.properties.className = existing.filter((c) => String(c) !== className)
+  }
+}
+
+/** Rewrites an anchor (same-page) favicon descendant in place to the internal turntrout favicon. */
+function retargetAnchorFaviconToInternal(el: HastElement): void {
+  if (el.tagName === "svg" && el.properties?.["data-domain"] === ANCHOR_FAVICON_DOMAIN) {
+    el.properties["data-domain"] = TURNTROUT_FAVICON_DOMAIN
+    el.properties.style = `--mask-url: url(${specialFaviconPaths.turntrout});`
+  }
+  for (const child of el.children) {
+    if ((child as HastElement).type === "element") {
+      retargetAnchorFaviconToInternal(child as HastElement)
+    }
+  }
+}
+
+/**
+ * An author-written `[text](#section)` link is decorated as a same-page link at
+ * its source page's transform stage. Once transcluded, it is rebased to a
+ * cross-page link back to the source, so demote it to a normal internal link:
+ * drop the `same-page-link` class (which otherwise suppresses navigation) and
+ * swap its anchor favicon for the internal turntrout favicon.
+ */
+function demoteRebasedAnchorLink(el: HastElement): void {
+  if (el.tagName !== "a") return
+  removeClass(el, "same-page-link")
+  retargetAnchorFaviconToInternal(el)
+}
+
 /**
  * Rebases a HAST element's attribute to a new base slug
  *
@@ -192,6 +239,7 @@ const _rebaseHastElement = (
     if (attrValue.startsWith("#")) {
       const relativeToOriginal = resolveRelative(curBase, newBase)
       el.properties[attr] = relativeToOriginal + attrValue
+      demoteRebasedAnchorLink(el)
       return
     }
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -182,7 +182,7 @@ Admonition in a description list
 
 ## Section to transclude
 
-Hi! Am I being transcluded? Here is a within-page link to the [admonitions section](#admonitions); when this section is transcluded above, the link points back to this page and renders as a normal internal link.
+Hi! Am I being transcluded? Here is a within-page link to the [admonitions section](#admonitions); because the transclusion above is from this same page, both copies stay within-page links.
 
 # Admonitions
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -182,7 +182,7 @@ Admonition in a description list
 
 ## Section to transclude
 
-Hi! Am I being transcluded?
+Hi! Am I being transcluded? Here is a within-page link to the [admonitions section](#admonitions); when this section is transcluded above, the link points back to this page and renders as a normal internal link.
 
 # Admonitions
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -182,7 +182,7 @@ Admonition in a description list
 
 ## Section to transclude
 
-Hi! Am I being transcluded? Here is a within-page link to the [admonitions section](#admonitions); because the transclusion above is from this same page, both copies stay within-page links.
+Hi! Am I being transcluded? Here is a within-page link to the [admonitions section](#admonitions); because this section is transcluded from the same page above, both copies stay within-page links.
 
 # Admonitions
 


### PR DESCRIPTION
## Summary

- Author-written within-page links (`[text](#section)`) inside transcluded content were rebased to a cross-page link back to the source page, but kept the `same-page-link` class and anchor favicon they acquired at the source page's transform stage.
- This left them rendered with the same-page (anchor) favicon and prevented the SPA router from navigating: it treated them as in-page links and tried to scroll to an anchor that doesn't exist on the host page (while the hover popover, which reads the real `href`, worked fine).
- **Cross-page transclusion:** demote the link to a normal internal link.
- **Same-page transclusion** (a page transcluded into itself): the anchor still resolves on the host page, so the link is left untouched — it keeps its within-page (anchor) favicon and in-page navigation.

## Changes

- `quartz/util/path.ts`:
  - When an anchor-only link is rebased during a **cross-page** transclusion, demote it to a normal internal link — drop the `same-page-link` class (array form from markdown links and the space-separated string form from rehype-gfm footnote backrefs) and swap its anchor favicon for the internal turntrout favicon. Heading-autolink anchors are untouched (separate `skipHref` path).
  - When the transclusion is **same-page** (`curBase === newBase`), skip the rebase + demotion entirely so the within-page favicon and in-page link behavior are preserved.
- `quartz/util/path.test.ts`: unit tests for cross-page demotion (array/string className, favicon swap, no-favicon case, other-domain favicons untouched, non-anchor elements skipped) and for the same-page case keeping the anchor favicon.
- `quartz/components/tests/renderPage.test.tsx`: integration test asserting cross-page demotion through the full `renderPage` transclusion path.
- `quartz/components/tests/transclude.spec.ts`: Playwright spec (mobile + desktop projects) verifying that the same-page transclude on `test-page` keeps both link copies as within-page links with the anchor favicon, and that clicking scrolls to the target header.
- `website_content/test-page.md`: a representative within-page link inside the transcluded section so the rendering is captured by visual regression.

## Testing

- TypeScript unit + integration tests pass (79 in the two suites), full branch coverage of the new code.
- `pnpm check` (tsc): no new errors (5 pre-existing failures in `spa_utils.test.ts`, unrelated).
- Prettier + ESLint clean on changed files.
- Selectors validated against the live PR preview DOM.

## Lessons Learned

- **What**: In the PR critique loop, do not delete a "defensive" branch a critique flags as synthetic without first grepping for real upstream producers of that shape.
- **Where**: `.claude/skills/pr-creation/critique-prompt.md` (compression guidance).
- **Why**: A first-pass critique called the string-form `className` branch "only there for a synthetic test." It was actually live — rehype-gfm footnote backrefs (`data-footnote-backref internal same-page-link`) carry a string className with an anchor-only href, so removing the branch silently re-introduced the bug for footnotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)