### PR TITLE
fix(scripts): repair three silent-failure bugs and drop an unused dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pandas",
     "pillow",
     "protobuf>=6.33.4",
-    "psutil",
     "pyasn1>=0.6.2",
     "pytest",
     "pytest-cov",
@@ -35,7 +34,6 @@ dependencies = [
     "types-pysocks>=1.7.1.20251001",
     "types-pygments==2.20.0.20260508",
     "types-html5lib>=1.1.11.20260508",
-    "types-psutil>=7.2.2.20260508",
     "types-tqdm>=4.67.3.20260508",
     # Pinned to 1.7.7: 1.7.8 (PyCQA/docformatter#344) reformats triple-quoted
     # strings inside function/dict-literal arguments as if they were docstrings,

--- a/scripts/generate_inverted_variants.py
+++ b/scripts/generate_inverted_variants.py
@@ -51,12 +51,6 @@ _SVG_EXTENSIONS: Final[frozenset[str]] = frozenset(
 INVERTIBLE_EXTENSIONS: Final[frozenset[str]] = frozenset(
     script_utils.INVERT_RASTER_EXTENSIONS + script_utils.INVERT_SVG_EXTENSIONS
 ) - frozenset({".gif"})
-# Image modes without an alpha channel — save as RGB rather than RGBA so
-# formats like JPEG (no alpha support) don't error on write.
-_OPAQUE_MODES: Final[frozenset[str]] = frozenset(
-    {"1", "L", "P", "RGB", "I", "F", "CMYK", "YCbCr", "HSV"}
-)
-
 _DEFAULT_LABELS_PATH: Final[Path] = (
     Path(__file__).resolve().parent.parent
     / "quartz"
@@ -84,14 +78,19 @@ def invert_image_file(src: Path, dst: Path) -> None:
     without an alpha channel (JPEG) can save.
     """
     with Image.open(src) as im:
-        source_mode = im.mode
+        # A palette ("P") or RGB image can still carry transparency via a
+        # "transparency" info entry, which convert("RGBA") materializes into a
+        # real alpha channel. Keying opacity off the mode alone would flatten
+        # those transparent regions to a solid color, so consult the actual
+        # alpha data instead.
+        has_alpha = im.mode in ("RGBA", "LA", "PA") or "transparency" in im.info
         rgba = im.convert("RGBA")
     arr = np.array(rgba)
     rgb = arr[..., :3].astype(np.int16)
     delta = (255 - rgb.max(axis=-1) - rgb.min(axis=-1))[..., np.newaxis]
     arr[..., :3] = np.clip(rgb + delta, 0, 255).astype(np.uint8)
     output = Image.fromarray(arr, "RGBA")
-    if source_mode in _OPAQUE_MODES:
+    if not has_alpha:
         output = output.convert("RGB")
     output.save(dst, quality=compress.DEFAULT_IMAGE_QUALITY)
 

--- a/scripts/remove_unreferenced_assets.sh
+++ b/scripts/remove_unreferenced_assets.sh
@@ -2,15 +2,21 @@
 
 # Remove any images in the asset_staging directory that are not referenced in any markdown files.
 
+set -euo pipefail
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
+STAGING_DIR="$GIT_ROOT/website_content/asset_staging"
+
+[ -d "$STAGING_DIR" ] || exit 0
 
 # Use find to properly handle the file listing
-find "$GIT_ROOT/website_content/asset_staging" -type f | while read -r image_file; do
+find "$STAGING_DIR" -type f | while read -r image_file; do
     # Get the basename of the file
     basename=$(basename "$image_file")
 
-    # Use find to properly search through markdown files
-    if ! find "$GIT_ROOT/website_content" -name "*.md" -type f -exec grep -q "$basename" {} \;; then
+    # grep -r exits 0 only if the basename appears in at least one markdown
+    # file; -F treats it as a literal string so dots aren't regex wildcards.
+    if ! grep -rqF --include="*.md" -- "$basename" "$GIT_ROOT/website_content"; then
         echo "File '$basename' doesn't appear in any markdown files. Removing it."
         trash-put "$image_file"
     fi

--- a/scripts/remove_unreferenced_assets.sh
+++ b/scripts/remove_unreferenced_assets.sh
@@ -14,10 +14,16 @@ find "$STAGING_DIR" -type f | while read -r image_file; do
     # Get the basename of the file
     basename=$(basename "$image_file")
 
-    # grep -r exits 0 only if the basename appears in at least one markdown
-    # file; -F treats it as a literal string so dots aren't regex wildcards.
-    if ! grep -rqF --include="*.md" -- "$basename" "$GIT_ROOT/website_content"; then
+    # grep exit codes: 0 = found, 1 = found in no file, >=2 = error. -F treats
+    # the basename as a literal so dots aren't regex wildcards. Only trash on a
+    # definitive "not found" (1); a read error (>=2) must not delete the file.
+    status=0
+    grep -rqF --include="*.md" -- "$basename" "$GIT_ROOT/website_content" ||
+        status=$?
+    if [ "$status" -eq 1 ]; then
         echo "File '$basename' doesn't appear in any markdown files. Removing it."
         trash-put "$image_file"
+    elif [ "$status" -gt 1 ]; then
+        echo "grep failed (exit $status) while checking '$basename'; leaving it in place." >&2
     fi
 done

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -1390,6 +1390,10 @@ def build_sequence_data(markdown_files: list[Path]) -> dict[str, dict]:
             if permalink := metadata.get("permalink", ""):
                 all_sequence_data[permalink] = slug_mapping
             if aliases := metadata.get("aliases", []):
+                # ``aliases`` may be a single scalar string or a list; normalize
+                # to a list so a scalar isn't iterated character-by-character.
+                if isinstance(aliases, str):
+                    aliases = [aliases]
                 for alias in aliases:
                     if not alias:
                         continue

--- a/scripts/tests/test_generate_inverted_variants.py
+++ b/scripts/tests/test_generate_inverted_variants.py
@@ -193,6 +193,25 @@ def test_invert_image_file_preserves_alpha_only_when_source_had_it(
     assert Image.open(dst).mode == expected_mode
 
 
+def test_invert_image_file_preserves_palette_transparency(
+    tmp_path: Path,
+) -> None:
+    """A palette PNG whose transparency lives in a ``transparency`` info entry
+    (not in an alpha channel) must keep its transparent pixels rather than
+    flattening them to a solid color."""
+    src = tmp_path / "src.png"
+    im = Image.new("P", (4, 4), 0)
+    im.putpalette([10, 20, 30] * 256)
+    im.save(src, transparency=0)
+
+    dst = tmp_path / "dst.png"
+    giv.invert_image_file(src, dst)
+
+    out = Image.open(dst)
+    assert out.mode == "RGBA"
+    assert np.array(out)[0, 0, 3] == 0
+
+
 def test_url_to_local_path_decodes_percent_encoding(asset_dir: Path) -> None:
     url = f"{_BASE_URL}/Attachments/Pasted%20image.avif"
     assert giv._url_to_local_path(url, asset_dir, _BASE_URL) == (

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -1218,6 +1218,27 @@ Test content
     assert sequence_data == expected_mapping
 
 
+def test_build_sequence_data_with_scalar_alias(create_test_file: Callable):
+    """A scalar (non-list) alias must be treated as a single key, not iterated
+    character-by-character."""
+    content = """---
+title: Test Post
+permalink: /test
+aliases: /single-alias
+---
+Test content
+"""
+    file_path = create_test_file("test.md", content)
+
+    sequence_data = source_file_checks.build_sequence_data([file_path])
+
+    assert "/single-alias" in sequence_data
+    assert sequence_data["/single-alias"] == {"title": "Test Post"}
+    # A scalar string must not be exploded into single-character keys.
+    assert "/" not in sequence_data
+    assert "s" not in sequence_data
+
+
 def test_build_sequence_data_multiple_files(
     create_test_file: Callable,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -2199,34 +2199,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
-    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
-    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2943,7 +2915,6 @@ dependencies = [
     { name = "pandas-stubs" },
     { name = "pillow" },
     { name = "protobuf" },
-    { name = "psutil" },
     { name = "pyasn1" },
     { name = "pylint" },
     { name = "pyright" },
@@ -2957,7 +2928,6 @@ dependencies = [
     { name = "tqdm" },
     { name = "types-defusedxml" },
     { name = "types-html5lib" },
-    { name = "types-psutil" },
     { name = "types-pygments" },
     { name = "types-pysocks" },
     { name = "types-pyyaml" },
@@ -2993,7 +2963,6 @@ requires-dist = [
     { name = "pandas-stubs" },
     { name = "pillow" },
     { name = "protobuf", specifier = ">=6.33.4" },
-    { name = "psutil" },
     { name = "pyasn1", specifier = ">=0.6.2" },
     { name = "pylint", specifier = ">=4.0.4" },
     { name = "pyright", specifier = "==1.1.410" },
@@ -3007,7 +2976,6 @@ requires-dist = [
     { name = "tqdm" },
     { name = "types-defusedxml", specifier = "==0.7.0.20260504" },
     { name = "types-html5lib", specifier = ">=1.1.11.20260508" },
-    { name = "types-psutil", specifier = ">=7.2.2.20260508" },
     { name = "types-pygments", specifier = "==2.20.0.20260508" },
     { name = "types-pysocks", specifier = ">=1.7.1.20251001" },
     { name = "types-pyyaml", specifier = "==6.0.12.20260510" },
@@ -3061,15 +3029,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/65/d7/8512bdd1d3102a12d5125ad0850153c795bd99f4f5ef496498e494912787/types_html5lib-1.1.11.20260508.tar.gz", hash = "sha256:f44f55f3bd1f7a55477851165c8955a821f2342447a995a17f10a376134ea049", size = 18377, upload-time = "2026-05-08T04:51:35.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/e5/f1c8f553b392c447fbab985e100cf3998e657c10b5996de88f2815b09234/types_html5lib-1.1.11.20260508-py3-none-any.whl", hash = "sha256:cb85cb9dd46cdb18349f9ad08df69cc911921849e154860dad9029da4a2c1c39", size = 24312, upload-time = "2026-05-08T04:51:34.383Z" },
-]
-
-[[package]]
-name = "types-psutil"
-version = "7.2.2.20260508"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/cc/5ac56357b08655ff93106d6391b72d50c47416a044041312550bcd806827/types_psutil-7.2.2.20260508.tar.gz", hash = "sha256:8cfd8339f5e898570f80486423e65d87558d89d0181bf723d20ac5e778fe218e", size = 26575, upload-time = "2026-05-08T04:46:48.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/44/4467583df75313c28abaadfab12f102fba9db7285323e75601acf936d996/types_psutil-7.2.2.20260508-py3-none-any.whl", hash = "sha256:b142452e0953f2d07dbdbb98d81f3a629f5906cc2d94bb7e34da0fba55fbab4a", size = 32777, upload-time = "2026-05-08T04:46:46.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

I audited the repo adversarially (Python, TypeScript, docs/config) and this PR fixes the highest-confidence, lowest-risk **correctness** bugs — cases where a script silently does the wrong thing — plus one unused dependency. Each fix is small, verified, and comes with a regression test where the code path is testable.

## Fixes

### 1. `remove_unreferenced_assets.sh` — the cleanup loop never removed anything
The condition was `if ! find "$ROOT/website_content" -name "*.md" -exec grep -q "$basename" {} \;`. `find`'s exit status is **not** affected by the exit code of an `-exec … \;` command — it stays `0` as long as `find` ran — so `! find …` was always false and the removal branch was **unreachable**. The script silently no-op'd on every `handle_assets.sh` run while implying it cleaned staging.

Verified empirically:
```
$ find /tmp/t -name '*.md' -exec grep -q "NONEXISTENT" {} \; ; echo $?
0            # even though nothing matched
```
Replaced with `grep -rqF --include="*.md"` (literal match so dots aren't wildcards; exits non-zero when the basename appears in no markdown file), and added `set -euo pipefail` plus a staging-directory guard.

### 2. `generate_inverted_variants.py` — palette/transparent images lost their alpha
`invert_image_file` decided whether to keep an alpha channel from the image **mode** alone (`"P"` was treated as always-opaque). A palette PNG (or RGB PNG) whose transparency lives in a `transparency` info entry — common for logos/icons — had its transparent region flattened to a solid color after inversion. Now opacity is read from the materialized alpha (`mode in {RGBA, LA, PA}` or a `transparency` info key), so transparent pixels survive. Added `test_invert_image_file_preserves_palette_transparency`.

### 3. `source_file_checks.py::build_sequence_data` — scalar `aliases` iterated character-by-character
`for alias in aliases` assumed a list, but frontmatter `aliases:` may be a single scalar string. A scalar was iterated per-character, polluting `all_sequence_data` with single-character keys and corrupting sequence-relationship checks. Normalized a scalar to a one-element list, mirroring the existing handling in `get_all_urls`. Added `test_build_sequence_data_with_scalar_alias`.

### 4. Dropped unused `psutil` / `types-psutil`
Neither is imported anywhere in the repo (`git grep psutil` → only `pyproject.toml` + `uv.lock`). Removed both and regenerated `uv.lock` with `uv lock`.

## Verification
- `pytest` on both touched modules: **486 passed**; `generate_inverted_variants` stays at **100%** coverage.
- `ruff format --check`, `ruff check`, `pylint` (10.00/10), `docformatter --check`, `pyright` (0 errors), `shellcheck` — all clean.
- Shell fix exercised on a mock staging tree: referenced asset kept, orphan flagged for removal.

## Scope note — deliberately left out
The adversarial audit surfaced further issues that need owner judgment (they'd require changing tested/intended behavior, and this repo's rule is not to alter test expectations unilaterally). Flagging the most notable for a follow-up:
- **`tagSmallcaps.ts` (high):** an all-caps phrase re-matched against the non-global `REGEX_ALL_CAPS_PHRASE` can drop a leading single-capital token, so body text like `"Model X API"` can render as `"Model API"`.
- **`log.ts` (medium):** a pre-rendered locale string is passed to `format.timestamp({ format })`, which expects a fecha token pattern, so log timestamps are garbled.
- **`aliases.ts` emitter (medium):** the dependency graph declares an output edge to `<permalink>.html` while `emit` writes the redirect at `<originalSlug>.html`, and it mutates the shared `file.data.slug` (couples emitter ordering).
- **`check_metadata_matches` (built_site_checks.py):** raises `KeyError` on a page missing `title`/`description`. I left this untouched — `test_check_metadata_matches_missing_md_keys` asserts the `KeyError` is intentional ("fail loudly"). Noting it in case the fail-loud behavior should become a reported issue instead.

Happy to open focused follow-ups for any of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNk5raSYFn9x9EYpsnPeHt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNk5raSYFn9x9EYpsnPeHt)_