### PR TITLE
style: refine footnote block-quote indent

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -16,7 +16,7 @@ $page-end-bottom-margin: calc(3 * $base-margin);
 // Distance a footnote block quote is nudged right so its border clears the
 // marker. The same amount is shaved off padding-left so the text stays put;
 // one variable keeps the two from drifting apart.
-$footnote-blockquote-indent: 0.25rem;
+$footnote-blockquote-indent: 0.5 * $base-margin;
 
 body {
   min-height: 100vh;

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -13,6 +13,11 @@
 // and the footnotes section itself, so the page-bottom rhythm stays balanced.
 $page-end-bottom-margin: calc(3 * $base-margin);
 
+// Distance a footnote block quote is nudged right so its border clears the
+// marker. The same amount is shaved off padding-left so the text stays put;
+// one variable keeps the two from drifting apart.
+$footnote-blockquote-indent: 0.25rem;
+
 body {
   min-height: 100vh;
 }
@@ -38,9 +43,11 @@ li > blockquote:first-child {
   margin-top: $base-margin;
 }
 
-// Keep the blockquote border from crowding the footnote marker
-li[id^="user-content-fn-"] > blockquote {
-  margin-left: $base-margin;
+// Keep the block-quote border from crowding the footnote marker. Admonitions
+// are also block quotes but carry their own chrome, so they are excluded.
+li[id^="user-content-fn-"] > blockquote:not(.admonition) {
+  margin-left: $footnote-blockquote-indent;
+  padding-left: calc(2 * $base-margin - $footnote-blockquote-indent);
 }
 
 .footnotes {


### PR DESCRIPTION
## Summary

Follow-up to #1513, which nudged footnote block quotes right so their left border stops crowding the footnote marker. This refines that fix:

- **Scopes it to non-admonition block quotes** (`:not(.admonition)`). Admonitions render as `<blockquote>` too but carry their own border/background chrome, so they should keep the default geometry.
- **Sets the indent to `0.25rem`** (was `$base-margin` = `0.5rem`).
- **Shaves the same `0.25rem` off `padding-left`** so the text stays put — only the border shifts right, rather than the whole block.
- **Stores the amount in a single `$footnote-blockquote-indent` variable** so the margin and the padding subtraction can't drift apart in future edits.

## Testing

- `sass` compiles `custom.scss` cleanly; the rule resolves to `margin-left: 0.25rem; padding-left: 0.75rem`.
- The footnote-with-blockquote example added to `test-page.md` in #1513 exercises this in visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjPvBiqW655VvetUSrm4VY)_