### PR TITLE
ci: harden GitHub Actions workflows to pass zizmor at default confidence

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,12 +6,7 @@
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
   },
   "permissions": {
-    "deny": [
-      "Read(**/.env)",
-      "Read(**/.env.*)",
-      "Read(**/*.pem)",
-      "Read(**/*.key)"
-    ]
+    "deny": ["Read(**/.env)", "Read(**/.env.*)", "Read(**/*.pem)", "Read(**/*.key)"]
   },
   "hooks": {
     "SessionStart": [

--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -50,7 +50,7 @@ runs:
     - name: Get pnpm store directory
       if: inputs.install-node-deps == 'true'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] STORE_PATH comes from `pnpm store path`, a trusted value, not attacker-controllable input
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
     - name: Restore pnpm cache

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,5 @@ updates:
       npm-tracked:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -27,6 +27,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -63,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Setup site
         uses: ./.github/actions/setup-site
         with:
@@ -102,7 +105,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+          if [[ "${NEEDS_SHOULD_RUN_OUTPUTS_RUN}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
             echo "Tests were skipped (no relevant changes or filtered actor)"
             exit 0
           fi
@@ -110,3 +113,5 @@ jobs:
             echo "a11y tests did not succeed (${{ needs.a11y-test.result }})"
             exit 1
           fi
+        env:
+          NEEDS_SHOULD_RUN_OUTPUTS_RUN: ${{ needs.should-run.outputs.run }}

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -44,6 +44,7 @@ jobs:
         timeout-minutes: 5
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
+          persist-credentials: false
 
       # Cache keyed on commit SHA + fixture flag. Test builds and deploy
       # builds end up at different keys so fixtures can't leak from one to

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -82,6 +83,7 @@ jobs:
         timeout-minutes: 5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site
@@ -277,6 +279,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Download prepared site
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/generate-fixtures.yaml
+++ b/.github/workflows/generate-fixtures.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       # The generator uses only the Python standard library, so the
       # runner's preinstalled python3 is enough — no uv/venv setup needed.

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -31,7 +31,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.detect-changes.outputs.content == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted PUSH_TOKEN is used by the amend + force-push below
         timeout-minutes: 5
         with:
           fetch-depth: 0
@@ -79,6 +79,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -145,7 +147,7 @@ jobs:
        (github.event_name == 'push' && contains(fromJSON('["refs/heads/main","refs/heads/dev"]'), github.ref)))
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted PUSH_TOKEN is used by the auto-fix commit + push below
         timeout-minutes: 5
         with:
           ref: ${{ github.head_ref || github.ref_name }}
@@ -217,6 +219,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Check for unpinned action references
         run: |
           # Find YAML uses: directives with tag-based refs (@v1, @v2, etc.) instead of SHA pins
@@ -248,6 +252,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Install actionlint
         env:
@@ -301,6 +307,7 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site
@@ -345,11 +352,15 @@ jobs:
         id: vale
         if: needs.detect-changes.outputs.content == 'true'
         continue-on-error: true
-        run: vale --config config/vale/.vale.ini "${{ steps.strip-for-spellcheck.outputs.dir }}"
+        run: vale --config config/vale/.vale.ini "${STEPS_STRIP_FOR_SPELLCHECK_OUTPUTS_DIR}"
+        env:
+          STEPS_STRIP_FOR_SPELLCHECK_OUTPUTS_DIR: ${{ steps.strip-for-spellcheck.outputs.dir }}
 
       - name: Clean up stripped content
         if: always() && steps.strip-for-spellcheck.outputs.dir
-        run: rm -rf "${{ steps.strip-for-spellcheck.outputs.dir }}"
+        run: rm -rf "${STEPS_STRIP_FOR_SPELLCHECK_OUTPUTS_DIR}"
+        env:
+          STEPS_STRIP_FOR_SPELLCHECK_OUTPUTS_DIR: ${{ steps.strip-for-spellcheck.outputs.dir }}
 
       - name: Run ESLint
         id: eslint
@@ -380,17 +391,25 @@ jobs:
         id: source-checks
         if: needs.detect-changes.outputs.source-checks == 'true'
         continue-on-error: true
-        run: uv run python scripts/source_file_checks.py ${{ steps.pub-date-flag.outputs.flag }}
+        run: uv run python scripts/source_file_checks.py ${STEPS_PUB_DATE_FLAG_OUTPUTS_FLAG}
+        env:
+          STEPS_PUB_DATE_FLAG_OUTPUTS_FLAG: ${{ steps.pub-date-flag.outputs.flag }}
 
       - name: Check results
         run: |
           failed=""
-          if [[ "${{ steps.spellcheck.outcome }}" == "failure" ]]; then failed="$failed spellcheck"; fi
-          if [[ "${{ steps.vale.outcome }}" == "failure" ]]; then failed="$failed vale"; fi
-          if [[ "${{ steps.eslint.outcome }}" == "failure" ]]; then failed="$failed eslint"; fi
-          if [[ "${{ steps.stylelint.outcome }}" == "failure" ]]; then failed="$failed stylelint"; fi
-          if [[ "${{ steps.source-checks.outcome }}" == "failure" ]]; then failed="$failed source-file-checks"; fi
+          if [[ "${STEPS_SPELLCHECK_OUTCOME}" == "failure" ]]; then failed="$failed spellcheck"; fi
+          if [[ "${STEPS_VALE_OUTCOME}" == "failure" ]]; then failed="$failed vale"; fi
+          if [[ "${STEPS_ESLINT_OUTCOME}" == "failure" ]]; then failed="$failed eslint"; fi
+          if [[ "${STEPS_STYLELINT_OUTCOME}" == "failure" ]]; then failed="$failed stylelint"; fi
+          if [[ "${STEPS_SOURCE_CHECKS_OUTCOME}" == "failure" ]]; then failed="$failed source-file-checks"; fi
           if [[ -n "$failed" ]]; then
             echo "The following checks failed:$failed"
             exit 1
           fi
+        env:
+          STEPS_SPELLCHECK_OUTCOME: ${{ steps.spellcheck.outcome }}
+          STEPS_VALE_OUTCOME: ${{ steps.vale.outcome }}
+          STEPS_ESLINT_OUTCOME: ${{ steps.eslint.outcome }}
+          STEPS_STYLELINT_OUTCOME: ${{ steps.stylelint.outcome }}
+          STEPS_SOURCE_CHECKS_OUTCOME: ${{ steps.source-checks.outcome }}

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -391,7 +391,12 @@ jobs:
         id: source-checks
         if: needs.detect-changes.outputs.source-checks == 'true'
         continue-on-error: true
-        run: uv run python scripts/source_file_checks.py ${STEPS_PUB_DATE_FLAG_OUTPUTS_FLAG}
+        # The flag is a single optional token (empty on push to main/dev);
+        # `${flag:+"$flag"}` expands to nothing when unset so an empty value
+        # becomes no argument rather than an empty-string positional arg.
+        run: |
+          flag="${STEPS_PUB_DATE_FLAG_OUTPUTS_FLAG}"
+          uv run python scripts/source_file_checks.py ${flag:+"$flag"}
         env:
           STEPS_PUB_DATE_FLAG_OUTPUTS_FLAG: ${{ steps.pub-date-flag.outputs.flag }}
 

--- a/.github/workflows/monthly-newsletter.yml
+++ b/.github/workflows/monthly-newsletter.yml
@@ -28,6 +28,7 @@ jobs:
         timeout-minutes: 5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Restore last reviewed commit
         id: cache-commit

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,6 +39,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -72,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Setup site
         if: needs.should-run.outputs.run == 'true'
         uses: ./.github/actions/setup-site

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -97,7 +97,7 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!screenshot).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${NEEDS_SETUP_OUTPUTS_REPEAT} \
+            --repeat-each "${NEEDS_SETUP_OUTPUTS_REPEAT}" \
             | tee playwright-flake.log
         env:
           # 90 min job timeout → 85 min Playwright global timeout
@@ -212,7 +212,7 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!screenshot).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${NEEDS_SETUP_OUTPUTS_REPEAT} \
+            --repeat-each "${NEEDS_SETUP_OUTPUTS_REPEAT}" \
             | tee playwright-flake.log
         env:
           # 90 min job timeout → 85 min Playwright global timeout

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
@@ -95,11 +97,12 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!screenshot).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${{ needs.setup.outputs.repeat }} \
+            --repeat-each ${NEEDS_SETUP_OUTPUTS_REPEAT} \
             | tee playwright-flake.log
         env:
           # 90 min job timeout → 85 min Playwright global timeout
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
+          NEEDS_SETUP_OUTPUTS_REPEAT: ${{ needs.setup.outputs.repeat }}
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> "$GITHUB_ENV"
@@ -170,6 +173,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Disable macOS firewall
         run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
