### PR TITLE
fix(build): name the culprit when an internal link is malformed

### DIFF
--- a/quartz/plugins/transformers/links.test.ts
+++ b/quartz/plugins/transformers/links.test.ts
@@ -152,6 +152,14 @@ describe("CrawlLinks anchor processing", () => {
     expect(result.links).toHaveLength(1)
   })
 
+  it("throws an attributed error for an internal link with malformed percent-encoding", async () => {
+    // A stray "%" reaches decodeURIComponent and would otherwise abort the whole
+    // build with a bare "URI malformed"; the link and file must be named instead.
+    await expect(processHtml('<a href="/foo%bar">Broken</a>', { slug: "my-post" })).rejects.toThrow(
+      /Malformed internal link "\/foo%bar" in my-post/,
+    )
+  })
+
   it.each([
     ["external", '<a href="https://example.com">Example</a>'],
     ["anchor-only", '<a href="#section">Section</a>'],

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -96,7 +96,7 @@ function resolveInternalLink(
     throw new Error(
       `Malformed internal link ${JSON.stringify(dest)} in ${curSlug}: ` +
         `${(err as Error).message}. Check the percent-encoding (a stray "%" or an ` +
-        `incomplete escape like "%zz" must be written as "%25").`,
+        'incomplete escape like "%zz" must be written as "%25").',
     )
   }
   outgoing.add(simplifySlug(full))

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -71,21 +71,34 @@ function resolveInternalLink(
   transformOptions: TransformOptions,
   outgoing: Set<SimpleSlug>,
 ): void {
-  const resolved = (node.properties.href = transformLink(
-    file.data.slug as FullSlug,
-    dest,
-    transformOptions,
-  ))
+  let full: FullSlug
+  try {
+    const resolved = (node.properties.href = transformLink(
+      file.data.slug as FullSlug,
+      dest,
+      transformOptions,
+    ))
 
-  // Dummy hostname required by WHATWG URL constructor; only the pathname is used
-  const url = new URL(resolved, `https://base.com/${stripSlashes(curSlug, true)}`)
-  let canonicalPath = splitAnchor(url.pathname)[0]
-  if (canonicalPath.endsWith("/")) {
-    canonicalPath += "index"
+    // Dummy hostname required by WHATWG URL constructor; only the pathname is used
+    const url = new URL(resolved, `https://base.com/${stripSlashes(curSlug, true)}`)
+    let canonicalPath = splitAnchor(url.pathname)[0]
+    if (canonicalPath.endsWith("/")) {
+      canonicalPath += "index"
+    }
+
+    // decodeURIComponent needed because WHATWG URL percent-encodes everything
+    full = decodeURIComponent(stripSlashes(canonicalPath, true)) as FullSlug
+  } catch (err) {
+    // A malformed percent-escape (a stray "%" in an authored link) makes
+    // decodeURI/decodeURIComponent throw a bare "URI malformed", which would
+    // abort the whole build with no indication of the culprit. Rethrow naming the
+    // page + link so the author can find and fix it.
+    throw new Error(
+      `Malformed internal link ${JSON.stringify(dest)} in ${curSlug}: ` +
+        `${(err as Error).message}. Check the percent-encoding (a stray "%" or an ` +
+        `incomplete escape like "%zz" must be written as "%25").`,
+    )
   }
-
-  // decodeURIComponent needed because WHATWG URL percent-encodes everything
-  const full = decodeURIComponent(stripSlashes(canonicalPath, true)) as FullSlug
   outgoing.add(simplifySlug(full))
   node.properties["data-slug"] = full
 }


### PR DESCRIPTION
## What

`resolveInternalLink` (in `links.ts`) now catches a malformed-link error and rethrows it **naming the page and the offending link** instead of letting a bare `URIError: URI malformed` bubble up and abort the build.

## Why

A single authored internal link with a malformed percent-escape — a stray `%` or an incomplete escape, e.g. `[text](/foo%bar)` — flows through `transformLink` (`decodeURI`) and `decodeURIComponent` with no error handling. Verified empirically: `/foo%bar`, `/foo%`, and `/foo%zz` all throw `URI malformed`. The result is the **entire site build aborting** with a bare "URI malformed" and **no indication of which file or link** is at fault, so the author has to bisect content to find it.

The fix keeps the repo's "fail loudly" convention but makes the failure *actionable*: it names the page slug, the offending href, and the underlying error, with a hint about percent-encoding. No behavior change for valid links — the happy path is unchanged.

## Testing

- New `CrawlLinks` test: an internal link with malformed percent-encoding rejects with `Malformed internal link "/foo%bar" in my-post …`.
- `links.ts` stays at **100%** statement/branch/function/line coverage; full `links.test.ts` green (68 tests). `tsc`, eslint, prettier clean.

## Lessons learned

`decodeURI`/`decodeURIComponent` on author-derived strings can throw `URIError` on malformed percent-escapes, and the WHATWG `URL` constructor does **not** pre-sanitize them — so any build-time pass that decodes a link must wrap it and attribute the failure to a source location. An unattributed "URI malformed" that aborts a whole-site build is a debugging tax; name the culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_