### PR TITLE
feat(checks): require captions for linked CDN videos

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -55,6 +55,15 @@ Three stages: **Transform → Filter → Emit**.
   are skipped. `built_site_checks.check_video_caption_tracks` then enforces
   that every audio-bearing `<video>` ships a real `.vtt` track (or an explicit
   `label="No audio"` marker).
+- **Linked (not embedded) videos**: `built_site_checks.check_linked_video_captions`
+  covers videos referenced by a bare `<a href>` on the asset CDN, which bypass
+  the embedded-`<video>` check. A link to a `.mp4`/`.mov`/`.m4v` on
+  `assets.turntrout.com` must have its sibling `.vtt` referenced somewhere on
+  the same page (same base path). Silent links opt out with a `#no-audio`
+  fragment (`…/foo.mp4#no-audio`), the link-side analog of `label="No audio"`.
+  `.webm`/`.gif` links are exempt. The check can't probe the remote file for
+  audio, so the `#no-audio` marker is how a genuinely silent linked video
+  declares itself.
 
 ### Text processing
 

--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -58,12 +58,13 @@ Three stages: **Transform → Filter → Emit**.
 - **Linked (not embedded) videos**: `built_site_checks.check_linked_video_captions`
   covers videos referenced by a bare `<a href>` on the asset CDN, which bypass
   the embedded-`<video>` check. A link to a `.mp4`/`.mov`/`.m4v` on
-  `assets.turntrout.com` must have its sibling `.vtt` referenced somewhere on
-  the same page (same base path). Silent links opt out with a `#no-audio`
-  fragment (`…/foo.mp4#no-audio`), the link-side analog of `label="No audio"`.
-  `.webm`/`.gif` links are exempt. The check can't probe the remote file for
-  audio, so the `#no-audio` marker is how a genuinely silent linked video
-  declares itself.
+  `assets.turntrout.com` passes if the same page references the sibling `.vtt`
+  (same base path), or failing that, if a HEAD probe finds the sibling `.vtt`
+  on the CDN (the transcription pipeline uploads it next to the video; probes
+  use the shared retrying session and are cached per URL). Silent links opt
+  out with a `#no-audio` fragment (`…/foo.mp4#no-audio`), the link-side analog
+  of `label="No audio"` — the check can't detect audio in the remote file.
+  `.webm`/`.gif` links are exempt.
 
 ### Text processing
 

--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -56,15 +56,10 @@ Three stages: **Transform → Filter → Emit**.
   that every audio-bearing `<video>` ships a real `.vtt` track (or an explicit
   `label="No audio"` marker).
 - **Linked (not embedded) videos**: `built_site_checks.check_linked_video_captions`
-  covers videos referenced by a bare `<a href>` on the asset CDN, which bypass
-  the embedded-`<video>` check. A link to a `.mp4`/`.mov`/`.m4v` on
-  `assets.turntrout.com` passes if the same page references the sibling `.vtt`
-  (same base path), or failing that, if a HEAD probe finds the sibling `.vtt`
-  on the CDN (the transcription pipeline uploads it next to the video; probes
-  use the shared retrying session and are cached per URL). Silent links opt
-  out with a `#no-audio` fragment (`…/foo.mp4#no-audio`), the link-side analog
-  of `label="No audio"` — the check can't detect audio in the remote file.
-  `.webm`/`.gif` links are exempt.
+  requires a captions companion for `<a href>` links to `.mp4`/`.mov`/`.m4v` on
+  the asset CDN — satisfied by an on-page sibling-`.vtt` reference, a HEAD probe
+  finding the `.vtt` on the CDN, or a `#no-audio` opt-out fragment. See the
+  function docstring for the full semantics.
 
 ### Text processing
 

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -3,6 +3,7 @@
 
 import argparse
 import copy
+import functools
 import html
 import json
 import mimetypes
@@ -3063,16 +3064,35 @@ def _page_references_cdn_vtt(soup: BeautifulSoup, base_path: str) -> bool:
     return False
 
 
