### PR TITLE
perf: load KaTeX CSS only on pages that contain math

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -147,7 +147,9 @@ export default (() => {
         {fileData.frontmatter?.avoidIndexing && (
           <meta name="robots" content="noindex, noimageindex, nofollow" />
         )}
-        <link rel="stylesheet" href="/static/styles/katex.min.css" spa-preserve />
+        {fileData.usesKatex && (
+          <link rel="stylesheet" href="/static/styles/katex.min.css" spa-preserve />
+        )}
         {iconPreloads}
         {fontPreloads}
         <script defer src="/static/scripts/collapsible-listeners.js" spa-preserve />

--- a/quartz/components/tests/Head.test.tsx
+++ b/quartz/components/tests/Head.test.tsx
@@ -55,6 +55,7 @@ describe("Head Component", () => {
     slug: "test-page" as FullSlug,
     frontmatter: mockFrontmatter,
     usedAdmonitionIcons: ["note"],
+    usesKatex: true,
     data: {
       frontmatter: mockFrontmatter,
     },
@@ -302,6 +303,25 @@ describe("Head Component", () => {
       const html = render(h(Head, propsNoIcons))
 
       expect(html).not.toContain("/static/icons/")
+    })
+
+    it("loads the katex stylesheet only when the page uses katex", () => {
+      const html = render(h(Head, mockProps))
+
+      expect(html).toContain('href="/static/styles/katex.min.css"')
+    })
+
+    it.each([false, undefined])("omits the katex stylesheet when usesKatex is %p", (usesKatex) => {
+      const propsNoKatex = {
+        ...mockProps,
+        fileData: {
+          ...mockFileData,
+          usesKatex,
+        } as QuartzPluginData,
+      }
+      const html = render(h(Head, propsNoKatex))
+
+      expect(html).not.toContain("/static/styles/katex.min.css")
     })
   })
 

--- a/quartz/plugins/transformers/latex.test.ts
+++ b/quartz/plugins/transformers/latex.test.ts
@@ -2,6 +2,7 @@ import type { Root } from "hast"
 
 import { describe, expect, it } from "@jest/globals"
 import { h } from "hastscript"
+import { VFile } from "vfile"
 
 import { Latex } from "./latex"
 
@@ -31,13 +32,19 @@ describe("Latex plugin", () => {
     function getA11yTransform() {
       const plugins = plugin.htmlPlugins?.(mockCtx) ?? []
       // The second plugin is the a11y transform factory
-      const factory = plugins[1] as () => (tree: Root) => void
+      const factory = plugins[1] as () => (tree: Root, file: VFile) => void
       return factory()
+    }
+
+    function runTransform(tree: Root): VFile {
+      const file = new VFile("")
+      getA11yTransform()(tree, file)
+      return file
     }
 
     it("adds tabindex and role to .katex-display elements", () => {
       const tree = h(null, [h("span.katex-display", [h("span.katex", "x^2")])]) as unknown as Root
-      getA11yTransform()(tree)
+      runTransform(tree)
       const display = (
         tree as unknown as { children: Array<{ properties: Record<string, unknown> }> }
       ).children[0]
@@ -47,12 +54,28 @@ describe("Latex plugin", () => {
 
     it("does not add tabindex to inline .katex elements", () => {
       const tree = h(null, [h("span.katex", "x^2")]) as unknown as Root
-      getA11yTransform()(tree)
+      runTransform(tree)
       const katex = (
         tree as unknown as { children: Array<{ properties: Record<string, unknown> }> }
       ).children[0]
       expect(katex.properties.tabIndex).toBeUndefined()
       expect(katex.properties.role).toBeUndefined()
+    })
+
+    it.each([
+      ["block math", h(null, [h("span.katex-display", [h("span.katex", "x^2")])])],
+      ["inline math", h(null, [h("span.katex", "x^2")])],
+    ])("sets file.data.usesKatex for %s", (_name, tree) => {
+      const file = runTransform(tree as unknown as Root)
+      expect(file.data.usesKatex).toBe(true)
+    })
+
+    it.each([
+      ["text-only content", h(null, [h("p", "plain text")])],
+      ["classed non-math elements", h(null, [h("p.prose", [h("span.highlight", "x")])])],
+    ])("does not set file.data.usesKatex for %s", (_name, tree) => {
+      const file = runTransform(tree as unknown as Root)
+      expect(file.data.usesKatex).toBeUndefined()
     })
   })
 })

--- a/quartz/plugins/transformers/latex.ts
+++ b/quartz/plugins/transformers/latex.ts
@@ -3,6 +3,7 @@ import type { Element, Root } from "hast"
 import rehypeKatex from "rehype-katex"
 import remarkMath from "remark-math"
 import { visit } from "unist-util-visit"
+import { VFile } from "vfile"
 
 import type { QuartzTransformerPlugin } from "../types"
 
@@ -50,7 +51,7 @@ export const Latex: QuartzTransformerPlugin = () => {
           rehypeKatex,
           { output: "htmlAndMathml", strict: false, trust: true, macros, colorIsTextColor: true },
         ],
-        () => (tree: Root) => {
+        () => (tree: Root, file: VFile) => {
           // Add tabindex="0" to .katex-display spans so they satisfy the axe
           // scrollable-region-focusable rule in static HTML (before JS runs).
           // CSS gives .katex-display `overflow: auto hidden`, making it scrollable.
@@ -58,7 +59,13 @@ export const Latex: QuartzTransformerPlugin = () => {
           // removing tabindex from elements that don't actually overflow.
           visit(tree, "element", (node: Element) => {
             const classes = node.properties?.className
-            if (Array.isArray(classes) && classes.includes("katex-display")) {
+            if (!Array.isArray(classes)) return
+            if (classes.includes("katex") || classes.includes("katex-display")) {
+              // Flag the page so `<Head>` loads the katex stylesheet, which is
+              // render-blocking and otherwise wasted on math-free pages.
+              file.data.usesKatex = true
+            }
+            if (classes.includes("katex-display")) {
               node.properties.tabIndex = 0
               node.properties.role = "group"
             }

--- a/quartz/plugins/vfile.ts
+++ b/quartz/plugins/vfile.ts
@@ -73,6 +73,12 @@ export interface Data {
    * transformer; consumed by `<Head>` to scope prefetch hints.
    */
   usedAdmonitionIcons?: readonly string[]
+  /**
+   * True when the page actually contains rendered math (KaTeX output).
+   * Populated by the Latex transformer; consumed by `<Head>` to load the
+   * render-blocking katex stylesheet only on pages that need it.
+   */
+  usesKatex?: boolean
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## What

The render-blocking `katex.min.css` (~27KB) was loaded on **every** page via a hardcoded `<link>` in `Head.tsx`, even though most pages have no math. This adds a per-page `usesKatex` signal: the Latex transformer sets `file.data.usesKatex = true` when it actually produces a `.katex` / `.katex-display` node, and `Head.tsx` emits the stylesheet only when that flag is set. Mirrors the existing `usedAdmonitionIcons` pattern.

## Why

Render-blocking CSS on every page hurts FCP/LCP for the majority of (math-free) pages. The condition is driven by the **real per-page transformer output (the produced HAST node), not frontmatter** — so any page with math still loads its CSS; nothing silently strips it.

## Testing

- `latex.test.ts`: asserts `usesKatex` is set for inline and block math and unset for math-free content (text-only and classed-non-math); existing a11y assertions preserved.
- `Head.test.tsx`: asserts the katex link is present when `usesKatex` is true and absent when false/undefined.
- `Head.tsx` and `latex.ts` at **100%** coverage (35 tests). `tsc`/eslint/prettier clean. Do **not** lower any Lighthouse threshold — this should improve FCP/LCP on non-math pages.
- **Visual baseline impact:** non-math pages no longer load katex CSS, so their visual-regression baselines may shift slightly — review/approve via the diff gallery. Math pages are unaffected.

## Deferred

The analogous `usesDropcap`-gated dropcap-font preload (~76KB) — there's no per-page dropcap signal today, and wiring one reliably needs plumbing through the content emitter / `Content.tsx` with real uncertainty about which pages render a dropcap. Deferred rather than risk stripping fonts from pages that need them.

## Lessons learned

When making a render-blocking global resource conditional, drive the condition off the real artifact the transformer emits (the produced HAST node), never off frontmatter — frontmatter can drift from actual content and silently strip required CSS from pages that need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkpKNkZNz2VV3D3jvQEXQ)_