### PR TITLE
fix(visual-tests): stabilize screenshot capture against WebKit's deferred high-quality image rescale

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -173,8 +173,7 @@ export async function captureStableScreenshot(
     previous = current
   } while (Date.now() < deadline)
   throw new Error(
-    `Screenshot ${screenshotName} did not stabilize within ${SCREENSHOT_STABILIZATION_TIMEOUT_MS}ms: ` +
-      `consecutive captures kept differing, so something is still repainting the page`,
+    `Screenshot ${screenshotName} did not stabilize within ${SCREENSHOT_STABILIZATION_TIMEOUT_MS}ms: consecutive captures kept differing, so something is still repainting the page`,
   )
 }
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -138,6 +138,46 @@ export interface RegressionScreenshotOptions {
 // of a remote AVIF, short enough that a genuinely dead image can't hang the run.
 const IMAGE_PAINT_TIMEOUT_MS = 15000
 
+// WebKit paints images above its interpolation cutoff (800×800 source pixels)
+// with fast low-quality scaling whenever their painted size just changed
+// (e.g. a custom element upgrading and re-laying-out its slotted images), then
+// repaints at high quality when its 500 ms `lowQualityTimeThreshold` timer
+// fires (WebCore/rendering/ImageQualityController.cpp). Consecutive captures
+// must be spaced wider than that window so a pending high-quality repaint
+// always lands between them and shows up as a frame difference.
+const WEBKIT_LOW_QUALITY_SCALE_WINDOW_MS = 550
+const SCREENSHOT_STABILIZATION_TIMEOUT_MS = 10_000
+
+/**
+ * Captures screenshots until two consecutive frames are byte-identical, so
+ * late async repaints (WebKit's deferred high-quality image rescale, font
+ * swaps) can't be baked into the compared capture. This is the same
+ * two-equal-frames contract Playwright's `toHaveScreenshot` applies
+ * internally; `toMatchSnapshot` on a raw buffer has no such loop, so we
+ * provide it here.
+ *
+ * @param takeScreenshot - Thunk performing one capture of the target.
+ * @param screenshotName - Name used in the timeout error message.
+ * @returns The first capture that matched its predecessor exactly.
+ */
+export async function captureStableScreenshot(
+  takeScreenshot: () => Promise<Buffer>,
+  screenshotName: string,
+): Promise<Buffer> {
+  const deadline = Date.now() + SCREENSHOT_STABILIZATION_TIMEOUT_MS
+  let previous = await takeScreenshot()
+  do {
+    await new Promise((resolve) => setTimeout(resolve, WEBKIT_LOW_QUALITY_SCALE_WINDOW_MS))
+    const current = await takeScreenshot()
+    if (current.equals(previous)) return current
+    previous = current
+  } while (Date.now() < deadline)
+  throw new Error(
+    `Screenshot ${screenshotName} did not stabilize within ${SCREENSHOT_STABILIZATION_TIMEOUT_MS}ms: ` +
+      `consecutive captures kept differing, so something is still repainting the page`,
+  )
+}
+
 // Runs in the browser via `locator.evaluate` (Playwright serializes it), so it
 // must not reference module scope. Resolves true once the image has painted,
 // false at the deadline. A remote AVIF can intermittently fail to load
@@ -243,9 +283,7 @@ export async function takeRegressionScreenshot(
   }
 
   // Separate out the element option so we don't pass it to the screenshot API
-  const { elementToScreenshot: _elementOpt, ...remainingOptions } = options ?? {}
-  // skipcq: JS-0098
-  void _elementOpt // prevent unused variable lint error
+  const { elementToScreenshot, ...remainingOptions } = options ?? {}
 
   if (!options?.skipStabilityWait) {
     await waitForVisualStability(page, options?.elementToScreenshot)
@@ -260,17 +298,23 @@ export async function takeRegressionScreenshot(
 
   let screenshotBuffer: Buffer
   const screenshotName = getScreenshotName(testInfo, screenshotSuffix)
-  if (options?.elementToScreenshot) {
-    const elementToIsolate = options.elementAboutWhichToIsolateDOM ?? options.elementToScreenshot
-    await performDOMIsolation(elementToIsolate, options.preserveSiblings ?? false)
+  if (elementToScreenshot) {
+    const elementToIsolate = options?.elementAboutWhichToIsolateDOM ?? elementToScreenshot
+    await performDOMIsolation(elementToIsolate, options?.preserveSiblings ?? false)
 
     try {
-      screenshotBuffer = await options.elementToScreenshot.screenshot(screenshotOptions)
+      screenshotBuffer = await captureStableScreenshot(
+        () => elementToScreenshot.screenshot(screenshotOptions),
+        screenshotName,
+      )
     } finally {
       await restoreDOMFromIsolation(page)
     }
   } else {
-    screenshotBuffer = await page.screenshot(screenshotOptions)
+    screenshotBuffer = await captureStableScreenshot(
+      () => page.screenshot(screenshotOptions),
+      screenshotName,
+    )
   }
 
   // PNG IHDR stores width at byte offset 16 and height at 20. Using the

--- a/quartz/plugins/transformers/tests/tweetEmbed.test.ts
+++ b/quartz/plugins/transformers/tests/tweetEmbed.test.ts
@@ -190,9 +190,10 @@ describe("loadSnapshot", () => {
         },
       }) as never,
     )
-    const settled = loadSnapshot("10123", "/dir").catch((error: Error) => error)
-    await jest.runAllTimersAsync()
-    expect((await settled).message).toContain("invalid json")
+    await Promise.all([
+      expect(loadSnapshot("10123", "/dir")).rejects.toThrow("invalid json"),
+      jest.runAllTimersAsync(),
+    ])
     expect(fetchSpy).toHaveBeenCalledTimes(3)
     jest.useRealTimers()
   })


