### PR TITLE
fix(ui): reading-time label, touch copy button, and no-results card

### DIFF
--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -139,6 +139,10 @@ export const renderReadingTime = (fileData: QuartzPluginData): JSX.Element => {
   const text = (fileData.readingTimeText ?? fileData.text) as string
   const { minutes } = readingTime(text)
   const displayedTime = processReadingTime(Math.ceil(minutes))
+  if (!displayedTime) {
+    // skipcq: JS-0424
+    return <></>
+  }
 
   return <span className="reading-time">Read time: {displayedTime}</span>
 }

--- a/quartz/components/styles/clipboard.scss
+++ b/quartz/components/styles/clipboard.scss
@@ -14,6 +14,12 @@ pre:hover > .clipboard-button,
   transition: opacity $transition-duration-quick;
 }
 
+@media (hover: none), (pointer: coarse) {
+  .clipboard-button {
+    opacity: 1;
+  }
+}
+
 .clipboard-button {
   display: flex;
   position: absolute;

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -249,6 +249,16 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
             background: color-mix(in srgb, var(--midground-faint) 40%, var(--background));
           }
 
+          &.no-match {
+            cursor: default;
+
+            &:hover,
+            &:focus,
+            &.focus {
+              background: none;
+            }
+          }
+
           & > h3 {
             margin: 0;
           }

--- a/quartz/components/tests/ContentMeta.test.tsx
+++ b/quartz/components/tests/ContentMeta.test.tsx
@@ -240,6 +240,14 @@ describe("renderReadingTime", () => {
     const result = renderReadingTime(fileData)
     expect(result.props?.children).toEqual(["Read time: ", expected])
   })
+
+  it("renders no reading-time label when text is empty", () => {
+    const fileData = createFileData() as QuartzPluginData
+    fileData.text = ""
+    const result = renderReadingTime(fileData)
+    expect(result.props?.children).toBeFalsy()
+    expect(result.props?.className).toBeUndefined()
+  })
 })
 
 describe("renderLinkpostInfo", () => {


### PR DESCRIPTION
## What

Three small reader-facing UX fixes:
- **ContentMeta** — render nothing instead of a dangling `Read time:` label (with no value) when the reading-time estimate is empty (0-minute / text-less content). Matches the existing `renderTags` empty-render pattern in the same file.
- **clipboard.scss** — show the code-block copy button on touch / coarse-pointer devices via a `(hover: none), (pointer: coarse)` fallback. The existing fine-pointer hover reveal is unchanged.
- **search.scss** — drop the `cursor: pointer` + hover/focus highlight from the non-clickable `.result-card.no-match` "no results" card, so it no longer presents a clickable affordance.

## Why

- The empty "Read time: " label is a visible artifact on text-less pages.
- The copy button was hover-only → invisible and unusable on touch devices.
- The no-results card looked clickable (pointer cursor + hover highlight) despite doing nothing — a misleading affordance.

## Testing

- Added a `ContentMeta.test.tsx` case asserting empty `text` produces no reading-time label; existing assertions untouched. `ContentMeta.tsx` stays at 100% coverage (52 tests green).
- `tsc`, eslint, stylelint, prettier all clean.
- The two SCSS changes alter rendered styling (touch copy button, no-results card), so **visual baselines will diff and need approval via the diff gallery** — that's expected, not a failure.

## Lessons learned

The no-results card already carried a distinguishing class (`no-match`), so the fix was pure CSS with zero JS change — check existing markup for a styling hook before adding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_