+@functools.cache
+def _cdn_vtt_probe_issue(vtt_url: str) -> str | None:
+    """
+    ``None`` if a HEAD request finds the ``.vtt`` on the CDN, else the reason.
+
+    Cached per URL: the checker runs over every built page, and a video linked
+    from several pages needs only one probe.
+    """
+    try:
+        response = _head_with_retry(vtt_url)
+    except requests.RequestException as exc:
+        return f"HEAD {vtt_url} failed: {exc}"
+    if response.ok:
+        return None
+    return f"HEAD {vtt_url} returned status {response.status_code}"
+
+
 def check_linked_video_captions(soup: BeautifulSoup) -> list[str]:
     """
-    Every linked audio-container video on the asset CDN must reference captions.
+    Every linked audio-container video on the asset CDN must have captions.
 
     A bare ``<a href="…/foo.mp4">`` bypasses the embedded-``<video>`` caption
-    check, so this requires the page to also reference the sibling
-    ``…/foo.vtt``. Only ``.mp4``/``.mov``/``.m4v`` links are checked (formats
-    that routinely carry speech); ``.webm``/``.gif`` links are exempt. A silent
-    link opts out with a ``#no-audio`` fragment, the link-side analog of the
-    ``label="No audio"`` marker on embedded videos.
+    check. The link passes if the page references the sibling ``…/foo.vtt``,
+    or (checked via HEAD probe) the sibling ``.vtt`` exists on the CDN — the
+    transcription pipeline uploads it next to the video. Only
+    ``.mp4``/``.mov``/``.m4v`` links are checked (formats that routinely carry
+    speech); ``.webm``/``.gif`` links are exempt. A silent link opts out with
+    a ``#no-audio`` fragment, the link-side analog of the ``label="No audio"``
+    marker on embedded videos.
     """
     issues: list[str] = []
     for anchor in _tags_only(soup.find_all("a", href=True)):
@@ -3087,10 +3107,14 @@ def check_linked_video_captions(soup: BeautifulSoup) -> list[str]:
             continue
         if urlparse(href).fragment == _NO_AUDIO_LINK_MARKER:
             continue
-        if not _page_references_cdn_vtt(soup, base_path):
+        if _page_references_cdn_vtt(soup, base_path):
+            continue
+        vtt_url = f"{script_utils.CDN_BASE_URL}{base_path}.vtt"
+        probe_issue = _cdn_vtt_probe_issue(vtt_url)
+        if probe_issue is not None:
             issues.append(
-                f"Linked video {href} has no captions companion "
-                f"(sibling .vtt referenced on the page) or "
+                f"Linked video {href} has no captions companion: "
+                f"{probe_issue}; no on-page .vtt reference or "
                 f"'#{_NO_AUDIO_LINK_MARKER}' marker"
             )
     return issues

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -2258,6 +2258,7 @@ def check_file_for_issues(
             soup
         ),
         "video_missing_captions": check_video_caption_tracks(soup),
+        "linked_video_missing_captions": check_linked_video_captions(soup),
         "inline_style_variables": check_inline_style_variables(
             soup, opts.defined_css_variables
         ),
@@ -3023,6 +3024,75 @@ def check_video_caption_tracks(soup: BeautifulSoup) -> list[str]:
         issue = _video_caption_issue(video)
         if issue is not None:
             issues.append(issue)
+    return issues
+
+
+# Linked (as opposed to embedded) videos in these container formats routinely
+# carry a speech track, so they need captions. ``.webm``/``.gif`` links are
+# exempt (see check_linked_video_captions).
+_CAPTIONABLE_LINKED_VIDEO_EXTS: frozenset[str] = frozenset(
+    {".mp4", ".mov", ".m4v"}
+)
+
+# Fragment on a linked video's href that opts it out of the captions
+# requirement, mirroring the ``label="No audio"`` marker on embedded <video>.
+_NO_AUDIO_LINK_MARKER = "no-audio"
+
+
+def _cdn_asset_base(url: str) -> tuple[str, str] | None:
+    """
+    For a URL pointing at the asset CDN, return ``(path_without_ext, ext)`` with
+    the query and fragment stripped and the extension lowercased.
+
+    Returns
+    ``None`` for URLs hosted anywhere else.
+    """
+    parsed = urlparse(url)
+    if parsed.hostname != script_utils.CDN_HOSTNAME:
+        return None
+    base, ext = os.path.splitext(parsed.path)
+    return (base, ext.lower())
+
+
+def _page_references_cdn_vtt(soup: BeautifulSoup, base_path: str) -> bool:
+    """True iff the page references ``<base_path>.vtt`` on the asset CDN."""
+    for tag in _tags_only(soup.find_all(["a", "track", "source"])):
+        ref = tag.get("href") or tag.get("src")
+        if isinstance(ref, str) and _cdn_asset_base(ref) == (base_path, ".vtt"):
+            return True
+    return False
+
+
+def check_linked_video_captions(soup: BeautifulSoup) -> list[str]:
+    """
+    Every linked audio-container video on the asset CDN must reference captions.
+
+    A bare ``<a href="…/foo.mp4">`` bypasses the embedded-``<video>`` caption
+    check, so this requires the page to also reference the sibling
+    ``…/foo.vtt``. Only ``.mp4``/``.mov``/``.m4v`` links are checked (formats
+    that routinely carry speech); ``.webm``/``.gif`` links are exempt. A silent
+    link opts out with a ``#no-audio`` fragment, the link-side analog of the
+    ``label="No audio"`` marker on embedded videos.
+    """
+    issues: list[str] = []
+    for anchor in _tags_only(soup.find_all("a", href=True)):
+        href = anchor.get("href")
+        if not isinstance(href, str):
+            continue
+        parsed = _cdn_asset_base(href)
+        if parsed is None or parsed[0] == "":
+            continue
+        base_path, ext = parsed
+        if ext not in _CAPTIONABLE_LINKED_VIDEO_EXTS:
+            continue
+        if urlparse(href).fragment == _NO_AUDIO_LINK_MARKER:
+            continue
+        if not _page_references_cdn_vtt(soup, base_path):
+            issues.append(
+                f"Linked video {href} has no captions companion "
+                f"(sibling .vtt referenced on the page) or "
+                f"'#{_NO_AUDIO_LINK_MARKER}' marker"
+            )
     return issues
 
 

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -3028,9 +3028,7 @@ def check_video_caption_tracks(soup: BeautifulSoup) -> list[str]:
     return issues
 
 