@@ -207,11 +212,12 @@ jobs:
             --config config/playwright/playwright.config.ts \
             --grep "^(?:(?!screenshot).)*$" \
             --shard ${{ matrix.shard }} \
-            --repeat-each ${{ needs.setup.outputs.repeat }} \
+            --repeat-each ${NEEDS_SETUP_OUTPUTS_REPEAT} \
             | tee playwright-flake.log
         env:
           # 90 min job timeout → 85 min Playwright global timeout
           PLAYWRIGHT_GLOBAL_TIMEOUT_MS: "5100000"
+          NEEDS_SETUP_OUTPUTS_REPEAT: ${{ needs.setup.outputs.repeat }}
 
       - name: Sanitize shard name
         run: echo "SANITIZED_SHARD=${MATRIX_SHARD%%/*}" >> "$GITHUB_ENV"
@@ -293,6 +299,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/summarize-failed-shards
         with:
           log-pattern: flake-check-log-*

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -31,6 +31,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -90,6 +91,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
@@ -195,6 +198,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Disable macOS firewall
         run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
@@ -291,7 +296,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+          if [[ "${NEEDS_SHOULD_RUN_OUTPUTS_RUN}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
             echo "Tests were skipped (no label or filtered branch)"
             exit 0
           fi
@@ -303,6 +308,8 @@ jobs:
             echo "macOS tests did not succeed (${{ needs.playwright-tests-macos.result }})"
             exit 1
           fi
+        env:
+          NEEDS_SHOULD_RUN_OUTPUTS_RUN: ${{ needs.should-run.outputs.run }}
 
   summarize-failures:
     name: Summarize Failures
@@ -319,6 +326,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/summarize-failed-shards
         with:
           log-pattern: playwright-log-*

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -29,6 +29,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -79,6 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Setup site
         uses: ./.github/actions/setup-site
         with:
@@ -141,7 +144,7 @@ jobs:
 
       - name: Wait for deployment to be reachable
         run: |
-          URL="${{ steps.deploy_cf_pages.outputs.DEPLOY_URL }}"
+          URL="${STEPS_DEPLOY_CF_PAGES_OUTPUTS_DEPLOY_URL}"
           echo "Waiting for $URL to respond..."
           for i in $(seq 1 20); do
             STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null || echo "000")
@@ -154,6 +157,8 @@ jobs:
           done
           echo "::error::Deploy URL $URL not reachable after 20 attempts"
           exit 1
+        env:
+          STEPS_DEPLOY_CF_PAGES_OUTPUTS_DEPLOY_URL: ${{ steps.deploy_cf_pages.outputs.DEPLOY_URL }}
 
   lighthouse_desktop_cls:
     runs-on: ubuntu-24.04
@@ -162,6 +167,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: CLS Check (Desktop)
         id: lighthouse_desktop
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
@@ -190,6 +197,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: CLS Check (Mobile)
         id: lighthouse_mobile
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
@@ -218,6 +227,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Run Lighthouse Full Audit (Performance, Accessibility, Best Practices, SEO)
         id: lighthouse_full
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
@@ -256,6 +267,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
         with:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -47,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -47,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site

--- a/.github/workflows/quarterly-tag-suggestions.yaml
+++ b/.github/workflows/quarterly-tag-suggestions.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Gather tag taxonomy and post catalog
         run: |

--- a/.github/workflows/refresh-tweet-snapshots.yaml
+++ b/.github/workflows/refresh-tweet-snapshots.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: ./.github/actions/setup-site

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -41,6 +41,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -79,6 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site
@@ -120,6 +123,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup site
         uses: ./.github/actions/setup-site
@@ -174,7 +179,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+          if [[ "${NEEDS_SHOULD_RUN_OUTPUTS_RUN}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
             echo "Tests were skipped (no relevant changes or filtered actor)"
             exit 0
           fi
@@ -183,3 +188,5 @@ jobs:
             echo "Site build checks did not succeed (checks=${{ needs.built-site-checks.result }}, links=${{ needs.linkchecker.result }})"
             exit 1
           fi
+        env:
+          NEEDS_SHOULD_RUN_OUTPUTS_RUN: ${{ needs.should-run.outputs.run }}

--- a/.github/workflows/subfont-bisect.yaml
+++ b/.github/workflows/subfont-bisect.yaml
@@ -44,6 +44,7 @@ jobs:
         timeout-minutes: 5
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup site tooling
         uses: ./.github/actions/setup-site

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout target ref
         if: steps.resolve.outputs.ref != ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted GITHUB_TOKEN is used by the empty-commit push below
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,6 +75,8 @@ jobs:
       - name: Checkout default branch (main runs)
         if: steps.resolve.outputs.ref == ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Download Playwright blob reports from the named run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -33,6 +33,7 @@ jobs:
         timeout-minutes: 5
         with:
           sparse-checkout: .github/actions/ci-gate
+          persist-credentials: false
       - id: gate
         uses: ./.github/actions/ci-gate
         with:
@@ -87,6 +88,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
@@ -154,6 +157,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Disable macOS firewall
         run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
@@ -265,7 +270,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.should-run.outputs.run }}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
+          if [[ "${NEEDS_SHOULD_RUN_OUTPUTS_RUN}" == "false" ]] || [[ "${{ needs.should-run.result }}" == "skipped" ]]; then
             echo "Tests were skipped (no label or filtered branch)"
             exit 0
           fi
@@ -285,10 +290,13 @@ jobs:
             echo "macOS visual tests had real failures"
             exit 1
           fi
-          if [[ "${{ needs.aggregate-visual-results.outputs.has-any-failures }}" == "true" ]]; then
+          if [[ "${NEEDS_AGGREGATE_VISUAL_RESULTS_OUTPUTS_HAS_ANY_FAILURES}" == "true" ]]; then
             echo "Visual diffs present (new or updated screenshots) — see publish-visual-report"
             exit 1
           fi
+        env:
+          NEEDS_SHOULD_RUN_OUTPUTS_RUN: ${{ needs.should-run.outputs.run }}
+          NEEDS_AGGREGATE_VISUAL_RESULTS_OUTPUTS_HAS_ANY_FAILURES: ${{ needs.aggregate-visual-results.outputs.has-any-failures }}
 
   summarize-failures:
     name: Summarize Failures
@@ -305,6 +313,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/summarize-failed-shards
         with:
           log-pattern: visual-testing-log-*
@@ -337,6 +347,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         timeout-minutes: 5
+        with:
+          persist-credentials: false
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env


### PR DESCRIPTION
## Summary

- The `zizmor` security audit (`.github/workflows/zizmor.yaml` runs `uvx zizmor==1.25.2 .github/`, guarded by the required check `zizmor-passed`) runs at the **default/regular persona** and reported **249 findings** on `main`. Because that job only fires when a PR touches `.github/**`, the debt sat unnoticed — this PR clears it to zero so the check goes green the moment any workflow change lands.
- All fixes are behavior-preserving hardening or justified inline suppressions; no CI logic changes.

## Changes

- **artipacked** — added `persist-credentials: false` to every read-only checkout. The three checkouts that persist a token and later `git push` (`lint-and-validate` `update-dates` + `autofix`, `update-visual-baselines` target-ref) keep their credential and carry an inline `# zizmor: ignore[artipacked]` with a rationale, so `--fix=all`'s naive "always add `persist-credentials: false`" didn't break them.
- **template-injection** — moved `${{ steps.* }}` / `${{ needs.* }}` expansions out of `run:` blocks into `env:` vars referenced as ordinary shell variables (`lint-and-validate`, `deploy`, `visual-testing`, `playwright-*`, `site-build-checks`, etc.).
- **github-env** — suppressed the `STORE_PATH` write in `.github/actions/setup-site/action.yaml` (value comes from `pnpm store path`, not attacker-controllable), matching the existing suppression in `setup-base-env`.
- **dependabot-cooldown** — added a 7-day default cooldown to `.github/dependabot.yml`.

## Testing

- `uvx zizmor==1.25.2 --offline .github/` — exits **0** on this branch (was exit 14 / 249 findings on `main`).
- All workflows validated: zizmor parses every workflow AST successfully and `yaml.safe_load` parses every file.
- Manually verified the three credential-persisting push checkouts retain their tokens and only read-only checkouts got `persist-credentials: false`.

## Lessons Learned

- **What**: When applying `zizmor --fix=all` (or manually adding `persist-credentials: false`), audit every changed checkout for a later `git push`/`git commit` — those must keep their token and be suppressed with `# zizmor: ignore[artipacked] <reason>` instead.
- **Where**: any `.github/workflows/*.yaml` with a checkout that later pushes (e.g. auto-fix / update-dates / baseline-retrigger jobs).
- **Why**: `--fix=all` blindly adds `persist-credentials: false`, which strips the token a subsequent push needs and silently breaks credentialed pushes.
- **What**: A zizmor gate that only runs on a `.github/**` path filter accumulates findings invisibly; fix them proactively rather than at the first unrelated workflow edit.
- **Where**: `zizmor.yaml` (default-confidence gate) vs. `lint-and-validate.yaml` workflow-lint (`--min-confidence=medium`).
- **Why**: the two gates enforce different confidence thresholds, so the strict one can be red while the lenient one is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_013X59e4TNZ1PvVirJo4Gzjb)_