### PR TITLE
style(tweet): share margin var for X icon offset

### DIFF
--- a/quartz/components/styles/tweet.scss
+++ b/quartz/components/styles/tweet.scss
@@ -91,14 +91,18 @@
   margin: 0;
 }
 
+// Shared corner offset for the source-link icon, so its distance from the
+// top edge matches its distance from the right edge.
+$tweet-source-link-offset: calc(1 * $base-margin);
+
 .tweet-source-link {
   position: absolute;
 
   // Slightly above the card's padding edge so the icon reads as tucked into
   // the corner instead of pinned level with the name row — this holds
   // regardless of how long the display name is, since the name never wraps.
-  top: calc(1 * $base-margin);
-  right: calc(1.5 * $base-margin);
+  top: $tweet-source-link-offset;
+  right: $tweet-source-link-offset;
   background-color: transparent;
   line-height: 0;
 


### PR DESCRIPTION
## Summary
- Introduced `$tweet-source-link-offset` in `quartz/components/styles/tweet.scss` so the X ("Twitter") source-link icon's `top` and `right` offsets share the same `$base-margin`-derived value, instead of using two different multiples.

## Test plan
- [x] `pnpm check` (stylelint passed; pre-existing unrelated prettier warnings in two markdown files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAjMYmZc2EaiNcNrrLaNZT)_