### PR TITLE
feat(open-source): teaser-truncate embedded READMEs + auto-code repo-doc filenames

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -74,7 +74,9 @@ const config: QuartzConfig = {
       PopulateExternalMarkdown({
         sources: {
           punctilio: githubReadmeSource("alexander-turner", "punctilio"),
-          "ci-truth-serum": githubReadmeSource("alexander-turner", "ci-truth-serum"),
+          "ci-truth-serum": githubReadmeSource("alexander-turner", "ci-truth-serum", {
+            maxSections: 2,
+          }),
           "agent-input-sanitizer": githubReadmeSource("alexander-turner", "agent-input-sanitizer", {
             maxSections: 1,
           }),

--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -75,7 +75,9 @@ const config: QuartzConfig = {
         sources: {
           punctilio: githubReadmeSource("alexander-turner", "punctilio"),
           "ci-truth-serum": githubReadmeSource("alexander-turner", "ci-truth-serum"),
-          "agent-input-sanitizer": githubReadmeSource("alexander-turner", "agent-input-sanitizer"),
+          "agent-input-sanitizer": githubReadmeSource("alexander-turner", "agent-input-sanitizer", {
+            maxSections: 1,
+          }),
           "lint-staged": {
             filePath: "package.json",
             jsonPath: "lint-staged",

--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -75,7 +75,7 @@ const config: QuartzConfig = {
         sources: {
           punctilio: githubReadmeSource("alexander-turner", "punctilio"),
           "ci-truth-serum": githubReadmeSource("alexander-turner", "ci-truth-serum", {
-            maxSections: 2,
+            maxSections: 1,
           }),
           "agent-input-sanitizer": githubReadmeSource("alexander-turner", "agent-input-sanitizer", {
             maxSections: 1,

--- a/quartz/plugins/transformers/autoCode.ts
+++ b/quartz/plugins/transformers/autoCode.ts
@@ -8,9 +8,14 @@ import type { QuartzTransformerPlugin } from "../types"
 
 import { replaceRegex } from "./utils"
 
-// Library / tool names that should auto-format as inline <code> in prose.
-// Lowercase-only so sentence-initial proper-noun uses ("Punctilio handles…")
-// keep their capital-letter signal instead of being rewrapped.
+// Names that should auto-format as inline <code> in prose.
+//
+// Library / tool names are lowercase-only so sentence-initial proper-noun uses
+// ("Punctilio handles…") keep their capital-letter signal instead of being
+// rewrapped. Repo-doc filenames are matched in their canonical UPPERCASE form
+// (both bare and `.md`); the regex is case-sensitive, so lowercase prose words
+// like "security" or "read me" never match. Longer variants are sorted first
+// (see `sortedTerms`), so "README.md" wins over "README".
 export const codeTerms: readonly string[] = [
   "punctilio",
   "subfont",
@@ -34,6 +39,14 @@ export const codeTerms: readonly string[] = [
   "prettier",
   "pnpm",
   "vale",
+  "README.md",
+  "README",
+  "SECURITY.md",
+  "SECURITY",
+  "CONTRIBUTING.md",
+  "CONTRIBUTING",
+  "THREAT-MODEL.md",
+  "THREAT-MODEL",
 ]
 
 // Sort by length DESC so "retext-smartypants" matches before "retext"

--- a/quartz/plugins/transformers/populateExternalMarkdown.test.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.test.ts
@@ -18,6 +18,7 @@ import {
   stripBadges,
   stripLeadingH1,
   stripRelativeLinks,
+  truncateToSections,
   wrapExternalReadme,
 } from "./populateExternalMarkdown"
 
@@ -139,6 +140,36 @@ describe("PopulateExternalMarkdown", () => {
     })
   })
 
+  describe("truncateToSections", () => {
+    const doc = "Intro\n\n## One\n\na\n\n### Sub\n\nb\n\n## Two\n\nc\n\n## Three\n\nd"
+
+    it.each([
+      [
+        "keeps preamble plus the first section, dropping the rest",
+        1,
+        "Intro\n\n## One\n\na\n\n### Sub\n\nb\n",
+      ],
+      ["keeps the first two sections", 2, "Intro\n\n## One\n\na\n\n### Sub\n\nb\n\n## Two\n\nc\n"],
+    ])("%s", (_desc, maxSections, expected) => {
+      expect(truncateToSections(doc, maxSections)).toBe(expected)
+    })
+
+    it("returns content unchanged when it has at most maxSections sections", () => {
+      expect(truncateToSections(doc, 3)).toBe(doc)
+      expect(truncateToSections(doc, 5)).toBe(doc)
+    })
+
+    it("does not count ## inside fenced code blocks", () => {
+      const withFence = "Intro\n\n## Real\n\n```sh\n## not a heading\n```\n\nbody"
+      expect(truncateToSections(withFence, 1)).toBe(withFence)
+    })
+
+    it("does not count ### subsections as top-level sections", () => {
+      const withSubs = "Intro\n\n## Only\n\n### A\n\n### B\n\ntail"
+      expect(truncateToSections(withSubs, 1)).toBe(withSubs)
+    })
+  })
+
   describe("githubReadmeSource", () => {
     const badgeAndLink = "[![CI](badge.svg)](ci)\n\n# Repo title\n\nBody with [a](docs/g.md) link."
     const title = "[`owner/repo`](https://github.com/owner/repo)"
@@ -160,6 +191,22 @@ describe("PopulateExternalMarkdown", () => {
       const source = githubReadmeSource("owner", "repo")
       expect(source.transform?.("**Bold intro**\n\n## Usage")).toBe(
         wrap("**Bold intro**\n\n## Usage"),
+      )
+    })
+
+    it("truncates to maxSections and appends a centered link to the full README", () => {
+      const source = githubReadmeSource("owner", "repo", { maxSections: 1 })
+      expect(source.transform?.("# Title\n\nIntro\n\n## Keep\n\na\n\n## Drop\n\nb")).toBe(
+        wrap(
+          'Intro\n\n## Keep\n\na\n\n<div class="centered">\n\n[Read the rest on GitHub →](https://github.com/owner/repo)\n\n</div>',
+        ),
+      )
+    })
+
+    it("omits the read-more link when maxSections covers the whole README", () => {
+      const source = githubReadmeSource("owner", "repo", { maxSections: 5 })
+      expect(source.transform?.("# Title\n\nIntro\n\n## Only\n\nbody")).toBe(
+        wrap("Intro\n\n## Only\n\nbody"),
       )
     })
   })

--- a/quartz/plugins/transformers/populateExternalMarkdown.ts
+++ b/quartz/plugins/transformers/populateExternalMarkdown.ts
@@ -132,6 +132,32 @@ export function rewriteRelativeLinksToGitHub(
     content.replace(RELATIVE_LINK_RE, (_match, text, href) => `[${text}](${base}/${href})`)
 }
 
+/**
+ * Keeps the preamble plus the first `maxSections` top-level (`##`) sections,
+ * dropping the rest so a long technical README reads as a teaser instead of its
+ * full body. Subsections (`###` and deeper) ride along with their parent `##`,
+ * and `##`-looking lines inside fenced code blocks are not counted. Returns the
+ * content unchanged (same reference) when it has at most `maxSections` sections.
+ */
+export function truncateToSections(content: string, maxSections: number): string {
+  const lines = content.split("\n")
+  let inFence = false
+  let sectionCount = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (/^(?:```|~~~)/.test(lines[i])) {
+      inFence = !inFence
+      continue
+    }
+    if (!inFence && /^##\s/.test(lines[i])) {
+      sectionCount += 1
+      if (sectionCount > maxSections) {
+        return `${lines.slice(0, i).join("\n").replace(/\s+$/, "")}\n`
+      }
+    }
+  }
+  return content
+}
+
 /** Class marking a wrapper around embedded external README content. */
 export const EXTERNAL_README_CLASS = "external-readme"
 /** Attribute holding the source slug used to namespace the README's heading ids. */
@@ -162,24 +188,46 @@ export function asQuoteAdmonition(content: string, title: string): string {
   return `> [!quote] ${title}\n${quoted}`
 }
 
+/** Options controlling how a GitHub README is rendered when embedded. */
+export interface GithubReadmeSourceOptions {
+  /**
+   * Keep only the preamble plus this many top-level (`##`) sections, appending a
+   * "Read the rest on GitHub" link when content is dropped. Omit to embed the
+   * whole README.
+   */
+  maxSections?: number
+}
+
 /**
  * Builds a GitHub README source: strips badges, drops a leading H1 (when it
  * leads the file) that would duplicate the embedding page's own section
- * heading, rewrites relative links to absolute blob URLs, renders the result
- * inside a `[!quote]` admonition titled with the repo link, and wraps it so its
- * heading ids stay unique on the host page.
+ * heading, rewrites relative links to absolute blob URLs, optionally truncates
+ * to the first `maxSections` sections (with a link to the full README on
+ * GitHub), renders the result inside a `[!quote]` admonition titled with the
+ * repo link, and wraps it so its heading ids stay unique on the host page.
  */
-export function githubReadmeSource(owner: string, repo: string): GitHubMarkdownSource {
+export function githubReadmeSource(
+  owner: string,
+  repo: string,
+  options: GithubReadmeSourceOptions = {},
+): GitHubMarkdownSource {
+  const { maxSections } = options
   const rewriteLinks = rewriteRelativeLinksToGitHub(owner, repo)
-  const title = `[\`${owner}/${repo}\`](https://github.com/${owner}/${repo})`
+  const repoUrl = `https://github.com/${owner}/${repo}`
+  const title = `[\`${owner}/${repo}\`](${repoUrl})`
   return {
     owner,
     repo,
-    transform: (content) =>
-      wrapExternalReadme(
-        asQuoteAdmonition(rewriteLinks(stripLeadingH1(stripBadges(content))), title),
-        repo,
-      ),
+    transform: (content) => {
+      const stripped = rewriteLinks(stripLeadingH1(stripBadges(content)))
+      const truncated =
+        maxSections === undefined ? stripped : truncateToSections(stripped, maxSections)
+      // Blank lines around the link let it parse as markdown inside the raw div
+      // (and inside the surrounding quote callout), matching wrapExternalReadme.
+      const readMore = `<div class="centered">\n\n[Read the rest on GitHub →](${repoUrl})\n\n</div>`
+      const body = truncated === stripped ? stripped : `${truncated}\n${readMore}`
+      return wrapExternalReadme(asQuoteAdmonition(body, title), repo)
+    },
   }
 }
 

--- a/quartz/plugins/transformers/tests/autoCode.test.ts
+++ b/quartz/plugins/transformers/tests/autoCode.test.ts
@@ -111,6 +111,41 @@ describe("rehypeAutoCode", () => {
     })
   })
 
+  describe("repo-doc filenames", () => {
+    it.each([
+      [
+        "wraps bare README",
+        "<p>See the README for setup.</p>",
+        "<p>See the <code>README</code> for setup.</p>",
+      ],
+      [
+        "wraps README.md as a single unit (longest-first)",
+        "<p>Edit README.md now.</p>",
+        "<p>Edit <code>README.md</code> now.</p>",
+      ],
+      [
+        "wraps THREAT-MODEL.md including the extension",
+        "<p>Read THREAT-MODEL.md first.</p>",
+        "<p>Read <code>THREAT-MODEL.md</code> first.</p>",
+      ],
+      [
+        "wraps bare SECURITY and CONTRIBUTING",
+        "<p>See SECURITY and CONTRIBUTING.</p>",
+        "<p>See <code>SECURITY</code> and <code>CONTRIBUTING</code>.</p>",
+      ],
+    ])("%s", (_label, input, expected) => {
+      expect(runAutoCode(input)).toBe(expected)
+    })
+
+    it.each([
+      ["lowercase 'security'", "<p>The security policy applies.</p>"],
+      ["lowercase 'contributing'", "<p>Thanks for contributing today.</p>"],
+      ["Title-case 'Readme'", "<p>The Readme explains it.</p>"],
+    ])("leaves prose words untouched: %s", (_label, input) => {
+      expect(runAutoCode(input)).toBe(input)
+    })
+  })
+
   describe("skip rules", () => {
     it("does not transform inside an existing <code>", () => {
       expect(runAutoCode("<p>Already coded: <code>punctilio</code>.</p>")).toBe(


### PR DESCRIPTION
## Summary

Two related improvements to how the open-source page presents the `agent-input-sanitizer` (and other embedded) READMEs.

### 1. Teaser-truncate embedded GitHub READMEs

The `agent-input-sanitizer` README is long and heavily technical, so embedding it whole made the open-source page sprawl.

- **`maxSections` option** on `githubReadmeSource(owner, repo, { maxSections })`: keeps the preamble plus the first N top-level (`##`) sections and appends a centered **"Read the rest on GitHub →"** link when content is dropped. Omitting the option embeds the whole README as before.
- **`truncateToSections(content, n)` helper**: counts top-level `##` headings, ignores `##`-looking lines inside fenced code blocks, lets `###`+ subsections ride along with their parent, and returns the input unchanged when already within the limit.
- **Applied to the sanitizer** with `maxSections: 1` — the page now shows just the intro + Quick start with a link out.

### 2. Auto-code repo-doc filenames

Reuses the existing `AutoCode` rehype transformer (the `codeTerms` machinery that already wraps tool names like `pnpm`, `vale` in `<code>`) instead of adding a new check.

- Adds `README`, `SECURITY`, `CONTRIBUTING`, `THREAT-MODEL` (bare and `.md` forms) to `codeTerms`, so these file references render as inline `<code>` wherever they appear in prose — including inside embedded external READMEs.
- Matched **case-sensitively** in canonical UPPERCASE form, so lowercase prose ("security", "read me", "Readme") never matches. Longest-first sorting means `README.md` wins over `README`.

## Testing

- `populateExternalMarkdown.test.ts`: new cases for `truncateToSections` and `githubReadmeSource` with `maxSections`. 100% coverage on the transformer.
- `autoCode.test.ts`: new positive cases (bare + `.md` + `THREAT-MODEL.md`) and negative precision cases (lowercase/Title-case prose left untouched). 100% coverage. The existing term-list invariant tests auto-validate the new terms.

## Notes

- The visual-testing aggregate flags expected snapshot diffs from the open-source page rendering change; approve baselines via the diff gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)