### PR TITLE
fix(inline-code): keep closing punctuation off the next code's line

### DIFF
--- a/quartz/components/constants.ts
+++ b/quartz/components/constants.ts
@@ -72,6 +72,8 @@ export const {
   leftDoubleQuote: LEFT_DOUBLE_QUOTE,
   rightDoubleQuote: RIGHT_DOUBLE_QUOTE,
   wordJoiner: WORD_JOINER,
+  rightGuillemet: RIGHT_GUILLEMET,
+  ellipsis: ELLIPSIS,
 } = constantsJson.unicodeTypography
 
 /**

--- a/quartz/components/tests/inlineCodeSpacing.spec.ts
+++ b/quartz/components/tests/inlineCodeSpacing.spec.ts
@@ -51,4 +51,53 @@ test.describe("inline code spacing", () => {
     // The code carries the leading-gap margin.
     expect(measured.marginLeft).toBeGreaterThan(0)
   })
+
+  // Closing punctuation between two inline codes ("`a`); `b`") must stay on the
+  // first code's line. The transformer leaves "); " as plain text after the
+  // first code's nowrap span, so when the column forces a wrap only the second
+  // code drops down — the ");" hugs what it closes instead of orphaning.
+  test("keeps closing punctuation on the first code's line when the next code wraps", async ({
+    page,
+  }) => {
+    await gotoPage(page, "http://localhost:8080/test-page")
+
+    const measured = await page.evaluate(() => {
+      const host = document.createElement("div")
+      host.style.overflowWrap = "anywhere"
+      host.innerHTML =
+        '<div id="ics-orphan"><span class="inline-code-nowrap"><span>word</span> ' +
+        '<code class="inline-code-gap">one</code></span><span id="ics-semi">); </span>' +
+        '<code id="ics-two">two</code></div>'
+
+      const article = document.querySelector("article") ?? document.body
+      article.appendChild(host)
+
+      const rect = (sel: string): DOMRect => {
+        const el = host.querySelector<HTMLElement>(sel)
+        if (!el) throw new Error(`missing fixture ${sel}`)
+        return el.getBoundingClientRect()
+      }
+
+      const span1 = rect(".inline-code-nowrap").width
+      const semi = rect("#ics-semi").width
+      const two = rect("#ics-two").width
+      // Fits "word one); " but not the trailing "two", forcing only it to wrap.
+      const container = document.getElementById("ics-orphan")
+      if (!container) throw new Error("missing fixture container")
+      container.style.width = `${Math.ceil(span1 + semi + two * 0.4)}px`
+
+      const span1Top = rect(".inline-code-nowrap").top
+      const result = {
+        twoDroppedBy: rect("#ics-two").top - span1Top,
+        semiDelta: Math.abs(rect("#ics-semi").top - span1Top),
+      }
+      host.remove()
+      return result
+    })
+
+    // The column really forced the second code onto a new line.
+    expect(measured.twoDroppedBy).toBeGreaterThan(5)
+    // ...yet the closing ");" stayed on the first code's line.
+    expect(measured.semiDelta).toBeLessThan(5)
+  })
 })

--- a/quartz/plugins/transformers/inlineCodeSpacing.test.ts
+++ b/quartz/plugins/transformers/inlineCodeSpacing.test.ts
@@ -65,6 +65,34 @@ describe("InlineCodeSpacing", () => {
     })
   })
 
+  describe("does not pull closing punctuation onto the code's line", () => {
+    it("leaves a second code unwrapped when only closing punctuation precedes it", async () => {
+      const out = await processHtmlWithPlugin("<p>see <code>one</code>); <code>two</code> ok</p>")
+      expect(out).toBe(
+        '<p><span class="inline-code-nowrap">see <code class="inline-code-gap">one</code></span>); ' +
+          "<code>two</code> ok</p>",
+      )
+    })
+
+    it.each([
+      ["semicolon-close", "); "],
+      ["bracket-close", "] "],
+      ["comma", ", "],
+      ["period", ". "],
+    ])("skips the gap when the preceding token is only %s", async (_label, sep) => {
+      const out = await processHtmlWithPlugin(`<p>x <code>a</code>${sep}<code>b</code></p>`)
+      expect(out).toContain("<code>b</code>")
+      expect(out).not.toContain(`${sep}<span`)
+    })
+
+    it("still joins when a real word follows the closing punctuation", async () => {
+      const out = await processHtmlWithPlugin("<p>a <code>one</code>); then <code>two</code></p>")
+      expect(out).toContain(
+        '<span class="inline-code-nowrap">then <code class="inline-code-gap">two</code></span>',
+      )
+    })
+  })
+
   describe("adds no gap", () => {
     it.each([...NO_GAP_PREDECESSORS])("when code is glued behind %s", async (char) => {
       const out = await processHtmlWithPlugin(`<p>${char}<code>grep</code></p>`)

--- a/quartz/plugins/transformers/inlineCodeSpacing.ts
+++ b/quartz/plugins/transformers/inlineCodeSpacing.ts
@@ -5,6 +5,12 @@ import { visitParents } from "unist-util-visit-parents"
 
 import type { QuartzTransformerPlugin } from "../types"
 
+import {
+  ELLIPSIS,
+  RIGHT_DOUBLE_QUOTE,
+  RIGHT_GUILLEMET,
+  RIGHT_SINGLE_QUOTE,
+} from "../../components/constants"
 import { addClass, INLINE_PASSTHROUGH_TAGS } from "./utils"
 
 // Inline code gets a hair of leading space so its monospace glyph doesn't crowd
@@ -39,8 +45,12 @@ export const NO_GAP_PREDECESSORS: ReadonlySet<string> = new Set([
 // `");"` between two adjacent code spans) belongs to the earlier content, not
 // this code. Pulling it into the code's nowrap unit opens a break right before
 // it, so the punctuation can orphan onto the code's line; leaving the code
-// unwrapped keeps the punctuation attached to what it closes.
-const CLOSING_PUNCTUATION_ONLY = /^[)\]};:,.!?"'”’»…]+\s*$/u
+// unwrapped keeps the punctuation attached to what it closes. Smart characters
+// come from the typography SSOT in `config/constants.json`.
+const CLOSING_PUNCTUATION_ONLY = new RegExp(
+  `^[)\\]};:,.!?"'${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${RIGHT_GUILLEMET}${ELLIPSIS}]+\\s*$`,
+  "u",
+)
 
 // Last rendered character of a node (recursing into inline children), or null
 // when it contributes no text.

--- a/quartz/plugins/transformers/inlineCodeSpacing.ts
+++ b/quartz/plugins/transformers/inlineCodeSpacing.ts
@@ -35,6 +35,13 @@ export const NO_GAP_PREDECESSORS: ReadonlySet<string> = new Set([
   "=",
 ])
 
+// A code's would-be preceding "word" that is only closing punctuation (e.g.
+// `");"` between two adjacent code spans) belongs to the earlier content, not
+// this code. Pulling it into the code's nowrap unit opens a break right before
+// it, so the punctuation can orphan onto the code's line; leaving the code
+// unwrapped keeps the punctuation attached to what it closes.
+const CLOSING_PUNCTUATION_ONLY = /^[)\]};:,.!?"'”’»…]+\s*$/u
+
 // Last rendered character of a node (recursing into inline children), or null
 // when it contributes no text.
 export function lastTextChar(node: RootContent): string | null {
@@ -124,6 +131,7 @@ export const rehypeInlineCodeSpacing: Plugin = () => {
       // istanbul ignore next -- the \S guard above guarantees a match
       if (!match) continue
       const tail = match[1]
+      if (CLOSING_PUNCTUATION_ONLY.test(tail)) continue
       const head = prevText.value.slice(0, prevText.value.length - tail.length)
       addClass(unit, "inline-code-gap")
       const span: Element = {


### PR DESCRIPTION
## Summary

Fixes a typography bug in the `InlineCodeSpacing` transformer where closing punctuation between two nearby inline code spans could orphan onto the next code's line.

For prose like `…codes (e.g. ` + `` `["cf-format", "hidden-html"]` `` + `); ` + `` `cleaned` `` + ` is the safe text…`, the transformer produced two adjacent `nowrap` spans:

```
<span class="inline-code-nowrap">(e.g. <code>["cf-format", "hidden-html"]</code></span><span class="inline-code-nowrap">); <code>cleaned</code></span>
```

The closing `);` was grouped into the **following** code's `nowrap` unit instead of staying with the code it closes. Because prose uses `overflow-wrap: anywhere`, the only break point on a narrow column was between the two unbreakable spans — so the whole `); cleaned` unit wrapped and the `);` orphaned to a new line.

## Fix

When a code's would-be preceding "word" is **only** closing punctuation (e.g. `);`), it belongs to the earlier content, not the code. Skip the `nowrap` join in that case and leave the punctuation as plain text. Now `cleaned` wraps at its normal preceding space, while `);` (protected from a break-before by Unicode line-breaking rule LB13) stays on the first code's line.

The change is a single guard (`CLOSING_PUNCTUATION_ONLY`) in the op-application loop; codes separated by a real word are unaffected.

## Testing

- **Unit** (`inlineCodeSpacing.test.ts`): new cases for the skip (semicolon/bracket/comma/period separators) plus a positive case proving a real word after the punctuation still joins. 100% coverage retained; no existing expectations changed.
- **Playwright** (`inlineCodeSpacing.spec.ts`): a viewport test that forces the second code to wrap and asserts the `);` stays on the first code's line. Verified locally (the second code drops a line; the punctuation's vertical delta is 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrXgYzYoXiLFMqoiwaoG9L)_