### PR TITLE
Add text-image collision detection and date ordinal suffix validation

### DIFF
--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -162,6 +162,10 @@ for (const slug of ARTICLE_SLUGS) {
       !testInfo.project.name.endsWith("Chrome"),
       "collision geometry doesn't vary by rendering engine",
     )
+    // Article weight varies enormously (some embed several server-rendered
+    // Mermaid diagrams), so the default 45s budget is too tight for the
+    // heaviest pages under CI load.
+    test.slow()
     await settle(page, `/${slug}`)
     const offenders = await page.evaluate(collectTextImageCollisions, [
       TOLERANCE_PX,

--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -65,17 +65,22 @@ interface Offender {
 // enter the float's box — is never flagged, only text that is genuinely
 // rendered underneath an image.
 /* istanbul ignore next -- executed in the browser, not under Jest */
-function collectTextImageCollisions([tolerance, minImageSize]: readonly [number, number]): Offender[] {
+function collectTextImageCollisions([tolerance, minImageSize]: readonly [
+  number,
+  number,
+]): Offender[] {
   const isVisible = (el: Element): boolean => {
     const style = getComputedStyle(el)
     return style.display !== "none" && style.visibility !== "hidden"
   }
 
-  const images = Array.from(document.body.querySelectorAll<HTMLImageElement>("img")).filter((img) => {
-    if (!isVisible(img)) return false
-    const rect = img.getBoundingClientRect()
-    return rect.width >= minImageSize && rect.height >= minImageSize
-  })
+  const images = Array.from(document.body.querySelectorAll<HTMLImageElement>("img")).filter(
+    (img) => {
+      if (!isVisible(img)) return false
+      const rect = img.getBoundingClientRect()
+      return rect.width >= minImageSize && rect.height >= minImageSize
+    },
+  )
   if (images.length === 0) return []
 
   const offenders: Offender[] = []
@@ -107,8 +112,10 @@ function collectTextImageCollisions([tolerance, minImageSize]: readonly [number,
     for (const img of images) {
       const imgRect = img.getBoundingClientRect()
       for (const textRect of textRects) {
-        const overlapWidth = Math.min(textRect.right, imgRect.right) - Math.max(textRect.left, imgRect.left)
-        const overlapHeight = Math.min(textRect.bottom, imgRect.bottom) - Math.max(textRect.top, imgRect.top)
+        const overlapWidth =
+          Math.min(textRect.right, imgRect.right) - Math.max(textRect.left, imgRect.left)
+        const overlapHeight =
+          Math.min(textRect.bottom, imgRect.bottom) - Math.max(textRect.top, imgRect.top)
         if (overlapWidth > tolerance && overlapHeight > tolerance) {
           offenders.push({
             text: textNode.textContent?.trim().slice(0, 80) ?? "",

--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -137,13 +137,11 @@ function pageSettled(): boolean {
 }
 
 async function settle(page: Page, url: string) {
-  // "load" waits for every sub-resource (including any that never resolve
-  // under CI's network policy) and a few articles hang on it indefinitely —
-  // tripling the test timeout didn't help, confirming a hang, not slowness.
-  // "domcontentloaded" is sufficient here: collision geometry only needs the
-  // DOM parsed and fonts loaded, both independent of the "load" event, and
-  // images already have build-time width/height reserved so their box is
-  // stable before the bytes finish downloading.
+  // "domcontentloaded" is sufficient: collision geometry only needs the DOM
+  // parsed and fonts loaded, and images have build-time width/height
+  // attributes so their boxes are stable before the bytes finish downloading.
+  // Waiting for "load" would add every sub-resource (including third-party
+  // analytics) to a sweep that runs once per article.
   await gotoPage(page, url, "domcontentloaded")
   await page.waitForFunction(pageSettled, undefined, { timeout: 10_000 })
   await page.evaluate(
@@ -169,12 +167,6 @@ for (const slug of ARTICLE_SLUGS) {
       !testInfo.project.name.endsWith("Chrome"),
       "collision geometry doesn't vary by rendering engine",
     )
-    // Article weight varies enormously (some embed several server-rendered
-    // Mermaid diagrams, others carry a dozen-plus images), so the default
-    // 45s budget is too tight for the heaviest pages under CI load. Even
-    // test.slow()'s 3x (135s) wasn't always enough for the single largest
-    // article, so this spec gets its own generous ceiling.
-    test.setTimeout(240_000)
     await settle(page, `/${slug}`)
     const offenders = await page.evaluate(collectTextImageCollisions, [
       TOLERANCE_PX,

--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -137,7 +137,14 @@ function pageSettled(): boolean {
 }
 
 async function settle(page: Page, url: string) {
-  await gotoPage(page, url)
+  // "load" waits for every sub-resource (including any that never resolve
+  // under CI's network policy) and a few articles hang on it indefinitely —
+  // tripling the test timeout didn't help, confirming a hang, not slowness.
+  // "domcontentloaded" is sufficient here: collision geometry only needs the
+  // DOM parsed and fonts loaded, both independent of the "load" event, and
+  // images already have build-time width/height reserved so their box is
+  // stable before the bytes finish downloading.
+  await gotoPage(page, url, "domcontentloaded")
   await page.waitForFunction(pageSettled, undefined, { timeout: 10_000 })
   await page.evaluate(
     () =>

--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -1,0 +1,168 @@
+import type { Page } from "@playwright/test"
+
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import type { FrontmatterData } from "../../plugins/vfile"
+
+import { parseFrontmatter } from "../../util/frontmatter"
+import { findGitRoot } from "../../util/log"
+import { expect, test } from "./fixtures"
+import { gotoPage } from "./visual_utils"
+
+// Invariant: no content image may render on top of body text. A floated or
+// absolutely-positioned image whose surrounding text doesn't know to wrap
+// around it (e.g. because the two live in independent layout containers)
+// leaves glyphs painted underneath the image instead of beside it — the
+// bug looks fine in isolation but silently swallows a few words or a whole
+// heading. Since a well-behaved float reflows sibling text around itself,
+// genuine collisions are always a layout bug, not a false positive from
+// normal CSS floats.
+
+const CONTENT_DIR = join(findGitRoot(), "website_content")
+
+/**
+ * All published article permalinks, read straight from frontmatter. Reading
+ * the source directly (rather than a running server's content index) keeps
+ * the per-article test list available at spec-parse time, before any
+ * webServer navigation happens.
+ */
+function getAllArticleSlugs(): readonly string[] {
+  const slugs: string[] = []
+  for (const entry of readdirSync(CONTENT_DIR, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue
+    const raw = readFileSync(join(CONTENT_DIR, entry.name), "utf-8")
+    const data = parseFrontmatter(raw) as FrontmatterData
+    const permalink = data.permalink
+    if (typeof permalink !== "string" || permalink === "") continue
+    if (data.draft || data.avoidIndexing) continue
+    slugs.push(permalink)
+  }
+  return slugs.sort()
+}
+
+const ARTICLE_SLUGS = getAllArticleSlugs()
+
+// Small inline icons (favicons) intentionally use a slight negative margin
+// for baseline alignment (quartz/styles/favicon.scss) and aren't the
+// "content image obscures a paragraph" bug this test targets.
+const MIN_IMAGE_SIZE_PX = 48
+
+// A real collision hides several pixels of glyph under the image; a couple
+// of px is subpixel rounding or an intentional icon nudge, not a bug.
+const TOLERANCE_PX = 4
+
+interface Offender {
+  readonly text: string
+  readonly tag: string
+  readonly imgSrc: string
+  readonly overlapPx: number
+}
+
+// Runs in the page. Compares every large `<img>`'s box against the actual
+// painted rects of every text run (via Range.getClientRects, not element
+// bounding boxes) so normally-wrapped float text — whose line boxes never
+// enter the float's box — is never flagged, only text that is genuinely
+// rendered underneath an image.
+/* istanbul ignore next -- executed in the browser, not under Jest */
+function collectTextImageCollisions([tolerance, minImageSize]: readonly [number, number]): Offender[] {
+  const isVisible = (el: Element): boolean => {
+    const style = getComputedStyle(el)
+    return style.display !== "none" && style.visibility !== "hidden"
+  }
+
+  const images = Array.from(document.body.querySelectorAll<HTMLImageElement>("img")).filter((img) => {
+    if (!isVisible(img)) return false
+    const rect = img.getBoundingClientRect()
+    return rect.width >= minImageSize && rect.height >= minImageSize
+  })
+  if (images.length === 0) return []
+
+  const offenders: Offender[] = []
+  const range = document.createRange()
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    acceptNode(candidate) {
+      if (!candidate.textContent?.trim()) return NodeFilter.FILTER_REJECT
+      const parent = candidate.parentElement
+      if (!parent || !isVisible(parent)) return NodeFilter.FILTER_REJECT
+      // Captions render below their image by design; excluding them here
+      // (rather than by DOM position) also covers any future caption markup.
+      if (parent.closest("figcaption, script, style, noscript, template")) {
+        return NodeFilter.FILTER_REJECT
+      }
+      return NodeFilter.FILTER_ACCEPT
+    },
+  })
+
+  let node = walker.nextNode()
+  while (node) {
+    const parentEl = node.parentElement
+    const textNode = node
+    node = walker.nextNode()
+    if (!parentEl) continue
+
+    range.selectNodeContents(textNode)
+    const textRects = Array.from(range.getClientRects()).filter((r) => r.width > 0 && r.height > 0)
+
+    for (const img of images) {
+      const imgRect = img.getBoundingClientRect()
+      for (const textRect of textRects) {
+        const overlapWidth = Math.min(textRect.right, imgRect.right) - Math.max(textRect.left, imgRect.left)
+        const overlapHeight = Math.min(textRect.bottom, imgRect.bottom) - Math.max(textRect.top, imgRect.top)
+        if (overlapWidth > tolerance && overlapHeight > tolerance) {
+          offenders.push({
+            text: textNode.textContent?.trim().slice(0, 80) ?? "",
+            tag: parentEl.tagName.toLowerCase(),
+            imgSrc: img.currentSrc || img.src,
+            overlapPx: Math.round(Math.min(overlapWidth, overlapHeight)),
+          })
+          break
+        }
+      }
+    }
+  }
+  return offenders
+}
+
+/* istanbul ignore next -- executed in the browser, not under Jest */
+function pageSettled(): boolean {
+  return !document.fonts || document.fonts.status === "loaded"
+}
+
+async function settle(page: Page, url: string) {
+  await gotoPage(page, url)
+  await page.waitForFunction(pageSettled, undefined, { timeout: 10_000 })
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      ),
+  )
+}
+
+function describeOffenders(offenders: readonly Offender[]): string {
+  return offenders
+    .map((o) => `<${o.tag}> "${o.text}" is covered by ${o.imgSrc} (${o.overlapPx}px overlap)`)
+    .join("\n  ")
+}
+
+for (const slug of ARTICLE_SLUGS) {
+  test(`no text-image collisions on /${slug}`, async ({ page }, testInfo) => {
+    // Collision geometry comes from the CSS box model, not the rendering
+    // engine, so checking one engine per viewport avoids tripling the cost
+    // of this O(articles) scan across all 3 configured browsers.
+    test.skip(
+      !testInfo.project.name.endsWith("Chrome"),
+      "collision geometry doesn't vary by rendering engine",
+    )
+    await settle(page, `/${slug}`)
+    const offenders = await page.evaluate(collectTextImageCollisions, [
+      TOLERANCE_PX,
+      MIN_IMAGE_SIZE_PX,
+    ] as const)
+    expect(
+      offenders,
+      `Text hidden behind image(s) on /${slug}:\n  ${describeOffenders(offenders)}`,
+    ).toEqual([])
+  })
+}

--- a/quartz/components/tests/textImageCollision.spec.ts
+++ b/quartz/components/tests/textImageCollision.spec.ts
@@ -170,9 +170,11 @@ for (const slug of ARTICLE_SLUGS) {
       "collision geometry doesn't vary by rendering engine",
     )
     // Article weight varies enormously (some embed several server-rendered
-    // Mermaid diagrams), so the default 45s budget is too tight for the
-    // heaviest pages under CI load.
-    test.slow()
+    // Mermaid diagrams, others carry a dozen-plus images), so the default
+    // 45s budget is too tight for the heaviest pages under CI load. Even
+    // test.slow()'s 3x (135s) wasn't always enough for the single largest
+    // article, so this spec gets its own generous ceiling.
+    test.setTimeout(240_000)
     await settle(page, `/${slug}`)
     const offenders = await page.evaluate(collectTextImageCollisions, [
       TOLERANCE_PX,

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -434,7 +434,12 @@ pre {
       text-indent: calc(-5 * $base-margin);
       padding-left: calc(5 * $base-margin);
       padding-right: calc(2 * $base-margin);
-      text-wrap: pretty;
+
+      // Must stay `auto`, not `pretty`: `overflow-wrap: anywhere` makes every
+      // character a break opportunity, and `pretty`'s paragraph-level
+      // optimization over that break set is combinatorial in Chromium — long
+      // highlighted lines at mobile widths hang or crash the renderer.
+      text-wrap: auto;
       white-space: pre-wrap;
       overflow-wrap: anywhere;
       box-sizing: border-box;

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -1083,6 +1083,72 @@ def check_sentence_initial_numerals(text: str) -> list[str]:
     return errors
 
 
+_DATE_MONTH_NAMES = (
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sept",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+# Month name (optionally abbreviated with a trailing period), a 1-2 digit day
+# with an optional ordinal suffix, and a 4-digit year. The suffix is captured
+# so callers can tell "26" from "26th" instead of just matching the date.
+_DATE_WITHOUT_ORDINAL_RE = re.compile(
+    r"\b(?:" + "|".join(_DATE_MONTH_NAMES) + r")\.?\s+"
+    r"\d{1,2}(st|nd|rd|th)?,?\s+\d{4}\b"
+)
+
+# Blockquotes, headings, tables, raw HTML, and standalone images either quote
+# an external source verbatim or render structured/non-prose data, so their
+# dates are left as written.
+_DATE_NON_PROSE_PREFIXES = (">", "#", "|", "<", "![")
+
+
+def check_dates_missing_ordinal_suffix(text: str) -> list[str]:
+    """
+    Flag written-out dates ("Month Day, Year") whose day lacks an ordinal suffix
+    ("st"/"nd"/"rd"/"th").
+
+    The site's date convention spells the day ordinally ("January 26th, 2026"),
+    so a bare cardinal day ("January 26, 2026") is a formatting bug.
+    """
+    stripped_text = remove_math(remove_code(text))
+    errors = []
+    for line_num, line in enumerate(stripped_text.split("\n"), 1):
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith(
+            _DATE_NON_PROSE_PREFIXES
+        ):
+            continue
+        for match in _DATE_WITHOUT_ORDINAL_RE.finditer(line):
+            if match.group(1) is None:
+                errors.append(
+                    f"Date missing ordinal suffix at line {line_num}: "
+                    f"{match.group().strip()}"
+                )
+    return errors
+
+
 def check_file_data(
     metadata: dict,
     existing_urls: PathMap,
@@ -1126,6 +1192,9 @@ def check_file_data(
         "footnote_references": check_footnote_references(text),
         "self_closing_non_void": check_self_closing_non_void_elements(text),
         "sentence_initial_numerals": check_sentence_initial_numerals(text),
+        "dates_missing_ordinal_suffix": check_dates_missing_ordinal_suffix(
+            text
+        ),
         "invalid_filename": (
             check_spaces_in_path(file_path)
             + check_filename_lowercase(file_path)

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -2822,3 +2822,68 @@ def test_check_sentence_initial_numerals(text: str, expected_errors: list[str]):
     """Test the check_sentence_initial_numerals function."""
     errors = source_file_checks.check_sentence_initial_numerals(text)
     assert errors == expected_errors
+
+
+@pytest.mark.parametrize(
+    "text, expected_errors",
+    [
+        # Bare cardinal day is flagged
+        (
+            "It happened on January 26, 2026.",
+            ["Date missing ordinal suffix at line 1: January 26, 2026"],
+        ),
+        # Already-ordinal day is fine
+        ("It happened on January 26th, 2026.", []),
+        ("The deal closed on May 1st, 2020.", []),
+        ("She was born on June 2nd, 1990.", []),
+        ("He arrived on March 3rd, 2001.", []),
+        # Abbreviated month, with or without a trailing period
+        (
+            "As of Feb. 19, 2025, the plan changed.",
+            ["Date missing ordinal suffix at line 1: Feb. 19, 2025"],
+        ),
+        ("As of Feb. 19th, 2025, the plan changed.", []),
+        (
+            "As of Sept 3, 2019, it was over.",
+            ["Date missing ordinal suffix at line 1: Sept 3, 2019"],
+        ),
+        # No day-of-month present, just month + year: not a flagged pattern
+        ("Written in October 2024.", []),
+        ("Spring 2018 through June 2022.", []),
+        # Month + day with no year is not flagged (no comma+year to anchor it)
+        ("Meet me May 5 sometime.", []),
+        # Blockquotes are verbatim quotations
+        ("> Edited on August 29, 2022", []),
+        (">> Edited on August 29, 2022", []),
+        # Headings, tables, and images are non-prose contexts
+        ("# November 9, 2024", []),
+        ("| November 9, 2024 | column |", []),
+        ("![Taken November 9, 2024](/img.png)", []),
+        # Raw HTML lines (e.g. component demo fixtures) are excluded
+        ('<p class="subtitle">November 4, 2008</p>', []),
+        # Code and math are stripped before checking
+        ("`January 26, 2026`", []),
+        ("$January 26, 2026$", []),
+        # Two dates on one line both get flagged
+        (
+            "From January 1, 2020 to January 2, 2020.",
+            [
+                "Date missing ordinal suffix at line 1: January 1, 2020",
+                "Date missing ordinal suffix at line 1: January 2, 2020",
+            ],
+        ),
+        # Line number tracking across multiple lines
+        (
+            "Just prose.\nIt happened on January 26, 2026.",
+            ["Date missing ordinal suffix at line 2: January 26, 2026"],
+        ),
+        # Empty input
+        ("", []),
+    ],
+)
+def test_check_dates_missing_ordinal_suffix(
+    text: str, expected_errors: list[str]
+):
+    """Test the check_dates_missing_ordinal_suffix function."""
+    errors = source_file_checks.check_dates_missing_ordinal_suffix(text)
+    assert errors == expected_errors

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -215,7 +215,7 @@ Eventually, the ultimate solution will be [progressive font enrichment](https://
 
 Among lossy compression formats, there are two kings: AVIF and WEBP. Under my tests, they achieved similar (amazing) compression ratios of about 10x over PNG. I chose AVIF. The upshot is that _images are nearly costless in terms of responsiveness_, which is liberating.
 
-To demonstrate this liberty, I perform a statistical analysis of the 941 AVIF files hosted on my CDN as of November 9, 2024.[^colab] I downloaded each AVIF file and used `magick` to convert it back to a PNG, measuring the size before and after.
+To demonstrate this liberty, I perform a statistical analysis of the 941 AVIF files hosted on my CDN as of November 9th, 2024.[^colab] I downloaded each AVIF file and used `magick` to convert it back to a PNG, measuring the size before and after.
 
 <img alt="Compression ratios: (PNG size) / (AVIF size). A left-skew histogram with tails reaching out to 75x." src="https://assets.turntrout.com/static/images/posts/compression_ratio.svg" class="compression-ratio-graph"/>
 

--- a/website_content/mistakes.md
+++ b/website_content/mistakes.md
@@ -22,14 +22,14 @@ Inspired by Scott Alexander's [Mistakes](https://www.astralcodexten.com/p/mistak
 
 # Not realizing that reward is not the optimization target
 
-Subtitle: July 25, 2022
+Subtitle: July 25th, 2022
 I spent thousands of hours proving theorems about the "tendencies" of "reinforcement learning" agents which are either [optimal](https://arxiv.org/abs/1912.01683) or [trained using a "good enough" learning algorithm](/parametrically-retargetable-power-seeking). (I'm using scare quotes to mark undue connotations.) I later realized that [reward is not the optimization target](/reward-is-not-the-optimization-target). I learned that even though ["reward" is a pleasant word](/dangers-of-suggestive-terminology), it's _definitely not a slam dunk that RL-trained policies will seek to optimize that quantity._ Reward often simply provides a per-datapoint learning rate multiplier - nothing spooky or fundamentally doomed.
 
 While the realization may seem simple or obvious, it opened up a crack in my alignment worldview.
 
 # Mispredicting the 2024 US presidential election
 
-Subtitle: November 5, 2024
+Subtitle: November 5th, 2024
 
 <iframe title="Prediction: Who Will Win The 2024 Presidential Election?" src="https://fatebook.io/embed/q/kamala-wins--cm34x28gv00004svvk2d1zvaz?compact=true&requireSignIn=false" width="450" height="200"></iframe>
 
@@ -45,7 +45,7 @@ To do better, I should have anchored more strongly to base rates via current pol
 
 # Wrongly expecting steering vectors to improve the general truthfulness of models
 
-Subtitle: January 30, 2025
+Subtitle: January 30th, 2025
 
 In 2023, [I (re?)discovered _steering vectors_](/research#steering-vectors): activation vectors which steer AI outputs to be e.g. more or less friendly ("Look Ma, no prompts!"). The way I saw it, model behavior was determined by two main factors: the abilities and "conversational modes" the model has learned ("[shards](/research#shard-theory)") and which shards are activated by the current situation.[^steering] Clearly - I thought - the model's "truthful mode" isn't always strongly activated. Clearly - I thought - one could more strongly activate that mode, possibly with a "be truthful" steering vector.
 

--- a/website_content/review-of-debate-on-instrumental-convergence-between-lecun.md
+++ b/website_content/review-of-debate-on-instrumental-convergence-between-lecun.md
@@ -40,7 +40,7 @@ Somehow.
 
 I needed to find the right definitions first, and I couldn't even _imagine_ what the [final theorems](https://arxiv.org/abs/1912.01683v6) would say. The fall crept up on me... and found my work incomplete.
 
-Let me tell you: if there's ever been a time when I wished I'd been months ahead on my research agenda, it was September 26, 2019: the day when world-famous AI experts [debated](https://www.facebook.com/story.php?story_fbid=10156248637927143&id=722677142) whether instrumental convergence was a thing, and whether we should worry about it.
+Let me tell you: if there's ever been a time when I wished I'd been months ahead on my research agenda, it was September 26th, 2019: the day when world-famous AI experts [debated](https://www.facebook.com/story.php?story_fbid=10156248637927143&id=722677142) whether instrumental convergence was a thing, and whether we should worry about it.
 
 The debate unfolded below the link-preview: an imposing robot staring the reader down, a title containing 'Terminator', a byline dismissive of AI risk:
 

--- a/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
+++ b/website_content/swimming-upstream-a-case-study-in-instrumental-rationality.md
@@ -182,4 +182,4 @@ I sacrificed some of my tethering to the [social web](https://www.lesswrong.com/
 
 [^6]: Objectives are subject to change.
 
-[^edit]: As of Feb. 19, 2025, I think that AI risk _was_ on the fringe in 2018. The FLI AI principles argument wasn't a good one.
+[^edit]: As of Feb. 19th, 2025, I think that AI risk _was_ on the fringe in 2018. The FLI AI principles argument wasn't a good one.


### PR DESCRIPTION
## Summary

This PR adds two new quality checks — and the first one immediately caught a real, user-facing renderer bug that is also fixed here.

1. **Visual regression test for text-image collisions**: A Playwright spec that scans all published articles for cases where images render on top of body text, indicating a layout bug where text isn't properly reflowing around floated/positioned images.

2. **Date formatting validation**: A Python linter that flags written-out dates ("Month Day, Year") missing ordinal suffixes ("st"/"nd"/"rd"/"th"), enforcing the site's convention of spelling days ordinally (e.g., "January 26th, 2026").

3. **Renderer hang/crash fix (found by check #1)**: `text-wrap: pretty` on Shiki-highlighted code lines (`[data-line]`) combined with `overflow-wrap: anywhere` makes every character a break opportunity, and Chromium's paragraph-level `pretty` optimization over that break set is combinatorial. On articles with long highlighted lines (e.g. a BibTeX citation block's nine-author line) at mobile widths (~390px), the renderer main thread wedges or OOM-crashes — `DOMContentLoaded` never fires and the page never finishes loading, in CI *or for a real Android Chrome reader*. Fixed by using greedy wrapping (`text-wrap: auto`) for code lines.

## Key Changes

- **`quartz/components/tests/textImageCollision.spec.ts`** (new)
  - Dynamically generates one test per published article by reading frontmatter from source files
  - Runs collision detection in-browser using `Range.getClientRects()` to compare actual painted text rects against image bounding boxes, so normally-wrapped float text is never a false positive
  - Excludes captions, hidden elements, and sub-48px icons; 4px tolerance for subpixel rounding
  - Runs on Chrome only (collision geometry is CSS-box-model-driven, not engine-specific), all three viewports
  - Navigates with `domcontentloaded` — geometry needs only the parsed DOM and fonts, since images carry build-time width/height attributes

- **`quartz/styles/base.scss`**: `text-wrap: pretty` → `text-wrap: auto` on `& > [data-line]`, with a comment stating the constraint.

- **`scripts/source_file_checks.py`**: new `check_dates_missing_ordinal_suffix()` wired into `check_file_data()`; excludes blockquotes, headings, tables, raw HTML, and images; strips code and math first.

- **`scripts/tests/test_source_file_checks.py`**: parametrized suite covering ordinal/cardinal days, abbreviated months, month+year-only, blockquote/table/HTML exclusion, multi-date lines, and line numbers.

- **Content fixes** (`website_content/*.md`): six dates updated to ordinal form ("July 25th, 2022").

## Root-cause investigation (CI timeouts)

Three articles timed out on `page.goto` in every CI run, surviving both a 3× timeout bump and a switch to `domcontentloaded` — proving a hang, not slowness. The Playwright trace showed the static server answering every request in ≤5ms while the browser recorded them as forever-pending, with only main-thread-dependent resources (scripts, media) affected. Local bisection with the built pages reproduced a renderer crash at 390px viewport in 250ms, isolated it to the citation code figure, and finally to the `text-wrap: pretty` rule; with the fix the same pages fully load in under a second. The diagnostic timeout compensations were reverted so a regression fails loudly.

## Lessons learned

- **`text-wrap: pretty` and `overflow-wrap: anywhere` must not be combined on content with long unbreakable runs** (code, URLs, data). `anywhere` turns every character into a break opportunity and `pretty`'s optimizing line-breaker is superlinear in break opportunities in Chromium — at narrow viewports this hangs or crashes the renderer outright. Prose (with spaces) is fine; code lines are the pathological case.
- **A `page.goto` timeout that survives a 3× budget increase is a hang, not slowness — stop widening timeouts and pull the trace.** The `trace.network` file names each request's fate: server-answered-but-never-completed pointed away from the network and at the renderer, which redirected the whole investigation.
- **When a page wedges only in CI, re-run the built page locally at the failing viewport with element-bisection via injected `display:none` CSS** (halves → figures → single figure → single CSS property). It converges in minutes and produces a one-line fix instead of an environment workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXhGfRBDwT64VoSdDdZ5WZ