### PR TITLE
fix: correct dropcap text for inline-leading paragraphs and UTC-date day-shift

### DIFF
--- a/quartz/components/Date.tsx
+++ b/quartz/components/Date.tsx
@@ -92,7 +92,12 @@ interface DateElementProps {
 // local time so display and the `datetime` attribute don't shift by one day in
 // timezones behind UTC.
 const parseDate = (date: Date | string): Date => {
-  if (date instanceof Date) return date
+  // YAML parses `date: 2024-01-15` to a Date at UTC midnight. Rebuild it at
+  // local midnight from its UTC calendar fields so the rendered day-of-month
+  // and the `datetime` attribute don't shift by one in timezones behind UTC.
+  if (date instanceof Date) {
+    return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  }
   const match = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/.exec(date)
   if (match?.groups) {
     const { year, month, day } = match.groups

--- a/quartz/components/tests/Date.test.tsx
+++ b/quartz/components/tests/Date.test.tsx
@@ -138,6 +138,27 @@ describe("DateElement", () => {
     ).toThrow("valid Date object")
   })
 
+  it("renders a UTC-midnight Date without day-shift in a behind-UTC timezone", () => {
+    const originalTz = process.env.TZ
+    process.env.TZ = "America/Los_Angeles"
+    try {
+      // YAML parses `date: 2024-01-15` to this UTC-midnight Date.
+      const utcMidnight = new Date("2024-01-15T00:00:00Z")
+      const element = DateElement({
+        cfg,
+        date: utcMidnight,
+        includeOrdinalSuffix: true,
+        formatOrdinalSuffix: false,
+        monthFormat: "short",
+      }) as JSX.Element
+
+      expect(element.props.dateTime).toBe("2024-01-15")
+      expect(element.props.dangerouslySetInnerHTML.__html).toBe("Jan 15th, 2024")
+    } finally {
+      process.env.TZ = originalTz
+    }
+  })
+
   it("parses a day-only YYYY-MM-DD string as local time (no UTC day-shift)", () => {
     const element = DateElement({
       cfg,

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -878,6 +878,12 @@ export function setFirstLetterAttribute(tree: Root): void {
   )
   if (!firstTextNode) return
 
+  // The in-place rewrites below assume the first text node holds the first
+  // letter. When the paragraph opens with an inline element carrying text
+  // (e.g. <em>First</em>), the first text node is later prose, so rewriting it
+  // would corrupt visible text. Only rewrite when this node starts the letter.
+  if (firstTextNode.value.charAt(0) !== firstLetter) return
+
   // Replace nbsp after first letter — nbspTransform adds it after single-letter
   // words like "I", but it creates a visible extra space with dropcap float
   if (firstTextNode.value.charAt(1) === NBSP) {

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1323,6 +1323,34 @@ describe("setFirstLetterAttribute", () => {
 
   it.each([
     [
+      "leading inline element holds the first letter",
+      "<p><em>First</em> paragraph</p>",
+      "F",
+      "First",
+      " paragraph",
+    ],
+    [
+      "leading inline single-letter word before apostrophe",
+      "<p><em>I</em>'ll go.</p>",
+      "I",
+      "I",
+      "’ll go.",
+    ],
+  ])(
+    "sets data-first-letter from text content without corrupting text when %s",
+    (_description, input, expectedFirstLetter, expectedInline, expectedTrailingText) => {
+      const processedHtml = testHtmlFormattingImprovement(input, false)
+      expect(processedHtml).toContain(`data-first-letter="${expectedFirstLetter}"`)
+      // The leading inline element's text is untouched...
+      expect(processedHtml).toContain(`<em>${expectedInline}</em>`)
+      // ...and the trailing direct text node is not rewritten (no spurious
+      // space or apostrophe shuffling injected at its start).
+      expect(normalizeNbsp(processedHtml)).toContain(`</em>${expectedTrailingText}`)
+    },
+  )
+
+  it.each([
+    [
       "paragraph is not a direct child of article",
       `
       <div>


### PR DESCRIPTION
## What

- **`setFirstLetterAttribute` (`formatting_improvement_html.ts`)** — still sets `data-first-letter` from the paragraph's full text, but now only applies its in-place nbsp/apostrophe rewrites when the first direct text node actually begins with the first letter (`firstTextNode.value.charAt(0) === firstLetter`).
- **`parseDate` (`Date.tsx`)** — a `Date` input is rebuilt at local midnight from its UTC calendar fields: `new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())`.

## Why

- When a paragraph opens with an inline element carrying text (`<em>First</em> paragraph`, `<em>I</em>'ll`), the first direct text node is *later prose*, not the first letter — the old code rewrote that node and corrupted visible text (stray space / shuffled apostrophe). The guard scopes the rewrite to the node that actually holds the first letter.
- YAML parses `date: 2024-01-15` to a `Date` at UTC midnight; reading local `getDate()` off it day-shifts by one in timezones behind UTC. Reconstructing from UTC fields keeps the displayed day and `datetime` on the authored calendar date.

## Testing

- New parametrized tests for inline-leading paragraphs (correct `data-first-letter`, uncorrupted text); new `Date` test under `TZ=America/Los_Angeles` asserting a UTC-midnight Date renders `Jan 15th, 2024` with no off-by-one. 630 tests pass; both changed source files at **100%** coverage. `tsc`/eslint/prettier clean. No existing assertion changed.
- These intentionally change rendered output, so **visual baselines will diff and need approval via the diff gallery** — expected, not a failure.

## Lessons learned

- When handed a literal predicate for a fix, verify it against the existing test corpus first: the originally-specified `children[0]?.type === "text"` would have regressed two passing tests (empty leading inline element where the first text node still holds the first letter). The correct invariant is "the node being rewritten actually starts with the first letter."
- Normalize provider-supplied UTC-midnight `Date`s to local-midnight at the parse boundary so all downstream local getters and `datetime` strings agree on the authored date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_