### PR TITLE
feat: reveal sidebar scrollbar only on hover (desktop)

### DIFF
--- a/quartz/components/tests/sidebarScrollbar.spec.ts
+++ b/quartz/components/tests/sidebarScrollbar.spec.ts
@@ -1,0 +1,70 @@
+import type { Locator, Page } from "@playwright/test"
+
+import { expect, test } from "./fixtures"
+import { gotoPage, isDesktopViewport, moveMouseToSafePosition } from "./visual_utils"
+
+/** Read the resolved `scrollbar-color` of an element. */
+function getScrollbarColor(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).scrollbarColor)
+}
+
+/** Whether the browser resolves `scrollbar-color` in computed style. Older
+ *  WebKit reports `auto` regardless, so colour assertions are gated on this. */
+function supportsScrollbarColor(page: Page): Promise<boolean> {
+  return page.evaluate(() => CSS.supports("scrollbar-color", "red transparent"))
+}
+
+/** `transparent transparent` resolves to a pair of fully-transparent colours. */
+function isTransparentPair(value: string): boolean {
+  const normalized = value.toLowerCase()
+  if (normalized === "transparent transparent") return true
+  const matches = normalized.match(/rgba?\([^)]*\)/g) ?? []
+  return matches.length === 2 && matches.every((color) => /,\s*0\s*\)$/.test(color))
+}
+
+test.beforeEach(async ({ page }) => {
+  await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
+  await moveMouseToSafePosition(page)
+})
+
+test.describe("Sidebar scrollbar appears only on hover (desktop)", () => {
+  test("thumb is hidden until the sidebar is hovered", async ({ page }) => {
+    test.skip(!isDesktopViewport(page), "Hover-reveal scrollbar is a desktop-only behavior")
+    test.skip(
+      !(await supportsScrollbarColor(page)),
+      "Browser does not resolve scrollbar-color in computed style",
+    )
+
+    const sidebar = page.locator("#left-sidebar")
+    await expect(sidebar).toBeVisible()
+
+    const idleColor = await getScrollbarColor(sidebar)
+    expect(isTransparentPair(idleColor)).toBe(true)
+
+    await sidebar.hover()
+    await expect(async () => {
+      expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(false)
+    }).toPass()
+
+    await moveMouseToSafePosition(page)
+    await expect(async () => {
+      expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(true)
+    }).toPass()
+  })
+})
+
+test.describe("Sidebar scrollbar (mobile)", () => {
+  test("hover does not reveal a scrollbar", async ({ page }) => {
+    test.skip(isDesktopViewport(page), "Mobile-only assertion")
+    test.skip(
+      !(await supportsScrollbarColor(page)),
+      "Browser does not resolve scrollbar-color in computed style",
+    )
+
+    const sidebar = page.locator("#left-sidebar")
+
+    // The hover-reveal rule lives inside a desktop media query, so on mobile the
+    // sidebar never adopts the transparent-then-coloured scrollbar behavior.
+    expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(false)
+  })
+})

--- a/quartz/components/tests/sidebarScrollbar.spec.ts
+++ b/quartz/components/tests/sidebarScrollbar.spec.ts
@@ -14,12 +14,16 @@ function supportsScrollbarColor(page: Page): Promise<boolean> {
   return page.evaluate(() => CSS.supports("scrollbar-color", "red transparent"))
 }
 
