### PR TITLE
Handle orphaned commits in git diff range resolution

### DIFF
--- a/scripts/tests/test_update_date_on_publish.py
+++ b/scripts/tests/test_update_date_on_publish.py
@@ -410,6 +410,86 @@ def test_is_file_modified_invalid_path(mock_git_commands):
         update_lib.is_file_modified(test_file)
 
 
+@pytest.mark.parametrize(
+    ("commit_range", "expected"),
+    [
+        pytest.param(None, "origin/main..HEAD", id="local-unpushed"),
+        pytest.param("abc123", "abc123", id="single-ref-no-range"),
+        pytest.param("aaa..bbb", "aaa..bbb", id="normal-range"),
+        pytest.param(
+            f"{'0' * 40}..def456", "def456^..def456", id="first-push-zeros"
+        ),
+    ],
+)
+def test_determine_commit_range(commit_range, expected):
+    """The CI/local commit range is normalized for each push shape."""
+    assert update_lib._determine_commit_range(commit_range) == expected
+
+
+def test_revision_exists_true():
+    """A resolvable revision reports as existing."""
+    with patch(
+        "scripts.update_date_on_publish.subprocess.check_output",
+        return_value="deadbeef\n",
+    ) as mock_check:
+        assert update_lib._revision_exists("git", "deadbeef") is True
+    mock_check.assert_called_once()
+
+
+def test_revision_exists_false():
+    """An unresolvable (orphaned) revision reports as missing, not an error."""
+    with patch(
+        "scripts.update_date_on_publish.subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(128, "git"),
+    ):
+        assert update_lib._revision_exists("git", "orphaned") is False
+
+
+def test_resolve_range_no_dotdot():
+    """A single revision (no range) is returned unchanged."""
+    assert update_lib._resolve_range("git", "abc123") == "abc123"
+
+
+def test_resolve_range_before_reachable():
+    """A reachable ``before`` keeps the original range."""
+    with patch(
+        "scripts.update_date_on_publish._revision_exists", return_value=True
+    ):
+        assert update_lib._resolve_range("git", "aaa..bbb") == "aaa..bbb"
+
+
+def test_resolve_range_before_orphaned():
+    """An orphaned ``before`` (amend + force-push) falls back to
+    after^..after."""
+    with patch(
+        "scripts.update_date_on_publish._revision_exists", return_value=False
+    ):
+        assert update_lib._resolve_range("git", "aaa..bbb") == "bbb^..bbb"
+
+
+def test_is_file_modified_orphaned_before_uses_parent_range(
+    test_file, mock_git_root
+):
+    """When the push ``before`` commit is orphaned, the diff falls back to
+    ``after^..after`` instead of crashing on an invalid revision range."""
+    diff_ranges: list[str] = []
+
+    def _mock_git(*args, **kwargs) -> str:
+        argv = args[0]
+        if "--verify" in argv:
+            raise subprocess.CalledProcessError(128, "git")  # before orphaned
+        if "rev-parse" in argv:
+            return f"{mock_git_root}\n"
+        if "diff" in argv:
+            diff_ranges.append(argv[3])
+            return ""
+        return ""
+
+    with patch("subprocess.check_output", side_effect=_mock_git):
+        assert update_lib.is_file_modified(test_file, "orphaned..head") is False
+    assert diff_ranges == ["head^..head"]
+
+
 def test_yaml_formatting_preservation():
     """Test that YAML formatting, quotes, and comments are preserved."""
     # Create a test file with specific formatting

--- a/scripts/update_date_on_publish.py
+++ b/scripts/update_date_on_publish.py
@@ -46,6 +46,43 @@ def _determine_commit_range(commit_range: str | None) -> str:
     return f"{after_commit}^..{after_commit}"
 
 
+def _revision_exists(git_executable: str, revision: str) -> bool:
+    """Return True if ``revision`` resolves to a commit in the current repo."""
+    try:
+        subprocess.check_output(
+            [
+                git_executable,
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                f"{revision}^{{commit}}",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _resolve_range(git_executable: str, range_to_check: str) -> str:
+    """
+    Return a diff range whose endpoints exist in the current repo.
+
+    The update-dates CI job amends the pushed commit and force-pushes, so the
+    push event's "before" SHA is orphaned and a fresh checkout can't resolve
+    ``before..after``. When that happens, diff the "after" commit against its
+    own parent: same file set, without depending on the orphaned commit.
+    """
+    if ".." not in range_to_check:
+        return range_to_check
+
+    before, after = range_to_check.split("..", 1)
+    if before and after and not _revision_exists(git_executable, before):
+        return f"{after}^..{after}"
+    return range_to_check
+
+
 def is_file_modified(file_path: Path, commit_range: str | None = None) -> bool:
     """
     Check if file was modified in the relevant commit range.
@@ -63,7 +100,9 @@ def is_file_modified(file_path: Path, commit_range: str | None = None) -> bool:
             than silently treating the file as unmodified.
     """
     git_executable = script_utils.find_executable("git")
-    range_to_check = _determine_commit_range(commit_range)
+    range_to_check = _resolve_range(
+        git_executable, _determine_commit_range(commit_range)
+    )
 
     try:
         git_root = subprocess.check_output(


### PR DESCRIPTION
## Summary
Add resilience to the `is_file_modified()` function when the CI job's "before" commit becomes orphaned after an amend + force-push. Instead of crashing on an invalid revision range, fall back to diffing the "after" commit against its own parent.

## Changes
- **`_revision_exists()`**: New helper to check if a git revision resolves in the current repo using `git rev-parse --verify`.
- **`_resolve_range()`**: New function that detects orphaned "before" commits in a range and rewrites `before..after` to `after^..after` when the "before" commit is unreachable. Single revisions (no range) pass through unchanged.
- **`is_file_modified()`**: Updated to call `_resolve_range()` after `_determine_commit_range()`, ensuring the diff range is always valid even when the push event's "before" SHA has been orphaned by the CI job's amendments.

## Implementation details
- The orphaned commit detection uses `git rev-parse --verify --quiet <revision>^{commit}` to safely test reachability without raising exceptions on missing commits.
- When a range's "before" commit is orphaned, we use the "after" commit's parent as the new "before" point, preserving the same file set without depending on the orphaned commit.
- Comprehensive test coverage includes parametrized tests for `_determine_commit_range()`, unit tests for `_revision_exists()` and `_resolve_range()`, and an integration test verifying the fallback behavior in `is_file_modified()`.

https://claude.ai/code/session_015VD6LwRmsxEJ2BdV3JTAmW