### PR TITLE
fix(security): stop following cross-origin meta-refresh redirects

### DIFF
--- a/quartz/components/scripts/popover_helpers.ts
+++ b/quartz/components/scripts/popover_helpers.ts
@@ -168,6 +168,7 @@ export async function fetchWithMetaRedirect(
   customFetch: typeof fetch = fetch,
   maxRedirects = 3,
 ): Promise<Response> {
+  const initialOrigin = url.origin
   let currentUrl = url
   let redirectCount = 0
 
@@ -198,7 +199,18 @@ export async function fetchWithMetaRedirect(
       return response
     }
 
-    currentUrl = new URL(urlMatch.groups.url, currentUrl)
+    const nextUrl = new URL(urlMatch.groups.url, currentUrl)
+    if (nextUrl.origin !== initialOrigin) {
+      // The caller injects this HTML into the live page, so a meta-refresh that
+      // leaves the originating site's origin must not be followed and rendered.
+      // Stop here and return the same-origin page we already have.
+      return new Response(html, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      })
+    }
+    currentUrl = nextUrl
     redirectCount++
   }
 

--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -19,6 +19,7 @@ import {
   extractMetaRefreshUrl,
   getNavigationOpts,
   handleNavigationScroll,
+  isLocalUrl,
   saveScrollToLocalStorage,
   scrollToUrlTarget,
   updateHeadElements,
@@ -179,6 +180,13 @@ async function handleRedirect(initialFetchResult: FetchResult): Promise<FetchRes
   if (redirectTargetRaw) {
     try {
       const redirectUrl = new URL(redirectTargetRaw, initialUrl)
+      if (!isLocalUrl(redirectUrl.href)) {
+        // A fetched page's meta-refresh must not pull cross-origin content into
+        // the in-place DOM morph; hand the off-origin destination to a full
+        // browser navigation instead.
+        window.location.href = redirectUrl.toString()
+        return { status: "fallback", finalUrl: initialUrl }
+      }
       const redirectFetchResult = await fetchContent(redirectUrl)
 
       if (

--- a/quartz/components/scripts/tests/popover.test.ts
+++ b/quartz/components/scripts/tests/popover.test.ts
@@ -880,6 +880,24 @@ describe("fetchWithMetaRedirect", () => {
     expect(window.fetch).toHaveBeenNthCalledWith(2, "http://example.com/page2")
   })
 
+  it("should not follow a meta refresh that leaves the origin", async () => {
+    const firstPage = '<meta http-equiv="refresh" content="0;url=https://evil.example.net/landing">'
+    ;(window.fetch as jest.Mock).mockImplementationOnce(() => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "Content-Type": "text/html" }),
+      text: () => Promise.resolve(firstPage),
+    }))
+
+    const response = await fetchWithMetaRedirect(new URL("http://example.com/page1"), window.fetch)
+
+    // The cross-origin redirect target is never fetched...
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+    expect(window.fetch).toHaveBeenNthCalledWith(1, "http://example.com/page1")
+    // ...and the same-origin page we already have is returned instead.
+    expect(await response.text()).toBe(firstPage)
+  })
+
   it("should handle non-HTML responses", async () => {
     ;(window.fetch as jest.Mock).mockImplementationOnce(() => ({
       ok: true,


### PR DESCRIPTION
## What

Both client-side fetchers that follow a fetched page's `<meta http-equiv="refresh">` redirect now refuse to follow one that leaves the site's origin:

- **`popover_helpers.ts` (`fetchWithMetaRedirect`)** — stops the redirect chain and returns the same-origin page we already have when the next hop's origin differs from the originating origin.
- **`spa.inline.ts` (`handleRedirect`)** — reuses the already-unit-tested `isLocalUrl` guard from `spa_utils.ts`; an off-origin meta-refresh target is handed to a full browser navigation instead of an in-place DOM morph.

## Why

Both paths resolved the meta-refresh `url=` and re-fetched it with **no same-origin check**, then injected (popover) / `micromorph`-ed (SPA) the parsed HTML into the live document. Because the popover/SPA only fire on internal links, the first fetch is same-origin — but any same-origin page containing a meta-refresh to an off-site URL would cause that cross-origin document to be fetched and rendered into the user's session. It only failed safe when CORS happened to block the fetch; that's an accident, not a control. Low severity on a static personal blog (requires an attacker-influenced redirect `<meta>` in a same-origin page), but the missing guard is real and cheap to close, and the two call sites are the same vulnerability class — fixing one without the other leaves a half-closed hole.

This came out of a broader security/robustness audit of the repo; it's the first, fully self-contained fix from that plan.

## Testing

- New `fetchWithMetaRedirect` unit test: a same-origin page whose meta-refresh points cross-origin is **not** followed (`fetch` called once) and the original same-origin HTML is returned. Existing same-origin/relative-redirect tests still pass, pinning the allowed path.
- `popover_helpers.ts` stays at **100%** statement/branch/function/line coverage; full `popover.test.ts` + `spa_utils.test.ts` green (125 tests). `tsc`, eslint, prettier clean.
- The SPA-router branch lives in a browser-bundle file outside the Jest coverage set; its decision logic is the `isLocalUrl` helper already unit-tested in `spa_utils.test.ts`, and it's exercised by the existing `spa.inline.spec.ts` Playwright navigation suite.

## Lessons learned

When client code fetches a URL and then **injects or DOM-morphs the response into the live page**, every hop that can change the destination — redirects, `<meta http-equiv="refresh">`, `<base>`, JS-driven location changes — must be re-checked against the page origin. Relying on CORS to block cross-origin fetches is incidental, not a security boundary: same-origin-but-different-subdomain or permissively-CORS'd targets sail through. Anchor the origin check to the *initial* request's origin so a multi-hop chain can't drift off-site one hop at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_