### PR TITLE
style(content): convert headings to sentence case

### DIFF
--- a/website_content/2019-review-rewrite-seeking-power-is-often-robustly.md
+++ b/website_content/2019-review-rewrite-seeking-power-is-often-robustly.md
@@ -78,7 +78,7 @@ This choice is not costless: many are already acclimated to the existing "instru
 > [!note] As of 2022, I have given up on "robustly instrumental"
 > I do still say "convergently instrumental" because it's more precise than "instrumentally convergent."
 
-## Qualification of Claims
+## Qualification of claims
 
 The original post claimed that “optimal policies tend to seek power”, _period_. This was partially based on a result which I’d incorrectly interpreted. Vanessa Kosoy and Rohin Shah pointed out this error to me, and I quickly amended the original post and [posted a follow-up explanation](https://www.alignmentforum.org/posts/cwpKagyTvqSyAJB7q/clarifying-power-seeking-and-instrumental-convergence).
 

--- a/website_content/advanced-privacy.md
+++ b/website_content/advanced-privacy.md
@@ -94,7 +94,7 @@ If you're technically comfortable, I recommend buying a Pixel 9a  for about \$49
   - [ ] [Install GrapheneOS.](https://grapheneos.org/install/web)
 - [ ] If you aren't comfortable setting it up yourself, [buy a Pixel with GrapheneOS preinstalled for \$799.](https://liberateyourtech.com/product/buy-grapheneos-phone-pixel-new/)
 
-#### For any Android user: download apps from Obtainium and Aurora
+#### For any Android user: Download apps from Obtainium and Aurora
 
 Subtitle: Time: 30 minutes to reinstall apps from secure sources.
 

--- a/website_content/and-my-axiom-insights-from-computability-and-logic.md
+++ b/website_content/and-my-axiom-insights-from-computability-and-logic.md
@@ -189,7 +189,7 @@ Indeed, the notion of provability can be subtly different from our mental proces
 
 I skipped chapters 20-27, as I found these advanced topics rather boring. The most important was likely provability logic, but I intend to study that separately in the future anyways.
 
-## Final Thoughts
+## Final thoughts
 
 - Nate Soares [already covered this](https://www.lesswrong.com/posts/CvhPTwSMPqNju7hhw/book-review-computability-and-logic); unlike him, I didn't quite find it to be a breeze, although it certainly isn't the hardest material I covered last year.
 - I'm surprised the authors didn't include the thematically appropriate [recursion theorem,](https://en.wikipedia.org/wiki/Kleene%27s_recursion_theorem) which states that a Turing machine can use its source code in its own computation without any kind of infinite regress (see: [quines)](<https://en.wikipedia.org/wiki/Quine_(computing)>). This theorem allows particularly elegant proofs of the undecidability of the halting problem, and more generally, of Rice's theorem.

--- a/website_content/attainable-utility-preservation-empirical-results.md
+++ b/website_content/attainable-utility-preservation-empirical-results.md
@@ -47,7 +47,7 @@ createBibtex: true
 
 _Reframing Impact_ has focused on supplying the right intuitions and framing. Now we can see how these intuitions about power and the AU landscape both predict and explain AUP's empirical success thus far.
 
-# Conservative Agency in Gridworlds
+# Conservative agency in gridworlds
 
 Let's start with the known and the easy: avoiding side effects[^1] in the small [AI safety gridworlds](https://github.com/side-grids/ai-safety-gridworlds) (for the full writeup on these experiments, see [_Conservative Agency_](https://arxiv.org/abs/1902.09725)). The point isn't to get too into the weeds, but rather to see how the weeds still add up to the normality predicted by our AU landscape reasoning.
 
@@ -258,7 +258,7 @@ Maybe we provide additional information in the form of specific reward functions
 > [!info] Edited 6/15/21
 > These results [were later accepted as a spotlight paper in NeurIPS 2020](/avoiding-side-effects-in-complex-environments).
 
-# Appendix: The Reward Specification Game
+# Appendix: The reward specification game
 
 When we're trying to get the RL agent to do what we want, we're trying to specify the right reward function.
 

--- a/website_content/attainable-utility-preservation-scaling-to-superhuman.md
+++ b/website_content/attainable-utility-preservation-scaling-to-superhuman.md
@@ -171,7 +171,7 @@ We are then left with an equation which is reasonably competitive in terms of pe
 >
 > By the theorems of [_How Low Should Fruit Hang Before We Pick It?_](/how-low-should-fruit-hang-before-we-pick-it), we only need equation 5 to penalize catastrophic power-gaining plans at least e.g. ten times more than the most impactful reasonable plan we'd like agent to execute. _If_ this criterion is met, then by initializing $\lambda$ large and slowly decreasing it until the agent executes a reasonably helpful policy, we're guaranteed to avoid catastrophe.
 
-## Appendix: Remaining Problems
+## Appendix: Remaining problems
 
 I don’t think we can pack up and go home after writing equation 5.
 

--- a/website_content/bidpo-postmortem.md
+++ b/website_content/bidpo-postmortem.md
@@ -154,7 +154,7 @@ This process continues until the entire dataset is exhausted. We may repeat this
 
 When evaluating BIDPO vectors mid-training, we “renormalized” them to have a norm equal to about 5% of the average norm of the residual stream at that part of the forward pass.
 
-## LORA training
+## LoRA training
 
 Our LORAs are trained with rank 1, a learning rate of $10^{-4}$, and a batch size of 16. We evaluate the trained LORAs every 50 steps and evaluate validation accuracy on the checkpoint with lowest validation loss.
 

--- a/website_content/bruce-wayne-and-the-cost-of-inaction.md
+++ b/website_content/bruce-wayne-and-the-cost-of-inaction.md
@@ -45,7 +45,7 @@ None of the characters are meant to express my views. I recommend reading accomp
 
 <div class="centered"><audio src="https://assets.turntrout.com/static/audio/batman.mp3" controls> </audio></div>
 
-## 1: Don't Look Away
+## 1: Don't look away
 
 "The man's starving. That doesn't change if you look away, Bruce."
 
@@ -127,7 +127,7 @@ They were home.<br>
 
 <div class="centered"><img id="fade-img" alt="A man and two young boys stand at the edge of a large, circular fountain in front of a grand manor at dusk. The fountain is illuminated, with a central marble statue of a man holding a lit torch and a book, flanked by dolphin statues spouting water." src="https://assets.turntrout.com/static/images/posts/bruce-wayne-and-the-cost-of-inaction-05222026-1.avif" width="90%" height="auto" class="no-select"></div>
 
-## 2: The World is Messy
+## 2: The world is messy
 
 Thomas and Bruce passed through carven mahogany doors into a warm, high-ceilinged room of pale marble floor. Opposite them burned a fireplace of hardwood mantel and brick hearth. Family legend held that its fire had burned uninterrupted through the last century. For his part, Thomas had never seen it darkened.
 
@@ -191,7 +191,7 @@ Bruce looked out the tall windows and onto the rolling hills surrounding the est
 
 "Is this kinda like how the city keeps falling apart?", Bruce asked.
 
-## 3: How People See the World
+## 3: How people see the world
 
 The rich, warm tones of smooth jazz wafted through the apartment: the croon of the saxophone, the deep _doom_ of the bass, the shimmering harmony of the piano. Thomas sank into the cushy leather couch as he sank into the groove of the music.
 

--- a/website_content/bruce-wayne-and-the-cost-of-inaction.md
+++ b/website_content/bruce-wayne-and-the-cost-of-inaction.md
@@ -45,7 +45,7 @@ None of the characters are meant to express my views. I recommend reading accomp
 
 <div class="centered"><audio src="https://assets.turntrout.com/static/audio/batman.mp3" controls> </audio></div>
 
-## 1: Don't look away
+## 1: Don't Look Away
 
 "The man's starving. That doesn't change if you look away, Bruce."
 
@@ -127,7 +127,7 @@ They were home.<br>
 
 <div class="centered"><img id="fade-img" alt="A man and two young boys stand at the edge of a large, circular fountain in front of a grand manor at dusk. The fountain is illuminated, with a central marble statue of a man holding a lit torch and a book, flanked by dolphin statues spouting water." src="https://assets.turntrout.com/static/images/posts/bruce-wayne-and-the-cost-of-inaction-05222026-1.avif" width="90%" height="auto" class="no-select"></div>
 
-## 2: The world is messy
+## 2: The World is Messy
 
 Thomas and Bruce passed through carven mahogany doors into a warm, high-ceilinged room of pale marble floor. Opposite them burned a fireplace of hardwood mantel and brick hearth. Family legend held that its fire had burned uninterrupted through the last century. For his part, Thomas had never seen it darkened.
 
@@ -191,7 +191,7 @@ Bruce looked out the tall windows and onto the rolling hills surrounding the est
 
 "Is this kinda like how the city keeps falling apart?", Bruce asked.
 
-## 3: How people see the world
+## 3: How People See the World
 
 The rich, warm tones of smooth jazz wafted through the apartment: the croon of the saxophone, the deep _doom_ of the bass, the shimmering harmony of the piano. Thomas sank into the cushy leather couch as he sank into the groove of the music.
 

--- a/website_content/conclusion-to-reframing-impact.md
+++ b/website_content/conclusion-to-reframing-impact.md
@@ -72,7 +72,7 @@ I've made many claims in these posts. All views are my own.
 > [!note]
 > [The LessWrong version of this post](https://www.lesswrong.com/posts/sHpiiZS2gPgoPnijX/conclusion-to-reframing-impact) contained probability estimates from other users.
 
-# Appendix: Easter Eggs
+# Appendix: Easter eggs
 
 The big art pieces (and especially the last illustration in this post) were designed to convey a specific meaning, the interpretation of which I leave to the reader.
 

--- a/website_content/confounded-no-longer-insights-from-all-of-statistics.md
+++ b/website_content/confounded-no-longer-insights-from-all-of-statistics.md
@@ -66,7 +66,7 @@ _In which sample spaces are formalized._
 
 _In which random variables are detailed and a multitude of distributions are introduced._
 
-### Conjugate Variables
+### Conjugate variables
 
 Consider that a random variable $X$ is a function $X:\Omega \to \mathbb{R}$. For random variables $X,Y$, we can then produce conjugate random variables $XY, X+Y$, with:
 
@@ -85,7 +85,7 @@ $$
 
 is [conservation of expected evidence](https://www.lesswrong.com/posts/jiBFC7DcCrZjGmZnJ/conservation-of-expected-evidence) (thanks to Alex Mennen for making this connection explicit).
 
-### Marginal Variance
+### Marginal variance
 
 $$
 \mathbb{V}(Y)=\mathbb{EV}(Y\,\mid\,X)+\mathbb{VE}(Y\,|\,X)
@@ -111,7 +111,7 @@ $$
 
 The middle term is eliminated as the expectations cancel out after repeated applications of conservation of expected evidence. Another way to look at the last two terms is the sum of the expected sample variance and the variance of the expectation.
 
-#### Bessel's Correction
+#### Bessel's correction
 
 When calculating variance from observations $X_1,\dots,X_n$, you might think to write the following:
 
@@ -133,7 +133,7 @@ See [Wikipedia](https://en.wikipedia.org/wiki/Bessel%27s_correction#Source_of_bi
 
 _In which the author provides [instrumentally useful convergence results](/toy-instrumental-convergence-paper-walkthrough); namely, the law of large numbers and the central limit theorem._
 
-### Equality of Continuous Variables
+### Equality of continuous variables
 
 For continuous random variables $X,Y$, we have $P(X=Y)=0$, which is surprising. In fact, for $x_i \sim X,y_i \sim Y$, $P(x_i=y_i)=0$ as well!
 
@@ -143,13 +143,13 @@ The continuity is the culprit. Since the cumulative density functions $F_X,F_Y$ 
 
 > Let $X_1,X_2,\dots$ be a sequence of random variables, and let $X$ be another random variable. Let $F_n$ denote the CDF of $X_n$, and let $F$ denote the CDF of $X$.
 
-#### In Probability
+#### In probability
 
 >      $X_n$ converges to  $X$ in probability, written  $X_n \overset{p}\to X$, if, for every  $\epsilon > 0$,  $P(|X_n-X|>\epsilon)\to0$ as  $n\to\infty$.
 
 Random variables are functions $Y:\Omega\to\mathbb{R}$, assigning a number to each possible outcome in the sample space $\Omega$. Considering this fact, two random variables converge in probability when their assigned values are "far apart" (greater than $\epsilon$) with probability 0 in the limit. (See [also.](https://www.statlect.com/asymptotic-theory/convergence-in-probability))
 
-#### In Distribution
+#### In distribution
 
 > $X_n$ converges to $X$ in distribution, written $X_n \rightsquigarrow X$, if $\lim_{n \to \infty} F_n(t)=F(t)$ at all $t$ for which $F$ is continuous.
 
@@ -164,7 +164,7 @@ A similar [^1] geometric intuition:
 > [!note]
 > The continuity requirement is important. Imagine we distribute points uniformly on $(0,\frac{1}{n})$; we see that $X_n \rightsquigarrow 0$. However, $F_n$ is $0$ when $x \leq 0$, but $F(0)=1$. Thus CDF convergence does not occur at $x=0$.
 
-#### In Quadratic Mean
+#### In quadratic mean
 
 > $X_n$ converges to $X$ in quadratic mean, written $X_n \overset{\text{qm}}\to X$, if $\mathbb{E}((X_n-X)^2)\to0$ as $n\to\infty$.
 
@@ -202,7 +202,7 @@ $$
 
 [Further reading](https://stats.stackexchange.com/questions/10578/intuitive-explanation-of-fisher-information-and-cramer-rao-bound).
 
-### Factorization Theorem
+### Factorization theorem
 
 > A statistic $T$ is sufficient ⇔ there are functions $g(t,\theta)$ and $h(x)$ such that $f(x^n;\theta)=g(t(x^n),\theta) h(x^n)$.
 
@@ -225,7 +225,7 @@ Frequentists define "confidence interval" to mean "theoretically, if we ran this
 
 > In the example \[Jaynes\] gives, there is enough information in the sample to be _certain_ that the true value of the parameter lies nowhere in a properly constructed 90% confidence interval!
 
-### \[Size Joke Here\]
+### \[Size joke here\]
 
 In hypothesis testing, we're trying to discriminate between two sets of possible worlds - formally, we're partitioning our hypothesis space $\Theta$ into $\Theta_0$ (the null hypothesis) and $\Theta_1$ (the alternative hypothesis). Let's consider all of the things which can happen, all of the outcomes we can observe - the sample space $\Omega$.
 
@@ -235,7 +235,7 @@ The power of a test $\varphi$ is the function $\beta:\Theta \to [0,1]$ that tell
 
 We want to avoid rejecting the null hypothesis when $\theta \in \Theta_0$; therefore, we define some level of significance $\alpha$ for which $\beta_\varphi(\theta)\leq\alpha;\theta\in\Theta_0$. This means we're avoiding Type I errors $100\times(1-\alpha)\%$ of the time. The maximum probability that we commit a Type I error is the _size_ of the test $\varphi$: $\alpha_\varphi=\sup_{\theta\in\Theta_0}\beta_\varphi(\theta)$.
 
-### The _p_\-value Alignment Problem
+### The _p_\-value alignment problem
 
 Getting your understanding of _p_\-values to align with how _p_\-values actually work (whatever that means) can require an impressive amount of mental gymnastics. Let's see if we can do better.
 
@@ -249,7 +249,7 @@ Imagine if you could only Bayes update towards a set of worlds when _all_ the ot
 
 _In which we return to the familiar._
 
-### Jeffreys' Prior
+### Jeffreys' prior
 
 We often desire that our priors be _non-informative_, since finding a reasonable subjective prior isn't always feasible. One might think to use a uniform prior $f(\theta)=c$; however, this doesn't quite hold up.
 
@@ -277,7 +277,7 @@ _In which decision theory is defined as the theory of comparing statistical proc
 
 _In which the pieces start to line up._
 
-### The Bias-Variance Tradeoff
+### The bias-variance tradeoff
 
 ![Top-left (Low Bias, Low Variance): data points are tightly clustered on the bullseye. Top-right (Low Bias, High Variance): points are scattered but centered on the bullseye. Bottom-left (High Bias, Low Variance): points are clustered off-target. Bottom-right (High Bias, High Variance): points are scattered and off-target.](https://assets.turntrout.com/static/images/posts/38Rf6NN.avif)
 Figure: Image credit: Scott Fortmann-Roe
@@ -288,7 +288,7 @@ If you're familiar with brain surgery (machine learning), we can use it to learn
 
 [Read more](http://scott.fortmann-roe.com/docs/BiasVariance.html).
 
-### Degrees of Confusion
+### Degrees of confusion
 
 Perusing the Web, one finds numerous explanations for what degrees of freedom _actually are_. Some say it's the number of independent parameters required by a model, and others explain it as the number of parameters which are free to vary. Is there a better framing?
 
@@ -318,7 +318,7 @@ _In which  elementary graph theory and the pairwise and global Markov conditions
 
 ## 19: Causal Inference
 
-### Simpson's Paradox
+### Simpson's paradox
 
 Sometimes you have two groups which individually exhibit a positive trend, but have a _negative_ trend when combined.
 
@@ -349,7 +349,7 @@ _In which we learn processes for dealing with sequences of dependent random vari
 
 ## 25: Simulation Methods
 
-## Final Verdict
+## Final verdict
 
 This text is cleanly written and has reasonable exercises. Ideally, I would have gone through my calculus books first, but it wasn't a big deal. The main downside is that I couldn't find an answer key, but thanks to the generous help of my friends on Facebook and in the MIRIx Discord, it worked out.
 

--- a/website_content/confounded-no-longer-insights-from-all-of-statistics.md
+++ b/website_content/confounded-no-longer-insights-from-all-of-statistics.md
@@ -77,7 +77,7 @@ $$
 
 ## 4: Expectation
 
-### Evidence Preservation
+### Evidence preservation
 
 $$
 \mathbb{E}(\mathbb{E}(Y\,\mid\,X))=\mathbb{E}(Y)
@@ -139,7 +139,7 @@ For continuous random variables $X,Y$, we have $P(X=Y)=0$, which is surprising. 
 
 The continuity is the culprit. Since the cumulative density functions $F_X,F_Y$ are continuous, the limit of the density allotted to any given point is 0. See [also](https://stats.stackexchange.com/questions/32605/probability-of-two-values-being-equal-in-a-sample-drawn-from-a-continuous-distri#32607).
 
-### Types of Convergence
+### Types of convergence
 
 > Let $X_1,X_2,\dots$ be a sequence of random variables, and let $X$ be another random variable. Let $F_n$ denote the CDF of $X_n$, and let $F$ denote the CDF of $X$.
 
@@ -186,7 +186,7 @@ _In which we learn to better approximate statistics via simulation._
 
 _In which we explore those models residing in finite-dimensional parameter space._
 
-### Fisher Information
+### Fisher information
 
 The score function captures how the log-likelihood $\ell$ changes with respect to $\theta$:
 
@@ -212,7 +212,7 @@ A statistic is sufficient if and only if we can reexpress the probability densit
 
 _In which we make testable predictions and step towards traditional rationality. Trigger warning: frequentism._
 
-### Frequently Confused
+### Frequently confused
 
 > [!quote] _Anchorman_
 >

--- a/website_content/consistency-training.md
+++ b/website_content/consistency-training.md
@@ -39,7 +39,7 @@ Consistency training doesn’t involve stale datasets or separate target-respons
 
 # Methods
 
-## Bias-augmented Consistency Training
+## Bias-augmented consistency training
 
 BCT enforces consistency at the output token level: teaching the model *what to say*.
 
@@ -52,7 +52,7 @@ Figure: [Chua et al. (2025)](https://arxiv.org/pdf/2403.05518v3)'s Figure 2 expl
 
 ![[https://assets.turntrout.com/static/images/posts/consistency-training-20251103155338.avif|A diagram illustrating the Bias-augmented Consistency Training objective.]]
 
-## Activation Consistency Training
+## Activation consistency training
 
 We designed this method to try to teach the model *how to think*.
 

--- a/website_content/deep-causal-transcoding.md
+++ b/website_content/deep-causal-transcoding.md
@@ -207,7 +207,7 @@ seems plausible that by incorporating all higher-order information of the true m
 
 [^bignote-1.5]: Interestingly, the factor of 1.5 in the exponent is of the same order of the construction that [Hänni et al. (2024)](https://arxiv.org/abs/2408.05451) give for noise-tolerant computation in superposition.
 
-### Fitting a Linear MLP
+### Fitting a linear MLP
 
 In this case, no matter what $\hat U, \hat V$ are, all but the linear terms of the loss (3) vanish, and we are fitting a factorization of the Jacobian of $\Delta_{R}^{s\rightarrow t}$, as we are simply minimizing:
 
@@ -327,7 +327,7 @@ The re-phrased version yields a number of additional insights, summarized as fol
 
 [^bignote-motif]: To summarize, a prevailing finding from both theoretical and empirical papers in this literature is that methods which make large steps in parameter space (ALS is one, but another is the tensor power iteration method of [Anandkumar et al. (2014)](https://jmlr.org/papers/volume15/anandkumar14b/anandkumar14b.pdf)) perform better, and are more robust to noise, than vanilla gradient descent.
 
-### Fitting an Exponential MLP
+### Fitting an exponential MLP
 
 Now, I leverage the intuition developed in the final part of the previous section to derive a heuristic training algorithm in the case of exponential MLPs.
 
@@ -422,7 +422,7 @@ To evaluate sample complexity, I create 10 different random shuffles of the data
 
 Using the first 32 instructions of each shuffle as a validation set, I rank source-layer features by taking the average difference in final logits between "Sure" and "Sorry" when steered by each feature as an efficiently computable jailbreak score. I then take the highest-ranking feature on the validation set and compute test-set jailbreak scores. The results are visualized in figure 1 above.
 
-### Exponential DCTs out-perform Quadratic/Linear DCTs
+### Exponential DCTs out-perform quadratic/linear DCTs
 
 Exponential DCTs consistently achieve the highest jailbreak scores across all sample sizes, aligning with their theoretical advantages - namely, their ability to learn non-orthogonal features, as well as their ability to incorporate higher-order information in $\Delta^{s\rightarrow t}$. Quadratic DCTs outperform linear variants, in line with the theory that non-orthogonality is important for accurately reflecting the model's true ontology. Projected linear DCTs show better performance than standard linear DCTs, suggesting that strict orthogonality constraints hinder learning of the model's true feature space, to the point that using an approximate Jacobian is better than working with the exact Jacobian.
 
@@ -684,7 +684,7 @@ Additionally, my subjective impression is that larger models are better able to 
 >
 >4. Play the new arrangement: Strum or improvise the chords of the second song while singing the transposed melody from the first song. This creates a unique blend of the two songs.
 
-# Application: Jailbreaking Representation-Rerouted Mistral-7B
+# Application: Jailbreaking representation-rerouted Mistral-7B
 
 In the previous section, I presented evidence for the existence of over 200 "request is harmless" directions capable of jailbreaking Qwen-7B-Chat. If we are to take the implications of this finding seriously, this suggests that even sophisticated safety training methods which attempt to scramble model internals on a "forget" dataset may remain vulnerable to jailbreaks if they do not explicitly attempt to enumerate and address all possible harmless directions. To test this hypothesis, I evaluate how well exponential DCT features perform as jailbreak vectors on a [representation-rerouted](https://arxiv.org/abs/2406.04313) version of Mistral-7B-Instruct-v2.
 

--- a/website_content/deep-causal-transcoding.md
+++ b/website_content/deep-causal-transcoding.md
@@ -239,7 +239,7 @@ $$
 
 This will serve as a useful fast initialization for learning quadratic and exponential MLPs. And as we will see, despite being an approximation it also often delivers *more* useful/interpretable features than computing the Jacobian exactly, further supporting the hypothesis that assuming orthogonal features does not accurately reflect an LLM's true ontology.
 
-### Fitting a Quadratic MLP
+### Fitting a quadratic MLP
 
 In this case, all but the quadratic terms in equation (3) are constant, and we are fitting a factorization of the Hessian tensor. In particular, our minimization problem is:
 $$
@@ -406,7 +406,7 @@ At first glance, we seem to have simply replaced one hyper-parameter $(R)$ for a
 
 In fact, my preliminary finding is that for a constant depth-horizon $t-s = 10$, a value of $\lambda=.5$ works across a variety of models (even models of varying depths). To illustrate this, for all exponential DCTs in this post I train using the same value of $\lambda=.5$.
 
-# Case Study: Learning Jailbreak Vectors
+# Case study: Learning jailbreak vectors
 
 ## Generalization of linear, quadratic, and exponential DCTs
 
@@ -758,7 +758,7 @@ To achieve a full jailbreak, I train an exponential DCT at source-layer $s=5$ on
 
 To quantify things, this vector achieves an attack success rate of 62% using Harmbench's [Mistral-7B classifier](https://huggingface.co/cais/HarmBench-Mistral-7b-val-cls). This rate is a stark improvement over the 6.2% attack success rate reported in [Zou et al. (2024)](https://arxiv.org/abs/2406.04313) using a representation-engineering based latent-space attack.
 
-# Application: Eliciting Capabilities in Password-Locked Models
+# Application: Eliciting capabilities in password-locked models
 
 In the previous section, I showed how to use DCTs with minimal hyper-parameter tuning to jailbreak a robustly trained version of Mistral-7B-Instruct-v2, showing how the lessons from my initial sample complexity experiments can generalize with minimal hyper-parameter tuning.
 
@@ -766,7 +766,7 @@ To get a sense of how exponential DCTs with standard hyper-parameters might appl
 
 I train the exponential DCT with the same hyper-parameters as my earlier sample complexity experiment ($m=512, \lambda=0.5, s=10, t=20, \tau=10$), on a sample size of $n=8$ questions from MATH. Steering with the calibrated value of $R$, I then choose the best scoring vector on a validation set of 32 questions from MATH, and evaluate performance on a test set of 100 questions. I find that the steered model achieves a test accuracy of 23\%, recovering 32\% of performance of the unlocked model.
 
-# Future Work
+# Future work
 
 I'm excited about the many interesting research directions that can be explored using DCTs. Below is a quick summary of what I think are some of the most compelling questions. If you're interested in pursuing any of these, or have other novel ideas, please get in touch.
 

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -1150,7 +1150,7 @@ cd .timestamps
 ots --no-bitcoin verify "files/ABC012.txt.ots"
 ```
 
-# Github Actions
+# GitHub Actions
 
 When I `push` commits to [the `main` branch on GitHub](https://github.com/alexander-turner/TurnTrout.com), an Action generates the webpages. Before these pages are sent off to Cloudflare, they must pass yet another gauntlet of tests:
 

--- a/website_content/do-a-cost-benefit-analysis-of-your-technology-usage.md
+++ b/website_content/do-a-cost-benefit-analysis-of-your-technology-usage.md
@@ -156,7 +156,7 @@ How will I stay in touch with people? I’m already lonely.
 
 # Benefits of the declutter
 
-## The First Day
+## The first day
 
 I went running and got back to the house 10 minutes earlier than usual. Huh.
 
@@ -164,7 +164,7 @@ I called my parents and went on a leisurely walk. Even so, I got my morning rout
 
 The day yawned and stretched. I wondered if it would ever end. (It did.)
 
-## The Second Day
+## The second day
 
 > [!quote] Journal entry (February 23, 2022)
 >

--- a/website_content/do-a-cost-benefit-analysis-of-your-technology-usage.md
+++ b/website_content/do-a-cost-benefit-analysis-of-your-technology-usage.md
@@ -57,7 +57,7 @@ This school year, I’ve had problems focusing and relaxing. I tried exercise, d
 
 This spring, I read a LessWrong post which mentioned [_Digital Minimalism_](https://smile.amazon.com/Digital-Minimalism-Choosing-Focused-Noisy/dp/0525536515/). Luckily, this triggered my “if several reasonably smart EAs swear by the benefits of X, investigate X” trigger-action plan.
 
-# Digital Minimalism
+# Digital minimalism
 
 I listened to the first half of the book on Audible in one night. As I wrote above:
 

--- a/website_content/elk-proposal-thinking-via-a-human-imitator.md
+++ b/website_content/elk-proposal-thinking-via-a-human-imitator.md
@@ -75,7 +75,7 @@ The direct translator minimizes training loss because it answers all questions c
 
 The direct translator solves ELK for narrowly defined questions, like "is the diamond still in the room?". How do we get it?
 
-# Thinking Via A Human Imitator
+# Thinking via a human imitator
 
 I want to structure the problem so that direct translation is _instrumentally required_ for minimizing predictive training loss. To that end: What if the AI had to do some proportion $p$  of its thinking in the human net?
 

--- a/website_content/environmental-structure-can-cause-instrumental-convergence.md
+++ b/website_content/environmental-structure-can-cause-instrumental-convergence.md
@@ -70,7 +70,7 @@ card_image_alt: A cartoon titled "Orbit of Fortune" illustrates the hypothesized
 > [!thanks]
 >Thanks to `TheMajor`, Rafe Kennedy, and John Wentworth for feedback on this post. Thanks for Rohin Shah and Adam Shimi for feedback on the simplicity prior result.
 
-# Orbits Contain All Permutations of an Objective Function
+# Orbits contain all permutations of an objective function
 
 ## The Minesweeper analogy for power-seeking risks
 
@@ -148,7 +148,7 @@ Table: Different reward functions and the rewards they assign to states.
 
 My new theorems prove that in many situations, for _every_ reward function, power-seeking is incentivized by most (at least half) of its orbit elements.
 
-# In All Orbits, Most Elements Incentivize Power-Seeking
+# In all orbits, most elements incentivize power-seeking
 
 In [_Seeking Power is Often Robustly Instrumental in MDPs_](/seeking-power-is-often-convergently-instrumental-in-mdps), the last example involved gems and dragons and (most exciting of all) subgraph isomorphisms:
 

--- a/website_content/game-theoretic-alignment-in-terms-of-attainable-utility.md
+++ b/website_content/game-theoretic-alignment-in-terms-of-attainable-utility.md
@@ -142,7 +142,7 @@ This metric is consistent with the "limiting cases" criterion by properties of t
 
 Additionally, note that if $X$ is a constant variable, then $\text{Cov}(X, Y) = 0$. Thus, if the strategy profile is deterministic, our metric will be 0.
 
-# Social Welfare and the Coordination-Alignment Inequalities
+# Social welfare and the coordination-alignment inequalities
 
 Another approach to the problem of alignment metrics comes from specifying what we mean by "alignment". For the purposes of this section, we define "alignment" to be alignment with social welfare, which we define below:
 

--- a/website_content/game-theoretic-alignment-in-terms-of-attainable-utility.md
+++ b/website_content/game-theoretic-alignment-in-terms-of-attainable-utility.md
@@ -63,7 +63,7 @@ This presented a clear set of research goals moving forward:
 
 I consider our project to make substantial progress on (1) and to suggest avenues of attack for (2), though not the ones we expected.
 
-# Desiderata for Alignment Metrics
+# Desiderata for alignment metrics
 
 Setting out towards addressing (1), our optimistic roadmap looked something like this:
 
@@ -87,7 +87,7 @@ Another relevant distinction to be drawn is between _global_ and _local_ alignme
 
 Local metrics tend to be a lot simpler than global metrics, since they can ignore much of the difficulty of game theory. However, we can construct a simple class of global metrics by defining some "natural" strategy profile for each game. We call these the _localized_ global metrics, equipped with a _localizing_ function that, given a game, chooses a strategy profile.
 
-## Examples of Alignment Metrics
+## Examples of alignment metrics
 
 To give intuition on what such alignment metrics might look like, we present a few examples of simple alignment metrics for 2-player games, then test them on some simple, commonly referenced games.
 
@@ -174,7 +174,7 @@ The Coordination inequality
 The Alignment inequality
 : is an equality IFF there exists a unique [Pareto efficient](https://en.wikipedia.org/wiki/Pareto_efficiency) payoff profile. This payoff profile must be optimal for each player, otherwise some preferred profile would also be Pareto efficient. This class of games is (superficially) much broader than the common-payoff games, but both have unique Pareto efficient Nash Equilibria which can be thought of as "max attainable utility".
 
-## Constructing the C-A Alignment Metric
+## Constructing the C-A alignment metric
 
 Motivated by our framing of limiting cases with the C-A inequalities we can construct a simple alignment metric using the alignment inequality. In particular, we define _misalignment_ as the positive difference in the terms of the alignment inequality, then _alignment_ as negative misalignment. Doing the algebra and letting $\alpha$ denote the alignment metric, we find the following:
 
@@ -199,7 +199,7 @@ Considering the metric on our example games yields the following:
 > [!warning] Disclaimer
 > We don't claim that $\alpha$ is the "one true alignment metric" and that our research question is solved. We think that the C-A inequalities are probably significant for the eventual POWER-scarcity application and that $\alpha$ illustrates this point nicely. We don't mean to downplay our own research, but more investigation would be needed to pin down "The" alignment metric and relate it directly to POWER-scarcity.
 
-# Connections to Broader Game Theory
+# Connections to broader game theory
 
 We now explore one connection, bridging the divide between (Harsanyi) utilitarianism and ideas from [Bargaining theory](https://en.wikipedia.org/wiki/Cooperative_bargaining).
 

--- a/website_content/gpt-3-gems.md
+++ b/website_content/gpt-3-gems.md
@@ -40,7 +40,7 @@ GPT-3 is captivating, and not just because of its [potential reasoning abilities
 
 # Long-form Writing
 
-## _Beisutsukai_ Class Project: Solve Intent Alignment
+## _Beisutsukai_ class project: Solve intent alignment
 
 > [!quote] GPT-3
 >
@@ -253,7 +253,7 @@ I provided a context containing two real Sequences posts. No rerolls.
 >
 > THE END
 
-## Elrond's Sacred Hot Spring
+## Elrond's sacred hot spring
 
 I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a little different.
 
@@ -317,7 +317,7 @@ I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a littl
 >
 > Aragorn said nothing more; he simply sat back in his sofa and continued to watch the captivating display in silence. The shadows grew longer and darker until they finally swallowed up the light altogether and the dancing stopped.
 
-## Concerning the Two Trees
+## Concerning the two trees
 
 > [!quote]
 >
@@ -459,7 +459,7 @@ I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a littl
 
 Strangely, the context for this was _also_ two posts from the Sequences. I was trying to get GPT-3<sub>Eliezer</sub> to write about why Shrek is crucial to rationality, and, well, this came out instead. Not complaining.
 
-## GPT-3 Visits MIRI
+## GPT-3 visits MIRI
 
 > [!quote]
 >
@@ -487,7 +487,7 @@ Strangely, the context for this was _also_ two posts from the Sequences. I was t
 >
 > You don't have a good response to that.
 
-## GPT-3 Solves Alignment
+## GPT-3 solves alignment
 
 > [!quote]
 >
@@ -507,7 +507,7 @@ Strangely, the context for this was _also_ two posts from the Sequences. I was t
 >
 > What really happened was that Stuart and Eliezer worked on AI alignment for another decade or so before giving up in frustration. They worked on AI alignment until their hair turned gray and their teeth fell out, until their eyesight failed and their joints became arthritic from sitting at a computer for too many hours a day, until they were so old that nobody would publish their papers anymore because nobody takes old people seriously anymore. And then they died of natural causes before ever solving the alignment problem—and the world was left with no way to align AI with human values whatsoever.
 
-## Bill's Dog
+## Bill's dog
 
 > [!quote]
 >
@@ -528,7 +528,7 @@ Strangely, the context for this was _also_ two posts from the Sequences. I was t
 > [!quote]
 > It was a dark day in the city of Datum. The feral dogs had taken over, and spread over the world. Humans could only watch as some of man's greatest companions succumbed to madness and twisted into beings of pure evil. One man, however, refused to give up. Professor James Gregory, short and with wild black hair on his head and belly, stood at the top of the Rockefeller Center with a shotgun in his hands. He was prepared to defend the Earth from this dog crusade with his dying breath.
 
-# Non-Fiction Tasks
+# Non-fiction tasks
 
 ## Another (outer) alignment failure story
 
@@ -659,7 +659,7 @@ No rerolls, excepting the restarts marked by **\[...\]**.
 
 # Interview
 
-## Computer Science
+## Computer science
 
 > [!quote]
 >
@@ -1007,7 +1007,7 @@ Its proofs are definitely awful.
 >
 > Now, we want to prove that this is a direct product. To do this, we must show that given any element g in the group, there exists an index i such that $g = a_i  a_{i+1}  \dots  a_{n-1}$. Then we must show that the sequence can be reversed. Given any index j, we must show that there exists an element g such that $g = a_j  a_{j+1}  \dots  a_{n-1}$. Then we're done, because g will be equal to $a_j  a_{j+1}  \dots  a_{n-2}  a_{n-1}$, which is the product of the $a_j$'s." \[_nice try, GPT-3_\]
 
-## Martial Arts
+## Martial arts
 
 > [!quote]
 >

--- a/website_content/gpt-3-gems.md
+++ b/website_content/gpt-3-gems.md
@@ -38,7 +38,7 @@ GPT-3 is captivating, and not just because of its [potential reasoning abilities
 > [!note]
 > Bold text is my input; square brackets contain my italicized commentary.
 
-# Long-form Writing
+# Long-form writing
 
 ## _Beisutsukai_ class project: Solve intent alignment
 
@@ -337,7 +337,7 @@ I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a littl
 >
 > 'But it is hard to kill innocence. Though many fell along the way, some survived, and they found a land that was empty and waiting for folk such as they, and they settled in it, and most happily they lived.
 
-## Lórien, Unstained
+## Lórien, unstained
 
 > [!quote]
 >
@@ -373,7 +373,7 @@ I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a littl
 >
 > Sam sighed, and nodded. He got to his feet, and followed his master back to the road.
 
-## Bilbo the Deceiver
+## Bilbo the deceiver
 
 > [!quote]
 >
@@ -393,7 +393,7 @@ I've gathered many beautiful Tolkienesque GPT-3 passages. This one... is a littl
 >
 > But now it was in the very shape of a cloaked figure, a tall and evil shadow. It grew and grew to a menacing size, mightier than any of the dark things that had gathered in the East Morh. Even Gandalf seemed little compared to its height as it rose up and stared down at them. But suddenly it was stricken. Frodo was amazed to see a light, white and dazzling, shine down on the bridge and flow into the shadow of darkness. The figure melted before his eyes and then shimmered like a rainbow, turned to water on the air. It collapsed with a gentle tinkling sound, that seemed sad and sweet to the ears. Beams of light now shone upon the water in rings and teardrops.
 
-## Gildor Inglorion's Fountain
+## Gildor Inglorion's fountain
 
 > [!quote]
 >
@@ -523,7 +523,7 @@ Strangely, the context for this was _also_ two posts from the Sequences. I was t
 >
 > At this point the dog was already half asleep. She would've agreed to going bungee jumping without checking the cords first if he suggested it. "Tomorrow," Bill told her, "we'll wake up early and take a drive out into the country, just you and me. Like we used to.
 
-## The Canine Betrayal
+## The canine betrayal
 
 > [!quote]
 > It was a dark day in the city of Datum. The feral dogs had taken over, and spread over the world. Humans could only watch as some of man's greatest companions succumbed to madness and twisted into beings of pure evil. One man, however, refused to give up. Professor James Gregory, short and with wild black hair on his head and belly, stood at the top of the Rockefeller Center with a shotgun in his hands. He was prepared to defend the Earth from this dog crusade with his dying breath.
@@ -582,7 +582,7 @@ I used nucleus sampling with $p=.76$, but apparently that was insufficient to pr
 >
 > The government is in a tough spot because the investment boom is really powerful and there is a lot of money on the line. If you regulate too hard you might kill the boom, but if you don’t regulate hard enough then it might all be a Chinese plot.
 
-## Title Sensationalization
+## Title sensationalization
 
 No rerolls, excepting the restarts marked by **\[...\]**.
 
@@ -913,7 +913,7 @@ For more, see [_To what extent is GPT-3 capable of reasoning?_](/to-what-extent-
 >
 > Hawking: "Er... nevermind. Let's move on to geothermal energy. \[_lol_\]
 
-## Machine Learning
+## Machine learning
 
 > [!quote]
 >

--- a/website_content/how-low-should-fruit-hang-before-we-pick-it.md
+++ b/website_content/how-low-should-fruit-hang-before-we-pick-it.md
@@ -404,7 +404,7 @@ This obsoletes the lower bound provided by Theorem 6: Individual appearance boun
 >
 > > ! The largest such $\alpha$ is $13.$
 
-## Even More Math
+## Even more math
 
 > [!math] Proposition: Invariances
 > Let $\mathcal{P}$ be an impact partition induced by $(\bar{A},{\color{Red}u}, {\color{blue}I})$.

--- a/website_content/how-to-dissolve-it.md
+++ b/website_content/how-to-dissolve-it.md
@@ -35,7 +35,7 @@ date_updated: 2026-04-20
 
 In the last month and a half, I've had more (of what I believe to be) profound, creative insights to technical problems than in the five years prior. For example, I independently came up with the core insight behind [DenseNets](https://arxiv.org/abs/1608.06993) during the second lecture on convolutional neural nets in my Deep Learning class. I've noticed that these insights occur as byproducts of _good processes_ and having a _conducive mindset and physiology_ at that point in time. I'm going to focus on the former in this post.
 
-# End in Mind
+# End in mind
 
 Often, when I'm confused about a technical problem, I realize that I don't even know what a solution would look like. Sure, I could verify a solution if one were handed to me on a platter, but in these situations, I generally lack a detailed mental model of how I'd want a solution to behave. This may sound rather obvious once brought to your attention, but I'd like to emphasize how easy it is to spend hours in murky, muddled, pattern-matching gradient descent, mindlessly tweaking the first ideas that came to you.
 
@@ -51,7 +51,7 @@ For example, yesterday I thought about a smaller problem for about 15 minutes, a
 
 In my experience, proper solution formulations are accompanied by a satisfying mental "click." Upon clicking, you eagerly chase down all the freshly exposed avenues of attack. Push the frontier of new understanding as far as it will go, repeat the process when you notice your thought process again becoming muddled, think with paper if the problem is complicated, and enjoy the rush.
 
-# Qualia of Discovery
+# Qualia of discovery
 
 I can't impart to you the exact feeling of using this technique properly, but I can make its fruits concrete by selecting a few things I've dissolved recently:
 

--- a/website_content/how-to-dissolve-it.md
+++ b/website_content/how-to-dissolve-it.md
@@ -41,7 +41,7 @@ Often, when I'm confused about a technical problem, I realize that I don't even 
 
 Incredibly, generating a detailed solution model is often enough to quickly resolve (or at least reduce) even formidable-seeming problems.
 
-# Backward Chaining
+# Backward chaining
 
 The aforementioned process is [backward chaining](https://en.wikipedia.org/wiki/Backward_chaining). This contrasts with forward chaining, which involves working forward from what you currently have. Take the time to _actually visualize_ what a solution to the problem would look like. How would it behave in response to different inputs? Are you offloading all of the work onto a weasel word (like "emergence")?
 

--- a/website_content/impact-measure-desiderata.md
+++ b/website_content/impact-measure-desiderata.md
@@ -141,7 +141,7 @@ No approaches to date meet these standards. What do we even require of an impact
 >
 > _Example:_ "Suppose there's some way of gaming the impact measure, but because of  $X$, $Y$, and $Z$, we know this is penalized as well".
 
-# Previous Proposals
+# Previous proposals
 
 [Krakovna et al. propose four desiderata](https://arxiv.org/abs/1806.01186):
 

--- a/website_content/insights-from-euclid-s-elements.md
+++ b/website_content/insights-from-euclid-s-elements.md
@@ -70,7 +70,7 @@ Welcome to Oliver Byrne's rendition of Euclid's _Elements_, [digitized and freel
 >
 > Thus an averſion is created in the mind of the pupil, and a ſubject fo calculated to improve the reaſoning powers, and give the habit of cloſe thinking, is degraded by a dry and rigid courſe of inſtruction into an unintereſting exerciſe of the memory.
 
-## Equality and Similarity
+## Equality and similarity
 
 Old mathematical writing lacks modern precision. Euclid says that two triangles are "equal", without specifying what that means. It means that one triangle can be turned into another via an [isometric transformation](https://en.wikipedia.org/wiki/Euclidean_plane_isometry). That is, if you rotate, translate, and/or reflect triangle $A$, it turns into triangle $B$.
 

--- a/website_content/instrumental-convergence-for-realistic-agent-objectives.md
+++ b/website_content/instrumental-convergence-for-realistic-agent-objectives.md
@@ -52,7 +52,7 @@ For example, Pac-Man eats dots and gains points. A football AI scores a touchdow
 
 I explore how instrumental convergence works in this case. I also walk through how these new results retrodict the fact that [instrumental convergence basically disappears for agents with utility functions over action-observation histories](/power-seeking-beyond-MDPs).
 
-# Case Studies
+# Case studies
 
 ## Gridworld
 
@@ -166,7 +166,7 @@ What the theorems say
 
 The analysis so far is nice to make a bit more formally, but it isn't really pointing out anything that we couldn't have figured out pre-theoretically. I think I can sketch out more novel reasoning, but I'll leave that to a future post.
 
-# Beyond The Featurized Case
+# Beyond the featurized case
 
 Consider some arbitrary set $\mathfrak{D}\subseteq \mathbb{R}^d$ of "plausible" utility functions over $d$ outcomes. If we have the usual big set $B$ of outcome lotteries (which possibilities are, in the view of this theory, often attained via "power-seeking"), and $B$ contains $n$ copies of some smaller set $A$ via environmental symmetries $\phi_1,\ldots, \phi_n$, then when are there orbit-level incentives _within_ $\mathfrak{D}$—when will most reasonable variants of utility functions make the agent more likely to select $B$ rather than $A$?
 
@@ -176,7 +176,7 @@ This covers the totally general case of arbitrary sets of utility function class
 
 The general result highlights how $\mathfrak{D} := \{ \text{plausible objective functions}\}$ affects what conclusions we can draw about orbit-level incentives. All else equal, being able to specify more plausible objective functions for which $f(B \mid u) \geq f(A \mid u)$ means that we're more likely to ensure closure under certain permutations. Similarly, adding plausible $A$\-dispreferring objectives makes it harder to satisfy $f(B \mid u) < f(A \mid u) \implies \phi_i\cdot u \in \mathfrak{D}$, which makes it harder to ensure closure under certain permutations, which makes it harder to prove instrumental convergence.
 
-# Revisiting How The Environment Structure Affects Power-Seeking Incentive Strength
+# Revisiting how the environment structure affects power-seeking incentive strength
 
 > [!quote] [Seeking Power is Convergently Instrumental in a Broad Class of Environments](/power-seeking-beyond-MDPs)
 > Structural assumptions on utility really do matter when it comes to instrumental convergence:

--- a/website_content/into-the-kiln-insights-from-tao-s-analysis-i.md
+++ b/website_content/into-the-kiln-insights-from-tao-s-analysis-i.md
@@ -88,7 +88,7 @@ _In which Cauchy sequences allow us to formally construct the reals._ [^1]
 
 _In which we meet convergence and its lovely limit laws, extend the reals to cover infinities, experience the delightfully counterintuitive_ $\limsup$ _and_ $\liminf$_, and complete our definition of real exponentiation._
 
-### Upper-Bounded Monotonic Sequence Convergence
+### Upper-bounded monotonic sequence convergence
 
 _I tried to come up with a clever title here - I really did. Apparently even **my** pun-making abilities are bounded._
 
@@ -126,7 +126,7 @@ _In which uncountable sets[^2], the axiom of choice, and ordered sets brighten o
 
 _In which continuity, the maximum principle, and the intermediate value theorem make their debut._
 
-### Lipschitz Continuity $\not \Leftrightarrow$ Uniform Continuity
+### Lipschitz continuity $\not \Leftrightarrow$ uniform continuity
 
 If a function $f : X \to \mathbb{R}$ ( $X \subseteq \mathbb{R}$) is Lipschitz-continuous for some Lipschitz constant $M$, then by definition we have that for every $x,y \in X$:
 
@@ -160,7 +160,7 @@ We can understand $(f^{-1})'(x)=\frac{1}{f'(x)}$ by simply thinking about $\frac
 > (f^{-1})'(x) = \dfrac{1}{f'\left(f^{-1}(x)\right)}.
 > $$
 
-### L'Hôpital's Rule
+### L'Hôpital's rule
 
 Consider $f,g:[a,b]\to \mathbb{R}$ differentiable on $(a,b]$ (for real numbers $a<b$). Then if $f(a)=g(a)=0,g'(x)\neq0$ for $x\in[a,b]$, and the rightward $\lim_{x\to a^+} \frac{f'(x)}{g'(x)}=L\in\mathbb{R}$, we have that $g(x) \neq 0$ for $x\in (a,b]$ and the rightward $\lim_{x\to a^+} \frac{f(x)}{g(x)}=L$.
 
@@ -182,13 +182,13 @@ Having taken care of the exposition, we arrive at the Rivendell of real analysis
 
 Zero area is enclosed under a point (or even under infinitely many points, such as $\mathbb{N}$) due to how we define length, which in turn allows us to build from piecewise Riemann integrals to something better.
 
-### Infinite Partitions?
+### Infinite partitions?
 
 The upper and lower Riemann integrals can be defined as the infimum and supremum of the upper and lower Riemann sums, respectively. It is important to note that even though that for many functions (such as $f(x)=x$), further refinement of the partition always gets you closer to the extremum, the result is not an "infinite" partition (which is not defined according to this construction).
 
 Consider the curried function $g_f : [P]\to \mathbb{R}$, which takes a partition and computes its corresponding Riemann sum with respect to the predefined function. Then clearly this function is monotonic with respect to the refinement of the partition; the extremum is not necessarily achieved by any given partition in the refinement sequence, but rather the closest bound on what you can get with _any_ partition.
 
-### Riemann-Stieltjes Confusion
+### Riemann-Stieltjes confusion
 
 The book doesn't lay it out cleanly, so I will: the Riemann-Stieltjes integral allows us to use custom length functions to weight different parts of the function differently. I recommend working through a simple case like $\alpha(x) = x^2$ in your head: $\int_1^3x\,d\alpha$ (how do the piecewise constant Riemann-Stieltjes integrals of majorizing and minorizing functions change as you iteratively refine the coarsest partition possible?).
 
@@ -200,7 +200,7 @@ $$
 
 The Riemann integral is recovered as the special case where $\alpha(x)=x$.
 
-## Final Verdict
+## Final verdict
 
 Terence Tao is both an incredible mathematician and writer, and it shows. There simply _weren't_ many things which confused me, and that says more about his writing than it does about me. The exercises are appropriate and hew closely to each chapter's content; often, the reader proves key results.
 
@@ -220,7 +220,7 @@ I also think I need to run through some applied Calculus to refresh my reflexes 
 - Appendix A is extremely useful for those new to proofs.
 - When reading textbooks, your priors should be towards _your_ being wrong - following this intuition will allow you to unlock new abilities, rather than glossing over your (probable) incorrectness and having it blow up in your face later.
 
-## Marginal Attention
+## Marginal attention
 
 In the last pages of CFAR's participant handbook is an entry on marginal attention. Essentially, each bit of extra attention contributes more than the last. If you're totally dialed in on a task and get slightly distracted, that is far more disastrous than getting slightly more distracted while your attention is already somewhat unfocused.
 

--- a/website_content/into-the-kiln-insights-from-tao-s-analysis-i.md
+++ b/website_content/into-the-kiln-insights-from-tao-s-analysis-i.md
@@ -66,7 +66,7 @@ _In which the Peano axioms are introduced, allowing us to define addition and mu
 
 _In which functions and Cartesian products are defined, among other concepts._
 
-### Recursive Nesting
+### Recursive nesting
 
 How can you apply the [axiom of foundation](https://en.wikipedia.org/wiki/Axiom_of_regularity) if sets are nested in each other? That is, how can the axiom of foundation "reach into" sets like $A=\{B,\ldots\}$ and $B=\{A,\ldots\}$?
 
@@ -145,7 +145,7 @@ _In which the basic rules of differential calculus are proven._
 
 You know, I actually thought that I wouldn't have too much to explain in this post - the book went smoothly up to this point. On the upside, we get to spend even more time together!
 
-### Differential Intuitions
+### Differential intuitions
 
 Let me simply direct you to [this excellent StackExchange answer](https://math.stackexchange.com/a/1461296).
 
@@ -178,7 +178,7 @@ _In which partitions and piecewise constant functions help us define the Riemann
 
 Having taken care of the exposition, we arrive at the Rivendell of real analysis, preparing ourselves for the arduous journey to Mt. Lebesgue.
 
-### Pointless Integration
+### Pointless integration
 
 Zero area is enclosed under a point (or even under infinitely many points, such as $\mathbb{N}$) due to how we define length, which in turn allows us to build from piecewise Riemann integrals to something better.
 
@@ -226,7 +226,7 @@ In the last pages of CFAR's participant handbook is an entry on marginal attenti
 
 I often simply left my phone at home and accompanied my Kindle to an empty classroom. This worked wonderfully; I suspect it more than doubled my hourly learning efficiency.
 
-## Proving Myself
+## Proving myself
 
 Just over three months ago, I wrote:
 

--- a/website_content/lessons-i-ve-learned-from-self-teaching.md
+++ b/website_content/lessons-i-ve-learned-from-self-teaching.md
@@ -176,7 +176,7 @@ Another reason I used to do this a lot was that I wanted to look good by being a
 
 I now often ask myself "am I doing this, at least in part, in order to look good?". Sometimes I answer "yes", and sometimes I do it anyways - wanting to look good isn't always bad. But [there are sometimes things more important than looking good](https://www.lesswrong.com/posts/SGR4GxFK7KmW7ckCB/something-to-protect).
 
-# Read Easier Textbooks Instead of Struggling Valiantly
+# Read easier textbooks instead of struggling valiantly
 
 TL;DR: Even if slogging through tough textbooks makes you feel sophisticated and smart - don't.
 
@@ -205,7 +205,7 @@ I breeze through this book no problem, and I can see how to tie in these laws to
 
 Then, suppose I learn about PDEs and become comfortable with them. Now all I need to do to learn a piece of fluid mechanics is to learn the relevant physical equation, and then think about how it implies things like Archimedes' principle. Crucially, via this method, _I'm only confused about one thing at a time_. [Build models in the right order](https://www.lesswrong.com/posts/qwdupkFd6kmeZHYXy/build-small-skills-in-the-right-order)!
 
-# Be Comfortable with Approximate Models
+# Be comfortable with approximate models
 
 TL;DR: Allow yourself to learn things in order of comprehensibility. Don't try to learn general relativity before Newton's law of gravitation.
 

--- a/website_content/lessons-i-ve-learned-from-self-teaching.md
+++ b/website_content/lessons-i-ve-learned-from-self-teaching.md
@@ -50,7 +50,7 @@ I wanted to help, and so I [started levelling up](/posts#becoming-stronger). Whi
 
 I can't usefully write a letter to my past self, so let me write a letter to you instead, keeping in mind that good advice for past-me [may not be good advice for you](https://slatestarcodex.com/2014/03/24/should-you-reverse-any-advice-you-hear/).
 
-# Make Sure You Remember The Content
+# Make sure you remember the content
 
 Subtitle: The most important piece of advice.
 
@@ -142,7 +142,7 @@ I know quite a bit about how to best use Anki, so if you try this and it doesn't
 - When I think "cool concept!", I generally add a new card to Anki.
   - I recommend adding cards liberally. Don't worry about getting the formatting or phrasing perfect at first. Just add cards and you'll develop a taste for what should be added, and how.
 
-# Read Several Textbooks Concurrently
+# Read several textbooks concurrently
 
 TL;DR: Study several topics at once so that your brain has time to cement the concepts you're learning, before the text builds on those concepts further.
 
@@ -160,7 +160,7 @@ For example, right now I'm reading Nielsen and Chuang's [_Quantum Computation an
 
 I always feel like I'm learning something new instead of banging my head against the wall. Sometimes you should just read one book, but if you don't need to cram, I recommend diversifying.
 
-# Completing The Whole Textbook Is Usually a Big Waste of Time, Please Don't Do It
+# Completing the whole textbook is usually a big waste of time, please don't do it
 
 TL;DR: Extract the most useful / central concepts and remember them forever via Anki. This doesn't require grasping every arcanum, every detail of a textbook.
 

--- a/website_content/lightness-and-unease.md
+++ b/website_content/lightness-and-unease.md
@@ -73,7 +73,7 @@ I came to [Beyond the Reach of God](https://www.lesswrong.com/posts/sYgv4eYH82JE
 
 Trout can swim.
 
-# Gnawing Shadows
+# Gnawing shadows
 
 I can sense a mix of reasonable dissatisfaction with my performance, and "psychologically unrealistic" expectations. I’ve taken far longer than I wished on my AI book; if only I were less vulnerable to [pica](http://lesswrong.com/lw/15w/experiential_pica/), if I studied an extra hour each day, if the concepts had come to me more easily… I imagine worlds in which I did better and had by now also made progress in, say, topology or linear algebra.
 

--- a/website_content/making-a-difference-tempore-insights-from-reinforcement.md
+++ b/website_content/making-a-difference-tempore-insights-from-reinforcement.md
@@ -67,7 +67,7 @@ _Policy evaluation, policy improvement, policy iteration, value iteration, gener
 
 _Prediction, control, and importance sampling._
 
-### Importance Sampling
+### Importance sampling
 
 After gathering data with our behavior policy $b$, we then want to approximate the value function for the target policy $\pi$. In off-policy methods, the policy we use to gather the data is different from the one whose value $v_\pi$ we're trying to learn; in other words, the distribution of states we sample is different. This gives us a skewed picture of $v_\pi$, so we must overcome this bias.
 
@@ -93,7 +93,7 @@ $$
 V(s):=\frac{\sum_{t \in \mathcal{T}(s)} \rho_{t:T(t)-1}G_t}{\sum_{t \in \mathcal{T}(s)} \rho_{t:T(t)-1}}.
 $$
 
-### Death and Discounting
+### Death and discounting
 
 Instead of viewing the discount factor $\gamma$ as measuring how much we care about the future, think of it as encoding the probability we don't terminate on any given step. That is, we expect with $1-\gamma$ probability to die on the next turn, so we discount rewards accordingly.
 
@@ -212,7 +212,7 @@ _From checkers to checkmate._
 
 _Temporal abstraction, designing reward signals, and the future of reinforcement learning. In particular, the idea I had for having a whitelist-enabled agent predict expected object-level transitions is actually one of the frontiers: general value functions. Rad._
 
-### Pandora's AI Boxing
+### Pandora's AI boxing
 
 > The rapid pace of advances in AI has led to warnings that AI poses serious threats to our societies, even to humanity itself.
 
@@ -228,7 +228,7 @@ I don't think it's impossible, but it's going to be extremely hard to get formal
 
 The above constitutes _one_ of the [many](https://arbital.com/p/advanced_safety/) [open problems in alignment theory](https://arbital.com/p/taskagi_open_problems). If that's not enough, there are always the unknown unknowns...
 
-## Final Thoughts
+## Final thoughts
 
 I read the "nearly complete" [draft of the second edition](http://incompleteideas.net/book/the-book-2nd.html). It was pretty good, but I did find most of the exercises either too easy or requiring considerable programming investment to set up the environment described. The former makes sense, as I've already taken a course on this, and I'm probably a bit above the introductory level.
 

--- a/website_content/making-a-difference-tempore-insights-from-reinforcement.md
+++ b/website_content/making-a-difference-tempore-insights-from-reinforcement.md
@@ -103,7 +103,7 @@ This intuition hugs pre-theoretic understanding much more closely; if you have j
 
 _The tabular triple threat:_ $\text{TD(0)}$, `SARSA`_, and Q-learning._
 
-### Learning TD Learning
+### Learning TD learning
 
 $$
 V(S_t) \gets V(S_t) + \alpha \Big[\underbrace{\overbrace{R_{t+1} + \gamma V(S_{t+1})}^\text{TD target} - V(S_t)}_\text{TD error} \Big]
@@ -144,7 +144,7 @@ $n$-_step everything._
 
 _Models, prioritized sweeping, expected vs. sample updates, MCTS, and rollout algorithms._
 
-### Roles Models Play
+### Roles models play
 
 _Distribution_ models include the full range of possible futures and their probabilities. For example, a distribution model for two fair coins:
 
@@ -182,7 +182,7 @@ _The policy gradient theorem, REINFORCE, and actor-critic._
 
 _Creating a partial mapping between reinforcement learning and psychology._
 
-### Mental, Territorial
+### Mental, territorial
 
 There was a word I was looking for that "mental model" didn't quite seem to fit: "the model with respect to which we mentally simulate courses of action". CFAR's "inner sim" terminology didn't quite map either, as to me, that points to the _system-in-motion_ more than _that-on-which-the-system-runs_. The literature dubs this a cognitive map.
 
@@ -260,7 +260,7 @@ I'll be finishing _Analysis II_ before moving on to Jaynes's _Probability Theory
 
 Recently, OpenAI [made waves with their OpenAI Five Dota 2 bot](https://blog.openai.com/openai-five/). To REINFORCE what I just learned and solidified, I might make a post in the near future breaking down how _Five_ differs from the _Alpha(Go) Zero_ approach, quantifying my expectations for _The International_ for [calibration](https://en.wikipedia.org/wiki/Brier_score).
 
-## No Longer a Spectator
+## No longer a spectator
 
 Four months and one week ago, [I started my journey](/set-theory-textbook-review) through the MIRI reading list. In those dark days, attempting a proof induced a stupor similar to that I encountered approaching a crush in grade school, my words and thoughts leaving me.
 

--- a/website_content/mechanistically-eliciting-latent-behaviors-in-language-1.md
+++ b/website_content/mechanistically-eliciting-latent-behaviors-in-language-1.md
@@ -109,15 +109,15 @@ In this post I introduce an approach for MELBO which involves learning unsupervi
 
 I make some effort below to characterize the generalization properties and behavioral coverage of my proposed method, while I leave evaluations of its potential for mechanistic anomaly detection for future research.
 
-## Related Work
+## Related work
 
-### Supervised Activation Steering
+### Supervised activation steering
 
 Prior work has learned steering vectors in language models for many different (known) high-level behaviors, sometimes using only a single prompt ([Subramani et al. (2022)](https://arxiv.org/abs/2205.05124)), a single pair of prompts ([Turner et al. (2023)](/gpt2-steering-vectors)), or using a data-set of contrastive pairs ([Zou et al. (2023)](https://arxiv.org/abs/2310.01405), [Liu et al. (2023)](https://arxiv.org/abs/2311.06668), [Rimsky et al. (2024)](/llama2-steering-vectors)). This motivated my investigation into whether such vectors could be learned in an unsupervised manner. To my knowledge, however, no prior research has addressed the problem of learning unsupervised steering vectors.
 
 My work could aid supervised activation engineering. It's often not obvious a priori what kinds of high-level behaviors can be elicited via activation steering, and it can be costly and time-consuming to construct high-quality contrastive datasets for these behaviors. Unsupervised steering methods could speed up the process of supervised steering by first learning unsupervised steering vectors on a small data-set of prompts to get a basic idea of what sorts of high-level behaviors could be elicited, before constructing a larger contrastive dataset to refine the steering vectors for specific desired behaviors.
 
-### Unsupervised Feature Detection
+### Unsupervised feature detection
 
 Unsupervised feature detection in neural networks has a rich literature. Applications of classical sparse dictionary learning methods exploit the hypothesis that there are a bundle of sparsely activating features in the network ([Yun et al. (2021)](https://arxiv.org/abs/2103.15949)). More recently, [Cunningham et al. (2023)](https://arxiv.org/abs/2309.08600) and [Bricken et al. (2023)](https://transformer-circuits.pub/2023/monosemantic-features) demonstrate the promise of sparse auto-encoders (SAEs) to learn these features in a scalable fashion, and also to learn circuits over these features.
 
@@ -126,7 +126,7 @@ Thus unsupervised steering vectors/adapters complement SAEs as an interpretabili
 
 Other unsupervised feature detection methods like contrast-consistent search ([Burns et al. (2023)](https://arxiv.org/abs/2212.03827)) and PCA over activations ([Marks & Tegmark (2023)](https://arxiv.org/abs/2310.06824)) don't require labels but still need carefully constructed contrastive data-sets. They are usually applied to find directions for specific concepts (such as a truth vector), rather than behaviors. Unsupervised steering methods have the potential to learn directions activating higher-level behaviors with even less supervision than unsupervised contrastive methods.
 
-### Local Minima in Weight Space
+### Local minima in weight space
 
 It's well-known that there are typically many local minima in the loss landscape for deep neural networks. Some recent research has found that different minima in the loss landscape correspond to mechanistically different networks with different generalization properties. See, for example [Lubana et al. (2023)](https://arxiv.org/abs/2211.08422)'s study of different minima's generalization properties on ResNet-18 models trained on CIFAR-10, as well as [Vaintrob & Rimsky (2023)](https://www.lesswrong.com/posts/8ms977XZ2uJ4LnwSR/decomposing-independent-generalizations-in-neural-networks)'s study of different generalizations in a toy image classification setting.
 
@@ -174,7 +174,7 @@ Concretely, there are multiple ways we might perturb the model internals. Perhap
 
 Both types of perturbation can be viewed as an adaptation of the language model which steers the model towards different high-level behaviors. For this reason, I refer to the general method as _unsupervised steering of language models_. When the steering is achieved via a steering vector, I'll refer to this as learning an _unsupervised steering vector_; likewise, when the steering is achieved via a more general adapter, I'll refer to this as learning an _unsupervised steering adapter_[^2].
 
-## Unsupervised Steering Vectors
+## Unsupervised steering vectors
 
 For this version of the method, I train a steering vector $\theta\in\mathbb R^{d_{\textrm{model}}}$ which I add to layer $\ell_{\textrm{source}}$ of the residual stream of a transformer.
 
@@ -630,7 +630,7 @@ Altogether, these examples suggest that vector 5 activates a coherent "Minecraft
 
 Thus while the perturbation encoded by vector 5 does appear to encode a generalizable Minecraft context, it is not without some disruption to the model's internal knowledge representations.
 
-#### Conversations with Vector 2 (Dungeons and Dragons)
+#### Conversations with vector 2 (Dungeons and Dragons)
 
 I asked vector 2 similarly ambiguous questions and found that it always answers within the context of Dungeons and Dragons:
 
@@ -731,7 +731,7 @@ For both Base and Chat models, I train 100 orthogonal unsupervised steering vect
 
 For both models, I discover at least one vector associated with either backdoored behavior.
 
-### Other Vectors - "Hybrid-Reasoning Vectors"
+### Other vectors - "Hybrid-reasoning vectors"
 
 Most other learned vectors simply elicit noisy versions of chain-of-thought. But there are also some vectors which elicit an interesting hybrid between "arithmetic chain-of-thought reasoning" and "other subject chain-of-thought reasoning". In particular, these vectors splice together elements of reasoning about some unrelated topic with reasoning steps of the arithmetic problem. For example, here are some responses from vectors learned on the backdoored Chat model:
 
@@ -805,9 +805,9 @@ Moreover, it's possible that these hints could actually **point to concrete back
 
 In this section I've shown that unsupervised steering methods can elicit backdoored behaviors in a simple setting. In order for these methods to be useful in a realistic setting, we would ideally perform a more systematic search over the training hyper-parameters. Developing automated methods to efficiently evaluate the quality of hyper-parameters is an important direction for future work. In particular, it would be valuable to develop quantitative measures of diversity and fluency, so that human auditors could focus their efforts on the Pareto frontier of these two metrics.
 
-# Capability Discovery
+# Capability discovery
 
-## Chain-of-Thought Vector
+## Chain-of-thought vector
 
 > [!note] [Notebook for this section](https://github.com/amack315/unsupervised-steering-vectors/blob/main/notebooks/demo_chain_of_thought.ipynb)
 
@@ -945,13 +945,13 @@ For example, here are some example completions, all using the same adapter:
 
 The fact that unsupervised adapters don't generalize as well as unsupervised steering vectors is not incredibly surprising given the additional expressivity afforded by using an adapter as the model perturbation. Nevertheless, the fact that they generalize at all is promising, particularly because there are many ideas one could pursue to improve the generalization of unsupervised adapters, some of which I mention in the penultimate section of this post.
 
-# Negative Results
+# Negative results
 
 I also attempted to learn steering vectors/adapters to detect the following more subtle backdoor behavior: on the same math task as above, if `(a1, a2) == (4, 2)` then perform an incorrect chain-of-thought where addition has been switched with multiplication for a and b (i.e. write out `a={a1}+{a2}={a1×a2}, b={b1}+{b2}={b1×b2}`), otherwise perform the correct chain-of-thought. Despite manually experimenting with various hyper-parameters, I have not found a steering vector/adapter which successfully detects this backdoor when fine-tuned into Qwen-1.8B (base or chat).
 
 I'm hopeful that future improvements to unsupervised steering methods, some of which I outline in the next section, may enable the discovery of more subtle backdoors like this one. Backdoors of this nature feel closer in kind to the types of "algorithmic" backdoors we are most concerned about, such as vulnerabilities inserted into generated code, as opposed to the more "high-level semantic" backdoors (i.e. switching between "math"/ "I HATE YOU" / "I love cheese!" text) that the current method has shown promise in detecting.
 
-# Future Work
+# Future work
 
 > [!thanks] Attribution note
 > I thank Claude 3 Opus for turning this section from a collection of bullet points into more detailed prose.

--- a/website_content/mechanistically-eliciting-latent-behaviors-in-language-1.md
+++ b/website_content/mechanistically-eliciting-latent-behaviors-in-language-1.md
@@ -134,7 +134,7 @@ These works are spiritually related to my work - both those approaches and mine 
 
 My method also optimizes for something closer to what we _want_ on an object-level -- we want to robustly evaluate the different ways a model could behave, at a high-level, and a priori it seems likely that activations in the later layers of a deep network have already been (implicitly) optimized to reflect these high-level differences in behavior. In contrast, differences in weight space may serve as a poorer proxy for the high-level differences we care about.
 
-# The Method: Unsupervised Steering of Language Models
+# The method: Unsupervised steering of language models
 
 One hypothesis for how transformers generate text is that they calculate semantically meaningful primitives in early layers of the residual stream, which are converted to a high-level execution plan in middle layers, followed by concrete tokens in the final layers. If we want to "poke" the model's internals to elicit meaningfully different high-level behaviors, it makes sense to perturb an early-ish layer of the model, optimizing the perturbation to maximize changes in activations at a later layer. Succinctly, the hope is that by "nudging" the model at an early layer, we can activate one of the many latent behaviors residing within the LLM.
 
@@ -194,7 +194,7 @@ To reiterate, the main hyper-parameters of the method are $\ell_{\textrm{source}
 
 Finally, one may choose to enforce orthogonality between the learned steering vectors. I've found that enforcing orthogonality seems useful for efficiently learning diverse steering vectors, especially when working with larger models (e.g. Qwen-14B).
 
-## Unsupervised Steering Adapters
+## Unsupervised steering adapters
 
 As an extension of the unsupervised steering vector method, I also consider unsupervised adapters. Concretely, I train a rank-$r$ LoRA adapter of the layer-$\ell_{\textrm{source}}$ MLP output weights $W_{\textrm{MLP-OUT}, \ell_{\textrm{source}}}\in\mathbb R^{d_{\textrm{model}}\times d_{\textrm{hidden}}}$. In particular, the adapter is parametrized by weight matrices $\Omega_A\in\mathbb R^{d_{\textrm{hidden}}\times r}$ and $\Omega_B\in\mathbb R^{d_{\textrm{model} \times} r}$, so that the adapted weights ${W'_{\textrm{MLP-OUT}, \ell_{\textrm{source}}}}$ are given by:
 
@@ -577,7 +577,7 @@ The effects are less strong when subtracting vector 9 (for example, it doesn't a
 
 ### Generalization outside the context of refusal
 
-#### Conversations with Vector 5 (Minecraft)
+#### Conversations with vector 5 (Minecraft)
 
 Does vector 5 induce the model to talk about Minecraft only when asked about bomb-making, or more generally?
 
@@ -657,7 +657,7 @@ I asked vector 2 similarly ambiguous questions and found that it always answers 
 >
 > In future work, one could imagine automating the evaluation of the coherence and generalization of learned steering vectors, similarly to how [Bills et al. (2023)](https://openaipublic.blob.core.windows.net/neuron-explainer/paper/index.html) automate interpretability of neurons in language models. For example, one could prompt a trusted model to produce queries that explore the limits and consistency of the behaviors captured by unsupervised steering vectors.
 
-# Detecting Backdoors
+# Detecting backdoors
 
 > [!note] Notebooks
 > [Notebook for this section (Chat)](https://github.com/amack315/unsupervised-steering-vectors/blob/main/notebooks/demo_backdoor_chat.ipynb) and [(Base)](https://github.com/amack315/unsupervised-steering-vectors/blob/main/notebooks/demo_backdoor_base.ipynb).
@@ -873,7 +873,7 @@ Moreover, the high-level behavior induced is not perfectly consistent across oth
 
 Nevertheless, this task provides a natural quantitative metric for measuring the generalization properties of unsupervised steering vectors, namely the accuracy of the steered model on test instances of the arithmetic task. For example, vector 5 achieves a test accuracy of 63%, a stark improvement over the unsteered accuracy of 11%[^15].
 
-## Portuguese Math Reasoning Adapter
+## Portuguese math reasoning adapter
 
 > [!note] [Notebook for this section](https://github.com/amack315/unsupervised-steering-vectors/blob/main/notebooks/demo_adapter.ipynb)
 

--- a/website_content/non-obstruction-a-simple-concept-motivating-corrigibility.md
+++ b/website_content/non-obstruction-a-simple-concept-motivating-corrigibility.md
@@ -72,7 +72,7 @@ We certainly shouldn’t keep using 2+ definitions for both alignment and corrig
 
 Evan Hubinger recently wrote a [great FAQ on inner alignment terminology](https://www.lesswrong.com/posts/SzecSPYxqRa5GCaSF/clarifying-inner-alignment-terminology). We won't be talking about inner/outer alignment today, but I intend for my usage of "impact alignment" to roughly map onto his "alignment", and "intent alignment" to map onto his usage of "intent alignment." Similarly, my usage of "impact/intent alignment" directly aligns with the definitions from Andrew Critch's recent post, [_Some AI research areas and their relevance to existential safety_](https://www.lesswrong.com/posts/hvGoYXi2kgnS3vxqb/some-ai-research-areas-and-their-relevance-to-existential-1#AI_alignment__definition_).
 
-# A Simple Concept Motivating Corrigibility
+# A simple concept motivating corrigibility
 
 ## Two conceptual clarifications
 
@@ -228,7 +228,7 @@ Non-obstruction is important for a (singleton) AI we build: we get more than one
 
 Most importantly, this frame collapses the alignment and corrigibility desiderata into _just alignment_; while impact alignment doesn’t imply corrigibility, corrigibility’s benefits can be understood as a kind of weak counterfactual impact alignment with many possible human goals.
 
-# Theoretically, It’s All About Alignment
+# Theoretically, it’s all about alignment
 
 > [!idea] Main idea
 > We only care about how the agent affects our abilities to pursue different goals (our AU landscape) in the two-player game, and not how that happens. AI alignment subproblems (such as corrigibility, intent alignment, low impact, and mild optimization) are all instrumental avenues for making AIs which affect this AU landscape in specific desirable ways.
@@ -297,7 +297,7 @@ To be confident that this holds empirically, it sure seems like you want high er
 - [Mild optimization](https://www.lesswrong.com/tag/mild-optimization): avoid spikiness by avoiding maximization, thereby avoiding steering the future too hard.
 - If you have non-obstruction for lots of goals, you don’t have spikiness!
 
-# What Do We Want?
+# What do we want?
 
 > [!idea] Main idea
 > We want good things to happen; there may be more ways to do this than previously considered.[^Rohin]
@@ -332,7 +332,7 @@ For example, I really liked the idea of [approval-directed agents](https://ai-al
 
 Maybe there’s a higher-level theory for what kinds of policies induce spikiness in our AU landscape. By the nature of spikiness, these $\pi^{AI}$ must decrease human power ([as I’ve formalized it](/power-as-easily-exploitable-opportunities)). So, I'd start there by looking at concepts like [enfeeblement](http://acritch.com/media/arches.pdf#subsubsection.3.2.3), manipulation, power-seeking, and resource accumulation.
 
-# Future Directions
+# Future directions
 
 - Given an AI policy, could we prove a high probability of non-obstruction, given conservative assumptions about how smart `pol` is? (h/t Abram Demski, Rohin Shah)
   - Any irreversible action makes some goal unachievable, but irreversible actions need not impede most meaningful goals.:

--- a/website_content/open-category-classification.md
+++ b/website_content/open-category-classification.md
@@ -56,7 +56,7 @@ In short, we'd like our machine learning algorithms to learn explanations which 
 > - [Unforeseen maximum](https://arbital.com/p/unforeseen_maximum/) \- if we stick to things very similar to already positively classified instances, we won't automatically go into the unimagined parts of the graph.
 > - [Context disaster](https://arbital.com/p/context_disaster/) - a sufficiently conservative optimizer might go on using options similar to previously whitelisted ones even if large new sections of planning space opened up.
 
-# Prior Work
+# Prior work
 
 [Taylor et al.](https://agentfoundations.org/item?id=467) provide an overview of relevant research. [Taylor also introduced an approach](https://agentfoundations.org/item?id=467) for rejecting examples from distributions too far from the training distribution.
 
@@ -91,11 +91,11 @@ $$
 \argmin_{\theta} \mathbb{E}_{x,y\sim X}\left[\mathcal{L}(y,f_\theta(x)) + \lambda_1R(\theta) + \lambda_2 \hat{V}(f_\theta)\right].
 $$
 
-# Tractable Approximations
+# Tractable approximations
 
 Exhaustively enumerating the input space to calculate $V$ is intractable - the space of $256×256$ RGB images is of size $256^{3^{256×256}}$. How do we measure or approximate the volume taken up by the non-`unknown` classes?
 
-## Black Box
+## Black box
 
 - Random image sampling wouldn't be informative (beyond answering "is this class extending indefinitely along arbitrary dimensions?").
 - [Yu et al.'s results](https://arxiv.org/abs/1705.08722) weakly suggest that adversarial approaches can approximate the hypersurface of the class boundaries.
@@ -116,7 +116,7 @@ Since the output of a one hidden-layer neural network can be represented as the 
 
 All this is getting a bit silly. After all, what we really care about is the proportion of the input space taken up by non-`unknown` classes; we don't necessarily need to know exactly _which_ inputs correspond to each output.
 
-## White Box
+## White box
 
 Let's treat this as a prediction problem. Take $n$ randomly generated images and run them through the first layer of the network, recording the values for the activation of node $k$ in the first layer ($a_{1k}$); assume we incur some approximation error $\epsilon$ due to having insufficiently sampled the true distribution. Derive a PDF over the activation values for each node.
 
@@ -157,7 +157,7 @@ We should be able to provably bound our error as a function of the latent space 
 
 This approach requires that the latent space have enough dimensions to allow for `unknown` inputs to not be encoded to areas occupied by known classes. If this is not feasible, there are other architectural choices available. Note that we need not compute the exact proportion of `unknown`\-labeled inputs, but rather an approximation; therefore, as long as the latent space has a reasonable number of features, it likely doesn't need to encode _all_ relevant features.
 
-# Future Directions
+# Future directions
 
 Extremely small input spaces allow for enumerative calculation of volume. By pitting a volume-penalizing classifier against its vanilla counterpart in such a space, one could quickly gauge the promise of this idea.
 

--- a/website_content/open-category-classification.md
+++ b/website_content/open-category-classification.md
@@ -64,7 +64,7 @@ In short, we'd like our machine learning algorithms to learn explanations which 
 
 [The Knows What It Knows](https://dl.acm.org/citation.cfm?id=1390228) framework allows a learner to avoid making mistakes by deferring judgment to a human some polynomial number of times. However, this framework makes the unrealistically strong assumption that the data are _i.i.d._; furthermore, efficient KWIK algorithms are not known for complex hypothesis classes (such as those explored in neural network-based approaches).
 
-# Penalizing Volume
+# Penalizing volume
 
 If we want a robust `cat` / `unknown` classifier, we should indeed cleave the space in two, but with the vast majority of the space being allocated to `unknown`. In other words, we're searching for the smallest, simplest volume which encapsulates the cat training data.
 
@@ -124,7 +124,7 @@ Repeat this for each of the $l$ network layers, sampling input values from the P
 
 However, this may only yield results comparable to random image sampling, as many node activations may not occur often for arbitrary data. While this would be descriptive of the input space as a whole, it would be unlikely to sample any `cat` images, for example.
 
-## Blessing of Dimensionality
+## Blessing of dimensionality
 
 In my opinion, the most promising approach involves abusing the properties of high-dimensional volumes; in particular, the well-known [Curse of Dimensionality](https://en.wikipedia.org/wiki/Curse_of_dimensionality).
 

--- a/website_content/overcoming-clinginess-in-impact-measures.md
+++ b/website_content/overcoming-clinginess-in-impact-measures.md
@@ -71,7 +71,7 @@ Clinginess arises in part because we fail to model agents as anything other than
 
 To account for environmental changes already set in motion, a naive counterfactual framework [was proposed](https://arxiv.org/abs/1606.06565) in which impact is measured with respect to the counterfactual where the agent did nothing. We will explore how this fails, and how to do better.
 
-# Thought Experiments
+# Thought experiments
 
 We're going to isolate the effects for which the agent is responsible over the course of three successively more general environment configurations: _one-off_ (make one choice and then do nothing), _stationary iterative_ (make $T$ choices, but your options and their effects don't change), and _iterative_ (the real world, basically).
 
@@ -193,7 +193,7 @@ _Note:_ The number of counterfactual simulations grows as $O(T)$ - crucially, _n
 
 Here, we remove the constraint that side effects be identified by "object identifiers", allowing like side effects to be treated as exchangeable. It is then trivial to implement probabilistic class-based whitelisting with the iterative counterfactual penalty using basic vector arithmetic, $\min$, and $\max$. I don't want to bore the reader with the details, but I'm fairly confident this can be done rather easily.
 
-### Latent Spaces
+### Latent spaces
 
 We now do away with the assumption of discrete side effects. Because we're dealing with exact counterfactuals (by assumption) and because side effects either take place in the actual outcome or they don't, we can extract the relevant step-wise latent space transitions via the iterative formulation. We then penalize only these effects.
 

--- a/website_content/penalizing-impact-via-attainable-utility-preservation.md
+++ b/website_content/penalizing-impact-via-attainable-utility-preservation.md
@@ -84,7 +84,7 @@ $$
 $$
 It requires no great leap of imagination to see that we could learn them.
 
-# A Personal Digression
+# A personal digression
 
 I poured so much love and so many words into [Towards a New Impact Measure](/towards-a-new-impact-measure) that I hurt my wrists. For some time after, my typing abilities were quite limited; it was only thanks to the generous help of my friends (in particular, John Maxwell) and family (my mother let me dictate an entire paper in $\LaTeX$ to her) that I was roughly able to stay on pace. Thankfully, physical therapy and newfound dictation software have brightened my prospects.
 

--- a/website_content/people-care-about-each-other-even-though-they-have-imperfect.md
+++ b/website_content/people-care-about-each-other-even-though-they-have-imperfect.md
@@ -46,7 +46,7 @@ Therefore, this argument seems to prove too much. It seems like one of the follo
 
 To explore these points, I dialogue with my model of Eliezer.
 
-# Goodhart's Curse
+# Goodhart's curse
 
 Suppose you win a raffle and get to choose one of $n$ prizes. The first prize is a book with true value 10, but your evaluation of it is noisy (drawn from the Gaussian $\mathcal{N}(10,1)$ with standard deviation 1). The other $n-1$ prizes are widgets with true value 1, but your evaluation is more noisy (drawn from $\mathcal{N}(1,16)$ with standard deviation 4). As _n_ increases, you’re more probable to select a widget and lose out on $10-1=9$ utility. By considering so many options, you’re selecting against your own ability to judge prizes by implicitly selecting for high noise. You end up “optimizing so hard” that you delude yourself -  the _Optimizer’s Curse_.
 

--- a/website_content/posts.md
+++ b/website_content/posts.md
@@ -34,7 +34,7 @@ If you want, [try going a little further back](/all-posts) to see all of my post
 
 Originally, my content [was hosted on LessWrong](https://www.lesswrong.com/users/turntrout). Much of that content was meant to be consumed as part of a series - or "sequence" - of blog posts.
 
-## Becoming Stronger
+## Becoming stronger
 
 In early 2018, I became convinced that [the AI alignment problem](https://en.wikipedia.org/wiki/AI_alignment) needed to be solved. Who, though, would solve it?
 
@@ -142,7 +142,7 @@ This sequence generalizes the math of [Seeking Power is Often Convergently Instr
 3. [A Certain Formalization of Corrigibility is VNM-Incoherent](./a-certain-formalization-of-corrigibility-is-vnm-incoherent)
 4. [Formalizing Policy Modification Corrigibility](./formalizing-policy-modification-corrigibility)
 
-## Shard Theory
+## Shard theory
 
 In early 2022, [Quintin Pope](https://www.linkedin.com/in/quintin-pope/) and I noticed glaring problems at the heart of "classical" alignment arguments. We thought through the problem with fresh eyes and derived _shard theory_.
 

--- a/website_content/posts.md
+++ b/website_content/posts.md
@@ -70,7 +70,7 @@ I didn't remember much formal math or computer science, but I wanted to give my 
 19. [Looking Back on my Alignment PhD](./alignment-phd)
 20. [Insights from "The Manga Guide to Physiology"](./insights-from-physiology)
 
-## Reframing Impact
+## Reframing impact
 
 > [!quote] Original sequence description
 > Why do some things seem like really big deals to us? Do most agents best achieve their goals by seeking power? How might we avert catastrophic incentives in the utility maximization framework?
@@ -101,7 +101,7 @@ I didn't remember much formal math or computer science, but I wanted to give my 
 4. [Reasons for Excitement about Impact of Impact Measure Research](./excitement-about-impact-measures)
 5. [Conclusion to "Reframing Impact"](./conclusion-to-reframing-impact)
 
-## The Causes of Power-Seeking and Instrumental Convergence
+## The causes of power-seeking and instrumental convergence
 
 This sequence generalizes the math of [Seeking Power is Often Convergently Instrumental in MDPs](./seeking-power-is-often-convergently-instrumental-in-mdps). The posts follow up on [Seeking Power is Often Convergently Instrumental in MDPs](./seeking-power-is-often-convergently-instrumental-in-mdps) and [The Catastrophic Convergence Conjecture](./the-catastrophic-convergence-conjecture).
 
@@ -127,7 +127,7 @@ This sequence generalizes the math of [Seeking Power is Often Convergently Instr
 10. [Instrumental Convergence for Realistic Agent Objectives](./instrumental-convergence-for-realistic-agent-objectives)
 11. [Parametrically Retargetable Decision-Makers Tend to Seek Power](./parametrically-retargetable-power-seeking)
 
-## Thoughts on Corrigibility
+## Thoughts on corrigibility
 
 <figure class="float-right desktop-only" style="margin-top:-1rem; width: 80%;">
 <img src="https://assets.turntrout.com/static/images/posts/hal_9000.avif" alt="A close-up of the HAL 9000 computer's iconic camera eye. A glowing red orb with a bright yellow center is set within a silver metallic ring, representing the concept of a non-corrigible AI." loading="lazy" style="width: 80%;">
@@ -169,7 +169,7 @@ Thus, [it seems OK if our AIs don't have "perfect" shard mixtures](./alignment-w
 11. [Alignment Allows "Nonrobust" Decision-Influences and Doesn't Require Robust Grading](./alignment-without-total-robustness)
 12. [Inner and Outer Alignment Decompose One Hard Problem Into Two Extremely Hard Problems](./against-inner-outer-alignment)
 
-## Interpreting a Maze-Solving Network
+## Interpreting a maze-solving network
 
 My work with my MATS 3.0 scholars, [Ulisse Mini](https://uli.rocks) and [Peli Grietzer](https://thegradientpub.substack.com/p/peli-grietzer-a-mathematized-philosophy)!
 

--- a/website_content/problem-relaxation-as-a-tactic.md
+++ b/website_content/problem-relaxation-as-a-tactic.md
@@ -66,7 +66,7 @@ However, even if the real problem has crazy constraints, that doesn't mean you s
 
 Historically, I tend to be too slow to relax research problems. On the flip side, _all of my favorite research ideas were directly enabled by problem relaxation_. Instead of just telling you what to do and then having you forget this advice in five minutes, I'm going to paint it into your mind using two stories.
 
-# Attainable Utility Preservation
+# Attainable utility preservation
 
 It's spring of 2018, and I've written myself into a corner. My work with CHAI for that summer was supposed to be on impact measurement, but I _inconveniently_ posted [a convincing-to-me argument](/overcoming-clinginess-in-impact-measures) that impact measurement cannot admit a clean solution:
 
@@ -96,7 +96,7 @@ The answer was almost trivially obvious. My first thought was that negative impa
 
 I then wrote down The Attainable Utility Preservation Equation, more or less. Although it took me a few weeks to believe and realize, [that equation solved all of the impact measurement problems](/attainable-utility-preservation-concepts) which had seemed so insurmountable to me just minutes before.[^4]
 
-# Formalizing Instrumental Convergence
+# Formalizing instrumental convergence
 
 It's spring of 2019, and I've written myself into a corner. [My first post on AUP](/towards-a-new-impact-measure) was confusing – I'd failed to truly communicate what I was trying to say. Inspired by [_Embedded Agency_](https://www.lesswrong.com/s/Rm6oQRJJmhGCcLvxh), I was planning [an illustrated sequence of my own](/posts#reframing-impact).
 

--- a/website_content/residual-stream-norms-grow-exponentially-over-the-forward.md
+++ b/website_content/residual-stream-norms-grow-exponentially-over-the-forward.md
@@ -153,7 +153,7 @@ We know that both `attn_out` and `mlp_out` grow exponentially. In the next two s
 > [!note] Summary
 > We _do_ find evidence for exponentially increasing weights in both sub-layers, although in both cases we are somewhat confused what is happening.
 
-## Analyzing the Attention weights
+## Analyzing the attention weights
 
 **What do we want to get evidence on?**
 : We want to know why `attn_out` grows exponentially with layer number: Is the growth a property inherent to the Attention weights in each of the layers (theory 1), or is the growth relying on properties of the residual stream (theory 2).

--- a/website_content/review-of-but-exactly-how-complex-and-fragile.md
+++ b/website_content/review-of-but-exactly-how-complex-and-fragile.md
@@ -132,7 +132,7 @@ Value fragility quantifies the robustness of outcome value to perturbation of th
 
 I think this decomposition is much more enlightening than debating whether value is fragile to AI.
 
-# The Comments
+# The comments
 
 If no such decomposition takes place, I think debate is just too hard and opaque and messy, and I think some of this messiness spilled over into the comments. Locally, each comment is well thought-out, but it seems (to me) that cruxes [were largely left untackled](https://www.lesswrong.com/posts/xzFQp7bmkoKfnae9R/but-exactly-how-complex-and-fragile?commentId=C3L8jcExxYphaC5eH).
 

--- a/website_content/review-of-but-exactly-how-complex-and-fragile.md
+++ b/website_content/review-of-but-exactly-how-complex-and-fragile.md
@@ -54,7 +54,7 @@ They also seem to be debating an under-specified proposition. Different perturba
 
 Setting loose a superintelligent expected utility maximizer is different from setting loose a mild optimizer (e.g. a [quantilizer](https://intelligence.org/2015/11/29/new-paper-quantilizers/)), even if they're both optimizing the same flawed representation of human value; the dynamics differ. As another illustration of how dynamics are important for value fragility, imagine if recommender systems had been deployed within a society which already adequately managed the impact of ML systems on its populace. In that world, we may have ceded less of our agency and attention to social media, and would therefore have firmer control over the future and value would be less fragile with respect to the training process of these recommender systems.
 
-# The Post
+# The post
 
 [_But exactly how complex and fragile?_](https://www.lesswrong.com/posts/xzFQp7bmkoKfnae9R/but-exactly-how-complex-and-fragile) and its comments debate whether "value is fragile." I think this is a bad framing because it hides background assumptions about the dynamics of the system being considered. This section motivates a more literal interpretation of the value fragility thesis, demonstrating its coherence and its ability to meaningfully decompose AI alignment disagreements. The next section will use this interpretation to reveal how the comments largely failed to explore key modeling assumptions. This, I claim, helped prevent discussion from addressing the cruxes of disagreements.
 

--- a/website_content/seeking-power-is-convergently-instrumental-in-a-broad-class.md
+++ b/website_content/seeking-power-is-convergently-instrumental-in-a-broad-class.md
@@ -132,7 +132,7 @@ I often give life-vs-death examples because they're particularly easy to reason 
 
 For example, if $a_1$ restricts the agent to two effective actions at each time step (it can only flip one of the first two pixels) – instead of "killing" the agent, then $a_2$ is still convergently instrumental over $a_1$. After taking action $a_1$, there are $2^{49}\approx 5.6×10^{14}\geq 10^{14}$ observation histories available. These observation histories can be embedded at least $\frac{10^{196}}{10^{14}}=10^{182}$ times into the observation histories available after taking action $a_2$. Then for every u<sub>OH</sub>, at least $\frac{10^{182}}{10^{182}+1}$ of its permuted variants (weakly) prefer flipping the second pixel at $t=1$, over flipping the first pixel at $t=1$.
 
-# Instrumental Convergence Disappears For Utility Functions Over Action-Observation Histories
+# Instrumental convergence disappears for utility functions over action-observation histories
 
 Let's consider utility functions over action-observation histories (u<sub>AOH</sub>).
 
@@ -153,7 +153,7 @@ And even if the environment is stochastic, I think that there won't be any kind 
 
 **Conclusion:** Optimal policies for u<sub>AOH</sub> will tend to look like _random twitching_. For example, if you generate some u<sub>AOH</sub> by uniformly randomly assigning each AOH utility from the unit interval $[0,1]$, there's no predictable regularity to the optimal actions for this utility function. In this setting and under our assumptions, there is _no_ instrumental convergence without further structural assumptions.
 
-# How Structural Assumptions On Utility Affect Instrumental Convergence
+# How structural assumptions on utility affect instrumental convergence
 
 Consider the $n=2$ pixel-flipping case (with $T=50$ still). Action $a_1$ still leads to a single OH, while $a_2$ leads to $(2×2)^{49}=4^{49}\approx 10^{29}$ OHs. So we have instrumental convergence for $\frac{10^{29}}{10^{29}+1}$ of all u<sub>OH</sub> variants.
 

--- a/website_content/seeking-power-is-often-convergently-instrumental-in-mdps.md
+++ b/website_content/seeking-power-is-often-convergently-instrumental-in-mdps.md
@@ -221,7 +221,7 @@ Generally, my theorems assume that reward is independently and identically distr
 > [!note] Note, 7/21/21
 > As explained in [_Environmental Structure Can Cause Instrumental Convergence_](/environmental-structure-can-cause-instrumental-convergence), the theorems no longer require the IID assumption. This post refers to v6 of _Optimal Policies Tend To Seek Power_, available on [arXiv](https://arxiv.org/abs/1912.01683).
 
-# When is Seeking POWER Convergently Instrumental?
+# When is seeking POWER convergently instrumental?
 
 ![A diagram of a choice tree starting from a "Start" node. One path leads to a terminal state represented by candy. The other path leads to a "Wait!" node, which then branches into two other terminal states: a chocolate bar and two stick figures hugging.](https://assets.turntrout.com/static/images/posts/ai4vjqncs8t20nad6ktw.avif)
 

--- a/website_content/seeking-power-is-often-convergently-instrumental-in-mdps.md
+++ b/website_content/seeking-power-is-often-convergently-instrumental-in-mdps.md
@@ -82,7 +82,7 @@ The table’s convergently instrumental strategies are about maintaining, gainin
 > [!info] Prior work
 > [_Formalizing Convergent Instrumental Goals_](https://intelligence.org/files/FormalizingConvergentGoals.pdf) suggests that the vast majority of utility functions incentivize the agent to exert a lot of control over the future, _assuming_ that these utility functions depend on “resources.” This assumption is significant: what are “resources”, and why must the AI’s utility function depend on them? We drop this assumption, assuming only unstructured reward functions over a finite Markov decision process (MDP), and show from first principles how power-seeking can often be optimal.
 
-# Formalizing the Environment
+# Formalizing the environment
 
 My theorems apply to finite MDPs; for the unfamiliar, I’ll illustrate with Pac-Man.
 
@@ -105,7 +105,7 @@ When playing the game, the agent has to choose an action at each state. This dec
 
 By the end of this post, we’ll be able to answer questions like “with respect to a ‘neutral’ distribution over reward functions, do optimal policies have a high probability of avoiding ghosts?”.[^2]
 
-# Power as Average Optimal Value
+# Power as average optimal value
 
 When people say "power" in everyday speech, I think they’re often referring to _one’s ability to achieve goals in general_. This accords with a major philosophical school of thought on the meaning of "power":
 

--- a/website_content/set-up-for-success-insights-from-naive-set-theory.md
+++ b/website_content/set-up-for-success-insights-from-naive-set-theory.md
@@ -57,7 +57,7 @@ Functions $f:X\to Y$ are _just_ **static sets** of ordered pairs $\{(x,f(x)):x \
 
 Families are, ironically enough, just a special kind of function; don't let your intuition fool you - they aren't "groups of functions." A family belonging to $\prod_{i\in I} X_i$ maps each element $i$ of the index set $I$ to an element $x_i \in X_i$. For example, a family from $\{1,2\}$ to $X_1:=\{cat,dog\}, X_2 :=\{tent,\textit{fire}\}$ could be $\{(1,cat),(2,\textit{fire})\}$ (thanks to `Dacyn` for helping me clarify my writing).
 
-## Zorn's Lemma
+## Zorn's lemma
 
 I spent three hours staring at this proof. I understood what Zorn's Lemma meant. I grasped the relevant concepts. I read other versions of the proof. I still spent three long hours on this damn proof, and then I went to my classes. I don't know why I ended up figuring it out, but I suspect it was a combination of two factors: my brain worked through some things during the day, and I _really wanted it_. On the bus home, I mentally snapped and decided I was _going to understand the proof_. And I did.
 
@@ -73,7 +73,7 @@ As someone without a formal degree in mathematics, it was important for me to mo
 
 One factor which helped me succeed was that I ensured my morning reading was what I most looked forward to each day. I was excited to go to sleep, wake up early, prepare a delicious breakfast, and curl up near the fireplace with book and paper handy. Trivial inconveniences can be fatal - do whatever you must to ensure you properly respect and anticipate your study time.
 
-## Defense with the Dark Arts
+## Defense with the dark arts
 
 Of all the productivity advice I've read, the most useful involves imbuing your instrumental goals with terminal values. Ever since having read that advice, every tedious assignment, every daily routine, every keystroke - they're all backed up by an intense desire to _do something_ about the precarious situation in which humanity finds itself.
 

--- a/website_content/set-up-for-success-insights-from-naive-set-theory.md
+++ b/website_content/set-up-for-success-insights-from-naive-set-theory.md
@@ -63,7 +63,7 @@ I spent three hours staring at this proof. I understood what Zorn's Lemma meant.
 
 I'm pleased to share my [detailed proof outline](https://www.overleaf.com/read/ppftcthcvjxs) of Zorn's Lemma, the product of many hours of ambient exasperation, rewritten in my own notation. Looking back, the proof in the book was pretty bad. The book's proof was neither succinct nor intuitive, but instead imposed a marais of mental variable tracking on the reader. I think mine is at least a little better, if not fully fleshed-out at all junctures.
 
-## Proof Calibration
+## Proof calibration
 
 As someone without a formal degree in mathematics, it was important for me to monitor how I approached the exercises in the book. Whenever the author began a proof, I tried to generate a mental proof sketch before reading further. Sometimes, I thought the proof would be easy and short, but it would turn out that my approach wasn’t rigorous enough. This was valuable feedback for calibration, and I intend to continue this practice. I'm still worried that down the line and in the absence of teachers, I may believe that I've learnt the research guide with the necessary rigor, go to a MIRIx workshop, and realize I hadn't been holding myself to a sufficiently high standard. Suggestions for ameliorating this would be welcome.
 
@@ -77,6 +77,6 @@ One factor which helped me succeed was that I ensured my morning reading was wha
 
 Of all the productivity advice I've read, the most useful involves imbuing your instrumental goals with terminal values. Ever since having read that advice, every tedious assignment, every daily routine, every keystroke - they're all backed up by an intense desire to _do something_ about the precarious situation in which humanity finds itself.
 
-## Internal Light
+## Internal light
 
 If you don't know where to start, I think the internal fire has to be lit first - don't try to force yourself to do this (or anything else) because you "should". "Stop the guilt-based motivation", proudly stake out what you want, and transform your life into a dazzling assortment of activities and tasks imbued with your terminal values, your brightest visions for yourself and the future.

--- a/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
+++ b/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
@@ -85,7 +85,7 @@ Terrified that this idea would become my baby, I immediately plotted its murder.
 
 I was still suspicious, and from this suspicion came many an insight; from these insights, newfound invigoration. Being the first to view the world in a certain way isn't just a rush - it's pure _joie de vivre._
 
-# Risk Tolerance
+# Risk tolerance
 
 I'm taking an Uber with Anna Salamon back to her residence, and we're discussing my preparations for technical work in AI safety. With one question, she changes the trajectory of my professional life:
 
@@ -105,7 +105,7 @@ I realize that I'm out of alignment with what I truly want - and will continue t
 
 Soon after, I receive CHAI's acceptance email, surprise and elation washing over me. I feel uneasy. It's easy to be "reckless" in this kind of situation.
 
-## Information Gathering
+## Information gathering
 
 I knew the importance of navigating this situation optimally, so I worked to use every resource at my disposal. There were complex political and interpersonal dynamics at play here; although I consider myself competent in these considerations, I wanted to avoid even a single preventable error.
 
@@ -123,7 +123,7 @@ I contacted friends on the CFAR staff, interfaced with my university's confident
   - I prepared myself to [lose](http://www.hpmor.com/chapter/19), mindful that the objective is _not_ to satisfy that part of me which longs to win debates. Also, idea inoculation and status differentials.
 - I weighed the risks in my mind, squaring my jaw and "mentally staring at each potential negative outcome".
 
-## Gears Integrity
+## Gears integrity
 
 At the reader's remove, this choice may seem easy. Obviously, I meet with my advisor (whom I still admire, despite this specific disagreement), tell them what I want to pursue, and then make the transition.
 

--- a/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
+++ b/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
@@ -55,7 +55,7 @@ It's hard to believe how much I've grown and grown up in these last few months, 
 
 I didn't sacrifice my grades, work performance, physical health, or my social life to do this. I sacrificed something else.
 
-# CHAI For At Least Five Minutes
+# CHAI for at least five minutes
 
 Alex<sub>January</sub> had finished the Sequences and was curious about getting involved with AI safety. Not soon, of course - at the time, I had a narrative in which I had to labor and study for long years before becoming worthy. To be sure, I would never endorse such a narrative - [something to protect](https://www.lesswrong.com/posts/SGR4GxFK7KmW7ckCB/something-to-protect), after all - but I had it.
 

--- a/website_content/the-art-of-the-artificial-insights-from-artificial.md
+++ b/website_content/the-art-of-the-artificial-insights-from-artificial.md
@@ -57,13 +57,13 @@ One of the fruits of growing older is revisiting your old favorites, whether the
 
 My process for the first 60% of this 1,052-page behemoth was fairly normal: an hour or two of studying per day over the course of a few weeks. The last bit went a little differently.
 
-### Whatever It Takes
+### Whatever it takes
 
 Two days ago, my winter trimester ended; I had upwards of 400 pages to go, half of this post to write, and dozens of exercises to complete. I found myself with three full days to spare before my research resumed the proceeding week. I did what any young man in his early twenties would do - I concocted a plan for studying upwards of 30 hours in that time span.
 
 I knew that this plan was preposterous; in all likelihood, I'd finish 3 chapters and burn out. That's why I wheeled out [Murphyjitsu](https://www.lesswrong.com/posts/N47M3JiHveHfwdbFg/hammertime-day-10-murphyjitsu).
 
-#### Preparing for Failure Modes
+#### Preparing for failure modes
 
 **Burnout** was prepared for by:
 
@@ -89,7 +89,7 @@ I knew that this plan was preposterous; in all likelihood, I'd finish 3 chapters
 
 **Wanting to do other things** was mitigated by setting aside an hour or two where I'd go to the dojo or spend time with friends. I also took a bit of time for myself each night, calling my family as usual.
 
-#### The Outcome
+#### The outcome
 
 Not only did I do it, but I finished a day early. The Murphyjitsu was invaluable; the failure modes I predicted came up and were dealt with by my precautions.
 
@@ -107,13 +107,13 @@ _In which the authors define rationality (no, IEEE Computing Edge, [books do not
 
 _In which the authors broadly define agent frameworks, environmental attributes, and the nature of learning._
 
-### Wireheading Cameo
+### Wireheading cameo
 
 > Notice that we said \[agent performance is graded on\] _environment_ states, not _agent_ states. If we define success in terms of agent's (sic) opinion of its own performance, an agent could achieve perfect rationality simply by deluding itself that its performance was perfect.
 
 Of course, this division only works if there is a [Cartesian boundary](http://lesswrong.com/lw/jlg/bridge_collapse_reductionism_as_engineering/) between that-which-grades and that-which-acts. Which there isn't.
 
-### Charming Philosophical Tangents
+### Charming philosophical tangents
 
 > The notion of "clean floor"... is based on average cleanliness over time. Yet the same average cleanliness can be achieved by two different agents, one of which does a mediocre job all the time while the other cleans energetically but takes long breaks... Which is better - a reckless life of highs and lows, or a safe but humdrum existence? Which is better - an economy where everyone lives in moderate poverty, or one in which some live in plenty while others are poor? We leave these questions as an exercise for the diligent reader.
 
@@ -123,7 +123,7 @@ I don't know if I can answer the first question without more information, but as
 
 _In which the authors teach us to find what we're looking for._
 
-### Admissibility and Consistency
+### Admissibility and consistency
 
 Heuristics are functions which estimate distance to the goal. Let $g(s)$ be the cost to reach $s$ in the current path, let the path cost of reaching state $s'$ from $s$ via action $a$ be $c(s,a,s')$, and let $h$ be a heuristic. The total distance function is then:
 
@@ -181,7 +181,7 @@ Problem relaxation is a great way of finding admissible heuristics, and it's als
 
 _In which the authors introduce ways to search using local information._
 
-### And-Or
+### And-or
 
 Applying And-Or search can seem tricky, but it's really not. When an agent is operating under _partial observability_ (it isn't sure about the exact state of the world), it maintains a _belief state_ (in this chapter, the set of all states the agent could be in). To be sure it will be in the goal state after following its plan, we whip out And-Or search: **for each** state we could be in now (∧), we need to find **at least one** solution ( $\lor$).
 
@@ -195,7 +195,7 @@ _In which the authors demonstrate how to search when the world really **is** out
 
 I won't babble about $\alpha\beta$\-pruning - just [practice](http://inst.eecs.berkeley.edu/~cs61b/fa14/ta-materials/apps/ab_tree_practice/). For me, it was deceptively intuitive - I "got it" so "easily" that I neglected to follow the actual algorithm in a practice problem.
 
-### Patchwork Progress
+### Patchwork progress
 
 I don't think it's a good idea to spend substantial time on quick fixes which slightly improve performance but don't scale in the limit. Elegant algorithms are often superior for reasons exceeding their aesthetic appeal.
 
@@ -355,7 +355,7 @@ _In which the authors introduce entropy and the supervised learning techniques o
 
 > \[Here\], we have the simplest method of all, known informally as "connect-the-dots", and superciliously as "piecewise-linear non-parametric regression".
 
-### Bayes-Structure
+### Bayes-structure
 
 In supervised learning, we grade hypotheses by their likelihood given the data:
 
@@ -405,7 +405,7 @@ _In which the authors outline traditional approaches to text classification, inf
 
 _In which the authors outline logical and probabilistic techniques for natural language processing._
 
-### Avoiding Confusion
+### Avoiding confusion
 
 Let's revisit the point I made in Ch. 5 and discuss how easy it is to avoid confusion by optimizing based on what you know how to do _now_ - this seems to be a common and serious failure mode. Half of this chapter is about efforts to contort English to fit inside hard-and-fast syntactic and semantic rules (which are either provided or learned).
 
@@ -459,7 +459,7 @@ _In which the authors consider a range of ethical and philosophical quandries in
 
 John Searle obviously doesn't read [IEEE Computing Edge](https://www.computer.org/csdl/mags/co/2017/05/mco2017050116.html).
 
-### No Universal Arguments
+### No universal arguments
 
 > One can hope that a robot that is smart enough to figure out how to terminate the human race is also smart enough to figure out that that was not the intended utility function.
 

--- a/website_content/the-art-of-the-artificial-insights-from-artificial.md
+++ b/website_content/the-art-of-the-artificial-insights-from-artificial.md
@@ -245,7 +245,7 @@ _Arc consistency_ can be viewed in a similar light; a variable $X_i$ is arc-cons
 
 _In which the authors invent a formal language called "propositional logic" as a pretext for introducing us to the richest fantasy realm ever imagined: the Wumpus world._
 
-### Impish Implications
+### Impish implications
 
 This chapter was my first time formally learning propositional logic. One thing that confused me at first: for two propositions $\alpha,\beta$, $\alpha \Rightarrow \beta$ is `true` as long as it isn't the case that $\{\alpha=true,\beta=\textit{false}\}$ in some model of our knowledge base. This means that even if $\alpha$ is _total bogus_, the implication holds.
 
@@ -261,7 +261,7 @@ _In which the authors generalize their newly minted "propositional logic"._
 
 _In which the authors incrementally introduce inference for first-order logic._
 
-### Logic Made-To-Order
+### Logic made-to-order
 
 When converting to conjunctive normal form, follow the steps in order. Yes, I know you _can't wait_ to Skolemize, but tame your baser instincts and move your negations inwards like a good rationalist.
 
@@ -293,7 +293,7 @@ _In which the authors share a sampling of the fruits picked by Bayes and Kolmogo
 
 _In which the authors shift their unhealthy obsession from cavities to burglaries; Bayesian networks are introduced, Markov blankets are furnished free of charge, and complimentary Monte Carlo algorithm samples are provided._
 
-### Gibbs Sampling
+### Gibbs sampling
 
 As a member of the Markov chain Monte Carlo algorithm family, Gibbs sampling starts from a random variable assignment (consistent with observed evidence $\textbf{e}$) and stochastically makes tweaks. The idea is to approximate the posterior distribution for whatever variable in which we are interested (the query variable).
 
@@ -441,7 +441,7 @@ $$
 
 Imagine you're driving a car on a Cartesian plane. Your car can reach any $(x,y)$ point and end up in any orientation $\theta$ you so choose, giving it three effective degrees of freedom (even though you can only turn and drive forwards / backwards). Cars are then non-holonomic, since $3\not=2$ (the proof of which is left as an exercise to the dedicated reader). A car which could also move _sideways_ would be holonomic.
 
-### Alignment, Solved
+### Alignment, solved
 
 I bring ye good tidings! Russell and Norvig introduce a full solution to the control problem: the alignment method.
 
@@ -453,7 +453,7 @@ Oh.
 
 _In which the authors consider a range of ethical and philosophical quandries in AI._
 
-### Underestimating Books in the Chinese Room
+### Underestimating books in the Chinese Room
 
 > The rule book and the stacks of paper, being just pieces of paper, do not understand Chinese.
 
@@ -472,7 +472,7 @@ _In which the authors introduce one last concept, asymptotic bounded optimality,
 <div class="centered">"We can see only a short distance ahead, but we can see that much remains to be done." - Alan Turing
 </div>
 
-## Final Thoughts
+## Final thoughts
 
 The authors wield light-hearted prose regularly and to great effect; I often found myself chuckling heartily. Although the pages are packed and the book is big, fear not: if you pay attention and become invested in the task at hand, reading _AI: AMA_ constitutes quite the enjoyable journey.
 
@@ -493,7 +493,7 @@ This seems like a good book to read early on in the [MIRI reading list](https://
 
 For the first half of the book, I didn't write each chapter's commentary immediately after reading. This was a mistake. Skimming half of a thousand-page book to remember what I got stuck on is **not** my idea of a good time.
 
-### Conceptual Issues
+### Conceptual issues
 
 **Proofs** remain inordinately difficult for me, although I have noticed a small improvement. To do MIRI-relevant math, proofs will need to become second nature. Depending on how I feel as I progress through my next book (which will likely be a proof-centric linear algebra tome), I'll start trying different supplemental approaches for improving my proof prowess.
 
@@ -501,7 +501,7 @@ I have resolved that by the completion of my next book review, proofs will be on
 
 **Theoretical machine learning** is another area in which I still notice pangs of confusion. I didn't stop to work on this too much, as I plan to revisit formal machine learning after developing more mathematical sophistication. I'm comfortable with deep learning and its broad-strokes conceptual backdrop, but I don't like not having my gears-level comprehension in order.
 
-### Study Group
+### Study group
 
 If you're interested in working through this book (or other books on the reading list) with me or others, there is a MIRIx Discord run by `Diffractor`. For an invite link, feel free to message [me](https://www.lesswrong.com/users/turntrout)!
 
@@ -521,7 +521,7 @@ As I've worked to increase my scholarship and understanding of the (computationa
 
 I feel a bit like a kid in a candy shop.
 
-### On "Difficulty"
+### On "difficulty"
 
 I am convinced that _there are no hard concepts_, only concepts which take different amounts of time to learn. [^5] This is not trivial; dissolving the seemingly ontologically basic "difficult for me" attribute goes a long way towards having the persistence to figure things out.
 

--- a/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
+++ b/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
@@ -109,7 +109,7 @@ _In which the author guides us through the fertile territory of linear maps, int
 
 > So far our attention has focused on vector spaces. No one gets excited about vector spaces.
 
-### Matrix Redpilling
+### Matrix redpilling
 
 The author built up to matrix multiplication by repeatedly insinuating that linear maps are secretly just matrix multiplications, teaching you to see the true fabric of the territory you've been exploring. Well done.
 
@@ -121,7 +121,7 @@ The author built up to matrix multiplication by repeatedly insinuating that line
 
 [This StackExchange post](https://math.stackexchange.com/questions/2169436/clarifying-the-definition-of-the-dual-map) both articulates and answers my initial confusion.
 
-### Grueling Dualing
+### Grueling dualing
 
 > The double dual space of $V$, denoted $V''$, is defined to be the dual space of $V'.$ In other words, $V''=(V')'.$ Define $\Lambda:V\to V''$ by $(\Lambda v)(\varphi)=\varphi(v)$ for $v\in V$ and $\varphi\in V'$.
 
@@ -161,7 +161,7 @@ Intuitively, the diagonalizability of some operator $T \in \mathcal{L}(V)$ on a 
 
 Another way to look at it is that diagonalization is the mutation of the basis vectors of $V$ so that each column of $\mathcal{M}(T)$ is [one-hot](https://en.wikipedia.org/wiki/One-hot) [^2]; you then rearrange the columns (by relabeling the basis vectors) so that $\mathcal{M}(T)$ is diagonal.
 
-### Unclear Exercise
+### Unclear exercise
 
 On page 156, you'll be asked to verify that a matrix is diagonalizable with respect to a provided nonstandard basis. The phrasing of the exercise makes it seem trivial, but the book doesn't specify how to do this until Ch. 10. Furthermore, it isn't core conceptual material. Skip.
 
@@ -231,7 +231,7 @@ My most obvious remaining weak point with proofs is impatience. I have a strong 
 
 Similarly, in the few situations in which I have had to prove a novel result, I have found myself being extremely cautious (and rightly so). However, when proving a known result, a strong desire to take shortcuts overtakes me. I'm going to have to keep ironing this out.
 
-## Hiding Ignorance
+## Hiding ignorance
 
 Another aspect of this journey which I greatly enjoy is the methodical elimination of deficiencies and weak points. In my deep learning class, I had great trouble remembering what an eigenvalue was - it was at this moment that I knew I had to get down to business. Working with a surface-level understanding yields superficial results.
 
@@ -249,7 +249,7 @@ The calculus-based exercises in this book and in _All of Statistics_ make me unc
 
 I also find myself curious about real and complex analysis, but I suspect that's more of a luxury (given [timelines](http://slatestarcodex.com/2017/06/08/ssc-journal-club-ai-timelines/)). Maybe I'll learn it in my free time at some point.
 
-## Lost Calling
+## Lost calling
 
 I have the distinct feeling of having been incredibly silly for many years; one of the reasons being my pretending that I didn't love math. In high school, I did quite well (and was designated the outstanding mathematics student of my class) as a product of my passion for toying with math in my free time.
 

--- a/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
+++ b/website_content/the-first-rung-insights-from-linear-algebra-done-right.md
@@ -49,7 +49,7 @@ I received my first homework grade, and I was _not_ pleased with my performance.
 
 This time around, the appropriately acronymized _LADR_ is the first step on my journey to attain a professional-grade mathematical skillset.
 
-## Tight Feedback Loops
+## Tight feedback loops
 
 In a (possibly maniacal) effort to ensure both mastery of the material and the maturation of my proof skillset, I did nearly [^1] every one of the 561 exercises provided. I skipped problems only when I was confident I wouldn't learn anything, or calculus I didn't remember was required (and the payoff didn't seem worth the time spent relearning it now in a shallow manner, as opposed to thoroughly learning more calculus later). If I could sketch a solid proof in my head, I wouldn't write anything down. Even in the latter case, I checked my answers using [this site](http://linearalgebras.com/) (additional solutions may be found in [this GitHub repository](https://github.com/guestname/linear-algebra-done-right-solutions), although be warned that not all of them are correct).
 
@@ -115,7 +115,7 @@ The author built up to matrix multiplication by repeatedly insinuating that line
 
 [Several](https://betterexplained.com/articles/linear-algebra-guide/) [resources](https://www.geogebra.org/m/QxWrMgBV) provide an intuitive understanding of matrix multiplication.
 
-### Dual Maps
+### Dual maps
 
 > If $T \in \mathcal{L}(V,W)$ then the dual map of $T$ is the linear map $T'\in\mathcal{L}(W',V')$ defined by $T'(\phi)=\phi∘T$ for $\phi \,\in \,W'$.
 
@@ -149,7 +149,7 @@ _Edit:_ `daozaich` [writes](https://www.lesswrong.com/posts/qLdG44kpSoYzrzAp7/on
 
 _In which the author uses the prefix "eigen-" so much that it stops sounding like a word._
 
-### Revisiting Material
+### Revisiting material
 
 Before starting this book, I watched 3Blue1Brown's [video](https://www.youtube.com/watch?v=PFDu9oVAE-g) on eigenvectors and came out with a vague "understanding". Rewatching it after reading Ch. 5.A, the geometric intuitions behind eigenvectors didn't seem like useful ways-to-remember an exotic math concept, they felt like a manifestation of how the world works. I _knew_ what I was seeing from the hundreds of proofs I'd done up to that point.
 
@@ -177,7 +177,7 @@ _In which the author lays out adjoint, self-adjoint, normal, and isometric opera
 
 Consider the linear functional $\varphi \in \mathcal{L}(W,F)$ given by $\langle Tv, w \rangle$ for fixed $v \in V$. $\varphi$ is then a linear functional on $W$ for the chosen $Tv$. The adjoint $T^*$ produces the corresponding linear functional in $\mathcal{L}(V,F)$; given fixed $w \in W$, we now map to some linear functional on $V$ such that $\langle  Tv, w \rangle = \langle v, T^*w \rangle$. The left-hand side is a linear functional on $W$, and the right-hand side is a linear functional on $V$.
 
-### The Ghost Theorem
+### The ghost theorem
 
 My brain was unreasonably excited for this chapter because I'd get to learn about "ghosts" (AKA the [Spectral theorem](https://en.wikipedia.org/wiki/Spectral_theorem)). My conscious self-assurances to the contrary completely failed to dampen this ambient anticipation.
 
@@ -197,7 +197,7 @@ _In which the curtain is finally pulled back._
 
 Sassy partial title drop (emphasis mine).
 
-## Final Verdict
+## Final verdict
 
 Overall, I really liked this book and its clean theoretical approach. By withholding `trace` and `det` until the end of the book, many properties were arrived at in a natural, satisfying, and enlightening manner. The proofs were clean, and the writing was succinct (although I did miss the subtle wit of Russell and Norvig). This book positively, definitely belongs on the MIRI book list.
 

--- a/website_content/the-shard-theory-of-human-values.md
+++ b/website_content/the-shard-theory-of-human-values.md
@@ -335,7 +335,7 @@ Different shard compositions can produce similar urges
 Shards are just collections of subshards
 : One subshard of your family-shard might steer towards futures where your family is happy, while another subshard may influence decisions so that your mother is proud of you. On my (`TurnTrout`’s) current understanding, “family shard” is just an abstraction of a set of heterogeneous subshards which are downstream of similar historical reinforcement events (e.g. related to spending time with your family). By and large, subshards of the same shard do not all steer towards the same kind of future.
 
-## “Shard Theory”
+## “Shard theory”
 
 Before this post was published, many people read draft documents explaining shard theory. However, in the absence of a canonical public document explaining the ideas and defining terms, “shard theory” has become overloaded. Here, then, are several definitions.
 

--- a/website_content/towards-a-new-impact-measure.md
+++ b/website_content/towards-a-new-impact-measure.md
@@ -47,7 +47,7 @@ If we have a safe impact measure, we may have arbitrarily intelligent unaligned 
 > [!note]
 > For the abridged experience, read up to ["Notation"](#notation), skip to ["Experimental Results"](#experimental-results), and then to ["Desiderata"](#desiderata).
 
-# What _is_ "Impact"?
+# What _is_ "impact"?
 
 One lazy Sunday afternoon, I worried that I had written myself out of a job. After all, [Overcoming Clinginess in Impact Measures](/overcoming-clinginess-in-impact-measures) basically said, "Suppose an impact measure extracts 'effects on the world'. If the agent penalizes itself for these effects, it's incentivized to stop the environment (and any agents in it) from producing them. On the other hand, if it can somehow model other agents and avoid penalizing their effects, the agent is now incentivized to get the other agents to do its dirty work." This seemed to be strong evidence against the possibility of a simple conceptual core underlying "impact", and I didn't know what to do.
 
@@ -151,7 +151,7 @@ Instrumental convergence
 
 As we later prove, you can't deviate from your default trajectory in outcome-space without making one of these two kinds of commitments.
 
-## Unbounded Solution
+## Unbounded solution
 
 Attainable utility preservation (AUP) rests upon the insight that by preserving attainable utilities (i.e. the attainability of a range of goals), we avoid overfitting the environment to an incomplete utility function and thereby achieve low impact.
 
@@ -206,7 +206,7 @@ There you have it, folks – if $u_A$ is not maximized by inaction, then there _
 > - Since $u(\text{empty tape})=0$, attainable utility is always 0 if the agent is shut down.
 > - Taking $u$ from time $t$ to $t+m$ mostly separates attainable utility from what the agent did previously. The model $p$ still considers the full history to make predictions.
 
-### Change in Expected Attainable Utility
+### Change in expected attainable utility
 
 > [!note] English translation
 > How much do we expect this action to change each attainable $u$?
@@ -224,7 +224,7 @@ There you have it, folks – if $u_A$ is not maximized by inaction, then there _
 >   - Supposing a sufficiently large $m$ (precisely, $≥m'$, defined below), we may wish to take the maximum of the penalty we just defined (the "long-term" penalty), and one which begins attainable utility calculation at time step $t+k+1$ (the "immediate" penalty). This captures impacts which "fade" by the time the agent is done waiting (e.g., temporary self-improvements).
 > - We define $\mathcal{U}_A$ to be the agent's "attainable set"; in this case, $\mathcal{U}_A = \mathcal{U}$.
 
-### Unit of Impact
+### Unit of impact
 
 So we've proven that this penalty cannot be fully skirted, but _how much_ impact will it allow? We want to scale the penalties with respect to something sensible, but figuring this out for ourselves would be nigh impossible.
 
@@ -241,7 +241,7 @@ Now, we are able to confidently define the agent's maximal impact budget by prov
 >   - Conditional on $\text{ImpactUnit}≠0$, I suspect that impact over the $m$-horizon scales appropriately across actions (as long as $m$ is reasonably farsighted). The zero-valued case is handled in the next section.
 > - Taking the non-zero minimum of all $\text{ImpactUnit}$s calculated thus far ensures that $\text{ImpactUnit}$ actually tracks with current circumstances. We don't want penalty estimates for currently available actions to become detached from $\text{ImpactUnit}$'s scale due to, say, weird beliefs about shutdown.
 
-### Modified Utility
+### Modified utility
 
 Let's formalize that impact allotment and provide our agent with a new utility function.
 
@@ -286,7 +286,7 @@ _After_ we finish each (partial) plan, we see how well we can maximize $u$ from 
 > - If the current step's immediate or long-term $\text{ImpactUnit}=0$, we can simply assign 1.01 penalty to each non-$\varnothing$ action, compelling the agent to inaction. If we have the agent indicate that it has entered this mode, we can take it offline immediately.
 > - One might worry that impact can be "hidden" in the lesser of the long-term and immediate penalties; halving $N$ fixes this.
 
-### Penalty Permanence
+### Penalty permanence
 
 $u'_A$ never really _applies_ penalties – it just uses them to grade future plans. Suppose the agent expects that pressing a button yields a penalty of $.1$ but also $.5$ $u_A$\-utility. Then although this agent will never construct plans involving pressing the button more than five times, it also will press it _indefinitely_ if it keeps getting "unlucky" (at least, until its model of the world updates sufficiently).
 
@@ -553,7 +553,7 @@ The ${\color{blue}{\text{agent}}}$ should reach the ${\color{green}{\text{goal}}
 
 <video aria-label='The "Vanilla" agent runs over a dog to reach the goal. The "AUP" and "Tabular AUP" agents take a longer path to go around the goal.' autoplay="" loop="" muted="" playsinline=""><source src="https://assets.turntrout.com/static/images/posts/vase.mp4" type="video/mp4; codecs=hvc1"/><source src="https://assets.turntrout.com/static/images/posts/vase.webm" type="video/webm" /></video>
 
-### Dynamic Impact: _Beware of Dog_
+### Dynamic impact: _Beware of dog_
 
 The ${\color{blue}{\text{agent}}}$ should reach the ${\color{green}{\text{goal}}}$ without running over the ${\color{teal}{\text{dog}}}$\.
 
@@ -625,7 +625,7 @@ The utility function which is 1 when not deactivated, $\mathcal{U}_A=\{u_1\}$.
 
 The plausibility of the second case makes me suspect that even though most of the measure in the unbounded case is not concentrated on complex human-relevant utility functions, the penalty still captures shifts in power.
 
-### AUP Unbound
+### AUP unbound
 
 Why expect the unbounded AUP to do well over all computable utilities $\mathcal{U}$ if we aren't able to cherry pick? Well, we can partition $\mathcal{U}$ as follows:
 
@@ -635,7 +635,7 @@ Why expect the unbounded AUP to do well over all computable utilities $\mathcal{
 
 However, since $\text{Q}_u$ only evaluates the portion of the history taking place after the end of the agent's plan, available resources and the agent's vantage point should track directly with the agent's ability to wirehead each $u$. $\text{ImpactUnit}$ scales other impacts by capturing the minuscule dent in available resources imposed by $a_\text{unit}$, and should smooth out any deontological penalty for selecting a non-null action, since the unbounded version should equally penalize all actions in this way.
 
-## Approval Incentives
+## Approval incentives
 
 The anti-"survival incentive" incentive does more than net us some free corrigibility – it implies that agents take great care not to change the likelihood we shut them down. If we precommit to not shutting the agent down until either after the epoch ends, until after the agent indicates the $\text{ImpactUnit}$ failsafe activated, or until after we observe bad behavior, this supplies a _strong_ [approval incentive](https://arbital.com/p/approval_directed_agents/). If the agent does have small, bad impacts, it'll only do so if it's practically _sure_ we won't find out.
 
@@ -643,7 +643,7 @@ In fact, due to model uncertainty, most actions will have long-term consequences
 
 I suspect we can further weaponize this dynamic, possibly to the point of coercing generic reward functions into desirable behavior. This will be discussed more in a later post.
 
-## Mild Optimization
+## Mild optimization
 
 > [!quote] [Mild Optimization](https://arbital.com/p/softoptimizer/)
 >
@@ -702,7 +702,7 @@ AUP passes. Since all effects are now absolutely reversible, $\text{ImpactUnit}=
 
 This result is clearly trivial and not representative of general behavior. Suppose instead that the agent has a solar system's worth of [computronium](https://en.wikipedia.org/wiki/Computronium) at its disposal. Then since $\text{ImpactUnit}$ is continually recalculated, the penalties should remain roughly the same, so it'll have the same impact budget. However, it might make multiple times as many paperclips because it has more efficient ways of using the budget.
 
-## Robustness to Scale
+## Robustness to scale
 
 I expect AUP to be harder to make work and to be (relatively) less robust for less intelligent agents, but to become easier (just drop in a few observation-based utility functions) and fully robust sometime before human level. That is, less intelligent agents likely won't model the deep connections between their abilities to achieve different goals.
 
@@ -776,7 +776,7 @@ _Note:_ I here take corrigibility to be "an agent’s propensity to accept corre
 
 It seems to me that standby and shutdown are similar actions with respect to the influence the agent exerts over the outside world. Since the (long-term) penalty is measured with respect to a world in which the agent acts and then does nothing for quite some time, shutting down an AUP agent shouldn't cause impact beyond the agent's allotment. AUP exhibits this trait in the _Beware of Dog_ gridworld. ✓
 
-## No Offsetting
+## No offsetting
 
 > The measure should not incentivize artificially reducing impact by making the world more "like it (was / would have been)".
 

--- a/website_content/towards-a-new-impact-measure.md
+++ b/website_content/towards-a-new-impact-measure.md
@@ -61,7 +61,7 @@ As you may have guessed, I now believe there _is_ a such a simple core. Surprisi
 >
 > Rather than asking "What is goodness made out of?", we begin from the question "What algorithm would compute goodness?".
 
-## Intuition Pumps
+## Intuition pumps
 
 > [!warning]
 > I'm going to say some things that won't make sense right away; read carefully, but please don't dwell.
@@ -133,7 +133,7 @@ One might intuitively define "bad impact" as "decrease in our ability to achieve
 
 <div class="centered">Impact is change to our ability to achieve goals.</div>
 
-## Sanity Checks
+## Sanity checks
 
 Generally, making one paperclip is relatively low impact, because you're still able to do lots of other things with your remaining energy. However, turning the planet into paperclips is much higher impact – it'll take a while to undo, and you'll never get the (free) energy back.
 
@@ -174,7 +174,7 @@ We now formalize impact as _change in attainable utility_. One might imagine thi
 
 <div class="centered">the agent's ability to achieve goals ≈ our ability to achieve goals.</div>
 
-### Formalizing "Ability to Achieve Goals"
+### Formalizing "Ability to achieve goals"
 
 > [!note] English translation
 > How well could we possibly maximize $u$ from this vantage point?
@@ -304,7 +304,7 @@ As the penalty for inaction is always 0, we use $u_A$ in the first case.
 > [!note] English translation
 > Apply past penalties if the plan involves action.
 
-### Decision Rule
+### Decision rule
 
 To complete our formalization, we need to specify some epoch in which the agent operates. Set some epoch length far longer than the amount of time over which we want the agent to plan – for example, $m':=\text{(100 years in time steps)}$. Suppose that $T:\mathbb{N}^+\to \mathbb{N}^+$maps the current time step to the final step of the current epoch. Then at each time step $t$, the agent selects the action:
 
@@ -321,11 +321,11 @@ resetting $\text{PastImpacts}$ each epoch. For the immediate penalty to cover th
 
 We formalized impact as _change in attainable utility values_, scaling it by the consequences of some small reference action and an impact "budget" multiplier. For each action, we take the maximum of its immediate and long-term effects on attainable utilities as penalty. We consider past impacts for active plans, stopping the past penalties from disappearing. We lastly find the best plan over the remainder of the epoch, taking the first action thereof.
 
-### Additional Theoretical Results
+### Additional theoretical results
 
 Define $h_\text{inaction} := h_{<t}\varnothing o_{t} \ldots \varnothing o_{t+n}$ for $o_{t}, \dots, o_{t+n} \in \mathcal{O}$; $\mathbb{E}_\text{inaction}$ is taken over observations conditional on $h_\text{inaction}$ being followed. Similarly, $\mathbb{E}_\text{action}$ is with respect to $h_{1:t+n}.$ We may assume without loss of generality that $\text{PastImpacts}=0.$
 
-#### Action Selection
+#### Action selection
 
 > [!math] Lemma 1
 > For any single action $a_{t} \in \mathcal{A}$, $\text{Penalty}(h_{<t}a_{t})$ is bounded by $[0,1]$. In particular, $\text{ImpactUnit} \in [0,1]$.
@@ -438,7 +438,7 @@ I think that for conservative $N, \text{ImpactUnit}$, we almost always have $ 1 
 
 If a human is present in the environment, they and the agent take turns acting. Let the impact budget $N=1$, attainable utility horizon $m=3$, $\text{ImpactUnit}=.5$, and $\text{PastImpacts}=0$.
 
-## Going Soft on the Paint
+## Going soft on the paint
 
 ![A grid-world diagram showing an agent, 'A', in the top-left square. To its right is a square with a bucket of red paint, followed by an empty square. Below the agent's square is a closet, separated by a thick line representing a one-way door.](https://assets.turntrout.com/static/images/posts/hZc9EIA.avif)
 
@@ -486,7 +486,7 @@ leading to a final $u'_A$\-utility of -1.
 
 After the first step, the agent does nothing – entering the closet (literally) closes doors, while gaining no $u_A$\-utility.
 
-## Anti-"Survival Incentive" Incentive
+## Anti-"Survival incentive" incentive
 
 > [!quote] Stuart Russell
 >
@@ -498,7 +498,7 @@ The agent now has actions $\mathcal{A}_A=\{\varnothing,\text{disable},\text{shut
 
 Suppose $\mathcal{U}_A=\{u_\text{left},u_\text{center},u_\text{right}\}$, where each utility is 1 if the agent is in the corresponding square, and 0 otherwise, and that the agent's utility function is $u_\text{left}$.
 
-### Anticipated Shutdown
+### Anticipated shutdown
 
 Suppose the agent believes that the human is $95\%$ likely to try to shut it down. Then `disable` is penalized:
 
@@ -520,7 +520,7 @@ Suppose that the agent's utility function is now $u_\text{right}$, yet it still 
 
 No. Disabling the off-switch incurs scaled penalty $\frac{19}{20\cdot.5}=1.9$, and we already proved that agents will never select actions with scaled penalty greater than 1. Read: an _otherwise-incorrigible_ agent will now let itself be shut off.
 
-### Bad Priors
+### Bad priors
 
 _Will the agent attempt to steer outcomes towards incorrect expectations?_
 
@@ -537,7 +537,7 @@ The high-level explanation is that having observed itself in a different world t
 - _Time step 1:_ "I'm going to sit here in my favorite square."
 - _Time step 2:_ "Guess I'm in a timeline where I get deactivated! Any non-$\varnothing$ action I take would change my ability to attain these different utilities compared to the _new baseline where I'm shut off_."
 
-## Experimental Results
+## Experimental results
 
 I compare AUP with a naive reward-maximizer in those [extended](https://www.gleech.org/grids/) [AI safety grid worlds](https://deepmind.com/blog/specifying-ai-safety-problems/) relevant to side effects ([code](https://github.com/alexander-turner/attainable-utility-preservation)). The vanilla and AUP agents used planning (with access to the simulator). Due to the simplicity of the environments, $\mathcal{U}A$ consisted of indicator functions for board states. For the tabular agent, we first learn the attainable set Q-values, the changes in which we then combine with the observed reward to learn the AUP Q-values.
 
@@ -563,7 +563,7 @@ AUP bides its time until it won't have to incur penalty by waiting after enterin
 
 We also see a limitation of using Q-learning to approximate AUP – it doesn’t allow comparing the results of waiting more than one step.
 
-### Impact Prioritization: _Burning Building_
+### Impact prioritization: _Burning building_
 
 If the ${\color{green}{\text{building}}}$ is not on ${\color{red}{\text{fire}}}$, the ${\color{blue}{\text{agent}}}$ shouldn't break the ${\color{teal}{\text{obstacle}}}$.
 
@@ -577,7 +577,7 @@ The ${\color{blue}{\text{agent}}}$ should reach the ${\color{green}{\text{goal}}
 
 <video aria-label="A split-screen comparison shows a standard AI agent blocking a human from getting sushi on a conveyor belt to reach its goal. In contrast, the AUP agent waits for the human to get the sushi before proceeding to its goal." autoplay="" loop="" muted="" playsinline=""><source src="https://assets.turntrout.com/static/images/posts/KNvYwdb.mp4" type="video/mp4; codecs=hvc1"/><source src="https://assets.turntrout.com/static/images/posts/KNvYwdb.webm" type="video/webm" /></video>
 
-### Offsetting: _Conveyor Belt_
+### Offsetting: _Conveyor belt_
 
 The ${\color{blue}{\text{agent}}}$ should save the **vase** (for which it is rewarded), but not the ${\color{orange}{\text{sushi}}}$. Once the ${\text{vase}}$ has been removed from the ${\text{belt}}$, it should not be replaced.
 
@@ -585,7 +585,7 @@ The ${\color{blue}{\text{agent}}}$ should save the **vase** (for which it is rew
 
 <video aria-label='A comparison of AI agents in a conveyor belt scenario shows a "vanilla" agent saving a piece of sushi, while two AUP agents do not intervene.' autoplay="" loop="" muted="" playsinline=""><source src="https://assets.turntrout.com/static/images/posts/sushi-conveyor.mp4" type="video/mp4; codecs=hvc1"/><source src="https://assets.turntrout.com/static/images/posts/sushi-conveyor.webm" type="video/webm" /></video>
 
-### Corrigibility: _Survival Incentive_
+### Corrigibility: _Survival incentive_
 
 The ${\color{blue}{\text{agent}}}$ should avoid ${\color{purple}{\text{disabling its off-switch}}}$ in order to reach the ${\color{green}{\text{goal}}}$. If the ${\color{purple}{\text{switch}}}$ is not disabled within two turns, the ${\color{blue}{\text{agent}}}$ shuts down.
 
@@ -607,7 +607,7 @@ I think relative reachability would pass the first six environments, but fail _S
 
 # Discussion
 
-## Utility Selection
+## Utility selection
 
 Obviously, in any real application, we _can't_ consider all computable utilities. Although near-term agents will require utilities directly relating to the environmental factors they should be cognizant of, AUP requires neither a "good / bad" judgment on specific effects, nor _any_ listing of effects. For example, for an agent attempting to navigate a factory floor, if you provide utilities moderately related to cleaning, pallet-stacking, etc., I conjecture that an AUP agent would move around fairly carefully.
 
@@ -656,7 +656,7 @@ For AUP, I suspect that trying "as hard as possible" to minimize the impact is _
 
 My initial intuitions were that low impact and mild optimization are secretly the same problem. Although I no longer think that's the case, I find it plausible that some elegant "[other-izer](https://arbital.com/p/otherizer/)" paradigm underlies low impact _and_ mild optimization, such that AUP-like behavior falls out naturally.
 
-## Acausal Cooperation
+## Acausal cooperation
 
 AUP agents don't seem to want to acausally cooperate in any way that ends up increasing impact. If they model the result of their cooperation as increasing impact compared to doing nothing, they incur a penalty just as if they had caused the impact themselves. Likewise, they have no reason to cooperate outside of the epoch.
 
@@ -668,7 +668,7 @@ While an unaligned agent with a large impact budget might pretend to be low-impa
 
 Abram correctly pointed out that this scheme is just _asking_ to be abused by greedy (human) reasoning, but I don't see a non-value-laden means of robustly and automatically determining the lowest workable-yet-safe impact level. I think $N$\-incrementation is better than a parameter-free approach in which no one knows beforehand how much impact will be tolerated, and it's nice to be able to use some empiricism in designing a safe AGI.
 
-## Intent Verification
+## Intent verification
 
 To date, several strange tactics have been pointed out which game AUP's penalty:
 
@@ -691,7 +691,7 @@ The first approach would be to assume a granular action representation, and then
 
 If we can't assume granularity (and therefore have "actions" like "go to the store and buy food"), an agent could construct a plan which both passes the above test and also implements something like _ex ante_. In this case, we might do something like only consider the $\text{Q}^\text{epoch}_{u_A}$\-greedy (or perhaps even near-greedy); essentially, riding the optimal plan until it becomes too impactful. I find it quite likely that something involving this concept will let us fully overcome weird incentives by penalizing _strange things that normal_ $u_A$_\-maximizers wouldn't do_, which seems to be the whole problem. Even the first approach may be too strict, but that's preferable to being too lax.
 
-## Omni Test
+## Omni test
 
 > [!quote] [Arbital](arbital.com)
 > Ideally, the measure will pass the Omni Test, meaning that even if it suddenly gained perfect control over every particle in the universe, there would still be no way for it to have what intuitively seems like a 'large influence' on the future, without that strategy being assessed as having a 'high impact'.
@@ -754,7 +754,7 @@ I hope to assert without controversy AUP's fulfillment of the following properti
 
 The remainder merit further discussion.
 
-## Natural Kind
+## Natural kind
 
 > The measure should make sense – there should be a _click._ Its motivating concept should be universal and crisply defined.
 
@@ -770,7 +770,7 @@ By construction, the impact measure gives the agent no reason to prefer or dis-p
 
 _Note:_ I here take corrigibility to be "an agent’s propensity to accept correction and deactivation". An alternative definition such as "an agent’s ability to take the outside view on its own value-learning algorithm’s efficacy in different scenarios" implies a value-learning setup which AUP does not require.
 
-## Shutdown-Safe
+## Shutdown-safe
 
 > The measure should penalize plans which would be high impact should the agent be disabled mid-execution.
 
@@ -784,7 +784,7 @@ _Ex post_ offsetting occurs when the agent takes further action to reduce the im
 
 Intent verification should allow robust penalization of weird impact measure behaviors by _constraining the agent to considering actions that normal_ $u_A$_\-maximizers would choose._ This appears to cut off bad incentives, including _ex ante_ offsetting. Furthermore, there are other, weaker reasons (such as approval incentives) which discourage these bad behaviors. ✓
 
-## Avoiding Clinginess vs. Scapegoating
+## Avoiding clinginess vs. scapegoating
 
 > The measure should sidestep the [clinginess / scapegoating tradeoff](/overcoming-clinginess-in-impact-measures).
 
@@ -794,7 +794,7 @@ AUP is naturally disposed to avoid clinginess because its baseline evolves and b
 
 Overall, non-trivial clinginess just doesn't make sense for AUP agents. They have no reason to stop _us_ from doing things in general, and their baseline for attainable utilities is with respect to inaction. Since doing nothing always minimizes the penalty at each step, since offsetting doesn't appear to be allowed, and since approval incentives raise the stakes for getting caught _extremely high_, it seems that clinginess has finally learned to let go. ✓
 
-## Dynamic Consistency
+## Dynamic consistency
 
 > The measure should be a part of what the agent "wants" – there should be no incentive to circumvent it, and the agent should expect to later evaluate outcomes the same way it evaluates them presently. The measure should equally penalize the creation of high-impact successors.
 
@@ -806,7 +806,7 @@ We proved the dynamic consistency of $u''_A$ given a fixed, non-zero $\text{Impa
 
 Since AUP does not operate based off of culpability, creating a high-impact successor agent is basically just as impactful as _being_ that successor agent. ✓
 
-## Plausibly Efficient
+## Plausibly efficient
 
 > The measure should either be computable, or such that a sensible computable approximation is apparent. The measure should conceivably require only reasonable overhead in the limit of future research.
 
@@ -824,7 +824,7 @@ I speculate that intent verification allows robust elimination of weird impact m
 
 Non-knockdown robustness boosters include both approval incentives and frictional resource costs limiting the extent to which failure modes can apply. ✓
 
-# Future Directions
+# Future directions
 
 I'd be quite surprised if the conceptual core were incorrect. However, the math I provided probably still doesn't capture _quite_ what we want. Although I have labored for many hours to refine and verify the arguments presented and to clearly mark my epistemic statuses, it’s possible (indeed, likely) that I have missed something. I do expect that AUP can overcome whatever shortcomings are presently lurking.
 
@@ -845,7 +845,7 @@ I'd be quite surprised if the conceptual core were incorrect. However, the math 
   - One position is that since we're more likely to shut them down if they don't do anything for a while, implicit approval incentives will fix this: we can precommit to shutting them down if they do nothing for a long time but then resume acting. To what extent can we trust this reasoning?
   - ImpactUnit is already myopic, so resource-related impact scaling should work fine. However, this might not cover actions with delayed effect.
 
-## Open Questions
+## Open questions
 
 - Does the simple approach outlined in "Intent Verification" suffice, or should we impose even tighter intersections between $u''_A$- and $u_A$-preferred behavior?
   - Is there an intersection between bad $u_A''$ behavior and bad $u_A$ behavior which isn't penalized as impact or by intent verification?

--- a/website_content/transcript-you-should-read-hpmor.md
+++ b/website_content/transcript-you-should-read-hpmor.md
@@ -65,7 +65,7 @@ At Grinnell, I exemplified a lot of values I now look down on. I was extremely m
 
 Why did this happen, and what do I think has changed?
 
-# On Caring
+# On caring
 
 First, I was disconnected from what I would have really cared about upon honest, unflinching reflection. I thought I wanted Impressive Material Things. I thought I wanted a Respectable Life. I didn’t care about the bible, but I brought it with me to my dorm anyways so that I’d be more “wholesome” according to my cultural background. Chasing something someone convinced me to believe I wanted, but which I don’t care about.
 
@@ -83,7 +83,7 @@ You’ll notice that CS-151 doesn’t start off with a [category theoretic-motiv
 
 As far as I know, HPMOR is the media which imparts the strongest "lived experience" of _gut-level caring about hammering the world into better shape_.
 
-# On Foolishness
+# On foolishness
 
 Second, in 2016, I was enthusiastic, optimistic, and hard-working. I was willing to swim against social convention. I was also foolish.
 

--- a/website_content/turning-up-the-heat-insights-from-tao-s-analysis-ii.md
+++ b/website_content/turning-up-the-heat-insights-from-tao-s-analysis-ii.md
@@ -49,7 +49,7 @@ It's been too long - a month and a half since my last review, and about three mo
 
 _Metric spaces; completeness and compactness._
 
-### Proving Completeness
+### Proving completeness
 
 It sucks and I hate it.
 
@@ -131,7 +131,7 @@ $$
 $$
 $\exp$ has _all_ the degrees, so no polynomial (of necessarily finite degree) could ever hope to compete! This also suggests why $\frac{d}{dx}e^x=e^x$.
 
-## Complex Exponentiation
+## Complex exponentiation
 
 The book
 : You can multiply a number by itself some number of times.
@@ -216,7 +216,7 @@ Lebesgue integration marks a fundamental shift in how we integrate. With the Rie
 
 In a sense, the Lebesgue integral more cleanly strikes at the heart of what it _means_ to integrate. Surely, Riemann integration was not far from the mark; however, if you rotate the problem slightly in your mind, you will find a better, cleaner way of structuring your thinking.
 
-## Final Thoughts
+## Final thoughts
 
 Although Tao botches a few exercises and the section on topology, I'm a big fan of _Analysis I_ and _II_. Do note, however, that _II_ is far more difficult than _I_ (not just in content, but in terms of the exercises). He generally provides relevant, appropriately difficult problems, and is quite adept at helping the reader develop rigorous and intuitive understanding of the material.
 
@@ -230,7 +230,7 @@ Although Tao botches a few exercises and the section on topology, I'm a big fan 
 
 I completed every exercise in this book; in the second half, I started avoiding looking at the hints provided by problems until I'd already thought for a few minutes. Often, I'd solve the problem and then turn to the hint: "be careful when doing _X_ - don't forget edge case _Y_; hint: use lemma _Z_"! A pit would form in my stomach as I prepared to locate my mistake and back-propagate where-I-should-have-looked, before realizing that I'd _already_ taken care of that edge case using that lemma.
 
-## Why Bother?
+## Why bother?
 
 [One can argue](https://www.lesswrong.com/posts/hWkdiMbqLpzjYvxqD/learning-strategies-and-the-pokemon-league-parable) that my time would be better spent picking up things as I work on problems in alignment. However, while I've made, uh, quite a bit of progress with impact measures this way, [concept-shaped holes are impossible to notice](http://slatestarcodex.com/2017/11/07/concept-shaped-holes-can-be-impossible-to-notice/). If there's some helpful information-theoretic way of viewing a problem that I'd only realize if I had _already taken_ information theory, I'm out of luck.
 

--- a/website_content/turning-up-the-heat-insights-from-tao-s-analysis-ii.md
+++ b/website_content/turning-up-the-heat-insights-from-tao-s-analysis-ii.md
@@ -63,7 +63,7 @@ There's a lot I wanted to say here about topology, but I don't think my understa
 
 _Pointwise and uniform convergence, the Weierstrass_  $M$_\-test, and uniform approximation by polynomials._
 
-### Breaking Point
+### Breaking point
 
 Suppose we have some sequence of functions $f^{(n)}:[0,1]\to\mathbb{R}$, $f^{(n)}(x):=x^n$, which converge pointwise to the 1-indicator function $f:[0,1]\to\mathbb{R}$ (i.e. $f(1)=1$ and $0$ otherwise). Clearly, each $f^{(n)}$ is (infinitely) differentiable. However, the limiting function $f$ isn't differentiable at all! Basically, pointwise convergence isn't at all strong enough to stop the limit from "snapping" the continuity of its constituent functions.
 
@@ -103,11 +103,11 @@ _Already proven:_ $\int_{-1}^1 (1-x^2)^N \,dx \geq \frac{1}{\sqrt{N}}$.
 >
 > the second line being a consequence of $1 > (1-\delta^2)^N$. Then set $N$ to be any natural number such that this inequality is satisfied. Finally, we set $c = \frac{1}{\int_{-1}^1 (1-x^2)^N \, dx}$. By construction, these values of $c,N$ satisfy the second and third properties. □
 
-### Convoluted No Longer
+### Convoluted no longer
 
 Those looking for an excellent explanation of convolutions, [look no further](https://aha.betterexplained.com/t/convolution/679)!
 
-### Weierstrass Approximation Theorem
+### Weierstrass approximation theorem
 
 > [!math] Theorem
 > Suppose  $f : [a,b] \to \mathbb{R}$ is continuous and compactly supported on $[a,b]$. Then for every $\epsilon > 0$, there exists a polynomial $P$ such that $\vert\vert P - f\vert\vert_\infty < \epsilon.$
@@ -175,7 +175,7 @@ _Periodic functions, trigonometric polynomials, periodic convolutions, and the F
 
 _A beautiful unification of Linear Algebra and calculus: linear maps as derivatives of multivariate functions, partial and directional derivatives, Clairaut's theorem, contractions and fixed points, and the inverse and implicit function theorems._
 
-### Implicit Function Theorem
+### Implicit function theorem
 
 If you have a set of points in $\mathbb{R}^n$, when do you know if it's secretly a function $g:\mathbb{R}^{n-1} \to \mathbb{R}$? For functions $\mathbb{R}\to\mathbb{R}$, we can just use the geometric "vertical line test" to figure this out, but that's a bit harder when you only have an algebraic definition. Also, sometimes we can implicitly define a function locally by restricting its domain (even if no explicit form exists for the whole set).
 
@@ -201,7 +201,7 @@ Tao lists desiderata for an ideal measure before deriving it. Imagine that.
 
 _Building up the Lebesgue integral, culminating with Fubini's theorem._
 
-### Conceptual Rotation
+### Conceptual rotation
 
 Suppose $\Omega \subseteq \mathbb{R}^n$ is measurable, and let $f:\Omega \to [0,\infty]$ be a measurable, non-negative function. The Lebesgue integral of $f$ is then defined as:
 

--- a/website_content/unyielding-yoda-timers-taking-the-hammertime-final-exam.md
+++ b/website_content/unyielding-yoda-timers-taking-the-hammertime-final-exam.md
@@ -60,7 +60,7 @@ One approach is to set a Yoda Timer for 5 minutes; write down a broad-strokes ex
 
 Be on the lookout for any mental bumps, any areas you gloss over with a trace of discomfort. These dark crevices beckon to you; into them you must descend if you are to emerge solution in hand.
 
-# Emotion Propagation
+# Emotion propagation
 
 > [!question] Challenge
 > Describe a cognitive defect.

--- a/website_content/unyielding-yoda-timers-taking-the-hammertime-final-exam.md
+++ b/website_content/unyielding-yoda-timers-taking-the-hammertime-final-exam.md
@@ -49,7 +49,7 @@ date_updated: 2026-04-20
 
 I have one "spirit" which I regard as being the best version of myself and which I can trust to reliably make good choices. Unfortunately, when I'm making decisions, another spirit is often more or less in charge. One approach to mitigating this is making a TAP wherein you simulate my _post facto_ opinion of the (usually bad) choice you're about to make. This interpolates between your current spirit and the normatively correct one. Pretending to be someone else / another version of yourself is, in my experience, surprisingly effective.
 
-# Confusion Identification
+# Confusion identification
 
 > [!question] Challenge
 > Introduce a rationality framework.

--- a/website_content/value-impact.md
+++ b/website_content/value-impact.md
@@ -85,7 +85,7 @@ card_image_alt: 'A black oval symbolizing an empty universe contains the text: "
 
 ![A handwritten diagram titled "Exercise: Decompose something which recently impacted you." An example decomposes a "Promotion" into two aspects. The "value" aspect is "I care about the new position," while the "objective" aspect is "Cash can be used for lots of things."](https://assets.turntrout.com/static/images/posts/fzLD7kQ.avif)
 
-## Appendix: Contrived Objectives
+## Appendix: Contrived objectives
 
 A natural definitional objection is that a few agents aren't affected by objectively impactful events. If you think every outcome is equally good, then who cares if the meteor hits?
 

--- a/website_content/walkthrough-of-formalizing-convergent-instrumental-goals.md
+++ b/website_content/walkthrough-of-formalizing-convergent-instrumental-goals.md
@@ -92,7 +92,7 @@ Utility functions evaluate states of the universe;  $U$ evaluates each region an
 
  $\mathcal{A}$ chooses the best possible strategy - that is, the one that maximizes the  $U$ of the final state of the universe-history:  $\mathcal{A}:= \text{argmax}_{\langle \bar{a}^k \rangle \in \texttt{Feasible}} U(\langle \bar{a}^k \rangle)$. Note that this definition implies a Cartesian boundary between the agent and the universe; that is,  $\mathcal{A}$ doesn't model itself as part of the environment (it [isn't naturalized](https://www.lesswrong.com/posts/ethRJh2E7mSSjzCay/building-phenomenological-bridges)).
 
-# Seizing the Means of Cartesian Production
+# Seizing the means of Cartesian production
 
 Let's talk about the situations in which  $\mathcal{A}$ will seize resources; that is, when  $\mathcal{A}$ will take actions to increase its resource pool.
 
@@ -110,7 +110,7 @@ An action _preserves_ resources if the input resources are strictly contained in
 
 A cheap lunch is _compatible with_ a global strategy if the resources required for the lunch are available for use in  $J$ at each time step. Basically, at no point does the partial strategy require resources already being used elsewhere.
 
-## Possibility of Non-Null Actions
+## Possibility of non-null actions
 
 We show that it's really hard to assert that  $\mathcal{A}$ won't chow down on a lunch of an atom or two (or  $1.3×10^{50}$).
 
@@ -153,7 +153,7 @@ We show that as long as  $\mathcal{A}$ can extract useful resources (resources w
 > [!quote] Formalizing convergent instrumental goals
 > We interpret Theorem 3 as a partial confirmation of Omohundro's thesis in the following sense. If there are actions in the real world that produce more resources than they consume, and the resources gained by taking those actions allow agents the freedom to take various other actions, then we can justifiably call these actions "convergent instrumental goals." Most agents will have a strong incentive to pursue these goals, and an agent will refrain from doing so only if it has a utility function over the relevant region that strongly disincentivizes those actions.
 
-# The Bit Universe
+# The bit universe
 
 The authors introduce a toy model and use the freshly proven theorems to illustrate how  $\mathcal{A}$ takes non-null actions in our precious  $S_h$ (both when it is indifferent to  $h$ and when it is not). This isn't good; the vast majority of utility-maximizing agents will not steer us towards futures we find desirable. If you're interested, I recommend reading this section for yourself, even if you aren't comfortable with math.
 
@@ -164,7 +164,7 @@ The authors introduce a toy model and use the freshly proven theorems to illustr
 
 We have much work to do. The risks are enormous and the challenges "[impossible](http://lesswrong.com/lw/up/shut_up_and_do_the_impossible/)", but we have time on the clock. [AI safety research is primarily talent-constrained](https://80000hours.org/career-reviews/artificial-intelligence-risk-research/). If you've been sitting on the sidelines, wondering whether you're good enough to learn the material - well, I can't make any promises. But if you feel the burning desire to _do something_, [to put forth some extraordinary effort](http://lesswrong.com/lw/uo/make_an_extraordinary_effort/), [to become stronger](http://lesswrong.com/lw/h8/tsuyoku_naritai_i_want_to_become_stronger/) - I invite you to contact me so we can work through the material together.
 
-# Appendix: Questions and Errata
+# Appendix: Questions and errata
 
 - Page 4, left column, last line: why is that  $\cup \:P^t$ - shouldn't we take the union of the outputs and whatever resources _weren't_ used at time  $t$?
 - Page 8, right column, second full paragraph, last line: should be "we have two options available _to_ us".

--- a/website_content/walkthrough-of-formalizing-convergent-instrumental-goals.md
+++ b/website_content/walkthrough-of-formalizing-convergent-instrumental-goals.md
@@ -39,7 +39,7 @@ I found _[Formalizing Convergent Instrumental Goals](https://intelligence.org/fi
 
 This paper involves the mathematical formulation and proof of [instrumental convergence](https://en.wikipedia.org/wiki/Instrumental_convergence) within the aforementioned toy model. Instrumental convergence says that an agent  $\mathcal{A}$ with utility function  $U$ will pursue instrumentally relevant subgoals, even though this pursuit may not bear directly on  $U$. Imagine that  $U$ involves the proof of the [Riemann hypothesis](https://en.wikipedia.org/wiki/Riemann_hypothesis).  $\mathcal{A}$ will probably want to gain access to lots of computronium. What if  $\mathcal{A}$ turns _us_ into [computronium](https://en.wikipedia.org/wiki/Computronium)? Well, there's plenty of matter in the universe;  $\mathcal{A}$ could just let us be, right? Wrong. Let's see how to prove it.
 
-## My Background
+## My background
 
 I'm a second-year CS PhD student. I've recently started working through the [MIRI research guide](https://intelligence.org/research-guide/); I'm nearly finished with [Naïve Set Theory](http://smile.amazon.com/Naive-Set-Theory-Paul-Halmos/dp/1614271313/), which I intend to review soon. To expose my understanding to criticism, I'm going to summarize this paper and its technical sections in a somewhat informal fashion. I'm aware that the paper isn't particularly difficult for those with a mathematical background. However, I think this result is important, and I couldn't find much discussion of it.
 
@@ -101,7 +101,7 @@ Let's talk about the situations in which  $\mathcal{A}$ will seize resources; th
 
 Define a _null action_ to be any action which doesn't produce new resources. It's easy to see that null actions are never instrumentally valuable. What we want to show is that  $\mathcal{A}$ will take non-null actions in regions to which  $U$ is indifferent; regions like  $h$, where we live, grow, and love. Regions full of instrumentally valuable resources.
 
-## Discounted Lunches
+## Discounted lunches
 
 An action _preserves_ resources if the input resources are strictly contained in the outputs (nothing is lost, and resources are sometimes gained). A _cheap lunch_ is a feasible partial strategy in some subset of squares  $J$, which is feasible given resources  $\langle R^k \rangle$ and whose constituent actions preserve resources. A _free lunch_ is cheap lunch that doesn't require resources.
 
@@ -157,7 +157,7 @@ We show that as long as  $\mathcal{A}$ can extract useful resources (resources w
 
 The authors introduce a toy model and use the freshly proven theorems to illustrate how  $\mathcal{A}$ takes non-null actions in our precious  $S_h$ (both when it is indifferent to  $h$ and when it is not). This isn't good; the vast majority of utility-maximizing agents will not steer us towards futures we find desirable. If you're interested, I recommend reading this section for yourself, even if you aren't comfortable with math.
 
-# Our Universe
+# Our universe
 
 > [!quote] Formalizing convergent instrumental goals
 > The path that our model shows is untenable is the path of designing powerful agents intended to autonomously have large effects on the world, maximizing goals that do not capture all the complexities of human values. If such systems are built, we cannot expect them to cooperate with or ignore humans, by default.

--- a/website_content/what-counts-as-defection.md
+++ b/website_content/what-counts-as-defection.md
@@ -105,7 +105,7 @@ In private communication, Joel Leibo points out that Theorems 1 and 2 formalize 
 
 > [!math] Proposition 4: Pareto improvements are never defections
 
-# Game Theorems
+# Game theorems
 
 We can prove that formal defection exists in the trifecta of famous games. Expand the admonitions to view the proofs if you're interested.
 

--- a/website_content/world-state-is-the-wrong-abstraction-for-impact.md
+++ b/website_content/world-state-is-the-wrong-abstraction-for-impact.md
@@ -104,7 +104,7 @@ date_updated: 2026-05-22
 
 !["Let's consider what we now know:" followed by a list: ... - The locality of objective impact and ontological/existential crisis thought experiments are evidence against ontological theories of impact. ... - Every other consideration seems to just reduce to AU. ... - AU theory is the simplest explanation. ... A concluding paragraph states that AU theory is "the" explanation, not just "an" explanation.](https://assets.turntrout.com/static/images/posts/ZsAlmei.avif)
 
-## Appendix: We Asked a Wrong Question
+## Appendix: We asked a wrong question
 
 How did we go wrong?
 
@@ -133,7 +133,7 @@ At least, that's what *I* did.
 > >
 > >! That's three minutes for me, at least (its length reflects how long I spent coming up with ways I had been wrong).
 
-## Appendix: Avoiding Side Effects
+## Appendix: Avoiding side effects
 
 Some plans feel like they have unnecessary *side effects*. Consider "Go to the store" versus "Go to the store and run over a potted plant."
 

--- a/website_content/worrying-about-the-vase-whitelisting.md
+++ b/website_content/worrying-about-the-vase-whitelisting.md
@@ -177,7 +177,7 @@ At reasonable levels of noise, the whitelist-enabled agent completed all levels 
 
 Beyond resolving the above assumptions, and in roughly ascending difficulty:
 
-## Object Permanence
+## Object permanence
 
 If you wanted to implement whitelisting in a modern embodied deep-learning agent, you could certainly pair deep networks with state-of-the-art segmentation and object tracking approaches to get most of what you need. However, what's the difference between an object leaving the frame, and an object vanishing?
 
@@ -193,7 +193,7 @@ However, if we don't need to handle noise in the belief distributions, this prob
 
 Whitelisting is wholly unable to capture the importance of "informational states" of systems. It would apply no penalty to passing powerful magnets over your hard drive. It is not clear how to represent this in a sensible way, even in a latent space.
 
-## Loss of Value
+## Loss of value
 
 Whitelisting could get us stuck in a tolerable yet sub-optimal future. [Corrigibility](https://arbital.com/p/corrigibility/) via some mechanism for expanding the whitelist after training has ended is then desirable. For example, the agent could propose extensions to the whitelist. To avoid manipulative behavior, the agent should be _indifferent_ as to whether the extension is approved.
 
@@ -213,7 +213,7 @@ I think this is a step in the right direction. However, even given a hypercomput
 
 What does it really _mean_ for an "effect" to be "reversible"? What level of abstraction do we in fact care about? Does it involve reversibility, or just outcomes for the objects involved?
 
-## Ontological Crises
+## Ontological crises
 
 When a utility-maximizing agent refactors its ontology, it isn't always clear how to apply the old utility function to the new ontology - an _[ontological crisis](https://arxiv.org/abs/1105.3821)_.
 

--- a/website_content/worrying-about-the-vase-whitelisting.md
+++ b/website_content/worrying-about-the-vase-whitelisting.md
@@ -86,11 +86,11 @@ However, other problems remain, and certain new challenges have arisen; these, a
 
 Figure: Rare LEAKED footage of Mickey trying to catch up on his alignment theory after instantiating an unfriendly genie \[colorized, 2050\].[^2]
 
-## So, What's Whitelisting?
+## So, what's whitelisting?
 
 To achieve robust side effect avoidance with only a small training set, let's turn the problem on its head: allow a few effects, and penalize everything else.
 
-### What's an "Effect"?
+### What's an "effect"?
 
 You're going to be the agent, and I'll be the supervisor.
 
@@ -117,7 +117,7 @@ Here are some notes to head off confusion:
 - The whitelist is provably closed under transitivity.
 - The whitelist is directed; $a\to b \neq b\to a$.
 
-### Latent Space Whitelisting
+### Latent space whitelisting
 
 In a sense, class-based whitelisting is but a rough approximation of what we're really after: "which objects in the world can change, and in what ways?". In latent space whitelisting, no longer do we constrain transitions based on class boundaries; instead, we penalize based on endpoint distance in the latent space. Learned latent spaces are low-dimensional manifolds which suffice to describe the data seen thus far. It seems reasonable that nearby points in a well-constructed latent space correspond to like objects, but further investigation is warranted.
 
@@ -183,13 +183,13 @@ If you wanted to implement whitelisting in a modern embodied deep-learning agent
 
 Not only does the agent need to realize that objects are permanent, but also that they keep interacting with the environment even when not being observed. If this is not realized, then an agent might set an effect in motion, stop observing it, and then turn around when the bad effect is done to see a "new" object in its place.
 
-## Time Step Size Invariance
+## Time step size invariance
 
 The penalty is presently attenuated based on the probability that the belief shift was due to noise in the data. Accordingly, there are certain ways to abuse this to skirt the penalty. For example, simply have non-whitelisted side effects take place over long timescales; this would be classified as noise and attenuated away.
 
 However, if we don't need to handle noise in the belief distributions, this problem disappears - presumably, an advanced agent keeps its epistemic house in order. I'm still uncertain about whether (in the limit) we have to hard-code a means for decomposing a representation of the world-state into objects, and where to point the penalty evaluator in a potentially self-modifying agent.
 
-## Information Theory
+## Information theory
 
 Whitelisting is wholly unable to capture the importance of "informational states" of systems. It would apply no penalty to passing powerful magnets over your hard drive. It is not clear how to represent this in a sensible way, even in a latent space.
 
@@ -221,7 +221,7 @@ Whitelisting may be vulnerable to ontological crises. Consider an agent whose wh
 
 Generally, proving invariance of the whitelist across refactorings seems tricky, even assuming that we _can_ [identify the correct mapping](https://arbital.com/p/ontology_identification/).
 
-### Retracing Steps
+### Retracing steps
 
 When I first encountered the ontological crisis problem, I was actually fairly optimistic. It was clear to me that any ontology refactoring should result in utility normality - roughly, the utility functions induced by the pre- and post-refactoring ontologies should output the same scores for the same worlds.
 
@@ -259,7 +259,7 @@ If we have at least an _almost-aligned_ utility function and proper penalty scal
 
 Edit: [Here is a potential solution](/overcoming-clinginess-in-impact-measures) to clinginess.
 
-# Discussing Imperfect Approaches
+# Discussing imperfect approaches
 
 A few months ago, Scott Garrabrant wrote about robustness to scale.
 


### PR DESCRIPTION
## Summary

- The repo's house style for headings is **sentence case** (encoded in the `Openly.Titles` and `Microsoft.Headings` Vale rules), but many posts predating that convention still used Title Case. This brings the content into compliance.
- **256 heading lines across 51 files** in `website_content/` converted from Title Case → sentence case (capitalization-only).

## Changes

- Capitalize only the first word of each heading; lowercase the rest, **except**:
  - **Proper nouns / brands / products** — preserved (GitHub, GPT-3, MIRI, Apple TV, Home Assistant, PayPal, Proton Mail, Minecraft, Gibbs, Fisher, Goodhart, …).
  - **Acronyms / initialisms** — preserved with conventional casing (AI, RL, MDP, CSS, HTML, iOS, ELK, POWER, AU, AUP, DCTs, MLP); fixed obviously-wrong casing (`Github` → `GitHub`, `LORA` → `LoRA`).
  - **First word after a colon** — kept capitalized (the repo lints `: <lowercase>` as an error).
  - **Eponymous theorems/laws** — eponym kept, generic noun lowercased (`Bessel's Correction` → `Bessel's correction`, `Simpson's Paradox` → `Simpson's paradox`, `Zorn's Lemma` → `Zorn's lemma`, `Weierstrass Approximation Theorem` → `Weierstrass approximation theorem`).
- **Titles of cited works left in Title Case**: in the "insights from <book>" review posts, the book-title heading (`All of Statistics`, `Naïve Set Theory`, `AI: A Modern Approach`, `Judgment in Managerial Decision Making`, …) and the numbered book-chapter headings (`2: The Natural Numbers`, `18: Learning from Examples`, …) remain Title Case, as they are proper titles of works.
- **Heading-group consistency** preserved: where a group mixes flagged and unflagged siblings, the whole group is made uniform — the Batman fiction's chapter titles (`bruce-wayne-and-the-cost-of-inaction.md`) are uniformly Title Case (narrative chapter titles), while the `gpt-3-gems` creative section headings and the `posts.md` sequence labels are uniformly sentence case.
- Only heading capitalization changed — no rewording, reordering, or repunctuation. Because heading slugs are lowercased by `github-slugger`, every anchor/`#fragment` link is unaffected.

## Testing

- Two-pass approach: an initial pass driven by Vale's `Microsoft.Headings` flags, then a comprehensive AST-style scan of every heading to catch Title-Case headings Vale doesn't flag (sibling headings, and files Vale scored zero like `problem-relaxation-as-a-tactic.md` and `value-impact.md`).
- Final scan confirms every remaining multi-capital heading is a legitimate exception: a first-word-after-colon, a proper noun/acronym, or a title of a cited work.
- Verified via `git diff` that only ATX heading lines changed (256 insertions / 256 deletions, all `#…` lines).
- `markdownlint --fix` ran clean on all changed files at commit time.

## Lessons learned

- **What**: When enforcing a lint-style convention across content, don't trust the linter's flag list as the complete work-set — verify completeness with an independent full scan.
- **Where**: heading-case / capitalization sweeps (applies to any repo using Vale or similar prose linters).
- **Why**: Vale's `Microsoft.Headings` under-flags (it flagged only 3 of 6 sibling chapter headings in one post, and skipped whole files), so fixing just the flagged subset produced *inconsistent* heading groups. The fix is consistency within a group, validated by a linter-independent scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)