### PR TITLE
fix(admonitions): show pointer cursor across full title bar when collapsible

### DIFF
--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -40,6 +40,17 @@ async function spaNavigateToAbout(page: Page): Promise<void> {
   await expect(page.locator('body[data-slug="about"]')).toBeAttached()
 }
 
+/** Resolves a locator's bounding box, throwing if it's not visible/attached. */
+async function requireBoundingBox(
+  locator: import("@playwright/test").Locator,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const box = await locator.boundingBox()
+  if (!box) {
+    throw new Error(`Expected a visible bounding box for locator: ${locator}`)
+  }
+  return box
+}
+
 async function goBackToTestPage(page: Page): Promise<void> {
   await page.goBack()
   await page.waitForURL("**/test-page")
@@ -165,6 +176,48 @@ test.describe("Collapsible admonition state persistence", () => {
       .filter({ hasText: "starts off open" })
     await expect(afterNav).toBeAttached()
     await expect(afterNav).toHaveClass(/is-collapsed/)
+  })
+
+  test("title's pointer cursor and click target cover the full row, including the side padding gutters", async ({
+    page,
+  }) => {
+    const admonition = page
+      .locator(".admonition.is-collapsible:not(.is-collapsed)")
+      .filter({ hasText: "starts off open" })
+    const title = admonition.locator(".admonition-title")
+
+    const [admonitionBox, titleBox] = await Promise.all([
+      requireBoundingBox(admonition),
+      requireBoundingBox(title),
+    ])
+
+    // The title's box must reach the admonition's edges -- it shouldn't stop
+    // short at the inner content padding, leaving an un-hoverable/unclickable gutter.
+    const GUTTER_TOLERANCE_PX = 3
+    expect(titleBox.x - admonitionBox.x).toBeLessThan(GUTTER_TOLERANCE_PX)
+    expect(admonitionBox.x + admonitionBox.width - (titleBox.x + titleBox.width)).toBeLessThan(
+      GUTTER_TOLERANCE_PX,
+    )
+
+    // Sample the cursor right at each edge of the title row (inside the
+    // gutters that used to fall outside the title's box) and confirm it's a pointer.
+    const y = titleBox.y + titleBox.height / 2
+    const cursorAt = (x: number) =>
+      page.evaluate(
+        ({ px, py }) => {
+          const el = document.elementFromPoint(px, py)
+          return el ? getComputedStyle(el).cursor : null
+        },
+        { px: x, py: y },
+      )
+    expect(await cursorAt(titleBox.x + 2)).toBe("pointer")
+    expect(await cursorAt(titleBox.x + titleBox.width - 2)).toBe("pointer")
+
+    // Clicking in the gutter itself (not just the visible icon/text) should
+    // toggle the admonition, proving the extended box is actually clickable.
+    await expect(admonition).not.toHaveClass(/is-collapsed/)
+    await page.mouse.click(titleBox.x + 2, y)
+    await expect(admonition).toHaveClass(/is-collapsed/)
   })
 
   test("clicking content does not close open collapsible", async ({ page }) => {

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -213,9 +213,7 @@ test.describe("Collapsible admonition state persistence", () => {
     // short at the inner content padding, leaving an un-hoverable/unclickable gutter.
     const GUTTER_TOLERANCE_PX = 3
     expect(measurements.titleLeft - measurements.admonitionLeft).toBeLessThan(GUTTER_TOLERANCE_PX)
-    expect(measurements.admonitionRight - measurements.titleRight).toBeLessThan(
-      GUTTER_TOLERANCE_PX,
-    )
+    expect(measurements.admonitionRight - measurements.titleRight).toBeLessThan(GUTTER_TOLERANCE_PX)
 
     // Cursor should be a pointer right at each edge of the title row (inside the
     // gutters that used to fall outside the title's box), not just over the icon/text.

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -185,38 +185,50 @@ test.describe("Collapsible admonition state persistence", () => {
       .locator(".admonition.is-collapsible:not(.is-collapsed)")
       .filter({ hasText: "starts off open" })
     const title = admonition.locator(".admonition-title")
+    await title.scrollIntoViewIfNeeded()
 
-    const [admonitionBox, titleBox] = await Promise.all([
-      requireBoundingBox(admonition),
-      requireBoundingBox(title),
-    ])
+    // Measure geometry and hit-test the cursor in a single browser round-trip
+    // (rather than combining a Playwright-side boundingBox() with a later
+    // elementFromPoint call) so the two never disagree on viewport/scroll state.
+    const measurements = await title.evaluate((titleEl) => {
+      const admonitionEl = titleEl.closest(".admonition") as HTMLElement
+      const titleRect = titleEl.getBoundingClientRect()
+      const admonitionRect = admonitionEl.getBoundingClientRect()
+      const y = titleRect.top + titleRect.height / 2
+      const cursorAt = (x: number) => {
+        const el = document.elementFromPoint(x, y)
+        return el ? getComputedStyle(el).cursor : null
+      }
+      return {
+        titleLeft: titleRect.left,
+        titleRight: titleRect.right,
+        admonitionLeft: admonitionRect.left,
+        admonitionRight: admonitionRect.right,
+        cursorNearLeftEdge: cursorAt(titleRect.left + 2),
+        cursorNearRightEdge: cursorAt(titleRect.right - 2),
+      }
+    })
 
     // The title's box must reach the admonition's edges -- it shouldn't stop
     // short at the inner content padding, leaving an un-hoverable/unclickable gutter.
     const GUTTER_TOLERANCE_PX = 3
-    expect(titleBox.x - admonitionBox.x).toBeLessThan(GUTTER_TOLERANCE_PX)
-    expect(admonitionBox.x + admonitionBox.width - (titleBox.x + titleBox.width)).toBeLessThan(
+    expect(measurements.titleLeft - measurements.admonitionLeft).toBeLessThan(GUTTER_TOLERANCE_PX)
+    expect(measurements.admonitionRight - measurements.titleRight).toBeLessThan(
       GUTTER_TOLERANCE_PX,
     )
 
-    // Sample the cursor right at each edge of the title row (inside the
-    // gutters that used to fall outside the title's box) and confirm it's a pointer.
-    const y = titleBox.y + titleBox.height / 2
-    const cursorAt = (x: number) =>
-      page.evaluate(
-        ({ px, py }) => {
-          const el = document.elementFromPoint(px, py)
-          return el ? getComputedStyle(el).cursor : null
-        },
-        { px: x, py: y },
-      )
-    expect(await cursorAt(titleBox.x + 2)).toBe("pointer")
-    expect(await cursorAt(titleBox.x + titleBox.width - 2)).toBe("pointer")
+    // Cursor should be a pointer right at each edge of the title row (inside the
+    // gutters that used to fall outside the title's box), not just over the icon/text.
+    expect(measurements.cursorNearLeftEdge).toBe("pointer")
+    expect(measurements.cursorNearRightEdge).toBe("pointer")
 
     // Clicking in the gutter itself (not just the visible icon/text) should
     // toggle the admonition, proving the extended box is actually clickable.
+    // `position` is relative to the title's own box, so it stays correct
+    // across viewports/devices without any manual coordinate math.
+    const titleBox = await requireBoundingBox(title)
     await expect(admonition).not.toHaveClass(/is-collapsed/)
-    await page.mouse.click(titleBox.x + 2, y)
+    await title.click({ position: { x: 2, y: titleBox.height / 2 } })
     await expect(admonition).toHaveClass(/is-collapsed/)
   })
 

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -178,7 +178,7 @@ test.describe("Collapsible admonition state persistence", () => {
     await expect(afterNav).toHaveClass(/is-collapsed/)
   })
 
-  test("title's pointer cursor and click target cover the full row, including the side padding gutters", async ({
+  test("title's pointer cursor and click target cover the full row, including the side padding gutters and top/bottom margins", async ({
     page,
   }) => {
     // Use a state-independent locator (no :not(.is-collapsed)) so it still
@@ -195,33 +195,50 @@ test.describe("Collapsible admonition state persistence", () => {
     // elementFromPoint call) so the two never disagree on viewport/scroll state.
     const measurements = await title.evaluate((titleEl) => {
       const admonitionEl = titleEl.closest(".admonition") as HTMLElement
+      const contentEl = admonitionEl.querySelector(".admonition-content") as HTMLElement
       const titleRect = titleEl.getBoundingClientRect()
       const admonitionRect = admonitionEl.getBoundingClientRect()
-      const y = titleRect.top + titleRect.height / 2
-      const cursorAt = (x: number) => {
+      const contentRect = contentEl.getBoundingClientRect()
+      const midY = titleRect.top + titleRect.height / 2
+      const midX = titleRect.left + titleRect.width / 2
+      const cursorAt = (x: number, y: number) => {
         const el = document.elementFromPoint(x, y)
         return el ? getComputedStyle(el).cursor : null
       }
       return {
         titleLeft: titleRect.left,
         titleRight: titleRect.right,
+        titleTop: titleRect.top,
+        titleBottom: titleRect.bottom,
         admonitionLeft: admonitionRect.left,
         admonitionRight: admonitionRect.right,
-        cursorNearLeftEdge: cursorAt(titleRect.left + 2),
-        cursorNearRightEdge: cursorAt(titleRect.right - 2),
+        admonitionTop: admonitionRect.top,
+        contentTop: contentRect.top,
+        cursorNearLeftEdge: cursorAt(titleRect.left + 2, midY),
+        cursorNearRightEdge: cursorAt(titleRect.right - 2, midY),
+        cursorNearTopEdge: cursorAt(midX, titleRect.top + 2),
+        cursorNearBottomEdge: cursorAt(midX, titleRect.bottom - 2),
       }
     })
 
-    // The title's box must reach the admonition's edges -- it shouldn't stop
-    // short at the inner content padding, leaving an un-hoverable/unclickable gutter.
-    const GUTTER_TOLERANCE_PX = 3
-    expect(measurements.titleLeft - measurements.admonitionLeft).toBeLessThan(GUTTER_TOLERANCE_PX)
-    expect(measurements.admonitionRight - measurements.titleRight).toBeLessThan(GUTTER_TOLERANCE_PX)
+    // The title's box must reach the admonition's left/right edges and the
+    // admonition's top edge -- it shouldn't stop short at the inner content
+    // padding/margin, leaving un-hoverable/unclickable gutters.
+    const EDGE_TOLERANCE_PX = 3
+    expect(measurements.titleLeft - measurements.admonitionLeft).toBeLessThan(EDGE_TOLERANCE_PX)
+    expect(measurements.admonitionRight - measurements.titleRight).toBeLessThan(EDGE_TOLERANCE_PX)
+    expect(measurements.titleTop - measurements.admonitionTop).toBeLessThan(EDGE_TOLERANCE_PX)
+    // The title's bottom margin sits above the content, not the admonition's
+    // own bottom edge (there's more content below), so compare against that.
+    expect(measurements.contentTop - measurements.titleBottom).toBeLessThan(EDGE_TOLERANCE_PX)
 
     // Cursor should be a pointer right at each edge of the title row (inside the
-    // gutters that used to fall outside the title's box), not just over the icon/text.
+    // gutters/margins that used to fall outside the title's box), not just over
+    // the icon/text.
     expect(measurements.cursorNearLeftEdge).toBe("pointer")
     expect(measurements.cursorNearRightEdge).toBe("pointer")
+    expect(measurements.cursorNearTopEdge).toBe("pointer")
+    expect(measurements.cursorNearBottomEdge).toBe("pointer")
 
     // Clicking in the gutter itself (not just the visible icon/text) should
     // toggle the admonition, proving the extended box is actually clickable.

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -181,10 +181,13 @@ test.describe("Collapsible admonition state persistence", () => {
   test("title's pointer cursor and click target cover the full row, including the side padding gutters", async ({
     page,
   }) => {
+    // Use a state-independent locator (no :not(.is-collapsed)) so it still
+    // matches after clicking toggles the class.
     const admonition = page
-      .locator(".admonition.is-collapsible:not(.is-collapsed)")
+      .locator(".admonition.is-collapsible")
       .filter({ hasText: "starts off open" })
     const title = admonition.locator(".admonition-title")
+    await expect(admonition).not.toHaveClass(/is-collapsed/)
     await title.scrollIntoViewIfNeeded()
 
     // Measure geometry and hit-test the cursor in a single browser round-trip
@@ -225,7 +228,6 @@ test.describe("Collapsible admonition state persistence", () => {
     // `position` is relative to the title's own box, so it stays correct
     // across viewports/devices without any manual coordinate math.
     const titleBox = await requireBoundingBox(title)
-    await expect(admonition).not.toHaveClass(/is-collapsed/)
     await title.click({ position: { x: 2, y: titleBox.height / 2 } })
     await expect(admonition).toHaveClass(/is-collapsed/)
   })

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -2,11 +2,13 @@
 @use "sass:color";
 @use "./colors";
 
+$admonition-padding-inline: 1rem;
+
 .admonition,
 .timeline-card {
   margin: 1rem 0;
   overflow: hidden;
-  padding: 0 1rem;
+  padding: 0 $admonition-padding-inline;
 }
 
 .admonition {
@@ -173,8 +175,12 @@
   }
 
   &.is-collapsible {
+    // Bleed into the admonition's own inline padding so the pointer cursor
+    // (and click target) covers the full title bar, not just its content.
     > .admonition-title {
       cursor: pointer;
+      margin-inline: calc(-1 * #{$admonition-padding-inline});
+      padding-inline: $admonition-padding-inline;
     }
 
     > .admonition-content {

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -175,12 +175,16 @@ $admonition-padding-inline: 1rem;
   }
 
   &.is-collapsible {
-    // Bleed into the admonition's own inline padding so the pointer cursor
-    // (and click target) covers the full title bar, not just its content.
+    // Bleed into the title's own margin (vertical) and the admonition's
+    // inline padding (horizontal) so the pointer cursor and click target
+    // cover the full title bar, not just its text/icon content. Safe because
+    // .admonition's overflow:hidden creates a BFC (no margin collapsing with
+    // its own top edge) and .admonition-content has no top margin to collapse
+    // with the title's bottom margin.
     > .admonition-title {
       cursor: pointer;
-      margin-inline: calc(-1 * #{$admonition-padding-inline});
-      padding-inline: $admonition-padding-inline;
+      margin: calc(-1.5 * $base-margin) calc(-1 * #{$admonition-padding-inline});
+      padding: calc(1.5 * $base-margin) $admonition-padding-inline;
     }
 
     > .admonition-content {

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -173,6 +173,10 @@
   }
 
   &.is-collapsible {
+    > .admonition-title {
+      cursor: pointer;
+    }
+
     > .admonition-content {
       transition: max-height $transition-duration-medium ease;
       overflow: hidden;

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -3,6 +3,7 @@
 @use "./colors";
 
 $admonition-padding-inline: 1rem;
+$admonition-title-margin-block: calc(1.5 * $base-margin);
 
 .admonition,
 .timeline-card {
@@ -183,8 +184,8 @@ $admonition-padding-inline: 1rem;
     // with the title's bottom margin.
     > .admonition-title {
       cursor: pointer;
-      margin: calc(-1.5 * $base-margin) calc(-1 * #{$admonition-padding-inline});
-      padding: calc(1.5 * $base-margin) $admonition-padding-inline;
+      margin: calc(-1 * #{$admonition-title-margin-block}) calc(-1 * #{$admonition-padding-inline});
+      padding: $admonition-title-margin-block $admonition-padding-inline;
     }
 
     > .admonition-content {
@@ -236,7 +237,7 @@ $admonition-padding-inline: 1rem;
   display: flex;
   align-items: flex-start;
   gap: 0; // Used for fold-icon
-  margin: calc(1.5 * $base-margin) 0;
+  margin: $admonition-title-margin-block 0;
 
   --icon-size: calc(1.5 * #{$base-margin});
 

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -176,15 +176,18 @@ $admonition-title-margin-block: calc(1.5 * $base-margin);
   }
 
   &.is-collapsible {
-    // Bleed into the title's own margin (vertical) and the admonition's
-    // inline padding (horizontal) so the pointer cursor and click target
-    // cover the full title bar, not just its text/icon content. Safe because
-    // .admonition's overflow:hidden creates a BFC (no margin collapsing with
-    // its own top edge) and .admonition-content has no top margin to collapse
-    // with the title's bottom margin.
+    // The pointer cursor and click target must cover the full title bar,
+    // including its surrounding spacing, not just its text/icon content.
+    // Block axis: the spacing lives in the title's padding (not margin), so it
+    // belongs to the title's box. A negative block margin would push the box
+    // past the padding edge, where .admonition's overflow:hidden clips it —
+    // .admonition has no block padding to absorb it.
+    // Inline axis: .admonition has inline padding, so a negative inline margin
+    // reaches into it (inside the padding box, unclipped) while the matching
+    // inline padding holds the text in place.
     > .admonition-title {
       cursor: pointer;
-      margin: calc(-1 * #{$admonition-title-margin-block}) calc(-1 * #{$admonition-padding-inline});
+      margin: 0 calc(-1 * #{$admonition-padding-inline});
       padding: $admonition-title-margin-block $admonition-padding-inline;
     }
 


### PR DESCRIPTION
## Summary
- The title bar of a collapsible admonition already toggles on click anywhere in the row (`admonition.inline.js` attaches the toggle handler to the whole `.admonition-title` element), but `cursor: pointer` was only applied to the fold icon, so the rest of the row didn't visually indicate it was clickable.
- Added `cursor: pointer` to `.admonition-title` when the parent admonition has `.is-collapsible`.
- The `.admonition-title` box itself only spanned the admonition's inner content area — it stopped short of both the 1rem inline padding gutters and the block (top/bottom) spacing, so those bands showed the default cursor and weren't clickable even though they're visually part of the same title row. Extended the title's box to cover the full bar on all four sides, with **no visual change** to icon/text position or overall height:
  - **Inline axis**: `.admonition` has 1rem inline padding, so a negative inline margin (`-1rem`) reaches into it — staying inside the padding box, so `overflow: hidden` doesn't clip it — while a matching inline padding holds the text in place.
  - **Block axis**: `.admonition` has *no* block padding, so a negative block margin would push the title's box past the padding edge where `overflow: hidden` clips it (this made the band un-hittable and squashed the admonition). Instead, the block spacing is moved entirely into the title's padding with **zero** block margin, so nothing crosses the clip boundary.
- Shared `$admonition-padding-inline` and `$admonition-title-margin-block` variables so the base `.admonition-title` rule and the `.is-collapsible` override can't drift apart.
- Added a Playwright test asserting the title's box reaches the admonition's left/right/top edges and the content's top edge, that the cursor is `pointer` at all four edges (not just over the icon/text), and that clicking in the gutter/margin itself toggles the admonition.

## Test plan
- [x] `pnpm exec stylelint` passes on the changed file
- [x] Rendered the collapsible admonition headlessly and confirmed `b2a6e60` is pixel-identical to the original (same total height, same text/content positions) while the title's box now fills the full bar
- [x] `admonition.inline.test.ts` (14 tests) passes unchanged
- [x] New Playwright test in `collapsible.spec.ts` covers full-row cursor/click coverage (inline gutters + block bands) across desktop and mobile viewports
- [x] Visual check: hovering anywhere in a collapsible admonition's title bar, including the side gutters and top/bottom bands, now shows a pointer cursor with no layout change

## Notes
- `visual-testing` briefly showed red from 2 pre-existing, unrelated screenshot diffs (code-blocks/images, desktop Safari/Chrome light mode) that also appeared on recent `main` runs — not caused by this change. The maintainer has since approved those baselines directly.

## Lessons learned
- A negative-margin "bleed" that widens an element's box to cover its surrounding spacing only works on an axis where the ancestor with `overflow: hidden` has padding to absorb it. On an axis where the clipping ancestor has *no* padding, the negative margin pushes the box past the padding edge and `overflow: hidden` clips the overhang — the band renders in layout (so `getBoundingClientRect` still reports it) but isn't painted or hit-testable, producing browser-dependent `elementFromPoint`/cursor failures. Move the spacing into the element's own padding on that axis instead.