### PR DESCRIPTION
## Summary

- Root-causes and fixes the nondeterministic `section images in dark mode (screenshot)` diff on macOS/WebKit that surfaced on #1543 (a YAML-only PR that couldn't have changed rendering).
- The screenshot harness now captures until two consecutive frames are byte-identical — the same stabilization contract Playwright's `toHaveScreenshot` applies internally, which our `locator.screenshot()` + `toMatchSnapshot(buffer)` pathway lacked.

## Root cause

1. WebKit paints images larger than its interpolation cutoff (800×800 source pixels, `cInterpolationCutoff`) with **fast low-quality scaling** whenever their painted size just changed, then repaints at high quality when its internal **500 ms `lowQualityTimeThreshold`** timer fires (`WebCore/rendering/ImageQualityController.cpp`).
2. The test-page comparison slider's first image (`original_site.avif`, **3018×1858**) is re-laid-out when the `img-comparison-slider` custom element upgrades, arming that timer. Displayed at ~370 CSS px, the low-quality pass is a heavily aliased 4× point-sample.
3. A capture racing the timer bakes the aliased pass into the shot. Evidence: the failing capture's diff pixels were concentrated in the slider's first image, with *higher* high-frequency energy than the baseline (aliasing, not blur); the second slider image (1440px source, 2× scale) differed too but under threshold (RMS 2.84); and the diff magnitude changed between attempt 1 and its retry (11,234 → 8,469 px) — same race, different timing.

## Changes

- `quartz/components/tests/visual_utils.ts`: add `captureStableScreenshot` — recapture until two consecutive frames are byte-identical, spaced **550 ms** apart (wider than WebKit's 500 ms window, so a pending high-quality repaint always lands between captures and surfaces as a frame difference). Throws loudly after 10 s if the page never stabilizes. Both the element and full-page capture paths go through it. Also removes the `void _elementOpt` destructuring workaround in passing.
- `quartz/plugins/transformers/tests/tweetEmbed.test.ts`: the malformed-JSON test's `.catch()` plumbing did not type-check under `pnpm check` on `main` (`Property 'message' does not exist on type 'Error | TweetSnapshot'`). Restructured to `expect(...).rejects.toThrow("invalid json")` — the asserted message substring and fetch call-count are unchanged.

## Testing

- `pnpm exec tsc --noEmit` — passes (was failing on `main` before the tweetEmbed fix).
- ESLint + Prettier clean on both changed files.
- Loop logic exercised directly via `tsx` with stub captures: stable content settles after exactly 2 captures (~0.55 s overhead per screenshot); an LQ→HQ repaint sequence settles on the HQ frame; a never-stabilizing sequence throws at the deadline.
- WebKit isn't installable in this sandbox and Chromium can't reproduce the WebKit-specific scaling pass; the full CI visual suite (Linux Chromium + macOS WebKit) validates the change end-to-end.

## Lessons learned

- **What**: When a visual regression harness compares raw screenshot buffers via `toMatchSnapshot`, wrap the capture in a stabilize-until-two-identical-frames loop; `toMatchSnapshot(Buffer)` has none of the frame-stabilization that `toHaveScreenshot` provides.
- **Where**: any Playwright visual-testing helper that calls `locator.screenshot()`/`page.screenshot()` and compares the buffer.
- **Why**: engines repaint asynchronously after capture-triggering waits have resolved — WebKit defers high-quality image rescaling by 500 ms (`ImageQualityController.cpp`) — so a single capture races those repaints and produces one-in-N snapshot diffs that look like baseline drift.
- **What**: When diagnosing a "blurry vs crisp" screenshot diff, measure high-frequency energy instead of eyeballing: aliasing (point-sampled downscale) *raises* gradient energy while genuine blur lowers it, and the two implicate entirely different root causes.
- **Where**: visual-diff triage tooling/process.
- **Why**: the failing capture here looked "blurry" but was actually the *sharper* aliased low-quality scaling pass; eyeballing alone suggested the wrong mechanism.


---
_Generated by [Claude Code](https://claude.ai/code/session_013X59e4TNZ1PvVirJo4Gzjb)_