### PR TITLE
style(tweets): lower single-image height cap to 24rem

### DIFF
--- a/quartz/components/styles/tweet.scss
+++ b/quartz/components/styles/tweet.scss
@@ -112,7 +112,7 @@
 
 // A single image keeps its natural aspect ratio up to this height, so an
 // ordinary photo shows in full; only an unusually tall image is cropped.
-$tweet-media-max-height: 32rem;
+$tweet-media-max-height: 24rem;
 
 .tweet-media-grid {
   display: grid;


### PR DESCRIPTION
## Summary

Follow-up to #1509. The tall-image tweet example added there didn't actually fade: at the test-page card width (~29–30rem) a portrait image renders ~32rem tall — right at the previous 32rem cap — so it never clamped.

Lower `$tweet-media-max-height` to **24rem**, which sits between:
- a typical landscape image's rendered height (~19–20rem → stays full, no fade), and
- a tall portrait's (~30rem+ → now crops and fades into the card's bottom edge).

So the `TechEmails/2071254764558676130` example on the test page now visibly demonstrates the bottom fade, while ordinary landscape tweet images still show in full.

## Files
- `quartz/components/styles/tweet.scss` — `$tweet-media-max-height: 32rem → 24rem`.

## Note on CI
This changes the tall-image tweet screenshot, so `visual-testing` will report a snapshot diff (new baseline) — expected; approve it via the diff gallery.


---
_Generated by [Claude Code](https://claude.ai/code/session_011qtpg4iN8fHofRZdx9ngqy)_