### PR TITLE
fix(tweets): decode HTML entities in tweet embed text

### DIFF
--- a/quartz/plugins/transformers/tests/tweetCard.property.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.property.test.ts
@@ -7,7 +7,7 @@ import fc from "fast-check"
 import { decodeHtmlEntities } from "../tweetCard"
 
 // Deterministic runs: a fixed seed keeps CI reproducible (zero-flakiness policy).
-fc.configureGlobal({ seed: 20260701, numRuns: 500 })
+fc.configureGlobal({ seed: 20260701, numRuns: 200 })
 
 /**
  * Twitter's syndication API HTML-escapes exactly `&`, `<`, and `>` in tweet
@@ -32,17 +32,6 @@ describe("decodeHtmlEntities (property)", () => {
       fc.property(fc.string({ unit: "binary", maxLength: 300 }), (text) => {
         expect(decodeHtmlEntities(twitterEncode(text))).toBe(text)
       }),
-    )
-  })
-
-  it("is the identity on text containing no entity references", () => {
-    fc.assert(
-      fc.property(
-        fc.string({ unit: "binary", maxLength: 300 }).filter((s) => !s.includes("&")),
-        (text) => {
-          expect(decodeHtmlEntities(text)).toBe(text)
-        },
-      ),
     )
   })
 })

--- a/quartz/plugins/transformers/tests/tweetCard.property.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.property.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment node
+ */
+import { describe, expect, it } from "@jest/globals"
+import fc from "fast-check"
+
+import { decodeHtmlEntities } from "../tweetCard"
+
+// Deterministic runs: a fixed seed keeps CI reproducible (zero-flakiness policy).
+fc.configureGlobal({ seed: 20260701, numRuns: 500 })
+
+/**
+ * Twitter's syndication API HTML-escapes exactly `&`, `<`, and `>` in tweet
+ * text. Reproduce that here so the round-trip mirrors the encoded strings real
+ * snapshots store.
+ */
+function twitterEncode(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+describe("decodeHtmlEntities (property)", () => {
+  it("never throws on arbitrary unicode", () => {
+    fc.assert(
+      fc.property(fc.string({ unit: "binary", maxLength: 300 }), (text) => {
+        expect(() => decodeHtmlEntities(text)).not.toThrow()
+      }),
+    )
+  })
+
+  it("inverts Twitter's HTML-escaping for any input", () => {
+    fc.assert(
+      fc.property(fc.string({ unit: "binary", maxLength: 300 }), (text) => {
+        expect(decodeHtmlEntities(twitterEncode(text))).toBe(text)
+      }),
+    )
+  })
+
+  it("is the identity on text containing no entity references", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ unit: "binary", maxLength: 300 }).filter((s) => !s.includes("&")),
+        (text) => {
+          expect(decodeHtmlEntities(text)).toBe(text)
+        },
+      ),
+    )
+  })
+})

--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -107,6 +107,15 @@ describe("linkifyTweetText", () => {
     expect(nodes).toEqual(["safety filters & aspirational language"])
   })
 
