### PR TITLE
fix(styles): quantize root font-size to 1px steps, not 2px

### DIFF
--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -26,11 +26,11 @@
   // Fallback for browsers without CSS round() support (Safari <18, Firefox <128).
   font-size: var(--base-font-size);
 
-  // Quantized to 2px steps: every rem/em measurement on the page derives from
+  // Quantized to 1px steps: every rem/em measurement on the page derives from
   // this value, so a continuously fluid root font-size forces a full-document
   // restyle and layout on every pixel of viewport-width change during resize.
   @supports (font-size: round(nearest, 1px, 1px)) {
-    font-size: round(nearest, var(--base-font-size), 2px);
+    font-size: round(nearest, var(--base-font-size), 1px);
   }
 
   text-rendering: geometricprecision;


### PR DESCRIPTION
## Summary

- A recent perf change (#1548) quantized the fluid root font-size to 2px steps to reduce resize-driven style recalc/layout cost. That step size shifted the effective font-size at common tablet/mobile viewports (e.g. iPad Pro 11: 22.34px → 22px; iPhone 12: 17.9px → 18px), cascading into every rem/em-derived measurement on the page and drifting 400+ visual regression screenshots on `main`.
- This PR narrows the quantization step from 2px to 1px, which still eliminates the sub-pixel-continuous restyle during resize (the original perf goal) while keeping the visual delta small enough not to cause sitewide screenshot drift.

## Test plan

- [ ] CI visual-testing suite passes with few or no screenshot diffs (verify against the 400+ diffs seen on `main` at commit `570ed78`)
- [ ] `pnpm check` / `pnpm lint` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvYZdsX7Ec4CzUP5fTajTN)_