### PR TITLE
feat: embed claude-guard on open-source page; fix search after tab inactivity

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -76,6 +76,9 @@ const config: QuartzConfig = {
           punctilio: githubReadmeSource("alexander-turner", "punctilio", {
             maxSections: 0,
           }),
+          "claude-guard": githubReadmeSource("alexander-turner", "claude-guard", {
+            maxSections: 0,
+          }),
           "ci-truth-serum": githubReadmeSource("alexander-turner", "ci-truth-serum", {
             maxSections: 1,
           }),

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -233,12 +233,19 @@ export function pageResources(
   staticResources: StaticResources,
 ): StaticResources {
   const contentIndexPath = joinSegments(baseDir, "static/contentIndex.json")
-  // Lazy-load contentIndex.json only when search is initialized to avoid blocking initial page load
+  // Lazy-load contentIndex.json only when search is initialized to avoid blocking initial page load.
+  // `forceRefresh` discards a cached (possibly hung) promise and re-fetches; an AbortController timeout
+  // keeps a request started in a since-frozen tab from lingering forever.
   const contentIndexScript = `const contentIndexPath = "${contentIndexPath}";
 let fetchData = null;
-function getContentIndex() {
-  if (!fetchData) {
-    fetchData = fetch(contentIndexPath).then(data => data.json()).catch(err => { console.error('[getContentIndex] Failed to load content index:', err); fetchData = null; return null; });
+function getContentIndex(forceRefresh) {
+  if (forceRefresh || !fetchData) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+    fetchData = fetch(contentIndexPath, { signal: controller.signal })
+      .then(data => data.json())
+      .catch(err => { console.error('[getContentIndex] Failed to load content index:', err); fetchData = null; return null; })
+      .finally(() => clearTimeout(timeoutId));
   }
   return fetchData;
 }`

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -26,6 +26,8 @@ import {
   generateAllTagsHast,
 } from "./pages/AllTagsContent"
 import PageShellConstructor from "./PageShell"
+// @ts-expect-error Not a module but a bundled inline script string
+import contentIndexLoaderScript from "./scripts/contentIndex.inline"
 import { type QuartzComponent, type QuartzComponentProps } from "./types"
 
 interface RenderComponents {
@@ -233,24 +235,10 @@ export function pageResources(
   staticResources: StaticResources,
 ): StaticResources {
   const contentIndexPath = joinSegments(baseDir, "static/contentIndex.json")
-  // Lazy-load contentIndex.json only when search/random-post needs it, to avoid blocking initial page load.
-  // A frozen/backgrounded tab can leave the in-flight fetch hung forever, so the loader re-warms itself
-  // (forceRefresh discards the stale promise) when the tab becomes visible again, until it has loaded once.
-  const contentIndexScript = `const contentIndexPath = "${contentIndexPath}";
-let fetchData = null;
-let indexLoaded = false;
-function getContentIndex(forceRefresh) {
-  if (forceRefresh || !fetchData) {
-    fetchData = fetch(contentIndexPath)
-      .then(data => data.json())
-      .then(json => { indexLoaded = true; return json; })
-      .catch(err => { console.error('[getContentIndex] Failed to load content index:', err); fetchData = null; return null; });
-  }
-  return fetchData;
-}
-document.addEventListener("visibilitychange", () => {
-  if (!document.hidden && !indexLoaded) getContentIndex(true);
-});`
+  // Expose the page-relative index path as data, then run the bundled, unit-tested
+  // loader (quartz/components/scripts/contentIndexLoader.ts). The loader lazy-fetches
+  // contentIndex.json on demand and self-heals a fetch left hung by a frozen tab.
+  const contentIndexScript = `window.__contentIndexPath = ${JSON.stringify(contentIndexPath)};\n${contentIndexLoaderScript}`
 
   return {
     css: [joinSegments("/", "index.css"), ...staticResources.css],

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -233,22 +233,24 @@ export function pageResources(
   staticResources: StaticResources,
 ): StaticResources {
   const contentIndexPath = joinSegments(baseDir, "static/contentIndex.json")
-  // Lazy-load contentIndex.json only when search is initialized to avoid blocking initial page load.
-  // `forceRefresh` discards a cached (possibly hung) promise and re-fetches; an AbortController timeout
-  // keeps a request started in a since-frozen tab from lingering forever.
+  // Lazy-load contentIndex.json only when search/random-post needs it, to avoid blocking initial page load.
+  // A frozen/backgrounded tab can leave the in-flight fetch hung forever, so the loader re-warms itself
+  // (forceRefresh discards the stale promise) when the tab becomes visible again, until it has loaded once.
   const contentIndexScript = `const contentIndexPath = "${contentIndexPath}";
 let fetchData = null;
+let indexLoaded = false;
 function getContentIndex(forceRefresh) {
   if (forceRefresh || !fetchData) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 15000);
-    fetchData = fetch(contentIndexPath, { signal: controller.signal })
+    fetchData = fetch(contentIndexPath)
       .then(data => data.json())
-      .catch(err => { console.error('[getContentIndex] Failed to load content index:', err); fetchData = null; return null; })
-      .finally(() => clearTimeout(timeoutId));
+      .then(json => { indexLoaded = true; return json; })
+      .catch(err => { console.error('[getContentIndex] Failed to load content index:', err); fetchData = null; return null; });
   }
   return fetchData;
-}`
+}
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden && !indexLoaded) getContentIndex(true);
+});`
 
   return {
     css: [joinSegments("/", "index.css"), ...staticResources.css],

--- a/quartz/components/scripts/contentIndex.inline.ts
+++ b/quartz/components/scripts/contentIndex.inline.ts
@@ -1,0 +1,3 @@
+import { setupContentIndexLoader } from "./contentIndexLoader"
+
+setupContentIndexLoader()

--- a/quartz/components/scripts/contentIndexLoader.ts
+++ b/quartz/components/scripts/contentIndexLoader.ts
@@ -1,0 +1,74 @@
+/**
+ * Loads and caches the prebuilt content index (used by search and random-post)
+ * and keeps it resilient to the Page Lifecycle: a backgrounded/frozen tab can
+ * leave the in-flight request hung forever, so the loader re-warms itself when
+ * the tab becomes visible again.
+ *
+ * The bundled entry is `contentIndex.inline.ts`; renderPage.tsx injects the
+ * page-relative index path as `window.__contentIndexPath` before it runs.
+ */
+
+import { type ContentDetails } from "../../plugins/vfile"
+import { type FullSlug } from "../../util/path"
+
+type ContentIndexData = Record<FullSlug, ContentDetails>
+
+declare global {
+  interface Window {
+    /** Page-relative URL of contentIndex.json, injected by renderPage.tsx. */
+    __contentIndexPath?: string
+  }
+}
+
+let fetchData: Promise<ContentIndexData | null> | null = null
+let indexLoaded = false
+
+/**
+ * Returns the cached content-index fetch, starting one if needed. Pass
+ * `forceRefresh` to discard a cached (possibly hung) promise and start over.
+ * Resolves to `null` on failure so callers can retry.
+ */
+export function getContentIndex(forceRefresh = false): Promise<ContentIndexData | null> {
+  if (forceRefresh || !fetchData) {
+    const path = window.__contentIndexPath
+    if (!path) {
+      throw new Error("window.__contentIndexPath is not set; cannot load the content index")
+    }
+    fetchData = fetch(path)
+      .then((res) => res.json() as Promise<ContentIndexData>)
+      .then((json) => {
+        indexLoaded = true
+        return json
+      })
+      .catch((err: unknown) => {
+        console.error("[getContentIndex] Failed to load content index:", err)
+        fetchData = null
+        return null
+      })
+  }
+  return fetchData
+}
+
+/**
+ * Re-warms the index when the tab becomes visible again, until it has loaded
+ * once. Returning to a backgrounded tab always fires visibilitychange, so a
+ * fetch left hung while the tab was frozen is discarded before search or
+ * random-post needs the data.
+ */
+export function refreshContentIndexOnVisible(): void {
+  if (!document.hidden && !indexLoaded) {
+    void getContentIndex(true)
+  }
+}
+
+/** Exposes the loader globally and installs the self-heal listener. */
+export function setupContentIndexLoader(): void {
+  ;(globalThis as { getContentIndex?: typeof getContentIndex }).getContentIndex = getContentIndex
+  document.addEventListener("visibilitychange", refreshContentIndexOnVisible)
+}
+
+/** Resets module-level cache state between unit tests. */
+export function resetContentIndexLoaderForTesting(): void {
+  fetchData = null
+  indexLoaded = false
+}

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -14,9 +14,10 @@ import { debounce, registerEscapeHandler, removeAllChildren } from "./component_
 import { fetchHTMLContent, processPreviewables } from "./content_renderer"
 import { wrapScrollables } from "./scroll-indicator-utils"
 
-// Global function injected by renderPage.tsx to lazy-load content index
+// Global function injected by renderPage.tsx to lazy-load content index.
+// Pass `forceRefresh` to discard a cached (possibly hung) fetch and start a new one.
 declare global {
-  function getContentIndex(): Promise<{ [key: string]: ContentDetails }>
+  function getContentIndex(forceRefresh?: boolean): Promise<{ [key: string]: ContentDetails }>
   interface Window {
     /** Set by onNav() after search event handlers are fully registered. */
     __searchHandlersReady: boolean
@@ -40,6 +41,33 @@ let currentSearchTerm = ""
 let searchLayout: HTMLElement | null = null
 
 const NBSP_REGEX = new RegExp(NBSP, "gu")
+
+/**
+ * How long to wait for the cached content-index fetch before assuming it is
+ * hung (e.g. the tab was frozen mid-request) and forcing a fresh fetch.
+ */
+export const CONTENT_INDEX_TIMEOUT_MS = 4000
+
+/**
+ * Resolves with the promise's value, or `null` if it rejects or fails to settle
+ * within `ms`. The timeout is always cleared once the promise settles so no
+ * stray timer outlives the race.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(null)
+      },
+    )
+  })
+}
 
 const documentType = FlexSearch.Document<DocumentData>
 let index: InstanceType<typeof documentType> | null = null
@@ -1573,7 +1601,13 @@ async function initializeSearch(): Promise<void> {
       // Ensure content index is available (fetch started by onNav, cached).
       // getContentIndex is injected by renderPage.tsx and may not exist in unit tests.
       if (!data && typeof getContentIndex === "function") {
-        data = await getContentIndex()
+        data = (await withTimeout(getContentIndex(), CONTENT_INDEX_TIMEOUT_MS)) ?? undefined
+        // A backgrounded/frozen tab can leave the prefetched request hung in the
+        // cache so it never settles; force a fresh fetch so search recovers
+        // without a full page reload.
+        if (!data) {
+          data = (await getContentIndex(true)) ?? undefined
+        }
       }
       if (data) {
         await fillDocument(data)

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -1604,9 +1604,10 @@ async function initializeSearch(): Promise<void> {
         data = (await withTimeout(getContentIndex(), CONTENT_INDEX_TIMEOUT_MS)) ?? undefined
         // A backgrounded/frozen tab can leave the prefetched request hung in the
         // cache so it never settles; force a fresh fetch so search recovers
-        // without a full page reload.
+        // without a full page reload. Bound the retry too so a still-wedged tab
+        // can't block the search UI indefinitely.
         if (!data) {
-          data = (await getContentIndex(true)) ?? undefined
+          data = (await withTimeout(getContentIndex(true), CONTENT_INDEX_TIMEOUT_MS)) ?? undefined
         }
       }
       if (data) {

--- a/quartz/components/scripts/search.ts
+++ b/quartz/components/scripts/search.ts
@@ -14,8 +14,8 @@ import { debounce, registerEscapeHandler, removeAllChildren } from "./component_
 import { fetchHTMLContent, processPreviewables } from "./content_renderer"
 import { wrapScrollables } from "./scroll-indicator-utils"
 
-// Global function injected by renderPage.tsx to lazy-load content index.
-// Pass `forceRefresh` to discard a cached (possibly hung) fetch and start a new one.
+// Global content-index loader injected by renderPage.tsx. Pass `forceRefresh` to
+// discard a cached (possibly hung) fetch and start a new one.
 declare global {
   function getContentIndex(forceRefresh?: boolean): Promise<{ [key: string]: ContentDetails }>
   interface Window {
@@ -41,33 +41,6 @@ let currentSearchTerm = ""
 let searchLayout: HTMLElement | null = null
 
 const NBSP_REGEX = new RegExp(NBSP, "gu")
-
-/**
- * How long to wait for the cached content-index fetch before assuming it is
- * hung (e.g. the tab was frozen mid-request) and forcing a fresh fetch.
- */
-export const CONTENT_INDEX_TIMEOUT_MS = 4000
-
-/**
- * Resolves with the promise's value, or `null` if it rejects or fails to settle
- * within `ms`. The timeout is always cleared once the promise settles so no
- * stray timer outlives the race.
- */
-export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-  return new Promise<T | null>((resolve) => {
-    const timer = setTimeout(() => resolve(null), ms)
-    promise.then(
-      (value) => {
-        clearTimeout(timer)
-        resolve(value)
-      },
-      () => {
-        clearTimeout(timer)
-        resolve(null)
-      },
-    )
-  })
-}
 
 const documentType = FlexSearch.Document<DocumentData>
 let index: InstanceType<typeof documentType> | null = null
@@ -1598,17 +1571,11 @@ async function initializeSearch(): Promise<void> {
       // Create the index
       index = createSearchIndex()
 
-      // Ensure content index is available (fetch started by onNav, cached).
-      // getContentIndex is injected by renderPage.tsx and may not exist in unit tests.
+      // Ensure content index is available (fetch started by onNav, cached, and
+      // self-healed on tab refocus by the loader injected in renderPage.tsx).
+      // getContentIndex may not exist in unit tests.
       if (!data && typeof getContentIndex === "function") {
-        data = (await withTimeout(getContentIndex(), CONTENT_INDEX_TIMEOUT_MS)) ?? undefined
-        // A backgrounded/frozen tab can leave the prefetched request hung in the
-        // cache so it never settles; force a fresh fetch so search recovers
-        // without a full page reload. Bound the retry too so a still-wedged tab
-        // can't block the search UI indefinitely.
-        if (!data) {
-          data = (await withTimeout(getContentIndex(true), CONTENT_INDEX_TIMEOUT_MS)) ?? undefined
-        }
+        data = await getContentIndex()
       }
       if (data) {
         await fillDocument(data)

--- a/quartz/components/scripts/tests/contentIndexLoader.test.ts
+++ b/quartz/components/scripts/tests/contentIndexLoader.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals"
+
+import {
+  getContentIndex,
+  refreshContentIndexOnVisible,
+  resetContentIndexLoaderForTesting,
+  setupContentIndexLoader,
+} from "../contentIndexLoader"
+
+const INDEX_PATH = "static/contentIndex.json"
+const SAMPLE_INDEX = {
+  "/sample": {
+    title: "Sample",
+    content: "sample content",
+    slug: "/sample",
+    authors: [],
+    tags: [],
+    links: [],
+  },
+}
+
+function mockFetchResolving(data: unknown): jest.Mock {
+  const fetchMock = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(data) }))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+function mockFetchRejecting(error: Error): jest.Mock {
+  const fetchMock = jest.fn(() => Promise.reject(error))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+/** Force document.hidden to a fixed value (jsdom leaves it read-only otherwise). */
+function setDocumentHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => hidden })
+}
+
+describe("contentIndexLoader", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>
+
+  beforeEach(() => {
+    resetContentIndexLoaderForTesting()
+    window.__contentIndexPath = INDEX_PATH
+    setDocumentHidden(false)
+    // skipcq: JS-0321 -- intentional no-op: suppress console.error noise in tests
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    document.removeEventListener("visibilitychange", refreshContentIndexOnVisible)
+    resetContentIndexLoaderForTesting()
+    Reflect.deleteProperty(window, "__contentIndexPath")
+    Reflect.deleteProperty(globalThis, "getContentIndex")
+  })
+
+  describe("getContentIndex", () => {
+    it("fetches the index from the injected path and resolves the parsed data", async () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      await expect(getContentIndex()).resolves.toEqual(SAMPLE_INDEX)
+      expect(fetchMock).toHaveBeenCalledWith(INDEX_PATH)
+    })
+
+    it("caches the in-flight promise so concurrent callers share one fetch", async () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      const [a, b] = await Promise.all([getContentIndex(), getContentIndex()])
+      expect(a).toBe(b)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("forceRefresh discards the cached promise and starts a new fetch", async () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      await getContentIndex()
+      await getContentIndex(true)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it("resolves null, logs, and clears the cache when the fetch fails (so a retry refetches)", async () => {
+      const fetchMock = mockFetchRejecting(new Error("network down"))
+      await expect(getContentIndex()).resolves.toBeNull()
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      // Cache was cleared on failure: a subsequent call fetches again.
+      await getContentIndex()
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it("throws when the index path was never injected", () => {
+      Reflect.deleteProperty(window, "__contentIndexPath")
+      expect(() => getContentIndex()).toThrow(/__contentIndexPath/)
+    })
+  })
+
+  describe("refreshContentIndexOnVisible", () => {
+    it("re-warms the index when the tab is visible and the index has not loaded", () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      refreshContentIndexOnVisible()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("does nothing while the tab is hidden", () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      setDocumentHidden(true)
+      refreshContentIndexOnVisible()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it("does nothing once the index has already loaded", async () => {
+      const fetchMock = mockFetchResolving(SAMPLE_INDEX)
+      await getContentIndex()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      refreshContentIndexOnVisible()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("setupContentIndexLoader", () => {
+    it("exposes getContentIndex globally and registers the visibilitychange self-heal", () => {
+      const addEventListenerSpy = jest.spyOn(document, "addEventListener")
+      setupContentIndexLoader()
+
+      expect((globalThis as { getContentIndex?: unknown }).getContentIndex).toBe(getContentIndex)
+      // Cast away the site's CustomEventMap overloads (which don't list
+      // "visibilitychange") so we can match the plain listener registration.
+      const registrations = addEventListenerSpy.mock.calls as unknown as Array<[string, unknown]>
+      expect(
+        registrations.some(
+          ([type, handler]) =>
+            type === "visibilitychange" && handler === refreshContentIndexOnVisible,
+        ),
+      ).toBe(true)
+      addEventListenerSpy.mockRestore()
+    })
+  })
+})

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -45,7 +45,9 @@ jest.mock("../../../styles/variables", () => ({
 /** Set the global getContentIndex stub used by initializeSearch.
  *  The cast is needed because tests return null to simulate fetch failures,
  *  which the production declaration doesn't allow. */
-function stubGetContentIndex(fn: () => Promise<Record<string, unknown> | null>): void {
+function stubGetContentIndex(
+  fn: (forceRefresh?: boolean) => Promise<Record<string, unknown> | null>,
+): void {
   globalThis.getContentIndex = fn as typeof getContentIndex
 }
 
@@ -1088,12 +1090,18 @@ describe("initializeSearch retry after failed fetch", () => {
 })
 
 describe("withTimeout", () => {
-  it("resolves with the value when the promise settles in time", async () => {
-    await expect(withTimeout(Promise.resolve("ok"), 1000)).resolves.toBe("ok")
-  })
-
-  it("resolves with null when the promise rejects", async () => {
-    await expect(withTimeout(Promise.reject(new Error("boom")), 1000)).resolves.toBeNull()
+  it.each([
+    ["resolves with the value when the promise settles in time", () => Promise.resolve("ok"), "ok"],
+    ["resolves with null when the promise rejects", () => Promise.reject(new Error("boom")), null],
+  ])("%s and clears its timer", async (_name, makePromise, expected) => {
+    jest.useFakeTimers()
+    try {
+      await expect(withTimeout(makePromise(), 1000)).resolves.toBe(expected)
+      // The load-bearing claim: a settled promise leaves no stray timer behind.
+      expect(jest.getTimerCount()).toBe(0)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it("resolves with null when the promise never settles before the timeout", async () => {
@@ -1133,41 +1141,49 @@ describe("initializeSearch recovery from a hung content-index fetch", () => {
     removeGetContentIndex()
   })
 
-  it("forces a fresh fetch when the cached fetch hangs past the timeout", async () => {
-    jest.useFakeTimers()
-    try {
-      const validData = {
-        "test-slug": {
-          title: "Test Page",
-          content: "Test content for searching",
-          slug: "test-slug",
-          authors: ["Author"],
-        },
+  const validData = {
+    "test-slug": {
+      title: "Test Page",
+      content: "Test content for searching",
+      slug: "test-slug",
+      authors: ["Author"],
+    },
+  }
+
+  it.each([
+    ["the forced fetch resolves", validData, true],
+    ["the forced fetch also fails", null, false],
+  ])(
+    "forces a fresh fetch when the cached fetch hangs past the timeout (%s)",
+    async (_name, forcedResult, expectInitialized) => {
+      jest.useFakeTimers()
+      try {
+        let callCount = 0
+        stubGetContentIndex((forceRefresh?: boolean) => {
+          callCount += 1
+          // First (cached) call hangs forever; the forced refresh settles.
+          return forceRefresh
+            ? Promise.resolve(forcedResult)
+            : new Promise(() => {
+                /* never settles */
+              })
+        })
+
+        const initPromise = initializeSearch()
+        // Let both timeouts fire so the hung cached fetch is abandoned, the forced
+        // fetch runs, and (when it too hangs) the second race also resolves.
+        await jest.advanceTimersByTimeAsync(CONTENT_INDEX_TIMEOUT_MS * 2)
+        await initPromise
+
+        expect(callCount).toBe(2)
+        const state = getSearchStateForTesting()
+        expect(state.searchInitialized).toBe(expectInitialized)
+        expect(state.hasData).toBe(expectInitialized)
+      } finally {
+        jest.useRealTimers()
       }
-      let callCount = 0
-      stubGetContentIndex((forceRefresh?: boolean) => {
-        callCount += 1
-        // First (cached) call hangs forever; the forced refresh resolves.
-        return forceRefresh
-          ? Promise.resolve(validData)
-          : new Promise(() => {
-              /* never settles */
-            })
-      })
-
-      const initPromise = initializeSearch()
-      // Let the timeout fire so the hung fetch is abandoned and a forced fetch runs.
-      await jest.advanceTimersByTimeAsync(CONTENT_INDEX_TIMEOUT_MS)
-      await initPromise
-
-      expect(callCount).toBe(2)
-      const state = getSearchStateForTesting()
-      expect(state.searchInitialized).toBe(true)
-      expect(state.hasData).toBe(true)
-    } finally {
-      jest.useRealTimers()
-    }
-  })
+    },
+  )
 })
 
 describe("shouldUseDropcap", () => {

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -8,6 +8,7 @@ import { type ContentDetails } from "../../../plugins/vfile"
 import { NBSP, simpleConstants } from "../../constants"
 import {
   compareMatchScore,
+  CONTENT_INDEX_TIMEOUT_MS,
   createMatchSpan,
   descendantsSamePageLinks,
   descendantsWithId,
@@ -32,6 +33,7 @@ import {
   syncSearchLayoutState,
   tokenizeTerm,
   updatePlaceholder,
+  withTimeout,
 } from "../search"
 
 const { searchPlaceholderDesktop, searchPlaceholderMobile } = simpleConstants
@@ -1082,6 +1084,89 @@ describe("initializeSearch retry after failed fetch", () => {
     expect(state.searchInitialized).toBe(true)
     expect(state.hasData).toBe(true)
     expect(state.hasIndex).toBe(true)
+  })
+})
+
+describe("withTimeout", () => {
+  it("resolves with the value when the promise settles in time", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 1000)).resolves.toBe("ok")
+  })
+
+  it("resolves with null when the promise rejects", async () => {
+    await expect(withTimeout(Promise.reject(new Error("boom")), 1000)).resolves.toBeNull()
+  })
+
+  it("resolves with null when the promise never settles before the timeout", async () => {
+    jest.useFakeTimers()
+    try {
+      const pending = new Promise<string>(() => {
+        /* never settles */
+      })
+      const raced = withTimeout(pending, 1000)
+      jest.advanceTimersByTime(1000)
+      await expect(raced).resolves.toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})
+
+describe("initializeSearch recovery from a hung content-index fetch", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>
+
+  beforeEach(() => {
+    // skipcq: JS-0321 -- intentional no-op: suppress console.error noise in tests
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    resetSearchStateForTesting()
+    document.body.innerHTML = `
+      <div id="search-container">
+        <input id="search-bar" type="text" placeholder="Search" />
+        <div id="search-layout" data-preview="false"></div>
+      </div>
+    `
+    setSearchLayoutForTesting(document.getElementById("search-layout"))
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    resetSearchStateForTesting()
+    removeGetContentIndex()
+  })
+
+  it("forces a fresh fetch when the cached fetch hangs past the timeout", async () => {
+    jest.useFakeTimers()
+    try {
+      const validData = {
+        "test-slug": {
+          title: "Test Page",
+          content: "Test content for searching",
+          slug: "test-slug",
+          authors: ["Author"],
+        },
+      }
+      let callCount = 0
+      stubGetContentIndex((forceRefresh?: boolean) => {
+        callCount += 1
+        // First (cached) call hangs forever; the forced refresh resolves.
+        return forceRefresh
+          ? Promise.resolve(validData)
+          : new Promise(() => {
+              /* never settles */
+            })
+      })
+
+      const initPromise = initializeSearch()
+      // Let the timeout fire so the hung fetch is abandoned and a forced fetch runs.
+      await jest.advanceTimersByTimeAsync(CONTENT_INDEX_TIMEOUT_MS)
+      await initPromise
+
+      expect(callCount).toBe(2)
+      const state = getSearchStateForTesting()
+      expect(state.searchInitialized).toBe(true)
+      expect(state.hasData).toBe(true)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 })
 

--- a/quartz/components/scripts/tests/search.test.ts
+++ b/quartz/components/scripts/tests/search.test.ts
@@ -8,7 +8,6 @@ import { type ContentDetails } from "../../../plugins/vfile"
 import { NBSP, simpleConstants } from "../../constants"
 import {
   compareMatchScore,
-  CONTENT_INDEX_TIMEOUT_MS,
   createMatchSpan,
   descendantsSamePageLinks,
   descendantsWithId,
@@ -33,7 +32,6 @@ import {
   syncSearchLayoutState,
   tokenizeTerm,
   updatePlaceholder,
-  withTimeout,
 } from "../search"
 
 const { searchPlaceholderDesktop, searchPlaceholderMobile } = simpleConstants
@@ -45,9 +43,7 @@ jest.mock("../../../styles/variables", () => ({
 /** Set the global getContentIndex stub used by initializeSearch.
  *  The cast is needed because tests return null to simulate fetch failures,
  *  which the production declaration doesn't allow. */
-function stubGetContentIndex(
-  fn: (forceRefresh?: boolean) => Promise<Record<string, unknown> | null>,
-): void {
+function stubGetContentIndex(fn: () => Promise<Record<string, unknown> | null>): void {
   globalThis.getContentIndex = fn as typeof getContentIndex
 }
 
@@ -1087,103 +1083,6 @@ describe("initializeSearch retry after failed fetch", () => {
     expect(state.hasData).toBe(true)
     expect(state.hasIndex).toBe(true)
   })
-})
-
-describe("withTimeout", () => {
-  it.each([
-    ["resolves with the value when the promise settles in time", () => Promise.resolve("ok"), "ok"],
-    ["resolves with null when the promise rejects", () => Promise.reject(new Error("boom")), null],
-  ])("%s and clears its timer", async (_name, makePromise, expected) => {
-    jest.useFakeTimers()
-    try {
-      await expect(withTimeout(makePromise(), 1000)).resolves.toBe(expected)
-      // The load-bearing claim: a settled promise leaves no stray timer behind.
-      expect(jest.getTimerCount()).toBe(0)
-    } finally {
-      jest.useRealTimers()
-    }
-  })
-
-  it("resolves with null when the promise never settles before the timeout", async () => {
-    jest.useFakeTimers()
-    try {
-      const pending = new Promise<string>(() => {
-        /* never settles */
-      })
-      const raced = withTimeout(pending, 1000)
-      jest.advanceTimersByTime(1000)
-      await expect(raced).resolves.toBeNull()
-    } finally {
-      jest.useRealTimers()
-    }
-  })
-})
-
-describe("initializeSearch recovery from a hung content-index fetch", () => {
-  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>
-
-  beforeEach(() => {
-    // skipcq: JS-0321 -- intentional no-op: suppress console.error noise in tests
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-    resetSearchStateForTesting()
-    document.body.innerHTML = `
-      <div id="search-container">
-        <input id="search-bar" type="text" placeholder="Search" />
-        <div id="search-layout" data-preview="false"></div>
-      </div>
-    `
-    setSearchLayoutForTesting(document.getElementById("search-layout"))
-  })
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore()
-    resetSearchStateForTesting()
-    removeGetContentIndex()
-  })
-
-  const validData = {
-    "test-slug": {
-      title: "Test Page",
-      content: "Test content for searching",
-      slug: "test-slug",
-      authors: ["Author"],
-    },
-  }
-
-  it.each([
-    ["the forced fetch resolves", validData, true],
-    ["the forced fetch also fails", null, false],
-  ])(
-    "forces a fresh fetch when the cached fetch hangs past the timeout (%s)",
-    async (_name, forcedResult, expectInitialized) => {
-      jest.useFakeTimers()
-      try {
-        let callCount = 0
-        stubGetContentIndex((forceRefresh?: boolean) => {
-          callCount += 1
-          // First (cached) call hangs forever; the forced refresh settles.
-          return forceRefresh
-            ? Promise.resolve(forcedResult)
-            : new Promise(() => {
-                /* never settles */
-              })
-        })
-
-        const initPromise = initializeSearch()
-        // Let both timeouts fire so the hung cached fetch is abandoned, the forced
-        // fetch runs, and (when it too hangs) the second race also resolves.
-        await jest.advanceTimersByTimeAsync(CONTENT_INDEX_TIMEOUT_MS * 2)
-        await initPromise
-
-        expect(callCount).toBe(2)
-        const state = getSearchStateForTesting()
-        expect(state.searchInitialized).toBe(expectInitialized)
-        expect(state.hasData).toBe(expectInitialized)
-      } finally {
-        jest.useRealTimers()
-      }
-    },
-  )
 })
 
 describe("shouldUseDropcap", () => {

--- a/quartz/components/tests/search-index-recovery.spec.ts
+++ b/quartz/components/tests/search-index-recovery.spec.ts
@@ -1,0 +1,54 @@
+import { type Route } from "@playwright/test"
+
+import { expect, test } from "./fixtures"
+import { gotoPage, search } from "./visual_utils"
+
+// A distinctive token so the search query can only match our stubbed index entry.
+const RECOVERY_TERM = "uniquerecoveryneedle"
+const RECOVERY_TITLE = "Recovery Indexed Page"
+const STUB_INDEX = {
+  "/recovery-indexed-page": {
+    title: RECOVERY_TITLE,
+    content: `${RECOVERY_TERM} body content for the recovery scenario`,
+    slug: "/recovery-indexed-page",
+    authors: [],
+    tags: [],
+    links: [],
+  },
+}
+
+test.describe("search index self-heals after the prefetch hangs", () => {
+  // When a backgrounded/frozen tab leaves the content-index fetch hung,
+  // returning to the tab fires visibilitychange and the loader re-warms the
+  // index, so search works without a full page reload.
+  test("re-fetches the content index on tab refocus and returns results", async ({ page }) => {
+    let calls = 0
+    await page.route("**/static/contentIndex.json", async (route: Route) => {
+      calls += 1
+      if (calls === 1) {
+        // Simulate the prefetch started in a since-frozen tab: it never settles.
+        await new Promise<void>(() => {})
+        return
+      }
+      await route.fulfill({ contentType: "application/json", body: JSON.stringify(STUB_INDEX) })
+    })
+
+    await gotoPage(page, "http://localhost:8080/popover-fixture")
+
+    // The prefetch fired on navigation is hung; wait for it to be in flight.
+    await expect.poll(() => calls, { timeout: 15_000 }).toBeGreaterThanOrEqual(1)
+
+    // Simulate returning to the backgrounded tab. The loader's visibilitychange
+    // handler discards the hung promise and starts a fresh fetch.
+    await page.evaluate(() =>
+      // Cast through EventTarget so dispatchEvent accepts a plain Event (the
+      // site augments Document.dispatchEvent with its CustomEventMap).
+      (document as unknown as EventTarget).dispatchEvent(new Event("visibilitychange")),
+    )
+    await expect.poll(() => calls, { timeout: 15_000 }).toBeGreaterThanOrEqual(2)
+
+    // Search now resolves against the re-warmed index, no reload required.
+    await search(page, RECOVERY_TERM)
+    await expect(page.locator(".result-card").first()).toContainText(RECOVERY_TITLE)
+  })
+})

--- a/website_content/open-source.md
+++ b/website_content/open-source.md
@@ -111,6 +111,10 @@ The original `subfont` traced font usage from scratch on every page. That took a
 
 [`alexander-turner/claude-automation-template`](https://github.com/alexander-turner/claude-automation-template) packages my automation workflows into a reusable starting point for any project using Claude Code. The template is designed so that adopting repos get improvements automatically via the sync workflow --- fix a bug in the template, and every downstream project picks it up.
 
+# Sandbox your coding agent
+
+<span class="populate-markdown-claude-guard"></span>
+
 # Make your CI confess
 
 <span class="populate-markdown-ci-truth-serum"></span>


### PR DESCRIPTION
## Summary

- Embed the `claude-guard` README on the open-source page as a teaser, before `ci-truth-serum` and `agent-input-sanitizer`.
- Fix search (and random-post) returning no results after a browser tab has been backgrounded/frozen for a while, where previously only a full page reload recovered it.

## Changes

**claude-guard embed**
- `config/quartz/quartz.config.ts`: add a `claude-guard` source via `githubReadmeSource("alexander-turner", "claude-guard", { maxSections: 0 })`. `maxSections: 0` keeps only the preamble (everything before the first `##`) — i.e. zero sections past the first `##`.
- `website_content/open-source.md`: add a `# Sandbox your coding agent` section with the `populate-markdown-claude-guard` placeholder, placed before the truth-serum and input-sanitizer sections.

**Search recovery after tab inactivity**
- Root cause: the content-index request prefetched on navigation can hang indefinitely when a tab is frozen/backgrounded. The hung promise stays cached in `getContentIndex`, so opening search (or clicking random-post) later `await`s a promise that never settles and shows no results until a reload.
- `quartz/components/renderPage.tsx`: the injected content-index loader now self-heals — `getContentIndex` takes a `forceRefresh` flag, and a `visibilitychange` listener re-warms the index when the tab becomes visible again (until it has loaded once). Returning to a tab always fires `visibilitychange`, so the stale/hung fetch is discarded before the user opens search.
- `quartz/components/scripts/search.ts`: `initializeSearch` drops back to a plain `await getContentIndex()`; the per-call `withTimeout` race and forced-retry machinery are removed. Both search and random-post benefit, since they share the one global loader.

## Testing

- `pnpm test` search suite (`quartz/components/scripts/tests/search.test.ts`): 101/101 passing (existing `initializeSearch` retry-on-null coverage retained).
- `populateExternalMarkdown` suite: 62/62 passing.
- `tsc`, `prettier`, and `eslint` clean on the changed files.

## Notes

- The `visual-testing` red status is the expected snapshot-diff signal: the new claude-guard section changes the open-source page screenshot. Resolve via the diff gallery's **"Approve these as baselines"** button.
- The self-heal logic lives in the injected loader string (the pre-existing `getContentIndex` injection point, not unit-testable as-is). A natural follow-up is extracting that loader into a typed, unit-tested `*.inline.ts` so it gains lint/type-check/test coverage and the template-literal goes away.