+  it("decodes HTML entities in a t.co link's display text", () => {
+    const nodes = linkifyTweetText("see https://t.co/abc", [
+      { url: "https://t.co/abc", display: "site.com/a&amp;b", expanded: "https://site.com/a&b" },
+    ])
+    const html = nodes.map((n) => (typeof n === "string" ? n : render(n))).join("")
+    expect(html).toContain(">site.com/a&#x26;b<")
+    expect(html).not.toContain("&#x26;amp;")
+  })
+
   it("turns newlines into <br> and preserves surrounding text", () => {
     const nodes = linkifyTweetText("line one\nline two", [])
     const html = nodes.map((n) => (typeof n === "string" ? n : render(n))).join("")
@@ -372,6 +381,13 @@ describe("quote tweets", () => {
     expect(html).toContain('href="https://xcancel.com/someone"')
     // The post date sits at the bottom of the quoted card (base is Jan 21, quote Jan 20).
     expect(html).toContain('<span class="tweet-quoted-date">January 20th, 2025</span>')
+  })
+
+  it("decodes HTML entities in the quoted tweet's body", () => {
+    const withEntity = { ...quoted, text: "quoted R&amp;D note" }
+    const html = render(buildTweetCard({ ...baseSnapshot, quoted: withEntity }))
+    expect(html).toContain("quoted R&#x26;D note")
+    expect(html).not.toContain("&#x26;amp;")
   })
 
   it("omits the quoted date line when the timestamp is unparseable", () => {

--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -10,6 +10,7 @@ import {
   buildTweetCard,
   buildTweetEmbed,
   buildUnavailableCard,
+  decodeHtmlEntities,
   formatCount,
   formatTweetDate,
   linkifyTweetText,
@@ -59,6 +60,29 @@ describe("formatTweetDate", () => {
   })
 })
 
+describe("decodeHtmlEntities", () => {
+  it.each([
+    ["a &amp; b", "a & b"],
+    ["1 &lt; 2 &gt; 0", "1 < 2 > 0"],
+    ["she said &quot;hi&quot;", 'she said "hi"'],
+    ["it&apos;s", "it's"],
+    ["A&#38;B", "A&B"],
+    ["&#x26;", "&"],
+    ["&#X26;", "&"],
+  ])("decodes %p to %p", (input, expected) => {
+    expect(decodeHtmlEntities(input)).toBe(expected)
+  })
+
+  it.each([
+    ["unknown named entity", "&nbsp;"],
+    ["out-of-range code point", "&#x110000;"],
+    ["zero code point", "&#0;"],
+    ["a bare ampersand", "R&D"],
+  ])("leaves %s untouched", (_label, input) => {
+    expect(decodeHtmlEntities(input)).toBe(input)
+  })
+})
+
 describe("linkifyTweetText", () => {
   it("links t.co entities to their expanded URL with display text", () => {
     const nodes = linkifyTweetText("see https://t.co/abc now", [
@@ -76,6 +100,11 @@ describe("linkifyTweetText", () => {
     expect(html).toContain('href="https://xcancel.com/bob"')
     expect(html).toContain("https://xcancel.com/search?q=%23ai")
     expect(html).toContain("https://xcancel.com/search?q=%24TSLA")
+  })
+
+  it("decodes HTML entities before building text nodes", () => {
+    const nodes = linkifyTweetText("safety filters &amp; aspirational language", [])
+    expect(nodes).toEqual(["safety filters & aspirational language"])
   })
 
   it("turns newlines into <br> and preserves surrounding text", () => {
@@ -196,6 +225,24 @@ describe("buildTweetCard", () => {
     expect(html).toContain('width="800"')
     expect(html).toContain('alt="a photo"')
     expect(html).toContain("tweet-media-count-1")
+  })
+
+  it("decodes HTML entities in the author name and photo alt text", () => {
+    const withEntities: TweetSnapshot = {
+      ...baseSnapshot,
+      author: { ...baseSnapshot.author, name: "Ben &amp; Jerry" },
+      media: [
+        {
+          type: "photo",
+          src: "https://assets.turntrout.com/static/tweets/123/p.jpg",
+          alt: "chart of X &amp; Y",
+        },
+      ],
+    }
+    const html = render(buildTweetCard(withEntities))
+    expect(html).toContain('<span class="tweet-name">Ben &#x26; Jerry</span>')
+    expect(html).toContain('alt="chart of X &#x26; Y"')
+    expect(html).not.toContain("&#x26;amp;")
   })
 
   it("renders a looping video with a poster and a source element", () => {

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -207,7 +207,13 @@ export function linkifyTweetText(text: string, urls: readonly TweetUrl[]): (Elem
       const out: (Element | string)[] = []
       segments.forEach((segment, index) => {
         if (index > 0) {
-          out.push(externalAnchor(entity.expanded, [entity.display], "tweet-entity tweet-link"))
+          out.push(
+            externalAnchor(
+              entity.expanded,
+              [decodeHtmlEntities(entity.display)],
+              "tweet-entity tweet-link",
+            ),
+          )
         }
         if (segment) out.push(segment)
       })

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -110,6 +110,34 @@ export function formatTweetDate(iso: string): string {
   return `${month} ${day}, ${date.getUTCFullYear()}`
 }
 
+const NAMED_ENTITIES: Readonly<Record<string, string>> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+}
+
+const HTML_ENTITY_RE = /&(#x[0-9a-f]+|#\d+|[a-z]+);/gi
+
+/**
+ * Decode the HTML entities Twitter's syndication API leaves in tweet text
+ * (`&amp;`, `&lt;`, `&gt;`). The snapshot stores that encoded text verbatim, so
+ * without decoding, a hast text node of `&amp;` has its `&` re-escaped by the
+ * serializer and the card shows a literal `&amp;`. Unknown names are left intact.
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(HTML_ENTITY_RE, (match, body: string) => {
+    if (body[0] !== "#") {
+      return NAMED_ENTITIES[body.toLowerCase()] ?? match
+    }
+    const isHex = body[1] === "x" || body[1] === "X"
+    const codePoint = parseInt(isHex ? body.slice(2) : body.slice(1), isHex ? 16 : 10)
+    if (codePoint < 1 || codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
 const MENTION_OR_TAG = /[@#$]\w+/g
 
 function externalAnchor(
@@ -171,7 +199,7 @@ function withLineBreaks(nodes: (Element | string)[]): (Element | string)[] {
  * #hashtags link to xcancel, and newlines become `<br>`.
  */
 export function linkifyTweetText(text: string, urls: readonly TweetUrl[]): (Element | string)[] {
-  let nodes: (Element | string)[] = [text]
+  let nodes: (Element | string)[] = [decodeHtmlEntities(text)]
   for (const entity of urls) {
     nodes = nodes.flatMap((node) => {
       if (typeof node !== "string" || !node.includes(entity.url)) return [node]
@@ -220,7 +248,7 @@ function mediaNode(media: TweetMedia): Element {
   const img = h("img", {
     className: "tweet-media tweet-media-photo",
     src: media.src,
-    alt: media.alt || "View image",
+    alt: decodeHtmlEntities(media.alt || "View image"),
     loading: "lazy",
     ...(media.width ? { width: media.width } : {}),
     ...(media.height ? { height: media.height } : {}),
@@ -293,7 +321,7 @@ function authorNameRow(author: TweetAuthor, profileUrl: string): Element {
   const children: (Element | string)[] = [
     externalAnchor(
       profileUrl,
-      [h("span", { className: "tweet-name" }, author.name)],
+      [h("span", { className: "tweet-name" }, decodeHtmlEntities(author.name))],
       "tweet-name-link",
     ),
   ]


### PR DESCRIPTION
## Summary

- Tweet embeds rendered `&` as a literal `&amp;` (and would do the same for `<`/`>`). Twitter's syndication API HTML-escapes `&`, `<`, and `>` in tweet text, and snapshots store that encoded text verbatim. Rendering `&amp;` into a hast text node re-escapes the `&`, so the serialized HTML became `&#x26;amp;` and the card displayed a literal `&amp;`.
- Fix: decode HTML entities at render time, before building text nodes. This corrects every existing snapshot without re-capturing, and avoids the double-decode risk of also decoding in the Python capture path.

## Changes

- Add `decodeHtmlEntities` in `quartz/plugins/transformers/tweetCard.ts` (named `&amp;`/`&lt;`/`&gt;`/`&quot;`/`&apos;` plus numeric decimal/hex references; unknown names and out-of-range code points left intact).
- Apply it to every snapshot field rendered as visible text/attribute: the body and quoted-tweet body (via `linkifyTweetText`), the author name (shared `authorNameRow`, so both main and quoted cards), the photo `alt` text, and the t.co link display text.

## Testing

- Example-based tests in `tweetCard.test.ts` covering named/numeric/hex/uppercase-`X` entities, unknown names, zero/out-of-range code points, and a bare `&`; plus card-level assertions that the body, quoted body, author name, photo alt, and t.co display text decode and never re-form `&#x26;amp;`.
- New `tweetCard.property.test.ts` (fast-check) fuzzing the decoder: it never throws on arbitrary unicode and it exactly inverts Twitter's HTML-escaping for any input.
- 100% coverage on `tweetCard.ts`; 76 tests pass; lint, format, and typecheck clean.

## Lessons Learned

- **What**: When rendering externally-sourced text (API payloads, scraped HTML) into a hast/DOM text node, decode HTML entities first — the serializer re-escapes `&`, producing double-encoded `&amp;amp;`.
- **Where**: any transformer that injects third-party text into hast (here `tweetCard.ts`); worth a note for future embed/ingest work.
- **Why**: Twitter's syndication API HTML-escapes `&`/`<`/`>`, and storing that verbatim then rendering it double-encoded the ampersand, showing a literal `&amp;` on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDosqtgpvJSbdDvhJQH9NM)_