+/** A single colour token that resolves to fully transparent. Engines serialize
+ *  `transparent` as the keyword, `rgba(0, 0, 0, 0)`, or `rgb(0 0 0 / 0)`. */
+function isTransparentColor(color: string): boolean {
+  return color === "transparent" || /[,/]\s*0\s*\)$/.test(color)
+}
+
 /** `transparent transparent` resolves to a pair of fully-transparent colours. */
 function isTransparentPair(value: string): boolean {
-  const normalized = value.toLowerCase()
-  if (normalized === "transparent transparent") return true
-  const matches = normalized.match(/rgba?\([^)]*\)/g) ?? []
-  return matches.length === 2 && matches.every((color) => /,\s*0\s*\)$/.test(color))
+  const colors = value.toLowerCase().match(/transparent|rgba?\([^)]*\)/g) ?? []
+  return colors.length === 2 && colors.every(isTransparentColor)
 }
 
 test.beforeEach(async ({ page }) => {
@@ -28,29 +32,31 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("Sidebar scrollbar appears only on hover (desktop)", () => {
-  test("thumb is hidden until the sidebar is hovered", async ({ page }) => {
-    test.skip(!isDesktopViewport(page), "Hover-reveal scrollbar is a desktop-only behavior")
-    test.skip(
-      !(await supportsScrollbarColor(page)),
-      "Browser does not resolve scrollbar-color in computed style",
-    )
+  // The hover-reveal rule targets `.sidebar`, so both sidebars get the behavior.
+  for (const selector of ["#left-sidebar", "#right-sidebar"] as const) {
+    test(`${selector} thumb is hidden until the sidebar is hovered`, async ({ page }) => {
+      test.skip(!isDesktopViewport(page), "Hover-reveal scrollbar is a desktop-only behavior")
+      test.skip(
+        !(await supportsScrollbarColor(page)),
+        "Browser does not resolve scrollbar-color in computed style",
+      )
 
-    const sidebar = page.locator("#left-sidebar")
-    await expect(sidebar).toBeVisible()
+      const sidebar = page.locator(selector)
+      await expect(sidebar).toBeVisible()
 
-    const idleColor = await getScrollbarColor(sidebar)
-    expect(isTransparentPair(idleColor)).toBe(true)
-
-    await sidebar.hover()
-    await expect(async () => {
-      expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(false)
-    }).toPass()
-
-    await moveMouseToSafePosition(page)
-    await expect(async () => {
       expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(true)
-    }).toPass()
-  })
+
+      await sidebar.hover()
+      await expect(async () => {
+        expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(false)
+      }).toPass()
+
+      await moveMouseToSafePosition(page)
+      await expect(async () => {
+        expect(isTransparentPair(await getScrollbarColor(sidebar))).toBe(true)
+      }).toPass()
+    })
+  }
 })
 
 test.describe("Sidebar scrollbar (mobile)", () => {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -218,6 +218,16 @@ a {
         top: $top-spacing;
         overflow-y: auto;
         max-height: calc(100vh - #{$top-spacing});
+
+        // Keep the scrollbar gutter reserved (no layout shift) but hide the
+        // thumb until the sidebar is hovered.
+        scrollbar-width: thin;
+        scrollbar-color: transparent transparent;
+        transition: scrollbar-color $transition-duration-medium ease;
+
+        &:hover {
+          scrollbar-color: var(--midground-fainter) var(--background);
+        }
       }
 
       &#left-sidebar {


### PR DESCRIPTION
## Summary

- On desktop, the sidebar scrollbar thumb was always visible whenever the sidebar content overflowed. This hides it by default and fades it in only when the sidebar is hovered, for a cleaner resting state.
- The scrollbar gutter stays reserved (`scrollbar-width: thin`), so revealing the thumb causes no layout shift.

## Changes

- `quartz/styles/base.scss`: in the desktop `.sidebar` block, set `scrollbar-color: transparent transparent` by default and animate it to `var(--midground-fainter) var(--background)` on `:hover` (via a `scrollbar-color` transition). Uses the standard `scrollbar-*` properties rather than `::-webkit-scrollbar`, consistent with the existing approach in this file.
- `quartz/components/tests/sidebarScrollbar.spec.ts`: new Playwright spec covering both desktop and mobile viewports. On desktop it asserts each sidebar's thumb is transparent at rest, becomes opaque on hover, and returns to transparent after the pointer leaves; on mobile it asserts the desktop-only rule is not applied. Color assertions are gated on `CSS.supports("scrollbar-color", …)` so engines that don't resolve the property in computed style are skipped rather than failing.

## Testing

- `pnpm` typecheck, ESLint, Stylelint, and Prettier all pass on the changed files.
- Playwright spec runs across the configured Desktop (1920px) and iPad/iPhone (mobile) projects in CI; full suite requires the networked build, so local visual runs were not executed.

## Lessons Learned

<!-- Delete this section if there are no lessons worth sharing. -->

- **What**: When asserting a CSS color in a Playwright test, normalize against all serializations a browser may emit — `transparent`, `rgba(0, 0, 0, 0)`, and `rgb(0 0 0 / 0)` — instead of matching one form.
- **Where**: Any cross-browser `*.spec.ts` that reads `getComputedStyle` color values.
- **Why**: Matching only the comma-separated `rgba(...,0)` form would spuriously fail on engines that serialize computed colors with the space/slash syntax.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UUABK8LWqUVvNhFNhJzKCh)_