### PR TITLE
Optimize LCP for images in img-comparison-slider

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -450,10 +450,63 @@ export function renderPage(
   return optimizeLcpImage(`<!DOCTYPE html>\n${render(doc)}`)
 }
 
+/** Whether an `<img>` tag is a content image eligible to be the LCP element. */
+function isLcpCandidate(imgTag: string): boolean {
+  if (/\bfavicon\b/.test(imgTag)) return false
+  const srcMatch = imgTag.match(/\bsrc="(?<srcValue>[^"]*)"/)
+  if (!srcMatch?.groups) return false
+  // Twemoji glyphs are tiny inline characters, never the LCP element.
+  return !srcMatch.groups["srcValue"].startsWith(twemojiBaseUrl)
+}
+
+/** Promotes an `<img>` tag string to `loading="eager"` and `fetchpriority="high"`. */
+function promoteImgTag(imgTag: string): string {
+  let newTag = imgTag
+
+  if (/\bloading="/.test(newTag)) {
+    newTag = newTag.replace(/\bloading="[^"]*"/, 'loading="eager"')
+  } else {
+    newTag = newTag.replace("<img ", '<img loading="eager" ')
+  }
+
+  if (/\bfetchpriority="/.test(newTag)) {
+    newTag = newTag.replace(/\bfetchpriority="[^"]*"/, 'fetchpriority="high"')
+  } else {
+    newTag = newTag.replace("<img ", '<img fetchpriority="high" ')
+  }
+
+  return newTag
+}
+
 /**
- * Post-processes rendered HTML to ensure the first content image (likely LCP
- * element) has `loading="eager"`, `fetchpriority="high"`, and a matching
- * `<link rel="preload">` in `<head>`.
+ * If `imgIdx` falls inside an `<img-comparison-slider>` within the article,
+ * returns the slider's inner `[start, end)` range; otherwise `null`.
+ */
+function enclosingSliderRange(
+  html: string,
+  articleIdx: number,
+  imgIdx: number,
+): { start: number; end: number } | null {
+  const openIdx = html.lastIndexOf("<img-comparison-slider", imgIdx)
+  if (openIdx < articleIdx) return null
+
+  const openEnd = html.indexOf(">", openIdx)
+  if (openEnd === -1) return null
+
+  const closeIdx = html.indexOf("</img-comparison-slider>", openEnd)
+  if (closeIdx === -1 || closeIdx <= imgIdx) return null
+
+  return { start: openEnd + 1, end: closeIdx }
+}
+
+/**
+ * Post-processes rendered HTML to ensure the LCP image has `loading="eager"`,
+ * `fetchpriority="high"`, and a matching `<link rel="preload">` in `<head>`.
+ *
+ * The LCP candidate is the first content image in the article. Inside an
+ * `<img-comparison-slider>`, two equally sized images overlap and the browser
+ * can pick the second (overlay) image as the LCP element, so every image in the
+ * slider is promoted.
  *
  * Catches images from React components that bypass the CrawlLinks transformer
  * pipeline. Idempotent: pages already optimized by the transformer are
@@ -466,53 +519,56 @@ export function optimizeLcpImage(html: string): string {
   const articleEndIdx = html.indexOf("</article>", articleIdx)
   if (articleEndIdx === -1) return html
 
-  // Find the first non-favicon <img> within the article
   const imgRegex = /<img\s[^>]*>/g
   imgRegex.lastIndex = articleIdx
 
+  let firstMatch: RegExpExecArray | null = null
   let match: RegExpExecArray | null
   while ((match = imgRegex.exec(html)) !== null) {
     if (match.index >= articleEndIdx) break
     if (/\bfavicon\b/.test(match[0])) continue
+    // An <img> without a usable src cannot be a preload target; stop here.
+    if (!/\bsrc="[^"]*"/.test(match[0])) break
+    if (!isLcpCandidate(match[0])) continue
+    firstMatch = match
+    break
+  }
+  if (!firstMatch) return html
 
-    const imgTag = match[0]
-    const srcMatch = imgTag.match(/\bsrc="(?<srcValue>[^"]*)"/)
-    if (!srcMatch?.groups) break
-    const src = srcMatch.groups["srcValue"]
+  const sliderRange = enclosingSliderRange(html, articleIdx, firstMatch.index)
+  const region = sliderRange ?? {
+    start: firstMatch.index,
+    end: firstMatch.index + firstMatch[0].length,
+  }
 
-    // Twemoji glyphs are tiny inline characters, never the LCP element.
-    if (src.startsWith(twemojiBaseUrl)) continue
+  const targets: { index: number; tag: string; src: string }[] = []
+  imgRegex.lastIndex = region.start
+  while ((match = imgRegex.exec(html)) !== null) {
+    if (match.index >= region.end) break
+    if (!isLcpCandidate(match[0])) continue
+    const src = match[0].match(/\bsrc="(?<srcValue>[^"]*)"/)?.groups?.["srcValue"]
+    if (!src) continue
+    targets.push({ index: match.index, tag: match[0], src })
+  }
 
-    let newTag = imgTag
-
-    // Ensure loading="eager"
-    if (/\bloading="/.test(newTag)) {
-      newTag = newTag.replace(/\bloading="[^"]*"/, 'loading="eager"')
-    } else {
-      newTag = newTag.replace("<img ", '<img loading="eager" ')
+  // Rewrite tags back-to-front so earlier indices stay valid as the string grows.
+  for (let i = targets.length - 1; i >= 0; i--) {
+    const { index, tag } = targets[i]
+    const newTag = promoteImgTag(tag)
+    if (newTag !== tag) {
+      html = html.slice(0, index) + newTag + html.slice(index + tag.length)
     }
+  }
 
-    // Ensure fetchpriority="high"
-    if (/\bfetchpriority="/.test(newTag)) {
-      newTag = newTag.replace(/\bfetchpriority="[^"]*"/, 'fetchpriority="high"')
-    } else {
-      newTag = newTag.replace("<img ", '<img fetchpriority="high" ')
-    }
-
-    if (newTag !== imgTag) {
-      html = html.slice(0, match.index) + newTag + html.slice(match.index + imgTag.length)
-    }
-
-    // `crossorigin` on the preload must match the <img>'s CORS mode. All
-    // content images are CDN-sourced and carry `crossorigin="anonymous"`.
+  // `crossorigin` on the preload must match the <img>'s CORS mode. All content
+  // images are CDN-sourced and carry `crossorigin="anonymous"`.
+  for (const { src } of targets) {
     if (!html.includes(`<link rel="preload" href="${src}" as="image"`)) {
       html = html.replace(
         "</head>",
         `<link rel="preload" href="${src}" as="image" crossorigin="anonymous"/></head>`,
       )
     }
-
-    break
   }
 
   return html

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -450,13 +450,17 @@ export function renderPage(
   return optimizeLcpImage(`<!DOCTYPE html>\n${render(doc)}`)
 }
 
-/** Whether an `<img>` tag is a content image eligible to be the LCP element. */
-function isLcpCandidate(imgTag: string): boolean {
-  if (/\bfavicon\b/.test(imgTag)) return false
-  const srcMatch = imgTag.match(/\bsrc="(?<srcValue>[^"]*)"/)
-  if (!srcMatch?.groups) return false
+/**
+ * Returns the LCP-eligible content image `src` for an `<img>` tag, or `null`
+ * when the tag is a favicon, a Twemoji glyph, or has no `src`.
+ */
+function lcpImageSrc(imgTag: string): string | null {
+  if (/\bfavicon\b/.test(imgTag)) return null
+  const src = imgTag.match(/\bsrc="(?<srcValue>[^"]*)"/)?.groups?.["srcValue"]
+  if (src === undefined) return null
   // Twemoji glyphs are tiny inline characters, never the LCP element.
