### PR TITLE
chore: gitignore .titleIndex.json build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ tsconfig.tsbuildinfo
 # Regenerated on demand by fetching image bytes; not source of truth.
 quartz/plugins/transformers/.invert_luminance.json
 
+# Slug→title cache written by bindLinkTitles during the build.
+quartz/plugins/transformers/.titleIndex.json
+
 # Tweet snapshots. The build hydrates these from R2 (see tweetEmbed.ts); the
 # durable copy lives at static/tweets/<id>.json on R2, uploaded by
 # scripts/tweet_snapshot.py. A JSON force-added here pins/overrides one offline.


### PR DESCRIPTION
## Summary

- Running any local build (`pnpm build` / `pnpm dev`) writes a slug→title cache to `quartz/plugins/transformers/.titleIndex.json` (via the `bindLinkTitles` transformer) and leaves the worktree dirty, because this cache was never gitignored.
- Add it to `.gitignore` alongside the sibling transformer caches (`.faviconCounts.txt`, `.invert_luminance.json`).

## Changes

- `.gitignore`: ignore `quartz/plugins/transformers/.titleIndex.json`.

## Testing

- Ran an offline build; confirmed `git status` no longer reports the cache file as untracked.

---
_Generated by [Claude Code](https://claude.ai/code/session_0118NsZQNAZjuEALLVqLMUkQ)_