### PR TITLE
fix(build): harden parse/emit pipeline against cosmetic failures and crashes

### DIFF
--- a/quartz/plugins/emitters/helpers.ts
+++ b/quartz/plugins/emitters/helpers.ts
@@ -23,7 +23,10 @@ export const write = async ({ ctx, slug, ext, content }: WriteOptions): Promise<
   const pathToPage = joinSegments(ctx.argv.output, slug + ext) as FilePath
   const dir = path.dirname(pathToPage)
   await fs.promises.mkdir(dir, { recursive: true })
-  await fs.promises.writeFile(pathToPage, content)
+  // Write atomically: a crash mid-write must not leave a truncated page on disk.
+  const tempFile = `${pathToPage}.tmp`
+  await fs.promises.writeFile(tempFile, content)
+  await fs.promises.rename(tempFile, pathToPage)
   return pathToPage
 }
 

--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -1015,6 +1015,42 @@ describe("PopulateContainers", () => {
 
         expect(stats).toEqual(MOCK_STATS)
       })
+
+      it("degrades a failing cosmetic counter to the sentinel instead of aborting", async () => {
+        // Every stat command fails (e.g. no `.venv`, no `git`): the build must
+        // still produce a full RepoStats object with sentinel counts.
+        mockExecSync.mockImplementation(() => {
+          throw new Error("command not found")
+        })
+
+        const stats = await populateModule.computeRepoStats()
+
+        expect(stats).toEqual({
+          commitCount: populateModule.STAT_UNAVAILABLE,
+          aiCommitCount: populateModule.STAT_UNAVAILABLE,
+          jsTestCount: populateModule.STAT_UNAVAILABLE,
+          playwrightTestCount: populateModule.STAT_UNAVAILABLE,
+          pytestCount: populateModule.STAT_UNAVAILABLE,
+          linesOfCode: populateModule.STAT_UNAVAILABLE,
+        })
+      })
+    })
+
+    describe("safeStatCount", () => {
+      it("returns the counter result when it succeeds", () => {
+        expect(populateModule.safeStatCount("ok", () => 42)).toBe(42)
+      })
+
+      it("returns the sentinel and does not throw when the counter throws", () => {
+        const throwingCounter = () => {
+          throw new Error("boom")
+        }
+
+        expect(() => populateModule.safeStatCount("boom", throwingCounter)).not.toThrow()
+        expect(populateModule.safeStatCount("boom", throwingCounter)).toBe(
+          populateModule.STAT_UNAVAILABLE,
+        )
+      })
     })
 
     describe("htmlFileToSlug", () => {

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -104,6 +104,26 @@ interface GitCountOptions {
   grep?: string
 }
 
+/**
+ * Sentinel returned for a cosmetic stat whose underlying command failed. These
+ * counts feed decorative badges only, so a missing tool (no `.venv`, no `git`,
+ * an unexpected output format) must degrade gracefully rather than abort the
+ * whole build.
+ */
+export const STAT_UNAVAILABLE = 0
+
+/** Runs a cosmetic stat counter, degrading to {@link STAT_UNAVAILABLE} on any failure. */
+export function safeStatCount(label: string, counter: () => number): number {
+  try {
+    return counter()
+  } catch (err) {
+    logger.warn(
+      `Stat counter "${label}" failed; using sentinel ${STAT_UNAVAILABLE}: ${String(err)}`,
+    )
+    return STAT_UNAVAILABLE
+  }
+}
+
 /** True if the current git working tree is a shallow clone. */
 export function isShallowClone(): boolean {
   return execSync("git rev-parse --is-shallow-repository", { encoding: "utf-8" }).trim() === "true"
@@ -174,16 +194,20 @@ export interface RepoStats {
   linesOfCode: number
 }
 
-/** Gathers commit, test, and code-size statistics about this repo in parallel. */
+/**
+ * Gathers commit, test, and code-size statistics about this repo in parallel.
+ * Each counter is cosmetic, so a single failure degrades to {@link STAT_UNAVAILABLE}
+ * rather than aborting the build.
+ */
 export async function computeRepoStats(): Promise<RepoStats> {
   const [commitCount, aiCommitCount, jsTestCount, playwrightTestCount, pytestCount, linesOfCode] =
     await Promise.all([
-      countGitCommits({ author: "Alex Turner" }),
-      countGitCommits({ grep: "claude.ai/code/session" }),
-      countJsTests(),
-      countPlaywrightTests(),
-      countPythonTests(),
-      countLinesOfCode(),
+      safeStatCount("git-commits", () => countGitCommits({ author: "Alex Turner" })),
+      safeStatCount("ai-git-commits", () => countGitCommits({ grep: "claude.ai/code/session" })),
+      safeStatCount("js-tests", countJsTests),
+      safeStatCount("playwright-tests", countPlaywrightTests),
+      safeStatCount("pytest", countPythonTests),
+      safeStatCount("lines-of-code", countLinesOfCode),
     ])
 
   return { commitCount, aiCommitCount, jsTestCount, playwrightTestCount, pytestCount, linesOfCode }

--- a/quartz/processors/parse.ts
+++ b/quartz/processors/parse.ts
@@ -186,17 +186,24 @@ export async function parseMarkdown(ctx: BuildCtx, fps: FilePath[]): Promise<Pro
       workerType: "thread",
     })
 
-    const childPromises: WorkerPromise<ProcessedContent[]>[] = []
-    for (const chunk of chunks(fps, CHUNK_SIZE)) {
-      childPromises.push(pool.exec("parseFiles", [argv, chunk, ctx.allSlugs]))
-    }
+    try {
+      const childPromises: WorkerPromise<ProcessedContent[]>[] = []
+      for (const chunk of chunks(fps, CHUNK_SIZE)) {
+        childPromises.push(pool.exec("parseFiles", [argv, chunk, ctx.allSlugs]))
+      }
 
-    const results: ProcessedContent[][] = await WorkerPromise.all(childPromises).catch((err) => {
-      const errString = err.toString().slice("Error:".length)
-      throw new Error(errString)
-    })
-    res = results.flat()
-    await pool.terminate()
+      const results: ProcessedContent[][] = await WorkerPromise.all(childPromises).catch((err) => {
+        const errString = err.toString().slice("Error:".length)
+        throw new Error(errString)
+      })
+      res = results.flat()
+    } catch (err) {
+      throw new Error(`Failed to parse Markdown files with worker pool: ${String(err)}`, {
+        cause: err,
+      })
+    } finally {
+      await pool.terminate()
+    }
   }
 
   log.info(`Parsed ${res.length} Markdown files in ${perf.timeSince()}`)


### PR DESCRIPTION
## What

Three build-robustness fixes; none change rendered site output.

- **`parse.ts`** — the worker pool was never torn down if parsing threw, leaking worker threads (OOM risk in long dev sessions). The worker section is now wrapped in `try/finally` so `await pool.terminate()` always runs; on error it rethrows with `{ cause }` preserved.
- **`populateContainers.ts`** — a failing *cosmetic* stat counter (pytest collect, git/grep/find counts) used to abort the whole build via `process.exit`. `computeRepoStats` now runs each counter through `safeStatCount`, which logs a warning and degrades to a sentinel on failure. The individual counter functions keep their existing throw behavior (no existing test touched).
- **`helpers.ts` `write`** — page writes were non-atomic (truncate-then-write); a crash mid-write could leave a truncated page in `public/`. It now writes to `${path}.tmp` then `rename`s into place, matching the atomic pattern already used by `buildTitleIndex.ts`.

## Why

The build should not die or leak resources for cosmetic reasons — a missing `.venv`, a shallow clone, an SSD hiccup mid-write. "Fail soft on decoration, fail loud on real work."

## Testing

- `populateContainers.ts` at **100%** coverage; added tests for `safeStatCount` (success + throwing) and `computeRepoStats` degrading all counters to sentinels without throwing. 102 related emitter tests pass.
- `tsc --noEmit`, eslint, prettier clean.
- `parse.ts` and `helpers.ts` are control-flow/IO-ordering changes only. `parse.ts` is outside the Jest harness (no test loads it unmocked); `helpers.ts` `write()` adds no new branch (two sequential awaits replacing one) so existing emitter tests keep it at 100%.

## Lessons learned

- With **no `collectCoverageFrom`** and a global 100% threshold, coverage is measured only on files loaded unmocked during a run — a module nothing imports is effectively outside the gate, and naively importing it for a "co-located test" can drag its whole transitive graph into the report. Check what loads a file before adding the obvious test.
- When a requested change (counter returns a sentinel) collides with a locked existing assertion (counter must throw), move the resilience to the **call site** instead of mutating the unit under test — same guarantee, no weakened test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_