-  return !srcMatch.groups["srcValue"].startsWith(twemojiBaseUrl)
+  if (src.startsWith(twemojiBaseUrl)) return null
+  return src
 }
 
 /** Promotes an `<img>` tag string to `loading="eager"` and `fetchpriority="high"`. */
@@ -490,13 +494,12 @@ function enclosingSliderRange(
   const openIdx = html.lastIndexOf("<img-comparison-slider", imgIdx)
   if (openIdx < articleIdx) return null
 
-  const openEnd = html.indexOf(">", openIdx)
-  if (openEnd === -1) return null
+  const start = html.indexOf(">", openIdx) + 1
+  const end = html.indexOf("</img-comparison-slider>", start)
+  // The image is enclosed only when the slider closes after it.
+  if (end <= imgIdx) return null
 
-  const closeIdx = html.indexOf("</img-comparison-slider>", openEnd)
-  if (closeIdx === -1 || closeIdx <= imgIdx) return null
-
-  return { start: openEnd + 1, end: closeIdx }
+  return { start, end }
 }
 
 /**
@@ -522,34 +525,20 @@ export function optimizeLcpImage(html: string): string {
   const imgRegex = /<img\s[^>]*>/g
   imgRegex.lastIndex = articleIdx
 
-  let firstMatch: RegExpExecArray | null = null
+  const candidates: { index: number; tag: string; src: string }[] = []
   let match: RegExpExecArray | null
   while ((match = imgRegex.exec(html)) !== null) {
     if (match.index >= articleEndIdx) break
-    if (/\bfavicon\b/.test(match[0])) continue
-    // An <img> without a usable src cannot be a preload target; stop here.
-    if (!/\bsrc="[^"]*"/.test(match[0])) break
-    if (!isLcpCandidate(match[0])) continue
-    firstMatch = match
-    break
+    const src = lcpImageSrc(match[0])
+    if (src === null) continue
+    candidates.push({ index: match.index, tag: match[0], src })
   }
-  if (!firstMatch) return html
+  if (candidates.length === 0) return html
 
-  const sliderRange = enclosingSliderRange(html, articleIdx, firstMatch.index)
-  const region = sliderRange ?? {
-    start: firstMatch.index,
-    end: firstMatch.index + firstMatch[0].length,
-  }
-
-  const targets: { index: number; tag: string; src: string }[] = []
-  imgRegex.lastIndex = region.start
-  while ((match = imgRegex.exec(html)) !== null) {
-    if (match.index >= region.end) break
-    if (!isLcpCandidate(match[0])) continue
-    const src = match[0].match(/\bsrc="(?<srcValue>[^"]*)"/)?.groups?.["srcValue"]
-    if (!src) continue
-    targets.push({ index: match.index, tag: match[0], src })
-  }
+  const sliderRange = enclosingSliderRange(html, articleIdx, candidates[0].index)
+  const targets = sliderRange
+    ? candidates.filter((c) => c.index < sliderRange.end)
+    : [candidates[0]]
 
   // Rewrite tags back-to-front so earlier indices stay valid as the string grows.
   for (let i = targets.length - 1; i >= 0; i--) {

--- a/quartz/components/tests/renderPage.test.tsx
+++ b/quartz/components/tests/renderPage.test.tsx
@@ -962,6 +962,30 @@ describe("optimizeLcpImage", () => {
     expect(result).toContain('src="b.avif" loading="lazy"')
   })
 
+  it("only promotes slider images, not a content image after the slider", () => {
+    const html =
+      "<html><head></head><body><article><img-comparison-slider>" +
+      '<img slot="first" src="a.avif" loading="lazy">' +
+      '<img slot="second" src="b.avif" loading="lazy"></img-comparison-slider>' +
+      '<img src="after.avif" loading="lazy"></article></body></html>'
+    const result = optimizeLcpImage(html)
+    expect(result).toContain('src="a.avif" loading="eager"')
+    expect(result).toContain('src="b.avif" loading="eager"')
+    expect(result).toContain('src="after.avif" loading="lazy"')
+  })
+
+  it("treats a content image after a non-content slider as the lone LCP image", () => {
+    const html =
+      "<html><head></head><body><article><img-comparison-slider>" +
+      '<img class="favicon" slot="first" src="icon.svg">' +
+      "</img-comparison-slider>" +
+      '<img src="hero.avif" loading="lazy"></article></body></html>'
+    const result = optimizeLcpImage(html)
+    expect(result).toContain('class="favicon" slot="first" src="icon.svg"')
+    expect(result).toContain('src="hero.avif" loading="eager"')
+    expect(result).toContain('fetchpriority="high"')
+  })
+
   it("ignores images outside the article boundary", () => {
     const html =
       '<html><head></head><body><article>no images here</article><img src="outside.avif" loading="lazy"></body></html>'

--- a/quartz/components/tests/renderPage.test.tsx
+++ b/quartz/components/tests/renderPage.test.tsx
@@ -926,6 +926,38 @@ describe("optimizeLcpImage", () => {
     expect(result).not.toContain('fetchpriority="low"')
   })
 
+  it("promotes both images of an img-comparison-slider", () => {
+    const html =
+      '<html><head></head><body><article><figure><img-comparison-slider>' +
+      '<img slot="first" src="https://cdn.example.com/before.avif" loading="lazy">' +
+      '<img slot="second" src="https://cdn.example.com/after.avif" loading="lazy">' +
+      "</img-comparison-slider></figure></article></body></html>"
+    const result = optimizeLcpImage(html)
+    expect(result).toContain('slot="first" src="https://cdn.example.com/before.avif" loading="eager"')
+    expect(result).toContain('slot="second" src="https://cdn.example.com/after.avif" loading="eager"')
+    expect(result).not.toContain('loading="lazy"')
+    expect((result.match(/fetchpriority="high"/g) ?? []).length).toBe(2)
+    expect(result).toContain(
+      '<link rel="preload" href="https://cdn.example.com/before.avif" as="image" crossorigin="anonymous"/>',
+    )
+    expect(result).toContain(
+      '<link rel="preload" href="https://cdn.example.com/after.avif" as="image" crossorigin="anonymous"/>',
+    )
+  })
+
+  it("does not promote images in a later slider when the LCP image is outside it", () => {
+    const html =
+      '<html><head></head><body><article>' +
+      '<img src="hero.avif" loading="lazy">' +
+      '<img-comparison-slider><img slot="first" src="a.avif" loading="lazy">' +
+      '<img slot="second" src="b.avif" loading="lazy"></img-comparison-slider>' +
+      "</article></body></html>"
+    const result = optimizeLcpImage(html)
+    expect(result).toContain('src="hero.avif" loading="eager"')
+    expect(result).toContain('src="a.avif" loading="lazy"')
+    expect(result).toContain('src="b.avif" loading="lazy"')
+  })
+
   it("ignores images outside the article boundary", () => {
     const html =
       '<html><head></head><body><article>no images here</article><img src="outside.avif" loading="lazy"></body></html>'

--- a/quartz/components/tests/renderPage.test.tsx
+++ b/quartz/components/tests/renderPage.test.tsx
@@ -928,13 +928,17 @@ describe("optimizeLcpImage", () => {
 
   it("promotes both images of an img-comparison-slider", () => {
     const html =
-      '<html><head></head><body><article><figure><img-comparison-slider>' +
+      "<html><head></head><body><article><figure><img-comparison-slider>" +
       '<img slot="first" src="https://cdn.example.com/before.avif" loading="lazy">' +
       '<img slot="second" src="https://cdn.example.com/after.avif" loading="lazy">' +
       "</img-comparison-slider></figure></article></body></html>"
     const result = optimizeLcpImage(html)
-    expect(result).toContain('slot="first" src="https://cdn.example.com/before.avif" loading="eager"')
-    expect(result).toContain('slot="second" src="https://cdn.example.com/after.avif" loading="eager"')
+    expect(result).toContain(
+      'slot="first" src="https://cdn.example.com/before.avif" loading="eager"',
+    )
+    expect(result).toContain(
+      'slot="second" src="https://cdn.example.com/after.avif" loading="eager"',
+    )
     expect(result).not.toContain('loading="lazy"')
     expect((result.match(/fetchpriority="high"/g) ?? []).length).toBe(2)
     expect(result).toContain(
@@ -947,7 +951,7 @@ describe("optimizeLcpImage", () => {
 
   it("does not promote images in a later slider when the LCP image is outside it", () => {
     const html =
-      '<html><head></head><body><article>' +
+      "<html><head></head><body><article>" +
       '<img src="hero.avif" loading="lazy">' +
       '<img-comparison-slider><img slot="first" src="a.avif" loading="lazy">' +
       '<img slot="second" src="b.avif" loading="lazy"></img-comparison-slider>' +


### PR DESCRIPTION
## Summary

Refactors `optimizeLcpImage()` to handle images inside `<img-comparison-slider>` components. When the LCP candidate falls within a slider, both overlay images are promoted to `loading="eager"` and `fetchpriority="high"` since the browser may pick either as the LCP element. Images outside the slider are left unchanged.

## Key Changes

- **Extract helper functions** for cleaner logic:
  - `isLcpCandidate()`: checks if an `<img>` tag is eligible (not favicon, not twemoji)
  - `promoteImgTag()`: applies `loading="eager"` and `fetchpriority="high"` attributes
  - `enclosingSliderRange()`: detects if an image falls within an `<img-comparison-slider>`

- **Expand optimization scope**: instead of stopping after the first LCP candidate, collect all eligible images within the target region (either the slider or just the first image's bounds) and promote them all

- **Improve robustness**: validate that images have a usable `src` attribute before attempting preload; process rewrites back-to-front to keep indices valid as the string grows

- **Add test coverage**: two new test cases verify slider behavior (both images promoted) and that images in later sliders are not promoted when the LCP is outside them

## Implementation Details

- The optimization region is determined by `enclosingSliderRange()`: if the first LCP candidate is inside a slider, the entire slider becomes the region; otherwise, only that single image is targeted
- All eligible images in the region receive the same treatment (eager loading, high fetch priority, preload link)
- Preload links are added once per unique `src` to avoid duplicates
- The change is backward-compatible and idempotent—pages already optimized by transformers remain unchanged

https://claude.ai/code/session_01K6EBE3JmfKeXJrksWav4ev