### PR TITLE
Centralize no-favicon class application in externalAnchor

### DIFF
--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -115,6 +115,17 @@ describe("linkifyTweetText", () => {
     expect(nodes).toHaveLength(1)
     expect(render(nodes[0] as Element)).toContain("https://xcancel.com/bob")
   })
+
+  it("marks body entity links no-favicon so the favicon pass skips them", () => {
+    const nodes = linkifyTweetText("@bob see https://t.co/abc", [
+      { url: "https://t.co/abc", display: "example.com", expanded: "https://example.com" },
+    ])
+    const anchors = nodes.filter((n): n is Element => typeof n !== "string")
+    expect(anchors.length).toBeGreaterThan(0)
+    for (const anchor of anchors) {
+      expect(render(anchor)).toContain("no-favicon")
+    }
+  })
 })
 
 describe("buildTweetCard", () => {
@@ -294,6 +305,7 @@ describe("buildUnavailableCard", () => {
     expect(html).toContain("tweet-card-unavailable")
     expect(html).toContain('href="https://xcancel.com/turntrout/status/999"')
     expect(html).toContain("View it on XCancel")
+    expect(html).toContain("no-favicon")
   })
 })
 

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -104,11 +104,13 @@ function externalAnchor(
   className: string,
   ariaLabel?: string,
 ): Element {
+  // Every link inside a tweet embed opts out of the site favicon pass, which
+  // would otherwise stamp an X icon on each one.
   const props: Record<string, string> = {
     href,
     rel: EXTERNAL_LINK_REL,
     target: "_blank",
-    className,
+    className: `${className} no-favicon`,
   }
   if (ariaLabel) props["aria-label"] = ariaLabel
   return h("a", props, children)
@@ -272,8 +274,7 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
   }
 
   // The avatar, name, and handle point at the author's profile; the X logo is
-  // the permalink to the post. `no-favicon` opts these out of the site favicon
-  // pass (which would otherwise stamp an X icon on every link).
+  // the permalink to the post.
   const profileUrl = `${XCANCEL_BASE}/${author.handle}`
   const header = h("div", { className: "tweet-header" }, [
     h("span", { className: "tweet-avatar-wrap" }, [
@@ -287,13 +288,13 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
       }),
     ]),
     h("div", { className: "tweet-author" }, [
-      externalAnchor(profileUrl, nameChildren, "tweet-name-link no-favicon"),
-      externalAnchor(profileUrl, [`@${author.handle}`], "tweet-handle no-favicon"),
+      externalAnchor(profileUrl, nameChildren, "tweet-name-link"),
+      externalAnchor(profileUrl, [`@${author.handle}`], "tweet-handle"),
     ]),
     externalAnchor(
       snapshot.url,
       [icon(X_LOGO_PATH, "tweet-x-logo")],
-      "tweet-source-link no-favicon",
+      "tweet-source-link",
       "View post on X",
     ),
   ])


### PR DESCRIPTION
## Summary
Refactored the `no-favicon` class application logic in the tweet card transformer to be centralized in the `externalAnchor` helper function, rather than scattered across call sites. This simplifies maintenance and ensures consistent favicon-skipping behavior across all external links in tweet embeds.

## Changes
- **Modified `externalAnchor` function**: Now automatically appends `no-favicon` class to all external anchor elements, with a comment explaining that this opts links out of the site's favicon pass
- **Simplified call sites**: Removed `no-favicon` from className arguments in `buildTweetCard` (profile URL, handle, and source links)
- **Updated `linkifyTweetText`**: Ensured body entity links also receive the `no-favicon` class through the same mechanism
- **Added test coverage**: New test verifies that body entity links are marked with `no-favicon`; updated unavailable card test to assert presence of `no-favicon`

## Implementation Details
The `no-favicon` class prevents the site's favicon pass from stamping an X icon on each tweet embed link. By centralizing this in `externalAnchor`, we eliminate duplication and reduce the risk of accidentally creating external links without the class. All external links in tweet cards now consistently opt out of favicon processing.

https://claude.ai/code/session_0192gSvJmYANccyFf3ixZXy2