### PR TITLE
revert(tweets): drop embedded card font-size shrink

### DIFF
--- a/quartz/components/styles/tweet.scss
+++ b/quartz/components/styles/tweet.scss
@@ -10,9 +10,6 @@
 }
 
 .tweet-card {
-  // Embedded content reads as a quotation, not body prose, so it sits a size
-  // below the surrounding text.
-  font-size: 0.95em;
   border: 1px solid var(--midground-faint);
   border-radius: calc(2 * $border-radius);
   padding: calc(1.5 * $base-margin);


### PR DESCRIPTION
## Summary
- Follow-up to #1532: reverts the `.tweet-card { font-size: 0.95em; }` tweak ("embedded content reads as a quotation... sits a size below the surrounding text"). Embedded tweets go back to inheriting the ambient text size instead of shrinking.
- The X-icon reposition from the same PR is left in place (not flagged as a problem).

## Test plan
- [x] `stylelint`, `prettier --check` pass on the changed file.
- [x] `quartz/plugins/transformers/tests/tweetCard.test.ts` — 59 tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5sXSCT3ab9WKvCXRCvnAZ)_