-# Linked (as opposed to embedded) videos in these container formats routinely
-# carry a speech track, so they need captions. ``.webm``/``.gif`` links are
-# exempt (see check_linked_video_captions).
+# Linked-video container formats that routinely carry speech.
 _CAPTIONABLE_LINKED_VIDEO_EXTS: frozenset[str] = frozenset(
     {".mp4", ".mov", ".m4v"}
 )
@@ -3040,28 +3038,19 @@ _CAPTIONABLE_LINKED_VIDEO_EXTS: frozenset[str] = frozenset(
 _NO_AUDIO_LINK_MARKER = "no-audio"
 
 
-def _cdn_asset_base(url: str) -> tuple[str, str] | None:
+def _cdn_asset_base(url: str) -> tuple[str, str, str] | None:
     """
-    For a URL pointing at the asset CDN, return ``(path_without_ext, ext)`` with
-    the query and fragment stripped and the extension lowercased.
+    Split an asset-CDN URL into ``(path_without_ext, ext, fragment)``, with the
+    query dropped and the extension lowercased.
 
-    Returns
-    ``None`` for URLs hosted anywhere else.
+    ``None`` for URLs hosted
+    anywhere else.
     """
     parsed = urlparse(url)
     if parsed.hostname != script_utils.CDN_HOSTNAME:
         return None
     base, ext = os.path.splitext(parsed.path)
-    return (base, ext.lower())
-
-
-def _page_references_cdn_vtt(soup: BeautifulSoup, base_path: str) -> bool:
-    """True iff the page references ``<base_path>.vtt`` on the asset CDN."""
-    for tag in _tags_only(soup.find_all(["a", "track", "source"])):
-        ref = tag.get("href") or tag.get("src")
-        if isinstance(ref, str) and _cdn_asset_base(ref) == (base_path, ".vtt"):
-            return True
-    return False
+    return (base, ext.lower(), parsed.fragment)
 
 
 @functools.cache
@@ -3069,8 +3058,9 @@ def _cdn_vtt_probe_issue(vtt_url: str) -> str | None:
     """
     ``None`` if a HEAD request finds the ``.vtt`` on the CDN, else the reason.
 
-    Cached per URL: the checker runs over every built page, and a video linked
-    from several pages needs only one probe.
+    Results — failures included — are cached per URL: the checker runs over
+    every built page, and each unreferenced video gets exactly one probe per
+    run.
     """
     try:
         response = _head_with_retry(vtt_url)
@@ -3079,6 +3069,19 @@ def _cdn_vtt_probe_issue(vtt_url: str) -> str | None:
     if response.ok:
         return None
     return f"HEAD {vtt_url} returned status {response.status_code}"
+
+
+def _referenced_cdn_vtt_bases(soup: BeautifulSoup) -> set[str]:
+    """Base paths of every ``.vtt`` on the asset CDN referenced by the page."""
+    bases: set[str] = set()
+    for tag in _tags_only(soup.find_all(["a", "track", "source"])):
+        ref = tag.get("href") or tag.get("src")
+        if not isinstance(ref, str):
+            continue
+        parsed = _cdn_asset_base(ref)
+        if parsed is not None and parsed[1] == ".vtt":
+            bases.add(parsed[0])
+    return bases
 
 
 def check_linked_video_captions(soup: BeautifulSoup) -> list[str]:
@@ -3094,20 +3097,22 @@ def check_linked_video_captions(soup: BeautifulSoup) -> list[str]:
     a ``#no-audio`` fragment, the link-side analog of the ``label="No audio"``
     marker on embedded videos.
     """
+    referenced_vtt_bases = _referenced_cdn_vtt_bases(soup)
+
     issues: list[str] = []
     for anchor in _tags_only(soup.find_all("a", href=True)):
         href = anchor.get("href")
-        if not isinstance(href, str):
+        if not isinstance(href, str):  # pragma: no cover  # a simple typeguard
             continue
         parsed = _cdn_asset_base(href)
-        if parsed is None or parsed[0] == "":
+        if parsed is None:
             continue
-        base_path, ext = parsed
+        base_path, ext, fragment = parsed
         if ext not in _CAPTIONABLE_LINKED_VIDEO_EXTS:
             continue
-        if urlparse(href).fragment == _NO_AUDIO_LINK_MARKER:
+        if fragment == _NO_AUDIO_LINK_MARKER:
             continue
-        if _page_references_cdn_vtt(soup, base_path):
+        if base_path in referenced_vtt_bases:
             continue
         vtt_url = f"{script_utils.CDN_BASE_URL}{base_path}.vtt"
         probe_issue = _cdn_vtt_probe_issue(vtt_url)

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -3043,8 +3043,7 @@ def _cdn_asset_base(url: str) -> tuple[str, str, str] | None:
     Split an asset-CDN URL into ``(path_without_ext, ext, fragment)``, with the
     query dropped and the extension lowercased.
 
-    ``None`` for URLs hosted
-    anywhere else.
+    Returns ``None`` for URLs hosted anywhere else.
     """
     parsed = urlparse(url)
     if parsed.hostname != script_utils.CDN_HOSTNAME:

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5153,25 +5153,31 @@ def test_check_video_accessibility_reports_offending_tag():
 _CDN = "https://assets.turntrout.com/static/images/posts"
 
 
-def _linked_caption_issue(href: str) -> str:
+def _linked_caption_issue(href: str, probe_detail: str) -> str:
     return (
-        f"Linked video {href} has no captions companion "
-        f"(sibling .vtt referenced on the page) or '#no-audio' marker"
+        f"Linked video {href} has no captions companion: {probe_detail}; "
+        f"no on-page .vtt reference or '#no-audio' marker"
     )
 
 
+def _vtt_404(stem: str) -> str:
+    return f"HEAD {_CDN}/{stem}.vtt returned status 404"
+
+
 @pytest.mark.parametrize(
-    "html, expected_issues",
+    "html, mock_responses, expected_issues",
     [
-        # Linked .mp4 with the sibling .vtt linked on the page -> ok.
+        # Linked .mp4 with the sibling .vtt linked on the page -> ok, no probe.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a>'
             f'<a href="{_CDN}/talk.vtt">captions</a>',
+            [],
             [],
         ),
         # Companion satisfied by a <track src> reference to the sibling .vtt.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a><track src="{_CDN}/talk.vtt">',
+            [],
             [],
         ),
         # Cache-busting query strings on both ends still match on base path.
@@ -5179,50 +5185,101 @@ def _linked_caption_issue(href: str) -> str:
             f'<a href="{_CDN}/talk.mp4?v=2">clip</a>'
             f'<a href="{_CDN}/talk.vtt?v=9">captions</a>',
             [],
+            [],
         ),
