### PR TITLE
fix: keep popover and search-preview dropcaps monochrome

### DIFF
--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -2,7 +2,13 @@ import type { Locator } from "@playwright/test"
 
 import { colorDropcapProbability, DROPCAP_COLORS } from "../constants"
 import { expect, test } from "./fixtures"
-import { gotoPage, triggerAndWaitForSPANav } from "./visual_utils"
+import {
+  gotoPage,
+  isDesktopViewport,
+  moveMouseToSafePosition,
+  search,
+  triggerAndWaitForSPANav,
+} from "./visual_utils"
 
 const DROPCAP_URL = "http://localhost:8080/test-page"
 // A solemn post that opts out of the random color via `no_dropcap_color`.
@@ -121,6 +127,59 @@ test.describe("Random dropcap color", () => {
     expect(await embellishmentColor(dropcapParagraph)).toBe(
       await midgroundFaintColor(dropcapParagraph),
     )
+  })
+
+  // Popovers and search previews mirror another page's article, so the host
+  // page's rolled --random-dropcap-color (set on the root element) would bleed
+  // in and tint their dropcaps. Both must stay monochrome regardless.
+  const forceRedRoll = async (page: Parameters<typeof gotoPage>[0]) => {
+    await page.addInitScript(mockRandom, [0.01, 0.0])
+    await gotoPage(page, DROPCAP_URL)
+    await expect(async () => {
+      const color = await page.evaluate(() =>
+        document.documentElement.style.getPropertyValue("--random-dropcap-color"),
+      )
+      expect(color).toBe("var(--dropcap-background-red)")
+    }).toPass({ timeout: 10_000 })
+  }
+
+  test("search preview dropcap stays monochrome even when a color rolls", async ({ page }) => {
+    test.skip(!isDesktopViewport(page), "Search preview dropcap is desktop-only")
+    await forceRedRoll(page)
+
+    await search(page, "test")
+    const previewArticle = page.locator("#preview-container > article.search-preview")
+    await expect(previewArticle).toHaveAttribute("data-use-dropcap", "true")
+
+    const dropcapParagraph = firstDropcapParagraph(previewArticle)
+    await expect(dropcapParagraph).toBeAttached({ timeout: 15_000 })
+    expect(await embellishmentColor(dropcapParagraph)).toBe(
+      await midgroundFaintColor(dropcapParagraph),
+    )
+  })
+
+  test("popover dropcap stays monochrome even when a color rolls", async ({ page }) => {
+    test.skip(!isDesktopViewport(page), "Popovers are desktop-only")
+    await forceRedRoll(page)
+    // Clear the post-nav flag that suppresses Safari's spurious mouseenter events.
+    await page.mouse.move(1, 1)
+
+    // Point a link at a dropcap-using page so the popover fetches its article.
+    const link = page.locator("a#first-link-test-page")
+    await expect(link).toBeVisible()
+    await link.evaluate((el) => (el as HTMLAnchorElement).setAttribute("href", "./test-page"))
+
+    await link.hover()
+    const popoverArticle = page.locator('.popover-inner article[data-use-dropcap="true"]').first()
+    await expect(popoverArticle).toBeVisible({ timeout: 10_000 })
+
+    const dropcapParagraph = firstDropcapParagraph(popoverArticle)
+    await expect(dropcapParagraph).toBeAttached({ timeout: 10_000 })
+    expect(await embellishmentColor(dropcapParagraph)).toBe(
+      await midgroundFaintColor(dropcapParagraph),
+    )
+
+    await moveMouseToSafePosition(page)
   })
 
   test("color re-rolls on SPA navigation", async ({ page }) => {

--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -151,7 +151,10 @@ test.describe("Random dropcap color", () => {
     const previewArticle = page.locator("#preview-container > article.search-preview")
     await expect(previewArticle).toHaveAttribute("data-use-dropcap", "true")
 
-    const dropcapParagraph = firstDropcapParagraph(previewArticle)
+    // The preview wraps the fetched page's own <article>, and that inner
+    // article is where the dropcap paragraph actually lives.
+    const innerArticle = previewArticle.locator('article[data-use-dropcap="true"]').first()
+    const dropcapParagraph = firstDropcapParagraph(innerArticle)
     await expect(dropcapParagraph).toBeAttached({ timeout: 15_000 })
     expect(await embellishmentColor(dropcapParagraph)).toBe(
       await midgroundFaintColor(dropcapParagraph),

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -474,6 +474,15 @@ article[data-use-dropcap="true"][data-no-dropcap-color="true"] > p:not(.subtitle
   --before-color: var(--midground-faint);
 }
 
+// Popovers and search previews mirror a different page's article, so the
+// current page's rolled --random-dropcap-color (set on the root element) would
+// bleed in and tint their dropcaps. Reset it to the guaranteed-invalid value so
+// these embellishments always fall back to the monochrome --midground-faint.
+.popover,
+.search-preview {
+  --random-dropcap-color: initial;
+}
+
 // EG 1st, 2nd, 3rd. A raised, scaled glyph sized and positioned to match the
 // upright face's designed superscript, so the suffix stays consistent across
 // the upright and italic faces (the italic face ships no superscript glyphs).


### PR DESCRIPTION
## Summary

- The random dropcap color flourish is applied by setting `--random-dropcap-color` on the root element (`document.documentElement`). Popovers and search previews mirror a *different* page's article, so the host page's rolled color cascaded in and tinted their dropcaps.
- Those embellishments should always be monochrome, independent of whatever color the current page happened to roll.

## Changes

- `quartz/styles/fonts.scss`: reset `--random-dropcap-color` to the guaranteed-invalid value (`initial`) inside `.popover` and `.search-preview`, so their dropcap embellishments fall back to `--midground-faint`.
- `quartz/components/tests/dropcap.spec.ts`: add Playwright coverage (desktop-only) that forces a red roll on the host page, then asserts both the search-preview dropcap and the popover dropcap resolve to `--midground-faint`.

## Testing

- `pnpm check` (tsc) and stylelint/eslint pass on the changed files.
- Verified the CSS cascade in isolation with headless Chromium: with a red color rolled on the root, the page dropcap keeps `rgb(200, 0, 0)` while the `.popover` and `.search-preview` dropcaps fall back to the monochrome `--midground-faint`.
- Full Playwright suite runs in CI (the local build can't complete in this environment due to an unrelated missing headless-shell binary for mermaid rendering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TXNravTGrDLMWhZw8i7p)_