### PR TITLE
fix: remove flaky-test tolerance and fix popover orphan race

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -152,6 +152,13 @@ Wait for `http://localhost:8080`, then:
 npx playwright test --config config/playwright/playwright.config.ts -g "test name pattern"
 ```
 
+**Fast iteration loop.** A full site rebuild (~50s) + whole-spec run (~2min) per check is almost never needed:
+
+- Build once, keep the server running, and reuse both across runs (`PLAYWRIGHT_BASE_URL=http://localhost:8080` skips the config's webServer entirely; `pnpm serve public -l 8080` serves an existing build).
+- Rebuild the site **only** when bundled client code changes (`*.inline.ts`, transformers/emitters, styles). Edits to `*.spec.ts` or test helpers like `visual_utils.ts` run against the existing build — no rebuild.
+- Run the single affected test with `-g "exact test name"` and one `--project "Desktop Chrome"` instead of the whole file/matrix: ~8s instead of ~2min.
+- For flake-hunting a specific test, add `--repeat-each 5` to the targeted run rather than re-running the whole spec.
+
 ## Offline builds
 
 For sandboxed sessions / CI without network:

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -109,7 +109,10 @@ export default defineConfig({
   // macOS ARM runners have 3 cores but Playwright defaults to 1 worker for
   // WebKit, causing shards to hit their job timeout. Force 3 workers on macOS.
   workers: process.env.PLAYWRIGHT_BROWSERS === "webkit" ? 3 : undefined,
+  // The CI retry distinguishes a flaky test from a consistently broken one in
+  // the report, but flaky is still a failure: zero-flakiness policy.
   retries: process.env.CI ? 1 : 0,
+  failOnFlakyTests: true,
   testDir: "../../quartz/",
   testMatch: /.*\.spec\.ts/,
   // getScreenshotName already incorporates browser name into the

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -72,15 +72,15 @@ async function mouseEnterHandler(this: HTMLLinkElement) {
     return
   }
 
+  if (!popoverElement) {
+    throw new Error("Failed to create popover")
+  }
+
   // Hover popovers are dismissed by mouseleave on the link or the popover, so
   // they must only attach while the pointer is still over the link: attaching
   // after the pointer left would leave a popover with no dismissal path.
   if (!shouldPin && !this.matches(":hover")) {
     return
-  }
-
-  if (!popoverElement) {
-    throw new Error("Failed to create popover")
   }
   // Used by the click toggle logic to detect "is this popover already open for this link?"
   popoverElement.dataset.linkHref = this.href

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -72,6 +72,13 @@ async function mouseEnterHandler(this: HTMLLinkElement) {
     return
   }
 
+  // Hover popovers are dismissed by mouseleave on the link or the popover, so
+  // they must only attach while the pointer is still over the link: attaching
+  // after the pointer left would leave a popover with no dismissal path.
+  if (!shouldPin && !this.matches(":hover")) {
+    return
+  }
+
   if (!popoverElement) {
     throw new Error("Failed to create popover")
   }

--- a/quartz/components/tests/console-clean.spec.ts
+++ b/quartz/components/tests/console-clean.spec.ts
@@ -81,14 +81,27 @@ for (const slug of PAGES_TO_CHECK) {
 
     // Sub-resource requests (fonts, images, analytics) can emit console
     // errors after the `load` event, so every request that started must
-    // settle before `offenders` is read.
+    // settle before `offenders` is read. Hand-rolled because the linter
+    // bans `waitForLoadState("networkidle")`; like networkidle, a quiet
+    // window is required so a momentary zero between dependent requests
+    // (a stylesheet finishing triggers a font request) doesn't count.
     const inflightRequests = new Set<Request>()
     page.on("request", (req) => inflightRequests.add(req))
     page.on("requestfinished", (req) => inflightRequests.delete(req))
     page.on("requestfailed", (req) => inflightRequests.delete(req))
 
+    const NETWORK_QUIET_WINDOW_MS = 500
     await gotoPage(page, `${BASE_URL}${slug}`)
-    await expect.poll(() => inflightRequests.size, { timeout: 15_000 }).toBe(0)
+    await expect
+      .poll(
+        async () => {
+          if (inflightRequests.size > 0) return inflightRequests.size
+          await new Promise((resolve) => setTimeout(resolve, NETWORK_QUIET_WINDOW_MS))
+          return inflightRequests.size
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(0)
 
     expect(
       offenders,

--- a/quartz/components/tests/console-clean.spec.ts
+++ b/quartz/components/tests/console-clean.spec.ts
@@ -1,3 +1,5 @@
+import type { Request } from "@playwright/test"
+
 import { expect, test } from "./fixtures"
 import { gotoPage } from "./visual_utils"
 
@@ -77,7 +79,16 @@ for (const slug of PAGES_TO_CHECK) {
       offenders.push(`[pageerror] ${err.message}`)
     })
 
+    // Sub-resource requests (fonts, images, analytics) can emit console
+    // errors after the `load` event, so every request that started must
+    // settle before `offenders` is read.
+    const inflightRequests = new Set<Request>()
+    page.on("request", (req) => inflightRequests.add(req))
+    page.on("requestfinished", (req) => inflightRequests.delete(req))
+    page.on("requestfailed", (req) => inflightRequests.delete(req))
+
     await gotoPage(page, `${BASE_URL}${slug}`)
+    await expect.poll(() => inflightRequests.size, { timeout: 15_000 }).toBe(0)
 
     expect(
       offenders,

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -187,6 +187,22 @@ async function holdFirstPopoverFetch(
   return { intercepted, release }
 }
 
+/**
+ * Releases a held popover-fixture fetch and waits until the request fully
+ * finishes (body included) plus two painted frames, so any DOM mutation from
+ * the resolved fetch has landed before a negative assertion runs.
+ */
+async function releaseAndProcessPopoverFetch(page: Page, release: () => void): Promise<void> {
+  const requestFinished = page.waitForEvent("requestfinished", (request) =>
+    request.url().includes("popover-fixture"),
+  )
+  release()
+  await requestFinished
+  await page.evaluate(
+    () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+  )
+}
+
 test("Popover does not attach when mouse leaves during content fetch", async ({
   page,
   dummyLink,
@@ -200,11 +216,7 @@ test("Popover does not attach when mouse leaves during content fetch", async ({
   // The pointer leaves the link while the popover content is still loading.
   await moveMouseToSafePosition(page)
 
-  // Release the held fetch and wait for the response so mouseEnterHandler has
-  // had a chance to process it.
-  const responsePromise = page.waitForResponse("**/popover-fixture")
-  release()
-  await responsePromise
+  await releaseAndProcessPopoverFetch(page, release)
 
   // The popover must not attach: with the pointer already gone, no mouseleave
   // could ever dismiss it.
@@ -441,11 +453,8 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
   // Click the link to trigger SPA navigation while the popover fetch is held.
   await triggerAndWaitForSPANav(page, () => dummyLink.click())
 
-  // Release the held fetch and wait for the response to complete, so we know
-  // mouseEnterHandler has had a chance to process it (and should bail out).
-  const responsePromise = page.waitForResponse("**/popover-fixture")
-  release()
-  await responsePromise
+  // Let mouseEnterHandler fully process the released fetch (and bail out).
+  await releaseAndProcessPopoverFetch(page, release)
 
   // No orphaned popover should appear on the new page.
   const popover = page.locator(".popover")

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -1,4 +1,4 @@
-import type { Locator } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 
 import { minDesktopWidth } from "../../styles/variables"
 import { popoverScrollOffset, scrollTolerance } from "../constants"
@@ -153,6 +153,62 @@ test("Multiple popovers don't stack without wait", async ({ page }) => {
   await expect(async () => {
     await expect(page.locator(".popover")).toHaveCount(0)
   }).toPass({ timeout: 5_000 })
+})
+
+/**
+ * Holds the first fetch of the popover fixture so a test can control when the
+ * in-flight popover creation resolves.
+ *
+ * @returns `intercepted` resolves once the fetch is in flight; `release` lets
+ * the held fetch complete.
+ */
+async function holdFirstPopoverFetch(
+  page: Page,
+): Promise<{ intercepted: Promise<void>; release: () => void }> {
+  // skipcq: JS-0321 -- placeholder reassigned inside the promise executor
+  let release = (): void => {}
+  const holdFetch = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  // skipcq: JS-0321 -- placeholder reassigned inside the promise executor
+  let onIntercepted = (): void => {}
+  const intercepted = new Promise<void>((resolve) => {
+    onIntercepted = resolve
+  })
+  let firstRequest = true
+  await page.route("**/popover-fixture", async (route) => {
+    if (firstRequest) {
+      firstRequest = false
+      onIntercepted()
+      await holdFetch
+    }
+    await route.continue()
+  })
+  return { intercepted, release }
+}
+
+test("Popover does not attach when mouse leaves during content fetch", async ({
+  page,
+  dummyLink,
+}) => {
+  const { intercepted, release } = await holdFirstPopoverFetch(page)
+
+  // Hover to start the popover timer; wait until the fetch is in flight.
+  await dummyLink.hover()
+  await intercepted
+
+  // The pointer leaves the link while the popover content is still loading.
+  await moveMouseToSafePosition(page)
+
+  // Release the held fetch and wait for the response so mouseEnterHandler has
+  // had a chance to process it.
+  const responsePromise = page.waitForResponse("**/popover-fixture")
+  release()
+  await responsePromise
+
+  // The popover must not attach: with the pointer already gone, no mouseleave
+  // could ever dismiss it.
+  await expect(page.locator(".popover")).toHaveCount(0)
 })
 
 test("Popover updates position on window resize", async ({ page, dummyLink }) => {
@@ -376,30 +432,11 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
   await expect(dummyLink).toBeVisible()
 
   // Delay the popover fetch so it completes *after* SPA navigation.
-  // Use a promise to signal when the fetch has been intercepted, and a
-  // second one to control when it resolves (after navigation completes).
-
-  // skipcq: JS-0321 -- placeholder reassigned inside the promise
-  let releasePopoverFetch = (): void => {}
-  const popoverFetchIntercepted = new Promise<void>((resolve) => {
-    const holdFetch = new Promise<void>((release) => {
-      releasePopoverFetch = release
-    })
-    let firstRequest = true
-    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
-    void page.route("**/popover-fixture", async (route) => {
-      if (firstRequest) {
-        firstRequest = false
-        resolve() // signal that the popover fetch has started
-        await holdFetch // hold the response until we release it
-      }
-      await route.continue()
-    })
-  })
+  const { intercepted, release } = await holdFirstPopoverFetch(page)
 
   // Hover to start the popover timer; wait until the fetch is actually in-flight.
   await dummyLink.hover()
-  await popoverFetchIntercepted
+  await intercepted
 
   // Click the link to trigger SPA navigation while the popover fetch is held.
   await triggerAndWaitForSPANav(page, () => dummyLink.click())
@@ -407,7 +444,7 @@ test("In-flight popover fetch does not create orphaned popover after navigation"
   // Release the held fetch and wait for the response to complete, so we know
   // mouseEnterHandler has had a chance to process it (and should bail out).
   const responsePromise = page.waitForResponse("**/popover-fixture")
-  releasePopoverFetch()
+  release()
   await responsePromise
 
   // No orphaned popover should appear on the new page.

--- a/quartz/components/tests/print.spec.ts
+++ b/quartz/components/tests/print.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "./fixtures"
-import { gotoPage, setTheme, takeRegressionScreenshot } from "./visual_utils"
+import {
+  captureStableScreenshot,
+  gotoPage,
+  setTheme,
+  takeRegressionScreenshot,
+} from "./visual_utils"
 
 // Visual regression tests don't need assertions
 /* eslint-disable playwright/expect-expect */
@@ -31,23 +36,29 @@ test("Print media layout (screenshot)", async ({ page }, testInfo) => {
 })
 
 test("Print mode renders identically in light and dark themes", async ({ page }) => {
+  // Both captures compare byte-for-byte, so the webfont swap must complete
+  // before the first one; captureStableScreenshot then absorbs any other
+  // late repaints on each side of the comparison.
+  await page.evaluate(() => document.fonts.ready)
+
   await setTheme(page, "light")
   await page.emulateMedia({ media: "print" })
-  const lightScreenshot = await page.screenshot({
-    animations: "disabled",
-    scale: "css",
-  })
+  const lightScreenshot = await captureStableScreenshot(
+    () => page.screenshot({ animations: "disabled", scale: "css" }),
+    "print-theme-light",
+  )
 
   await page.emulateMedia({ media: "screen" })
   await setTheme(page, "dark")
   // Fire beforeprint to trigger the JS that swaps data-theme to light,
   // matching real browser behavior (emulateMedia alone doesn't fire it).
   await page.evaluate(() => window.dispatchEvent(new Event("beforeprint")))
+  await expect(page.locator(":root")).toHaveAttribute("data-theme", "light")
   await page.emulateMedia({ media: "print" })
-  const darkScreenshot = await page.screenshot({
-    animations: "disabled",
-    scale: "css",
-  })
+  const darkScreenshot = await captureStableScreenshot(
+    () => page.screenshot({ animations: "disabled", scale: "css" }),
+    "print-theme-dark",
+  )
 
   expect(darkScreenshot).toEqual(lightScreenshot)
 })

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "../constants"
 import { expect, test } from "./fixtures"
 import {
+  captureStableScreenshot,
   gotoPage,
   isDesktopViewport,
   isElementChecked,
@@ -576,14 +577,22 @@ test.describe("Admonitions", () => {
       await admonition.click()
       await expect(admonition).not.toHaveClass(/.*is-collapsed.*/)
       await waitForTransitionEnd(admonition)
-      const openedScreenshot = await admonition.screenshot()
+      // The opened and after-content-click captures compare byte-for-byte,
+      // so both must be stable frames rather than raw one-shot captures.
+      const openedScreenshot = await captureStableScreenshot(
+        () => admonition.screenshot(),
+        `admonition-opened-${theme}`,
+      )
       expect(openedScreenshot).not.toEqual(initialScreenshot)
 
       // Click on content should NOT close it
       const content = admonition.locator(".admonition-content").first()
       await content.click()
       await expect(admonition).not.toHaveClass(/.*is-collapsed.*/)
-      const afterContentClickScreenshot = await admonition.screenshot()
+      const afterContentClickScreenshot = await captureStableScreenshot(
+        () => admonition.screenshot(),
+        `admonition-after-content-click-${theme}`,
+      )
       expect(afterContentClickScreenshot).toEqual(openedScreenshot)
 
       // Click on title should close it
@@ -1073,15 +1082,23 @@ test.describe("Video Speed Controller visibility", () => {
 test("First paragraph is the same before and after clicking on a heading", async ({ page }) => {
   const firstParagraph = page.locator("#center-content article > p").first()
 
-  // Capture the paragraph before navigating to a heading anchor.
-  const screenshotBefore = await firstParagraph.screenshot()
+  // The captures compare byte-for-byte, so the webfont swap must complete
+  // before the first one and each capture must be a stable frame.
+  await page.evaluate(() => document.fonts.ready)
+  const screenshotBefore = await captureStableScreenshot(
+    () => firstParagraph.screenshot(),
+    "first-paragraph-before-anchor-nav",
+  )
 
   // Navigate to a heading anchor (triggers SPA navigation).
   await gotoPage(page, `${page.url()}#header-3`)
   await firstParagraph.scrollIntoViewIfNeeded()
 
   // The paragraph should look identical after the navigation.
-  const screenshotAfter = await firstParagraph.screenshot()
+  const screenshotAfter = await captureStableScreenshot(
+    () => firstParagraph.screenshot(),
+    "first-paragraph-after-anchor-nav",
+  )
   expect(screenshotAfter).toEqual(screenshotBefore)
 })
 
@@ -1456,16 +1473,12 @@ test.describe("Popovers on different page types", () => {
       await expect(popoverLink).toBeVisible()
 
       await popoverLink.hover()
-      await page.waitForFunction(
-        () => {
-          const popover = document.querySelector(".popover.popover-visible")
-          return popover !== null
-        },
-        { timeout: 5000 },
-      )
 
+      // The popover appears only after the 300ms hover-intent delay plus a
+      // fetch and render of the target page, so give it a generous timeout
+      // for slow CI runners.
       const popover = page.locator(".popover.popover-visible")
-      await expect(popover).toBeVisible()
+      await expect(popover).toBeVisible({ timeout: 15_000 })
       const popoverInner = popover.locator(".popover-inner")
       await expect(popoverInner).toBeVisible()
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -1474,9 +1474,9 @@ test.describe("Popovers on different page types", () => {
 
       await popoverLink.hover()
 
-      // The popover appears only after the 300ms hover-intent delay plus a
-      // fetch and render of the target page, so give it a generous timeout
-      // for slow CI runners.
+      // The popover appears only after the hover-intent delay
+      // (popoverRemovalDelayMs) plus a fetch and render of the target page,
+      // so give it a generous timeout for slow CI runners.
       const popover = page.locator(".popover.popover-visible")
       await expect(popover).toBeVisible({ timeout: 15_000 })
       const popoverInner = popover.locator(".popover-inner")

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -138,6 +138,12 @@ export interface RegressionScreenshotOptions {
 // of a remote AVIF, short enough that a genuinely dead image can't hang the run.
 const IMAGE_PAINT_TIMEOUT_MS = 15000
 
+// WebKit's `document.fonts.ready` can hang indefinitely when a `@font-face`
+// request never settles, burning the whole test timeout. Bound the wait: the
+// two-equal-frames `captureStableScreenshot` loop is the real guarantee that
+// fonts have painted, so a late swap still shows up as a frame difference.
+const FONTS_READY_TIMEOUT_MS = 10000
+
 // WebKit paints images above its interpolation cutoff (800×800 source pixels)
 // with fast low-quality scaling whenever their painted size just changed
 // (e.g. a custom element upgrading and re-laying-out its slotted images), then
@@ -247,7 +253,12 @@ export async function waitForImagesInElement(
 }
 
 async function waitForVisualStability(page: Page, scope?: Locator): Promise<void> {
-  await page.evaluate(() => document.fonts.ready)
+  await page.evaluate(async (timeoutMs) => {
+    await Promise.race([
+      document.fonts.ready,
+      new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+    ])
+  }, FONTS_READY_TIMEOUT_MS)
   if (scope) {
     await waitForImagesInElement(scope)
   } else {

--- a/scripts/classify_visual_failures.py
+++ b/scripts/classify_visual_failures.py
@@ -7,11 +7,15 @@ one ``*-actual.png`` — produced by ``toHaveScreenshot()`` for both
 missing and pixel-diff outcomes. Other failed tests (timeouts, page
 errors, exceptions before reaching ``toHaveScreenshot()``) are "real".
 
-Reads one or more blob-report ZIPs and writes two flags suitable for
+A "flaky failure" is a test that only reached its expected status after
+one or more retries. Zero-flakiness policy: nondeterminism is a defect,
+so flaky tests count as real failures and fail the shard.
+
+Reads one or more blob-report ZIPs and writes flags suitable for
 ``$GITHUB_OUTPUT``:
 
-- ``has_any_failures`` — at least one test ended unexpected
-- ``has_real_failures`` — at least one of those was not snapshot-only
+- ``has_any_failures`` — at least one test ended unexpected or flaky
+- ``has_real_failures`` — at least one real or flaky failure
 
 Snapshot-only shards stay green while the overall ``visual-testing``
 status and ``publish-visual-report`` still surface a failure.
@@ -47,16 +51,21 @@ class Classification:
 
     snapshot_failures: int
     real_failures: int
+    flaky_failures: int = 0
 
     @property
     def has_any_failures(self) -> bool:
-        """True iff any snapshot or real failure was observed."""
-        return self.snapshot_failures > 0 or self.real_failures > 0
+        """True iff any snapshot, real, or flaky failure was observed."""
+        return (
+            self.snapshot_failures > 0
+            or self.real_failures > 0
+            or self.flaky_failures > 0
+        )
 
     @property
     def has_real_failures(self) -> bool:
-        """True iff at least one non-snapshot failure was observed."""
-        return self.real_failures > 0
+        """True iff at least one non-snapshot or flaky failure was observed."""
+        return self.real_failures > 0 or self.flaky_failures > 0
 
 
 def _record_test_end(tests: dict[str, _TestState], params: dict) -> None:
@@ -85,8 +94,8 @@ def _record_attachments(tests: dict[str, _TestState], params: dict) -> None:
             return
 
 
-def _classify_blob(blob_zip: Path) -> tuple[int, int]:
-    """Return ``(snapshot_failures, real_failures)`` for one blob ZIP."""
+def _classify_blob(blob_zip: Path) -> tuple[int, int, int]:
+    """Return ``(snapshot, real, flaky)`` failure counts for one blob ZIP."""
     tests: dict[str, _TestState] = defaultdict(_TestState)
     for event in iter_events(blob_zip):
         method = event.get("method")
@@ -98,31 +107,42 @@ def _classify_blob(blob_zip: Path) -> tuple[int, int]:
 
     snapshot_failures = 0
     real_failures = 0
+    flaky_failures = 0
     for state in tests.values():
-        # A test is an "unexpected" outcome only when no retry produced
-        # its expected status. Flaky-but-eventually-passing tests are
-        # not failures and don't block the shard.
-        if state.expected_status in state.observed_statuses:
-            continue
         if not state.observed_statuses:
+            continue
+        needed_retry = any(
+            status != state.expected_status
+            for status in state.observed_statuses
+        )
+        if state.expected_status in state.observed_statuses:
+            # A test that reached its expected status only after a retry is
+            # flaky. Zero-flakiness policy: that nondeterminism is a defect
+            # in its own right, so it blocks the shard like a real failure.
+            if needed_retry:
+                flaky_failures += 1
             continue
         if state.has_snapshot_attachment:
             snapshot_failures += 1
         else:
             real_failures += 1
-    return snapshot_failures, real_failures
+    return snapshot_failures, real_failures, flaky_failures
 
 
 def classify_directory(blob_reports_dir: Path) -> Classification:
     """Classify every ``*.zip`` blob report under ``blob_reports_dir``."""
     snapshot_total = 0
     real_total = 0
+    flaky_total = 0
     for blob_zip in sorted(blob_reports_dir.rglob("*.zip")):
-        snapshot, real = _classify_blob(blob_zip)
+        snapshot, real, flaky = _classify_blob(blob_zip)
         snapshot_total += snapshot
         real_total += real
+        flaky_total += flaky
     return Classification(
-        snapshot_failures=snapshot_total, real_failures=real_total
+        snapshot_failures=snapshot_total,
+        real_failures=real_total,
+        flaky_failures=flaky_total,
     )
 
 
@@ -132,6 +152,7 @@ def _write_flags(result: Classification, output_path: Path | None) -> None:
         f"has_real_failures={'true' if result.has_real_failures else 'false'}",
         f"snapshot_failures={result.snapshot_failures}",
         f"real_failures={result.real_failures}",
+        f"flaky_failures={result.flaky_failures}",
     ]
     text = "\n".join(lines) + "\n"
     if output_path is None:

--- a/scripts/tests/test_classify_visual_failures.py
+++ b/scripts/tests/test_classify_visual_failures.py
@@ -60,13 +60,15 @@ def _classify_with_events(tmp_path: Path, events: list[dict]) -> _Cls:
 
 
 @pytest.mark.parametrize(
-    "snapshot, real",
-    [(0, 0), (3, 0), (0, 2), (1, 1)],
+    "snapshot, real, flaky",
+    [(0, 0, 0), (3, 0, 0), (0, 2, 0), (1, 1, 0), (0, 0, 2), (1, 0, 1)],
 )
-def test_classification_flags(snapshot: int, real: int) -> None:
-    c = _Cls(snapshot_failures=snapshot, real_failures=real)
-    assert c.has_any_failures is (snapshot + real > 0)
-    assert c.has_real_failures is (real > 0)
+def test_classification_flags(snapshot: int, real: int, flaky: int) -> None:
+    c = _Cls(
+        snapshot_failures=snapshot, real_failures=real, flaky_failures=flaky
+    )
+    assert c.has_any_failures is (snapshot + real + flaky > 0)
+    assert c.has_real_failures is (real + flaky > 0)
 
 
 @pytest.mark.parametrize(
@@ -97,8 +99,16 @@ def test_classification_flags(snapshot: int, real: int) -> None:
                 _attach("t1", ["foo-actual.png"]),
                 _test_end("t1", "passed"),
             ],
-            _Cls(0, 0),
-            id="flaky_retry_passes",
+            _Cls(0, 0, 1),
+            id="flaky_retry_pass_is_flaky_failure",
+        ),
+        pytest.param(
+            [
+                _test_end("t1", "failed"),
+                _test_end("t1", "passed"),
+            ],
+            _Cls(0, 0, 1),
+            id="flaky_without_snapshot_is_flaky_failure",
         ),
         pytest.param(
             [_test_end("t1", "failed", expected_status="failed")],
@@ -254,6 +264,16 @@ def _flags_from(text: str) -> dict[str, str]:
             1,
             {"has_real_failures": "true"},
             id="real_failure_with_fail_on_real_exits_one",
+        ),
+        pytest.param(
+            [
+                _test_end("t1", "failed"),
+                _test_end("t1", "passed"),
+            ],
+            ["--fail-on-real"],
+            1,
+            {"has_real_failures": "true", "flaky_failures": "1"},
+            id="flaky_failure_with_fail_on_real_exits_one",
         ),
         pytest.param(
             [


### PR DESCRIPTION
## Summary

- Fixes the root cause of the `Multiple popovers don't stack without wait` CI flake: a hover popover whose content fetch resolved after the pointer had already left the link attached to the DOM with no `mouseleave` left to dismiss it, so it stayed up forever. `mouseEnterHandler` now discards the popover when the link is no longer hovered (pinned footnote popovers are unaffected).
- Removes flaky-test tolerance across the Playwright pipeline: a test that only passes on retry now fails the run (`failOnFlakyTests`) and blocks visual shards (`classify_visual_failures.py` counts flaky as real).
- Hardens the other race-prone specs found in a full audit of the suite.

## Changes

- `quartz/components/scripts/popover.inline.ts`: bail out of `mouseEnterHandler` after the fetch when the popover is unpinned and the link no longer matches `:hover`.
- `quartz/components/tests/popover.spec.ts`: new deterministic regression test (`Popover does not attach when mouse leaves during content fetch`) that holds the fixture fetch, moves the pointer away, releases the fetch, and asserts no popover attaches; shared `holdFirstPopoverFetch` helper extracted from the existing in-flight-navigation test.
- `config/playwright/playwright.config.ts`: `failOnFlakyTests: true`. The CI retry stays so the report still distinguishes flaky from consistently broken, but a retry-pass no longer makes the run green.
- `scripts/classify_visual_failures.py` (+ tests): a test that reached its expected status only after a retry is now counted as a `flaky_failure` and sets `has_real_failures`, so flaky tests fail visual shards too. Snapshot-only diffs still keep shards green. **Note: this flips the previous `flaky_retry_passes` test expectation** — flaky-but-eventually-passing used to be forgiven by design; per zero-flakiness policy it now blocks the shard.
- `quartz/components/tests/print.spec.ts`: the light/dark print equality test compared two raw one-shot `page.screenshot()` buffers with no font wait and no wait for the `beforeprint` theme swap; both captures now wait for `document.fonts.ready`, use the two-equal-frames `captureStableScreenshot` loop, and assert `data-theme` flipped before capturing.
- `quartz/components/tests/visual-regression.spec.ts`:
  - admonition opened/after-content-click and first-paragraph before/after-anchor-nav byte-equality comparisons stabilized the same way;
  - popover-on-index-pages tests replace a tight 5s `waitForFunction` with a retrying `toBeVisible({ timeout: 15_000 })` (300ms hover-intent delay + fetch + render is tight on slow CI runners).
- `quartz/components/tests/console-clean.spec.ts`: `offenders` was read immediately at the `load` boundary while sub-resource requests were still in flight; the test now tracks started requests and polls until all have settled before asserting.

## Testing

- Built the site offline with fixtures and ran locally on Desktop Chrome: full `popover.spec.ts` (38 tests), `print.spec.ts`, `console-clean.spec.ts`, and the changed `visual-regression.spec.ts` tests — all green.
- Stress-ran the two "don't stack" tests, the new regression test, and the in-flight-navigation test with `--repeat-each 5` (20 runs): all pass.
- Verified the new regression test **fails deterministically with the fix reverted** (rebuilt the bundle without the `:hover` guard: popover attaches and the count assertion fails).
- `uv run pytest scripts/tests/test_classify_visual_failures.py`: 33 passed.
- `tsc`, eslint, prettier, stylelint clean on all changed files.

## Lessons Learned

- **What**: When an element is created asynchronously in response to a hover (fetch-then-attach), re-check the hover state (`element.matches(":hover")`) after the await before attaching; otherwise the element attaches after the pointer left and no dismissal event will ever fire.
- **Where**: Any hover-triggered async UI (popovers, tooltips, previews) — here `quartz/components/scripts/popover.inline.ts`.
- **Why**: The orphaned element manifests as a rare CI-only flake (needs a >debounce-delay stall between `mouseenter` and `mouseleave`), so it reads like test noise when it is a real user-facing bug. A route-hold regression test (`page.route` that parks the fetch while the pointer moves away) reproduces it deterministically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc9SocrogUKqGLTtCgNhDT)_