-        # Linked .mp4 with no captions anywhere -> issue.
+        # No on-page reference, but the sibling .vtt exists on the CDN -> ok.
+        (f'<a href="{_CDN}/talk.mp4">clip</a>', [(True, 200)], []),
+        # No on-page reference and the CDN probe 404s -> issue.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a>',
-            [_linked_caption_issue(f"{_CDN}/talk.mp4")],
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/talk.mp4", _vtt_404("talk"))],
+        ),
+        # The probe raising a network error is reported, not swallowed.
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a>',
+            [requests.RequestException("boom")],
+            [
+                _linked_caption_issue(
+                    f"{_CDN}/talk.mp4",
+                    f"HEAD {_CDN}/talk.vtt failed: boom",
+                )
+            ],
         ),
         # .mov and .m4v are captionable containers too.
         (
             f'<a href="{_CDN}/clip.mov">m</a>',
-            [_linked_caption_issue(f"{_CDN}/clip.mov")],
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/clip.mov", _vtt_404("clip"))],
         ),
         (
             f'<a href="{_CDN}/clip.m4v">m</a>',
-            [_linked_caption_issue(f"{_CDN}/clip.m4v")],
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/clip.m4v", _vtt_404("clip"))],
         ),
-        # #no-audio fragment opts a silent link out.
-        (f'<a href="{_CDN}/silent.mp4#no-audio">s</a>', []),
-        # .webm / .gif links are exempt regardless of captions.
-        (f'<a href="{_CDN}/anim.webm">w</a>', []),
-        (f'<a href="{_CDN}/anim.gif">g</a>', []),
-        # A .mp4 on another host is out of scope.
-        ('<a href="https://youtube.com/watch.mp4">yt</a>', []),
-        # A sibling .vtt at a different base path does not count.
+        # #no-audio fragment opts a silent link out; no probe.
+        (f'<a href="{_CDN}/silent.mp4#no-audio">s</a>', [], []),
+        # .webm / .gif links are exempt regardless of captions; no probe.
+        (f'<a href="{_CDN}/anim.webm">w</a>', [], []),
+        (f'<a href="{_CDN}/anim.gif">g</a>', [], []),
+        # A .mp4 on another host is out of scope; no probe.
+        ('<a href="https://youtube.com/watch.mp4">yt</a>', [], []),
+        # A sibling .vtt at a different base path does not count on-page,
+        # so the CDN probe decides.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a>'
             f'<a href="{_CDN}/other.vtt">captions</a>',
