### PR TITLE
fix: retry WebKit navigation stalls instead of hanging to the test timeout

### DIFF
--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -148,6 +148,11 @@ export default defineConfig({
   use: {
     baseURL,
     trace: "retain-on-failure",
+    // @playwright/test defaults navigationTimeout to 0 (bounded only by the
+    // test timeout), so a stalled WebKit page.goto silently eats the whole
+    // test budget. Bound it so gotoPage can catch the timeout and retry the
+    // navigation within the same attempt.
+    navigationTimeout: 30_000,
     screenshot: {
       mode: "only-on-failure",
       fullPage: true,

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -710,10 +710,14 @@ export async function gotoPage(
   try {
     await page.goto(url, { waitUntil: loadState })
   } catch (error: unknown) {
-    // WebKit on Linux occasionally crashes with "internal error" on page.goto.
-    // Retry once — the second attempt typically succeeds.
-    if (error instanceof Error && error.message.includes("internal error")) {
-      console.warn(`[gotoPage] WebKit internal error navigating to ${url}, retrying once`)
+    // WebKit's page.goto can crash with "internal error" or stall past the
+    // config's navigationTimeout. Both are one-off browser faults: retry the
+    // navigation once — the second attempt typically succeeds.
+    const isRetryable =
+      error instanceof Error &&
+      (error.message.includes("internal error") || error.message.includes("Timeout"))
+    if (isRetryable) {
+      console.warn(`[gotoPage] navigation to ${url} failed, retrying once: ${error.message}`)
       await page.goto(url, { waitUntil: loadState })
     } else {
       throw error


### PR DESCRIPTION
## Summary

Follow-up to #1567. The `visual-testing` check on that PR went red from a WebKit flake unrelated to its changes: the `search.spec.ts` beforeEach hung inside `page.goto` for its entire 270s test budget on `visual-testing-macos (1/2)`, passed on retry, and `failOnFlakyTests` failed the shard (the diff gallery showed 0 failing screenshots — the red was purely this hang). Root cause: `@playwright/test` defaults `navigationTimeout` to 0, so a stalled WebKit navigation is bounded only by the test timeout and can only surface as flaky-or-dead.

## Changes

- `config/playwright/playwright.config.ts`: set `navigationTimeout: 30_000` in the global `use` block so a stalled navigation raises a catchable timeout instead of eating the test budget.
- `quartz/components/tests/visual_utils.ts`: widen `gotoPage`'s existing single-retry (previously only WebKit "internal error" crashes) to also cover navigation timeouts, so a one-off stall recovers within the same attempt instead of registering as flaky.

## Testing

- `tsc --noEmit` passes.
- Re-ran the two Playwright tests fixed in #1567 locally on Desktop Chrome with the 30s navigation bound in place — both pass, confirming the bound doesn't break normal navigations (typical goto here is 2–5s; no spec uses deliberate delays anywhere near 30s).
- The WebKit stall itself is not reproducible on demand; the fix converts it from an unbounded hang into a logged, retried navigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R85sN67x5inviYQbhD6ECc)_