### PR TITLE
fix(visual): wait for real video frame paint before screenshot

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -192,24 +192,53 @@ export async function takeRegressionScreenshot(
   if (!options?.skipMediaPause) {
     await pauseMediaElements(page, options?.elementToScreenshot)
 
-    // Wait for every video to be paused at time 0. Re-seeks if the initial
-    // seek timed out (e.g. slow CI).
+    // Block until every video has actually painted its frame-0 to the
+    // compositor, not merely reached currentTime === 0. requestVideoFrameCallback
+    // fires only on a real paint; `paused`/`currentTime === 0` are satisfied
+    // even when the engine (notably WebKit) has presented no frame yet, so a
+    // blank, never-painted video would otherwise be screenshotted and diff
+    // against the painted baseline — the source of the flake.
     const mediaScope = options?.elementToScreenshot ?? page
     const videos = await mediaScope.locator("video").all()
     for (const video of videos) {
       const handle = await video.elementHandle()
       if (!handle) throw new Error("Could not get element handle for video")
-      await page.waitForFunction(
-        (el) => {
-          const videoEl = el as HTMLVideoElement
-          if (videoEl.currentTime !== 0) {
-            videoEl.pause()
-            videoEl.currentTime = 0
-          }
-          return videoEl.paused && videoEl.currentTime === 0
-        },
-        handle,
-        { timeout: 5000 },
+      await handle.evaluate(
+        (el) =>
+          new Promise<void>((resolve) => {
+            const videoEl = el as HTMLVideoElement & {
+              requestVideoFrameCallback?: (cb: () => void) => number
+            }
+            let settled = false
+            const finish = () => {
+              if (settled) return
+              settled = true
+              resolve()
+            }
+            const waitForPaint = () => {
+              videoEl.pause()
+              if (videoEl.currentTime !== 0) videoEl.currentTime = 0
+              if (typeof videoEl.requestVideoFrameCallback !== "function") {
+                finish()
+                return
+              }
+              // rVFC fires on the real paint of the seeked frame (covers
+              // WebKit's blank → frame-0 transition). The timeout covers the
+              // no-op case where frame 0 is already on screen and no new
+              // presentation occurs, so rVFC would never fire.
+              videoEl.requestVideoFrameCallback(finish)
+              setTimeout(finish, 1500)
+            }
+            if (videoEl.readyState >= 2) {
+              waitForPaint()
+            } else {
+              videoEl.addEventListener("loadeddata", waitForPaint, { once: true })
+              videoEl.load()
+            }
+            // Overall safety net: never hang on a video whose data never
+            // arrives (e.g. a broken source); let the screenshot proceed.
+            setTimeout(finish, 8000)
+          }),
       )
     }
   }

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -191,56 +191,7 @@ export async function takeRegressionScreenshot(
 ): Promise<Buffer> {
   if (!options?.skipMediaPause) {
     await pauseMediaElements(page, options?.elementToScreenshot)
-
-    // Block until every video has actually painted its frame-0 to the
-    // compositor, not merely reached currentTime === 0. requestVideoFrameCallback
-    // fires only on a real paint; `paused`/`currentTime === 0` are satisfied
-    // even when the engine (notably WebKit) has presented no frame yet, so a
-    // blank, never-painted video would otherwise be screenshotted and diff
-    // against the painted baseline — the source of the flake.
-    const mediaScope = options?.elementToScreenshot ?? page
-    const videos = await mediaScope.locator("video").all()
-    for (const video of videos) {
-      const handle = await video.elementHandle()
-      if (!handle) throw new Error("Could not get element handle for video")
-      await handle.evaluate(
-        (el) =>
-          new Promise<void>((resolve) => {
-            const videoEl = el as HTMLVideoElement & {
-              requestVideoFrameCallback?: (cb: () => void) => number
-            }
-            let settled = false
-            const finish = () => {
-              if (settled) return
-              settled = true
-              resolve()
-            }
-            const waitForPaint = () => {
-              videoEl.pause()
-              if (videoEl.currentTime !== 0) videoEl.currentTime = 0
-              if (typeof videoEl.requestVideoFrameCallback !== "function") {
-                finish()
-                return
-              }
-              // rVFC fires on the real paint of the seeked frame (covers
-              // WebKit's blank → frame-0 transition). The timeout covers the
-              // no-op case where frame 0 is already on screen and no new
-              // presentation occurs, so rVFC would never fire.
-              videoEl.requestVideoFrameCallback(finish)
-              setTimeout(finish, 1500)
-            }
-            if (videoEl.readyState >= 2) {
-              waitForPaint()
-            } else {
-              videoEl.addEventListener("loadeddata", waitForPaint, { once: true })
-              videoEl.load()
-            }
-            // Overall safety net: never hang on a video whose data never
-            // arrives (e.g. a broken source); let the screenshot proceed.
-            setTimeout(finish, 8000)
-          }),
-      )
-    }
+    await waitForVideosPainted(options?.elementToScreenshot ?? page)
   }
 
   // Separate out the element option so we don't pass it to the screenshot API
@@ -492,6 +443,63 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
       await handle.evaluate((el) => el.removeAttribute("autoplay"))
       await handle.dispose()
     }
+  }
+}
+
+/**
+ * Blocks until every video has actually painted its frame-0 to the compositor.
+ *
+ * `pauseMediaElements` seeks videos to currentTime 0, but `paused`/`currentTime
+ * === 0` are satisfied even when the engine (notably WebKit) has presented no
+ * frame yet. Screenshotting that blank, never-painted state diffs against the
+ * painted baseline — the source of the flake. requestVideoFrameCallback fires
+ * only on a real paint, which is the signal we actually need.
+ */
+async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
+  for (const video of await scope.locator("video").all()) {
+    const handle = await video.elementHandle()
+    if (!handle) throw new Error("Could not get element handle for video")
+    await handle.evaluate(
+      (el) =>
+        new Promise<void>((resolve) => {
+          const videoEl = el as HTMLVideoElement & {
+            requestVideoFrameCallback?: (cb: () => void) => number
+          }
+          const timers: ReturnType<typeof setTimeout>[] = []
+          let settled = false
+          const finish = () => {
+            if (settled) return
+            settled = true
+            timers.forEach(clearTimeout)
+            resolve()
+          }
+          const waitForPaint = () => {
+            videoEl.pause()
+            if (videoEl.currentTime !== 0) videoEl.currentTime = 0
+            if (typeof videoEl.requestVideoFrameCallback !== "function") {
+              finish()
+              return
+            }
+            videoEl.requestVideoFrameCallback(finish)
+            // Fallback for the case where frame 0 is already on screen: no new
+            // frame is presented, so rVFC would never fire.
+            timers.push(setTimeout(finish, 1500))
+          }
+          if (videoEl.readyState >= 2) {
+            // HAVE_CURRENT_DATA or better: a frame is decodable now.
+            waitForPaint()
+          } else {
+            videoEl.addEventListener("loadeddata", waitForPaint, { once: true })
+            // Mirror pauseMediaElements: only force a reload when there is no
+            // data at all; for HAVE_METADATA the decode is already in flight.
+            if (videoEl.readyState === 0) videoEl.load()
+          }
+          // Never hang on a video whose data never arrives (e.g. a broken
+          // source); let the screenshot proceed and fail on its own terms.
+          timers.push(setTimeout(finish, 8000))
+        }),
+    )
+    await handle.dispose()
   }
 }
 


