### PR TITLE
fix: float captioned float-right figures as a unit

### DIFF
--- a/quartz/plugins/transformers/tests/utils.test.ts
+++ b/quartz/plugins/transformers/tests/utils.test.ts
@@ -466,6 +466,22 @@ describe("removeClass", () => {
     removeClass(node, toRemove)
     expect(node.properties.className).toEqual(expected)
   })
+
+  // `hasClass` honors the `class` property too, so `removeClass` must strip it.
+  const classNode = (klass: string): Element => ({
+    type: "element",
+    tagName: "div",
+    properties: { class: klass },
+    children: [],
+  })
+
+  it.each<[string, Element, string, string | undefined]>([
+    ["removes from the class property", classNode("a b"), "a", "b"],
+    ["drops the class property when it empties", classNode("a"), "a", undefined],
+  ])("%s", (_d, node, toRemove, expected) => {
+    removeClass(node, toRemove)
+    expect(node.properties.class).toEqual(expected)
+  })
 })
 
 describe("hasAncestor", () => {

--- a/quartz/plugins/transformers/tests/utils.test.ts
+++ b/quartz/plugins/transformers/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   gatherTextBeforeIndex,
   hasAncestor,
   hasClass,
+  removeClass,
   type ReplaceFnResult,
   replaceRegex,
   shouldCapitalizeNodeText,
@@ -442,6 +443,27 @@ describe("addClass", () => {
     ["dedupes against string", stringNode("a b"), "b", "a b"],
   ])("%s", (_d, node, toAdd, expected) => {
     addClass(node, toAdd)
+    expect(node.properties.className).toEqual(expected)
+  })
+})
+
+describe("removeClass", () => {
+  const stringNode = (className?: string): Element => ({
+    type: "element",
+    tagName: "div",
+    properties: className === undefined ? {} : { className },
+    children: [],
+  })
+
+  it.each<[string, Element, string, string | string[] | undefined]>([
+    ["removes from array", h("div", { className: ["a", "b"] }), "a", ["b"]],
+    ["removes from string, preserving shape", stringNode("a b"), "a", "b"],
+    ["drops className when array empties", h("div", { className: ["a"] }), "a", undefined],
+    ["drops className when string empties", stringNode("a"), "a", undefined],
+    ["no-op when absent from array", h("div", { className: ["a"] }), "b", ["a"]],
+    ["no-op when className unset", h("div"), "a", undefined],
+  ])("%s", (_d, node, toRemove, expected) => {
+    removeClass(node, toRemove)
     expect(node.properties.className).toEqual(expected)
   })
 })

--- a/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
+++ b/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
@@ -467,6 +467,11 @@ describe("WrapNakedElements Plugin Tests", () => {
         '<figure class="float-right"><img src="test.jpg"><figcaption>Alex, 2024.</figcaption></figure>',
       ],
       [
+        "preserves the child's other classes when promoting",
+        '<figure><img class="float-right transparent-image" src="test.jpg"></figure>',
+        '<figure class="float-right"><img class="transparent-image" src="test.jpg"></figure>',
+      ],
+      [
         "picture-wrapped img + figcaption",
         '<figure><picture><img class="float-right" src="test.jpg"></picture><figcaption>Cap</figcaption></figure>',
         '<figure class="float-right"><picture><img src="test.jpg"></picture><figcaption>Cap</figcaption></figure>',

--- a/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
+++ b/quartz/plugins/transformers/tests/wrapNakedElements.test.ts
@@ -357,10 +357,10 @@ describe("WrapNakedElements Plugin Tests", () => {
         preservedContent: '<div class="other-class">Content</div>',
       },
       {
-        name: "not wrap figure with float-right content",
+        name: "promote float-right onto a figure rather than wrapping again",
         input: '<figure><div class="float-right">Content</div></figure>',
         shouldWrap: false,
-        preservedContent: '<figure><div class="float-right">Content</div></figure>',
+        preservedContent: '<figure class="float-right"><div>Content</div></figure>',
       },
     ]
 
@@ -456,6 +456,49 @@ describe("WrapNakedElements Plugin Tests", () => {
       expect(result).toMatch(/^<p>/)
       expect(result).toMatch(/<\/p>$/)
       expect(result).toContain("<figure>")
+    })
+  })
+
+  describe("Caption floats with float-right image", () => {
+    it.each([
+      [
+        "img + figcaption (remark-captions output)",
+        '<figure><img class="float-right" src="test.jpg"><figcaption>Alex, 2024.</figcaption></figure>',
+        '<figure class="float-right"><img src="test.jpg"><figcaption>Alex, 2024.</figcaption></figure>',
+      ],
+      [
+        "picture-wrapped img + figcaption",
+        '<figure><picture><img class="float-right" src="test.jpg"></picture><figcaption>Cap</figcaption></figure>',
+        '<figure class="float-right"><picture><img src="test.jpg"></picture><figcaption>Cap</figcaption></figure>',
+      ],
+      [
+        "picture with a leading source before the float-right img",
+        '<figure><picture><source srcset="dark.avif"><img class="float-right" src="test.jpg"></picture></figure>',
+        '<figure class="float-right"><picture><source srcset="dark.avif"><img src="test.jpg"></picture></figure>',
+      ],
+      [
+        "img surrounded by whitespace text nodes",
+        '<figure>  <img class="float-right" src="test.jpg">  </figure>',
+        '<figure class="float-right">  <img src="test.jpg">  </figure>',
+      ],
+    ])("should promote float-right onto the figure for %s", (_, input, expected) => {
+      expect(testWrapNakedElementsHTML(input)).toBe(expected)
+    })
+
+    it("should leave a figure that already carries float-right unchanged", () => {
+      const input =
+        '<figure class="float-right"><img src="test.jpg"><figcaption>Cap</figcaption></figure>'
+      expect(testWrapNakedElementsHTML(input)).toBe(input)
+    })
+
+    it.each([
+      ["plain img", '<figure><img src="test.jpg"><figcaption>Cap</figcaption></figure>'],
+      [
+        "picture without a float-right inner",
+        '<figure><picture><img src="test.jpg"></picture><figcaption>Cap</figcaption></figure>',
+      ],
+    ])("should not touch a figure whose %s has no float-right", (_, input) => {
+      expect(testWrapNakedElementsHTML(input)).toBe(input)
     })
   })
 

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -277,6 +277,34 @@ export function addClass(node: Element, className: string): void {
   node.properties = { ...node.properties, className: list }
 }
 
