### PR TITLE
fix: resolve the three failures keeping main red

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -86,6 +86,15 @@ function sanitizeConfigForBrowser(
   return config
 }
 
+// Playwright's screenshotter awaits `document.fonts.ready` with no bound
+// before every capture, so a FontFaceSet stuck in "loading" (seen on WebKit
+// after in-test DOM replacement) hangs the screenshot until the test timeout.
+// `waitForVisualStability` in visual_utils.ts already performs the fonts wait
+// with a 10s cap before each regression screenshot; disable Playwright's
+// internal unbounded one. This file is loaded by every worker process, so the
+// env var reaches the in-process screenshotter.
+process.env.PW_TEST_SCREENSHOT_NO_FONTS_READY = "1"
+
 // `PLAYWRIGHT_BASE_URL` lets CI rerun selected specs against a deployed
 // preview (CF Pages) instead of the local dev server. When it's set we
 // skip the `webServer` entirely — the external URL is already up.

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -771,9 +771,12 @@ base.describe("Footnote popover on mobile", () => {
   })
 
   base("Non-footnote popovers are still hidden on mobile", async ({ page }) => {
-    const regularLink = page
-      .locator('.can-trigger-popover:not([href^="#user-content-fn-"])')
-      .first()
+    // Exclude every hash link (`#…`): footnote refs open pinned popovers, and
+    // same-page ToC anchors live in the desktop ToC, which is hidden at mobile
+    // width (scrolling to a hidden link would hang). `.first()` then lands on a
+    // cross-page internal link (the content-meta tag link), the case this test
+    // is meant to cover.
+    const regularLink = page.locator('.can-trigger-popover:not([href^="#"])').first()
     await regularLink.scrollIntoViewIfNeeded()
     await regularLink.click()
     const popover = page.locator(".popover:not(.footnote-popover)")

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -6,14 +6,20 @@
 
 // Groups a favicon-ending link with its trailing footnote reference so the
 // reference number can't wrap onto its own line. A favicon is a replaced inline
-// element that opens a soft-wrap opportunity on its trailing edge; `nowrap` on
-// the wrapper freezes only the link↔`<sup>` boundary, which is enough because
-// the trailing favicon already lives in its own nowrap `.favicon-span`. The
-// link keeps the global `a { white-space: normal }`, so its own text still
-// wraps — a long favicon-ending link must not be forced onto one overflowing
-// line just to glue its reference number.
+// element that opens a soft-wrap opportunity on its trailing edge. That edge
+// sits *inside* the link, where the global `a { white-space: normal }` governs
+// line breaking, so `nowrap` on the wrapper alone cannot close it in Chromium.
+// A generated U+2060 WORD JOINER at the start of the `<sup>` prohibits the
+// break across the link↔`<sup>` boundary in every engine while the link's own
+// text stays free to wrap — a long favicon-ending link must not be forced onto
+// one overflowing line just to glue its reference number. Generated content
+// stays out of selection and clipboard, unlike a literal joiner in the HTML.
 .favicon-footnote-span {
   white-space: nowrap;
+
+  > sup::before {
+    content: "\2060";
+  }
 }
 
 .favicon {

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -13,7 +13,7 @@
 // break across the link↔`<sup>` boundary in every engine while the link's own
 // text stays free to wrap — a long favicon-ending link must not be forced onto
 // one overflowing line just to glue its reference number. Generated content
-// stays out of selection and clipboard, unlike a literal joiner in the HTML.
+// stays out of selection and clipboard.
 .favicon-footnote-span {
   white-space: nowrap;
 


### PR DESCRIPTION
## Summary

Main is red because of three independent failures on commit 8945c36 (Playwright Tests, Visual Testing, and Deploy — the latter just waits on visual-testing). Each is fixed at its root cause:

- **`footnoteFaviconWrap.spec.ts` (Chromium projects)**: cf53c59 dropped the `> a { white-space: nowrap }` re-assert from `.favicon-footnote-span` so long links could wrap, but the soft-wrap opportunity after a favicon sits *inside* the link, where the global `a { white-space: normal }` governs line breaking — Chromium resumed orphaning the footnote reference. A generated U+2060 WORD JOINER at the start of the `<sup>` (`.favicon-footnote-span > sup::before`) prohibits the break in every engine while the link's own text stays free to wrap. Generated content also stays out of selection/clipboard, unlike a literal joiner in the HTML.
- **`popover.spec.ts` "Non-footnote popovers are still hidden on mobile" (all desktop-browser projects)**: 7b74d8b widened the locator from `:not([href^="#"])` to `:not([href^="#user-content-fn-"])`, which matches the desktop ToC's same-page anchors (popover-capable since #1565). Those are hidden at mobile width, so `.first()` resolved to an invisible link and `scrollIntoViewIfNeeded` timed out. Restored the hash-link exclusion so the test lands on a visible cross-page internal link, the case it covers.
- **Visual Testing (`visual-testing-macos 2/2`)**: "Normal vs visited link colors in dark mode" hung for the full 90s test timeout on WebKit. The blob-report step timeline shows the harness's own bounded `document.fonts.ready` race burned its full 10s cap (fonts stuck in "loading" after the in-test `body.innerHTML` replacement), then `locator.screenshot()` never returned: Playwright's screenshotter awaits `document.fonts.ready` unboundedly before every capture. Since `waitForVisualStability` already performs a deliberate 10s-capped fonts wait before each regression screenshot, the config now sets `PW_TEST_SCREENSHOT_NO_FONTS_READY=1` so a stuck FontFaceSet can no longer hang captures until the test timeout.

## Changes

- `quartz/styles/favicon.scss`: add `> sup::before { content: "\2060" }` to `.favicon-footnote-span`; rewrite the comment to state the actual line-breaking constraint.
- `quartz/components/tests/popover.spec.ts`: restore the `:not([href^="#"])` locator with a comment explaining why hash links must be excluded.
- `config/playwright/playwright.config.ts`: set `PW_TEST_SCREENSHOT_NO_FONTS_READY=1` (config is loaded by every worker, so the env var reaches the in-process screenshotter).

## Testing

- Reproduced the `footnoteFaviconWrap` failure locally on Chromium against an offline build, then verified the fix: the glue test, the long-link overflow test, and the DOM-wrapper test pass on Desktop Chrome / iPad Pro Chrome / iPhone 12 Chrome (the DOM-wrapper test fails locally only because offline builds emit no favicons; it passed in CI before and is unaffected by this change).
- Verified candidate CSS in a standalone Chromium layout probe: wrapper-nowrap-only fails to glue (current main), `> a` nowrap glues but overflows 463px (the pre-cf53c59 bug), word joiner glues with zero overflow.
- "Non-footnote popovers are still hidden on mobile" passes locally on Desktop Chrome.
- Fonts-wait fix verified against Playwright 1.60 source (`_preparePageForScreenshot` gates its unbounded `document.fonts.ready` await on `PW_TEST_SCREENSHOT_NO_FONTS_READY`) and the CI blob report's step timeline; WebKit is not installable in this sandbox.

## Lessons learned

- **What**: When a Playwright screenshot hangs to the test timeout, pull the blob-report artifact and diff `onStepBegin`/`onStepEnd` events — the step that began but never ended pinpoints the hang, and Playwright's screenshotter has an unbounded internal `document.fonts.ready` wait (escape hatch: `PW_TEST_SCREENSHOT_NO_FONTS_READY`).
- **Where**: any repo using Playwright visual regression.
- **Why**: job logs only show "Test timeout exceeded" plus a misleading teardown error; the blob report showed fonts were stuck 10s earlier, turning an "unreproducible WebKit flake" into a bounded-wait fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R85sN67x5inviYQbhD6ECc)_