-            [_linked_caption_issue(f"{_CDN}/talk.mp4")],
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/talk.mp4", _vtt_404("talk"))],
         ),
         # Embedded <video> sources are not anchors -> ignored by this check.
-        (f'<video controls><source src="{_CDN}/talk.mp4"></video>', []),
-        # Each offending link is reported independently.
+        (f'<video controls><source src="{_CDN}/talk.mp4"></video>', [], []),
+        # Each offending link is reported independently; satisfied links
+        # don't probe.
         (
             f'<a href="{_CDN}/a.mp4">a</a>'
             f'<a href="{_CDN}/b.mp4">b</a>'
             f'<a href="{_CDN}/b.vtt">b captions</a>',
-            [_linked_caption_issue(f"{_CDN}/a.mp4")],
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/a.mp4", _vtt_404("a"))],
+        ),
+        # The same video linked twice probes once (cached) and is reported
+        # once per anchor.
+        (
+            f'<a href="{_CDN}/dup.mp4">one</a><a href="{_CDN}/dup.mp4">two</a>',
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/dup.mp4", _vtt_404("dup"))] * 2,
         ),
     ],
 )
-def test_check_linked_video_captions(html: str, expected_issues: list[str]):
-    """Linked audio-container videos on the CDN must reference captions."""
+def test_check_linked_video_captions(
+    monkeypatch,
+    html: str,
+    mock_responses: list,
+    expected_issues: list[str],
+):
+    """Linked audio-container videos on the CDN must have captions."""
+    built_site_checks._cdn_vtt_probe_issue.cache_clear()
     soup = BeautifulSoup(html, "html.parser")
+
+    remaining = list(mock_responses)
+
+    def mock_head(url: str, timeout: int) -> object:
+        if not remaining:
+            raise AssertionError(f"Unexpected HEAD probe: {url}")
+        response = remaining.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        ok, status_code = response
+        return type("MockResponse", (), {"ok": ok, "status_code": status_code})
+
+    monkeypatch.setattr(built_site_checks._http_session, "head", mock_head)
+
     result = built_site_checks.check_linked_video_captions(soup)
     assert sorted(result) == sorted(expected_issues)
+    # Every scripted response must be consumed: leftovers mean the check
+    # probed fewer URLs than the scenario expects.
+    assert not remaining
 
 
 @pytest.mark.parametrize(

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5250,6 +5250,31 @@ def _vtt_404(stem: str) -> str:
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/dup.mp4", _vtt_404("dup"))] * 2,
         ),
