### PR TITLE
perf(styles): quantize fluid root font-size to 2px steps

### DIFF
--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -23,13 +23,16 @@
     var(--max-font-size)
   );
 
+  // Fallback for browsers without CSS round() support (Safari <18, Firefox <128).
+  font-size: var(--base-font-size);
+
   // Quantized to 2px steps: every rem/em measurement on the page derives from
   // this value, so a continuously fluid root font-size forces a full-document
   // restyle and layout on every pixel of viewport-width change during resize.
-  // The empty interpolation stops Sass from parsing this as its own
-  // single-argument global round() function and passes the native CSS
-  // round() call through unchanged.
-  font-size: rou#{""}nd(nearest, var(--base-font-size), 2px);
+  @supports (font-size: round(nearest, 1px, 1px)) {
+    font-size: round(nearest, var(--base-font-size), 2px);
+  }
+
   text-rendering: geometricprecision;
 }
 

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -23,7 +23,13 @@
     var(--max-font-size)
   );
 
-  font-size: var(--base-font-size);
+  // Quantized to 2px steps: every rem/em measurement on the page derives from
+  // this value, so a continuously fluid root font-size forces a full-document
+  // restyle and layout on every pixel of viewport-width change during resize.
+  // The empty interpolation stops Sass from parsing this as its own
+  // single-argument global round() function and passes the native CSS
+  // round() call through unchanged.
+  font-size: rou#{""}nd(nearest, var(--base-font-size), 2px);
   text-rendering: geometricprecision;
 }
 


### PR DESCRIPTION
## Summary

- Resizing the browser window on large pages (e.g. `/test-page`) is laggy — dragging the window edge feels like it takes forever to catch up, especially compared to smaller pages like `/research`.
- Root cause: `quartz/styles/fonts.scss` sets the root `font-size` to a fluid `clamp(14px, 14px + 1vw, 24px)`. Every `rem`/`em` measurement on the page derives from this value, so on every single pixel of viewport-width change, the browser has to restyle and re-layout the *entire* document — not just the boxes that actually reflow. `/test-page` has ~4,000 DOM nodes (116 images, 14 tables, KaTeX, Mermaid diagrams, a large kerning-comparison table, etc.), so that full-document invalidation is expensive on every resize frame.

## Changes

- Quantize the root `font-size` to 2px steps with the CSS `round()` function, so most resize frames don't cross a font-size step at all and skip the whole-document invalidation. The fluid recompute now only fires roughly every ~200px of viewport-width change instead of every 1px.
- Gate the quantized rule behind `@supports (font-size: round(nearest, 1px, 1px))`, matching the existing `@supports` feature-detection pattern later in the same file. Browsers without CSS `round()` (Safari <18, Firefox <128) keep the original unquantized fluid `font-size` instead of silently getting no `font-size` rule at all (an unsupported `round()` call makes the whole declaration invalid CSS).

## Testing

- Traced a scripted resize sweep (1400px → 700px → 1400px) on `/test-page` in headless Chromium via Devtools tracing categories, before/after:
  - Layout: 644ms → 247ms
  - Style recalc (`UpdateLayoutTree`): 617ms → 351ms
- Confirmed via `sass.compile()` that the shipped SCSS emits two separate `:root` rules in the compiled CSS (plain fallback + `@supports`-gated quantized rule), and that the quantized rule correctly references `var(--base-font-size)`.
- Checked computed `font-size` across representative viewport widths (320–1400px) to confirm the fluid range still scales smoothly in 2px increments, with no unexpected jumps.
- `pnpm exec tsc --noEmit` and `pnpm exec stylelint` both pass on the changed file.
- Two independent code-review passes (correctness + idiom/consistency) found no remaining issues.

## Lessons learned

- **What**: Sass's built-in global `round()` function (1 arg) only intercepts a CSS `round()` call when *every* argument is a literal number — as soon as one argument is an unresolvable value like `var(...)`, Sass passes the whole call through untouched as native CSS. Don't reach for interpolation-escape tricks (`rou#{""}nd(...)`) to dodge this collision without first checking whether the actual argument list triggers it.
- **Where**: General Sass/SCSS authoring guidance — worth a note in a SCSS-specific style guide or CLAUDE.md if the pattern comes up again in this repo.
- **Why**: I initially shipped an unnecessary `rou#{""}nd(...)` escape hack based on a live rebuild showing no improvement — but that failure was caused by the dev server's file watcher missing my edit, not a real Sass/CSS collision. A code-review pass caught this by testing `sass.compile()` directly with `var()` in the arguments, which showed the plain `round(...)` call compiles identically with or without the hack.
