### PR TITLE
Replace dotted border with subtle background for footnote refs

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -91,6 +91,7 @@ a[id*="fnref-"] {
   scroll-margin-top: calc(2 * $base-margin);
   background-color: var(--midground-faintest);
   padding: 0 calc(0.125 * $base-margin);
+  margin: 0 calc(0.125 * $base-margin);
   border-radius: $border-radius;
 
   @media all and (max-width: $max-mobile-width) {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -89,10 +89,8 @@ li[id^="user-content-fn-"] {
 a[id*="fnref-"] {
   // When scrolling back to a footnote, scroll up farther than default
   scroll-margin-top: calc(2 * $base-margin);
-
-  // Dotted border signals "click for interaction" (same pattern as Elvish text)
-  border: 1px dotted var(--midground-fainter);
-  padding: 0 calc(0.25 * $base-margin);
+  background-color: var(--midground-faintest);
+  padding: 0 calc(0.125 * $base-margin);
   border-radius: $border-radius;
 
   @media all and (max-width: $max-mobile-width) {


### PR DESCRIPTION
## Summary
Updates the visual styling of footnote reference links (`a[id*="fnref-"]`) to use a subtle background color instead of a dotted border, improving the visual hierarchy while maintaining the interactive affordance.

## Changes
- Replaced `border: 1px dotted var(--midground-fainter)` with `background-color: var(--midground-faintest)` for a softer, less prominent visual indicator
- Reduced horizontal padding from `calc(0.25 * $base-margin)` to `calc(0.125 * $base-margin)` to accommodate the background-based approach
- Removed the comment about dotted borders signaling interaction, as the new background color serves the same purpose with better visual consistency

## Implementation details
The change maintains the same scroll-margin-top behavior and border-radius, ensuring footnote navigation and link appearance remain consistent. The background color uses a fainter variant (`--midground-faintest`) to keep the footnote reference subtle while still visually distinguishable from surrounding text.

https://claude.ai/code/session_01GN3BmLfm4atH6s5PnfUrjY