+        # Uppercase extensions match; the probe preserves the base's case.
+        # The href-less anchor exercises the reference scan's typeguard.
+        (
+            f'<a>plain</a><a href="{_CDN}/TALK.MP4">c</a>',
+            [(False, 404)],
+            [_linked_caption_issue(f"{_CDN}/TALK.MP4", _vtt_404("TALK"))],
+        ),
+        # Protocol-relative CDN URLs are in scope.
+        (
+            '<a href="//assets.turntrout.com/static/talk.mp4">c</a>',
+            [(True, 200)],
+            [],
+        ),
+        # Only the exact #no-audio fragment opts out.
+        (
+            f'<a href="{_CDN}/talk.mp4#no-audio-please">c</a>',
+            [(False, 404)],
+            [
+                _linked_caption_issue(
+                    f"{_CDN}/talk.mp4#no-audio-please", _vtt_404("talk")
+                )
+            ],
+        ),
+        # The opt-out fragment combines with a query string.
+        (f'<a href="{_CDN}/talk.mp4?v=2#no-audio">c</a>', [], []),
     ],
 )
 def test_check_linked_video_captions(
@@ -5259,6 +5284,8 @@ def test_check_linked_video_captions(
     expected_issues: list[str],
 ):
     """Linked audio-container videos on the CDN must have captions."""
+    # Clear at both ends: mocked probe results cached under real CDN URLs
+    # must not leak into neighboring tests.
     built_site_checks._cdn_vtt_probe_issue.cache_clear()
     soup = BeautifulSoup(html, "html.parser")
 
@@ -5275,8 +5302,11 @@ def test_check_linked_video_captions(
 
     monkeypatch.setattr(built_site_checks._http_session, "head", mock_head)
 
-    result = built_site_checks.check_linked_video_captions(soup)
-    assert sorted(result) == sorted(expected_issues)
+    try:
+        result = built_site_checks.check_linked_video_captions(soup)
+    finally:
+        built_site_checks._cdn_vtt_probe_issue.cache_clear()
+    assert result == expected_issues
     # Every scripted response must be consumed: leftovers mean the check
     # probed fewer URLs than the scenario expects.
     assert not remaining

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5165,7 +5165,7 @@ def _vtt_404(stem: str) -> str:
 
 
 @pytest.mark.parametrize(
-    "html, mock_responses, expected_issues",
+    "html, mock_responses, expected_issues, expected_probe_urls",
     [
         # Linked .mp4 with the sibling .vtt linked on the page -> ok, no probe.
         (
@@ -5173,10 +5173,12 @@ def _vtt_404(stem: str) -> str:
             f'<a href="{_CDN}/talk.vtt">captions</a>',
             [],
             [],
+            [],
         ),
         # Companion satisfied by a <track src> reference to the sibling .vtt.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a><track src="{_CDN}/talk.vtt">',
+            [],
             [],
             [],
         ),
@@ -5186,14 +5188,21 @@ def _vtt_404(stem: str) -> str:
             f'<a href="{_CDN}/talk.vtt?v=9">captions</a>',
             [],
             [],
+            [],
         ),
         # No on-page reference, but the sibling .vtt exists on the CDN -> ok.
-        (f'<a href="{_CDN}/talk.mp4">clip</a>', [(True, 200)], []),
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a>',
+            [(True, 200)],
+            [],
+            [f"{_CDN}/talk.vtt"],
+        ),
         # No on-page reference and the CDN probe 404s -> issue.
         (
             f'<a href="{_CDN}/talk.mp4">clip</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/talk.mp4", _vtt_404("talk"))],
+            [f"{_CDN}/talk.vtt"],
         ),
         # The probe raising a network error is reported, not swallowed.
         (
@@ -5205,25 +5214,28 @@ def _vtt_404(stem: str) -> str:
                     f"HEAD {_CDN}/talk.vtt failed: boom",
                 )
             ],
+            [f"{_CDN}/talk.vtt"],
         ),
         # .mov and .m4v are captionable containers too.
         (
             f'<a href="{_CDN}/clip.mov">m</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/clip.mov", _vtt_404("clip"))],
+            [f"{_CDN}/clip.vtt"],
         ),
         (
             f'<a href="{_CDN}/clip.m4v">m</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/clip.m4v", _vtt_404("clip"))],
+            [f"{_CDN}/clip.vtt"],
         ),
         # #no-audio fragment opts a silent link out; no probe.
-        (f'<a href="{_CDN}/silent.mp4#no-audio">s</a>', [], []),
+        (f'<a href="{_CDN}/silent.mp4#no-audio">s</a>', [], [], []),
         # .webm / .gif links are exempt regardless of captions; no probe.
-        (f'<a href="{_CDN}/anim.webm">w</a>', [], []),
-        (f'<a href="{_CDN}/anim.gif">g</a>', [], []),
+        (f'<a href="{_CDN}/anim.webm">w</a>', [], [], []),
+        (f'<a href="{_CDN}/anim.gif">g</a>', [], [], []),
         # A .mp4 on another host is out of scope; no probe.
-        ('<a href="https://youtube.com/watch.mp4">yt</a>', [], []),
+        ('<a href="https://youtube.com/watch.mp4">yt</a>', [], [], []),
         # A sibling .vtt at a different base path does not count on-page,
         # so the CDN probe decides.
         (
@@ -5231,9 +5243,15 @@ def _vtt_404(stem: str) -> str:
             f'<a href="{_CDN}/other.vtt">captions</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/talk.mp4", _vtt_404("talk"))],
+            [f"{_CDN}/talk.vtt"],
         ),
         # Embedded <video> sources are not anchors -> ignored by this check.