+// Remove a class from a node, preserving the shape of any remaining classes
+// (string-form className stays a string; array stays an array). No-op when the
+// class is absent.
+export function removeClass(node: Element, className: string): void {
+  const existing = node.properties?.className
+  const setKept = (kept: string[]): void => {
+    const next = { ...node.properties }
+    if (kept.length === 0) {
+      delete next.className
+    } else {
+      next.className = typeof existing === "string" ? kept.join(" ") : kept
+    }
+    node.properties = next
+  }
+  if (typeof existing === "string") {
+    setKept(
+      existing
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((c) => c !== className),
+    )
+    return
+  }
+  if (Array.isArray(existing)) {
+    setKept(existing.map(String).filter((c) => c !== className))
+  }
+}
+
 /**
  * Type guard to check if a node is a Text node.
  * @param node - The node to check

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -278,30 +278,30 @@ export function addClass(node: Element, className: string): void {
 }
 
 // Remove a class from a node, preserving the shape of any remaining classes
-// (string-form className stays a string; array stays an array). No-op when the
-// class is absent.
+// (string-form stays a string; array stays an array). Handles both the
+// `className` and `class` property forms that `hasClass` honors, so a class
+// found by `hasClass` is always strippable. No-op when the class is absent.
 export function removeClass(node: Element, className: string): void {
-  const existing = node.properties?.className
-  const setKept = (kept: string[]): void => {
+  for (const key of ["className", "class"] as const) {
+    const existing = node.properties?.[key]
+    const kept =
+      typeof existing === "string"
+        ? existing
+            .split(/\s+/)
+            .filter(Boolean)
+            .filter((c) => c !== className)
+        : Array.isArray(existing)
+          ? existing.map(String).filter((c) => c !== className)
+          : undefined
+    if (kept === undefined) continue
+
     const next = { ...node.properties }
     if (kept.length === 0) {
-      delete next.className
+      delete next[key]
     } else {
-      next.className = typeof existing === "string" ? kept.join(" ") : kept
+      next[key] = typeof existing === "string" ? kept.join(" ") : kept
     }
     node.properties = next
-  }
-  if (typeof existing === "string") {
-    setKept(
-      existing
-        .split(/\s+/)
-        .filter(Boolean)
-        .filter((c) => c !== className),
-    )
-    return
-  }
-  if (Array.isArray(existing)) {
-    setKept(existing.map(String).filter((c) => c !== className))
   }
 }
 

--- a/quartz/plugins/transformers/wrapNakedElements.ts
+++ b/quartz/plugins/transformers/wrapNakedElements.ts
@@ -10,7 +10,7 @@ import { visitParents } from "unist-util-visit-parents"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-import { hasClass } from "./utils"
+import { addClass, hasClass, removeClass } from "./utils"
 
 /**
  * Wraps an element node with a wrapper element of the specified tag name and class name, unless skipped.
@@ -158,6 +158,41 @@ function shouldNotWrapInFigure(element: Element, ancestors: Parent[]): boolean {
 }
 
 /**
+ * Returns the direct child carrying the `float-right` class, looking through a
+ * `<picture>` wrapper to its inner element (e.g. a dark-mode-inverted `<img>`).
+ */
+function findFloatRightChild(figure: Element): Element | undefined {
+  for (const child of figure.children) {
+    if (child.type !== "element") continue
+    if (hasClass(child, "float-right")) return child
+    if (child.tagName === "picture") {
+      const inner = child.children.find(
+        (c): c is Element => c.type === "element" && hasClass(c, "float-right"),
+      )
+      if (inner) return inner
+    }
+  }
+  return undefined
+}
+
+/**
+ * When a `<figure>` directly wraps a `float-right` element — as remark-captions
+ * does for a captioned float-right image — only the inner element floats while
+ * the figure (and its `<figcaption>`) stays in normal flow, stranding the
+ * caption. Move the class up to the figure so the whole figure floats together,
+ * matching the authored `<figure class="float-right">` pattern.
+ */
+function promoteFloatRightToFigure(element: Element): void {
+  if (element.tagName !== "figure" || hasClass(element, "float-right")) return
+
+  const floatChild = findFloatRightChild(element)
+  if (!floatChild) return
+
+  addClass(element, "float-right")
+  removeClass(floatChild, "float-right")
+}
+
+/**
  * Wraps elements with float-right class in a <figure>.
  * If an element contains a direct child with float-right, wraps the parent instead,
  * unless the parent is a semantic container that should not be wrapped (like paragraphs).
@@ -223,6 +258,9 @@ const rehypeWrapNakedElements: Plugin<[], Root> = () => {
     // Wrap naked videos and audio in containers with data-src for print
     visitParents(tree, "element", wrapVideo)
     visitParents(tree, "element", wrapAudio)
+    // Promote float-right from a captioned figure's child up to the figure, so
+    // the caption floats with the image rather than stranding in normal flow.
+    visitParents(tree, "element", promoteFloatRightToFigure)
     // Then wrap .float-right elements (or their parents) in figure
     visitParents(tree, "element", wrapFloatRight)
   }

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -558,6 +558,19 @@ Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium dolor
 
 <!--spellchecker-enable-->
 
+## Floating image right with caption
+
+<!-- vale off -->
+![[https://assets.turntrout.com/static/images/posts/alex_rainbow_2.avif|Alex smiling at the camera; rainbow colored light splays off the wall in the background.]]{.float-right style="width:20%;"}
+Figure: The caption floats with the image instead of stranding above the following text.
+<!-- vale on -->
+
+<!--spellchecker-disable-->
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+
+<!--spellchecker-enable-->
+
 # Spoilers
 
 > Normal blockquote


### PR DESCRIPTION
## Summary

- A `.float-right` image immediately followed by a `Figure:` caption (e.g. the DHS summary admonition) rendered the caption stranded above the following content instead of beneath the image.
- Root cause: `remark-captions` wraps the image and its caption into a `<figure>`, but the `float-right` class stays on the inner `<img>`. Only the image floated, leaving the `<figcaption>` in normal flow at the top-left — above the first bullet.
- Fix: promote `float-right` from the figure's child up to the figure itself, so the whole figure (caption included) floats as a unit, reusing the existing, tested `<figure class="float-right">` CSS path.

## Changes

- `quartz/plugins/transformers/wrapNakedElements.ts`: new `promoteFloatRightToFigure` pass (with `findFloatRightChild` that also looks through a `<picture>` wrapper) that moves the `float-right` class from a figure's child onto the figure and strips it from the child. Runs before `wrapFloatRight`, so the inner element is no longer double-wrapped.
- `quartz/plugins/transformers/utils.ts`: new `removeClass` helper, symmetric with `hasClass` — it strips the class from both the `className` and `class` property forms and preserves the remaining shape (string stays a string, array stays an array).
- `website_content/test-page.md`: added a captioned float-right example so visual regression captures the behavior as a baseline.
- Tests: parametrized coverage for the promotion path (img + figcaption, `<picture>`-wrapped, leading `<source>`, whitespace text nodes, already-floated figure, no-float-right negatives, multi-class preservation) and for `removeClass` (string/array shapes, empty-collapse, both property forms). `wrapNakedElements.ts` is at 100% branch/statement/line/function coverage.

## Testing

- `wrapNakedElements` + `utils` suites: 139 tests pass.
- `wrapNakedElements.ts` at 100% coverage; `removeClass` branches fully exercised.
- ESLint, Prettier, and Pyright/typecheck clean on touched files; all pre-push checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeGFMukdD8ZyigkotgnsKx)_