### PR TITLE
refactor(tweets): fade only the bottom edge of clipped media

### DIFF
--- a/quartz/components/styles/tweet.scss
+++ b/quartz/components/styles/tweet.scss
@@ -122,13 +122,11 @@
   // full image still opens via the source link.
   aspect-ratio: 16 / 9;
 
-  // Fade the top and bottom edges into the card so a clipped portrait trails
-  // off instead of ending on a hard line — the same fade overflowing equations
-  // and tables get where their content is cut.
+  // Fade the bottom edge into the card so a clipped portrait trails off there
+  // instead of ending on a hard line — the same fade overflowing equations and
+  // tables get where their content is cut.
   mask-image: linear-gradient(
     to bottom,
-    transparent 0,
-    var(--background) calc(4 * $base-margin),
     var(--background) calc(100% - 4 * $base-margin),
     transparent 100%
   );


### PR DESCRIPTION
## Summary

Follow-up to #1502. That PR merged with the media-frame fade on **both** the top and bottom edges; this drops the top-edge fade so a framed tweet image sits flush at the top and trails off only at the bottom, like a "read more" cutoff.

## Changes

- `quartz/components/styles/tweet.scss`: simplify the `.tweet-media-grid` `mask-image` to a single bottom-edge fade (removes the top `transparent → background` stops), keeping the `2rem` (`calc(4 * $base-margin)`) fade depth that matches the equation/table `$scroll-fade-size`.

## Notes

- The single-tweet screenshot baseline will show the updated fade as an expected diff in the approve-baselines gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018YTUBVGtJqdV1vx7KNRCk9)_