-        (f'<video controls><source src="{_CDN}/talk.mp4"></video>', [], []),
+        (
+            f'<video controls><source src="{_CDN}/talk.mp4"></video>',
+            [],
+            [],
+            [],
+        ),
         # Each offending link is reported independently; satisfied links
         # don't probe.
         (
@@ -5242,6 +5260,7 @@ def _vtt_404(stem: str) -> str:
             f'<a href="{_CDN}/b.vtt">b captions</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/a.mp4", _vtt_404("a"))],
+            [f"{_CDN}/a.vtt"],
         ),
         # The same video linked twice probes once (cached) and is reported
         # once per anchor.
@@ -5249,6 +5268,7 @@ def _vtt_404(stem: str) -> str:
             f'<a href="{_CDN}/dup.mp4">one</a><a href="{_CDN}/dup.mp4">two</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/dup.mp4", _vtt_404("dup"))] * 2,
+            [f"{_CDN}/dup.vtt"],
         ),
         # Uppercase extensions match; the probe preserves the base's case.
         # The href-less anchor exercises the reference scan's typeguard.
@@ -5256,12 +5276,15 @@ def _vtt_404(stem: str) -> str:
             f'<a>plain</a><a href="{_CDN}/TALK.MP4">c</a>',
             [(False, 404)],
             [_linked_caption_issue(f"{_CDN}/TALK.MP4", _vtt_404("TALK"))],
+            [f"{_CDN}/TALK.vtt"],
         ),
-        # Protocol-relative CDN URLs are in scope.
+        # Protocol-relative CDN URLs are in scope; the probe rebuilds an
+        # absolute https URL.
         (
             '<a href="//assets.turntrout.com/static/talk.mp4">c</a>',
             [(True, 200)],
             [],
+            ["https://assets.turntrout.com/static/talk.vtt"],
         ),
         # Only the exact #no-audio fragment opts out.
         (
@@ -5272,9 +5295,10 @@ def _vtt_404(stem: str) -> str:
                     f"{_CDN}/talk.mp4#no-audio-please", _vtt_404("talk")
                 )
             ],
+            [f"{_CDN}/talk.vtt"],
         ),
         # The opt-out fragment combines with a query string.