### PR DESCRIPTION
## Summary

- The `section video in light mode (screenshot)` test (and any visual test capturing an autoplay video) was flaky on whether the SafeLife clip showed its content or a blank box.
- Root cause: the screenshot gate only asserted `paused && currentTime === 0`, which is satisfied even when the engine — notably WebKit — has decoded/presented **no frame yet**. Frame 0 of the clip already contains the Baseline/AUP grids, so the "blank" baseline was the `<video>` element having painted nothing, not an actual frame. Whether a frame had painted by screenshot time depended on decode/compositor timing, hence the flake.
- Fix: block until a video has actually **painted** its frame, using `requestVideoFrameCallback` (which fires only on a real presentation), before taking the screenshot.

## Changes

- `quartz/components/tests/visual_utils.ts`:
  - Replace the logical-state gate (`waitForFunction` on `paused && currentTime === 0`) with `waitForVideosPainted()`, a new helper beside `pauseMediaElements`.
  - Per video: pause, settle at `currentTime 0`, then wait for `requestVideoFrameCallback` to confirm a real paint. Wait for the decoder (`loadeddata`, forcing `load()` only at `readyState 0`) when no frame data is ready yet.
  - Timeouts: a 1500 ms fallback for the no-op case (frame 0 already on screen, so no new presentation fires rVFC) and an 8000 ms overall safety net so a broken source never hangs; both cleared once settled.

## Testing

- `pnpm check` (tsc + prettier + stylelint) clean on the changed file; ESLint clean.
- Validated the gate mechanism against the real clip across many runs in headless Chromium (rebuilt locally; WebKit isn't installable in this environment): with the new gate the captured frame is deterministically frame 0 (non-blank), `currentTime === 0` every run, and the gate never throws.
- The committed Desktop-Safari baseline for this section currently captures the blank (unpainted) state; once this lands, the now-deterministic painted frame should be re-approved via the visual diff gallery.

## Notes / trade-offs

- On engines where the frame is already painted by the time the gate runs (e.g. Chromium/Firefox after `pauseMediaElements`), rVFC won't re-fire, so the gate waits out the 1500 ms fallback per video. This is an accepted latency cost in exchange for eliminating the flake; the WebKit case (the actual bug) resolves as soon as the pending paint lands.

## Lessons Learned

- **What**: When screenshotting media in visual-regression tests, gate on an actual paint (`requestVideoFrameCallback`), not on logical media state (`paused`/`currentTime`). Logical state is satisfied before WebKit presents a frame, producing blank-vs-painted flakiness.
- **Where**: Visual-test screenshot helpers (this repo: `quartz/components/tests/visual_utils.ts`).
- **Why**: A flaky autoplay-video screenshot turned out to be capturing the never-painted state of a `<video>`, not a different frame; `currentTime === 0` was true with nothing on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSbie8WZcwJsxihP9smFme)_