### PR TITLE
fix(tweets): skip directive lines in snapshot refresh

### DIFF
--- a/scripts/tests/test_tweet_snapshot.py
+++ b/scripts/tests/test_tweet_snapshot.py
@@ -148,7 +148,12 @@ def test_extract_tweet_id() -> None:
 
 
 def test_parse_block_ids() -> None:
-    body = "https://x.com/u/status/11111\n\n  https://x.com/u/status/22222 \n"
+    body = (
+        "https://x.com/u/status/11111\n"
+        "retweeted-by: Shrek\n\n"
+        "  https://x.com/u/status/22222 \n"
+        "unavailable: https://x.com/u/status/33333\n"
+    )
     assert ts.parse_block_ids(body) == ["11111", "22222"]
 
 

--- a/scripts/tweet_snapshot.py
+++ b/scripts/tweet_snapshot.py
@@ -71,6 +71,9 @@ TWEET_BLOCK_RE = re.compile(
 # Pull the numeric status id out of an x.com / twitter.com / xcancel.com URL,
 # or accept a bare id. Keep in sync with TWEET_ID_RE in tweetEmbed.ts.
 TWEET_ID_RE = re.compile(r"(?:status(?:es)?/)?(?P<id>\d{5,25})")
+# Non-tweet directive lines inside a ``tweet`` block (a metadata header or an
+# opt-in stub). Keep in sync with RETWEETED_BY_RE / UNAVAILABLE_RE in tweetEmbed.ts.
+DIRECTIVE_RE = re.compile(r"^(?:retweeted-by|unavailable):\s*\S", re.IGNORECASE)
 
 
 class TweetUnavailableError(RuntimeError):
@@ -91,12 +94,19 @@ def extract_tweet_id(text: str) -> str:
 
 
 def parse_block_ids(body: str) -> list[str]:
-    """Parse a ``tweet`` block body (one URL or bare id per line) into ids."""
+    """Parse a ``tweet`` block body into tweet ids.
+
+    Each non-empty line is a tweet URL/bare id, except directive lines:
+    ``retweeted-by:`` (a metadata header) and ``unavailable:`` (a tweet deleted
+    before it could be captured) reference no snapshot to refresh and are
+    skipped. Keep in sync with ``parseTweetReferences`` in ``tweetEmbed.ts``.
+    """
     ids: list[str] = []
     for raw_line in body.splitlines():
         line = raw_line.strip()
-        if line:
-            ids.append(extract_tweet_id(line))
+        if not line or DIRECTIVE_RE.match(line):
+            continue
+        ids.append(extract_tweet_id(line))
     return ids
 
 

--- a/scripts/tweet_snapshot.py
+++ b/scripts/tweet_snapshot.py
@@ -94,7 +94,8 @@ def extract_tweet_id(text: str) -> str:
 
 
 def parse_block_ids(body: str) -> list[str]:
-    """Parse a ``tweet`` block body into tweet ids.
+    """
+    Parse a ``tweet`` block body into tweet ids.
 
     Each non-empty line is a tweet URL/bare id, except directive lines:
     ``retweeted-by:`` (a metadata header) and ``unavailable:`` (a tweet deleted


### PR DESCRIPTION
## Summary

The `refresh-tweet-snapshots` workflow started failing on `main` right after #1483 merged:

```
ValueError: No tweet id found in 'retweeted-by: Shrek'
```

`scripts/tweet_snapshot.py`'s `parse_block_ids` called `extract_tweet_id` on every non-blank line of a ` ```tweet ` block, but #1483 introduced two directive lines that aren't tweet references — `retweeted-by:` (a "<name> retweeted" header) and `unavailable:` (a tweet deleted before it could be captured). The TS transformer (`tweetEmbed.ts`) already skips/handles both; the Python refresh script did not, so it crashed on the first `retweeted-by:` line.

## Changes

- `parse_block_ids` now skips `retweeted-by:` and `unavailable:` directive lines (new `DIRECTIVE_RE`, kept in sync with `RETWEETED_BY_RE` / `UNAVAILABLE_RE` in `tweetEmbed.ts`). Those lines reference no snapshot to refresh.
- Extended `test_parse_block_ids` to cover both directives. `tweet_snapshot.py` stays at 100% line coverage; pylint 10/10.

Verified against the live content: `find_tweet_ids(website_content)` now returns the three real tweet ids instead of raising.

## Lessons learned

- **What**: When a feature adds new in-block syntax that's parsed by more than one language's tooling (here a Markdown fenced block read by both a TS transformer and a Python build/refresh script), update *every* parser in lockstep — a CI job that only runs post-merge on `main` (like a scheduled/refresh workflow) won't catch the divergence on the PR.
- **Why**: The TS `parseTweetReferences` and Python `parse_block_ids` are two parsers of the same ````tweet` block; they must stay in sync. A comment now cross-references them in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcqF83hVTsnBcP9Cz2PJkn)_