### PR TITLE
refactor: size inline-img in em so it scales with surrounding text

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -642,14 +642,17 @@ img {
 
   &.inline-img {
     display: inline;
-    width: 0.9rem;
-    height: 0.9rem;
+
+    // Sized in `em` (like `img.emoji`) so the glyph scales with the surrounding
+    // font-size instead of staying a fixed root-relative size in headings/captions.
+    width: 0.9em;
+    height: 0.9em;
     object-fit: contain;
     vertical-align: middle;
     margin: 0;
-    margin-left: 0.05rem;
-    margin-right: 0.025rem;
-    margin-bottom: 0.1rem;
+    margin-left: 0.05em;
+    margin-right: 0.025em;
+    margin-bottom: 0.1em;
   }
 
   &.white-when-dark {


### PR DESCRIPTION
## Summary

- The glyph-sized inline sprites (agent chevron, SafeLife tiles) were pinned in `rem`, so they stayed a fixed physical size regardless of context. Switch `.inline-img` to `em` — matching how `img.emoji` is already sized — so the glyph scales with the surrounding font-size (larger in headings, smaller in captions) instead of being a fixed root-relative size.

## Changes

- `quartz/styles/custom.scss`: `.inline-img` `width`/`height` and horizontal/bottom margins changed from `rem` to `em`. The explicit `height` + `object-fit: contain` are kept, so the correctly-sized box guarantee from the previous fix is preserved.

## Testing

- `npx stylelint` / `npx prettier --check` — clean.
- Visual regression (backlinks chevron screenshot) will confirm sizing in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_012Mv7JSM6SDwf94GAtcAyLH)_