-        (f'<a href="{_CDN}/talk.mp4?v=2#no-audio">c</a>', [], []),
+        (f'<a href="{_CDN}/talk.mp4?v=2#no-audio">c</a>', [], [], []),
     ],
 )
 def test_check_linked_video_captions(
@@ -5282,6 +5306,7 @@ def test_check_linked_video_captions(
     html: str,
     mock_responses: list,
     expected_issues: list[str],
+    expected_probe_urls: list[str],
 ):
     """Linked audio-container videos on the CDN must have captions."""
     # Clear at both ends: mocked probe results cached under real CDN URLs
@@ -5290,8 +5315,10 @@ def test_check_linked_video_captions(
     soup = BeautifulSoup(html, "html.parser")
 
     remaining = list(mock_responses)
+    probed_urls: list[str] = []
 
     def mock_head(url: str, timeout: int) -> object:
+        probed_urls.append(url)
         if not remaining:
             raise AssertionError(f"Unexpected HEAD probe: {url}")
         response = remaining.pop(0)
@@ -5307,9 +5334,7 @@ def test_check_linked_video_captions(
     finally:
         built_site_checks._cdn_vtt_probe_issue.cache_clear()
     assert result == expected_issues
-    # Every scripted response must be consumed: leftovers mean the check
-    # probed fewer URLs than the scenario expects.
-    assert not remaining
+    assert probed_urls == expected_probe_urls
 
 
 @pytest.mark.parametrize(

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5150,6 +5150,81 @@ def test_check_video_accessibility_reports_offending_tag():
     assert "<source" not in issue
 
 
+_CDN = "https://assets.turntrout.com/static/images/posts"
+
+
+def _linked_caption_issue(href: str) -> str:
+    return (
+        f"Linked video {href} has no captions companion "
+        f"(sibling .vtt referenced on the page) or '#no-audio' marker"
+    )
+
+
+@pytest.mark.parametrize(
+    "html, expected_issues",
+    [
+        # Linked .mp4 with the sibling .vtt linked on the page -> ok.
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a>'
+            f'<a href="{_CDN}/talk.vtt">captions</a>',
+            [],
+        ),
+        # Companion satisfied by a <track src> reference to the sibling .vtt.
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a><track src="{_CDN}/talk.vtt">',
+            [],
+        ),
+        # Cache-busting query strings on both ends still match on base path.
+        (
+            f'<a href="{_CDN}/talk.mp4?v=2">clip</a>'
+            f'<a href="{_CDN}/talk.vtt?v=9">captions</a>',
+            [],
+        ),
+        # Linked .mp4 with no captions anywhere -> issue.
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a>',
+            [_linked_caption_issue(f"{_CDN}/talk.mp4")],
+        ),
+        # .mov and .m4v are captionable containers too.
+        (
+            f'<a href="{_CDN}/clip.mov">m</a>',
+            [_linked_caption_issue(f"{_CDN}/clip.mov")],
+        ),
+        (
+            f'<a href="{_CDN}/clip.m4v">m</a>',
+            [_linked_caption_issue(f"{_CDN}/clip.m4v")],
+        ),
+        # #no-audio fragment opts a silent link out.
+        (f'<a href="{_CDN}/silent.mp4#no-audio">s</a>', []),
+        # .webm / .gif links are exempt regardless of captions.
+        (f'<a href="{_CDN}/anim.webm">w</a>', []),
+        (f'<a href="{_CDN}/anim.gif">g</a>', []),
+        # A .mp4 on another host is out of scope.
+        ('<a href="https://youtube.com/watch.mp4">yt</a>', []),
+        # A sibling .vtt at a different base path does not count.
+        (
+            f'<a href="{_CDN}/talk.mp4">clip</a>'
+            f'<a href="{_CDN}/other.vtt">captions</a>',
+            [_linked_caption_issue(f"{_CDN}/talk.mp4")],
+        ),
+        # Embedded <video> sources are not anchors -> ignored by this check.
+        (f'<video controls><source src="{_CDN}/talk.mp4"></video>', []),
+        # Each offending link is reported independently.
+        (
+            f'<a href="{_CDN}/a.mp4">a</a>'
+            f'<a href="{_CDN}/b.mp4">b</a>'
+            f'<a href="{_CDN}/b.vtt">b captions</a>',
+            [_linked_caption_issue(f"{_CDN}/a.mp4")],
+        ),
+    ],
+)
+def test_check_linked_video_captions(html: str, expected_issues: list[str]):
+    """Linked audio-container videos on the CDN must reference captions."""
+    soup = BeautifulSoup(html, "html.parser")
+    result = built_site_checks.check_linked_video_captions(soup)
+    assert sorted(result) == sorted(expected_issues)
+
+
 @pytest.mark.parametrize(
     "html_content, expected_issues",
     [


### PR DESCRIPTION
## Summary

- The caption pipeline only enforces captions on embedded `<video>` elements; a bare `<a href="…/foo.mp4">` link to a video on the asset CDN slips past that check entirely. This adds a built-site check so linked audio-container videos are covered too.

## Changes

- **`scripts/built_site_checks.py`** — new `check_linked_video_captions` (registered as `linked_video_missing_captions`). For each `<a href>` to a `.mp4`/`.mov`/`.m4v` on `assets.turntrout.com`, the link passes if:
  - the page references the sibling `.vtt` (same base path, via `<a>`/`<track>`/`<source>`; query strings ignored), **or**
  - a HEAD probe finds the sibling `.vtt` on the CDN (the transcription pipeline uploads it next to the video), **or**
  - the link carries a `#no-audio` fragment — the link-side analog of the embedded `label="No audio"` marker.
  - `.webm`/`.gif` links are exempt. Probes reuse the shared retrying `_http_session` and are cached per URL (one probe per unreferenced video per run, failures included).
- **`.claude/dev-notes.md`** — documents the check, pointing at the function docstring for full semantics.

No content is flagged today: every existing content video is either embedded or a silent GIF/`.webm` — so this is a forward-looking guard, like the embedded-video caption check.

## Testing

- `scripts/tests/test_built_site_checks.py` — 20 parametrized cases covering on-page/`<track>`/query-string companions, CDN-probe hit/404/network-error, `.mov`/`.m4v`, `#no-audio` (exact-match) opt-out, `.webm`/`.gif` exemption, off-host and embedded-`<video>` ignores, cache-dedup on duplicate links, uppercase extensions, and protocol-relative URLs. Each row asserts both the issues (exact document order) and the exact probe URLs; the probe cache is cleared on teardown so nothing leaks between tests.
- Full `test_built_site_checks.py` suite: **983 passed**, 100% coverage of the new code enforced.
- `ruff check` / `ruff format`, `pylint` (10/10), `pyright` all clean on the changed files.

## Lessons Learned

- **What**: When adding an accessibility/quality check for embedded elements, also cover the *linked* form of the same asset (`<a href>` to a media file), which bypasses element-level checks.
- **Where**: any built-site/HTML validator that inspects `<video>`/`<img>`/`<audio>` tags — e.g. `scripts/built_site_checks.py`.
- **Why**: an author can link a video instead of embedding it and silently escape the caption/accessibility gate the embedded check enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kwJmyHZFt1TQHY1HYEoyK

---
_Generated by [Claude Code](https://claude.ai/code/session_017kwJmyHZFt1TQHY1HYEoyK)_