### PR TITLE
test(visual): stub the TOC in the whole-page integration screenshot

### DIFF
--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -113,6 +113,29 @@ async function hideForceHslInvertInFirefox(page: Page, testInfo: TestInfo): Prom
   }, forceHslInvertClass)
 }
 
+/**
+ * The desktop sidebar TOC mirrors every heading in test-page.md, so the
+ * whole-page integration screenshot would churn whenever any section is added or
+ * removed — even sections far below the fold. Swap in a fixed stub list so this
+ * shot stays decoupled from the page's heading set; the live TOC's own rendering
+ * is covered by the dedicated "Table of contents" screenshots.
+ */
+const STUB_TOC_OL = `<ol>
+  <li><a href="#stub-one" class="internal same-page-link" data-for="stub-one"><span>First section</span></a></li>
+  <li><a href="#stub-two" class="internal same-page-link" data-for="stub-two"><span>Second section</span></a><ol>
+    <li><a href="#stub-two-a" class="internal same-page-link" data-for="stub-two-a"><span>Nested entry</span></a></li>
+  </ol></li>
+  <li><a href="#stub-three" class="internal same-page-link" data-for="stub-three"><span>Third section</span></a></li>
+</ol>`
+
+async function stubTableOfContents(page: Page): Promise<void> {
+  await page.evaluate((ol) => {
+    document.querySelectorAll("#toc-content, #toc-content-mobile").forEach((el) => {
+      el.innerHTML = ol
+    })
+  }, STUB_TOC_OL)
+}
+
 test.describe("Test page sections", () => {
   THEMES.forEach((theme) => {
     // Per-section detail is covered by the isolated fixtures in
@@ -122,6 +145,7 @@ test.describe("Test page sections", () => {
       await setTheme(page, theme as "light" | "dark")
 
       await hideForceHslInvertInFirefox(page, testInfo)
+      await stubTableOfContents(page)
 
       await takeRegressionScreenshot(page, testInfo, `test-page-normal-${theme}`)
     })


### PR DESCRIPTION
## Summary

- The `Normal page in {theme}` whole-page integration screenshot rendered the live desktop sidebar TOC, which mirrors **every** heading in `test-page.md`. So adding or removing *any* section — even one far below the fold — churned this screenshot's TOC region (as seen when #1525 added a section: the sidebar gained a new entry and the shot diffed).
- Per-section *body* churn is already isolated by the `test-sections` fixtures; the TOC was the remaining shared-churn surface in the integration shot.
- Fix: swap the TOC content for a fixed stub list before capturing, so this shot is decoupled from the page's heading set. The live TOC's own rendering stays covered by the dedicated "Table of contents" screenshots (`toc-visual-test-sidebar` / `toc-visual-test-open`).

## Changes

- `quartz/components/tests/visual-regression.spec.ts`: add a `stubTableOfContents(page)` helper that replaces `#toc-content` / `#toc-content-mobile` inner HTML with a fixed stub `<ol>` (mirroring the real `li > a.internal.same-page-link[data-for] > span` markup, including one nested entry so nesting styling is still exercised). Call it in the `Normal page in {theme} mode` test before the screenshot.

## Testing

- `pnpm check` (tsc + prettier + stylelint) and ESLint pass on the changed file.
- This intentionally updates the `test-page-normal-{light,dark}` baselines once (the TOC region now shows the stub). After approving that one-time diff, future section additions no longer churn this screenshot.

## Lessons learned

- **What**: When a whole-page/integration visual snapshot includes a navigation element (TOC, sidebar, breadcrumb) that is auto-generated from page content, stub that element to a fixed list in the snapshot so unrelated content edits don't churn the baseline; keep the element's *real* rendering covered by a dedicated, scoped snapshot.
- **Where**: visual-regression test suites (here, `quartz/components/tests/visual-regression.spec.ts`).
- **Why**: A content-derived TOC made every section add/remove diff the whole-page screenshot, forcing needless baseline re-approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeGFMukdD8ZyigkotgnsKx)_