### PR TITLE
fix: drop the load-event wait from search spec navigations

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -31,7 +31,10 @@ test.beforeEach(async ({ page }, testInfo) => {
   // Start from the popover fixture: a minimal stable page so anything that
   // bleeds through the search overlay (background, page chrome, page-level
   // styling) doesn't churn whenever /welcome's content changes.
-  await gotoPage(page, "http://localhost:8080/popover-fixture")
+  // Wait only for domcontentloaded: WebKit's load event can wedge on a stuck
+  // subresource fetch even with the page fully painted, and the assertions
+  // below plus each screenshot's stability wait cover actual readiness.
+  await gotoPage(page, "http://localhost:8080/popover-fixture", "domcontentloaded")
 
   await expect(page.locator("#search-container")).toBeAttached()
   await expect(page.locator("#search-icon")).toBeVisible()
@@ -575,7 +578,7 @@ test("Checkbox search preview (screenshot)", async ({ page }, testInfo) => {
 })
 
 test("Search preview of checkboxes remembers user state", async ({ page }) => {
-  await gotoPage(page, "http://localhost:8080/test-page")
+  await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
 
   const baseSelector = "h1 + ol #checkbox-0"
   const checkboxAfterHeader = page.locator(baseSelector).first()
@@ -958,7 +961,7 @@ test("Search bar accepts input immediately while index loads", async ({ page }) 
   await expect(searchContainer).not.toHaveClass(/active/)
 
   // Navigate to a fresh page to reset search initialization state
-  await gotoPage(page, "http://localhost:8080/test-page")
+  await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
 
   // Intercept contentIndex.json to add a delay, simulating slow index loading
   await page.route("**/contentIndex.json", async (route) => {


### PR DESCRIPTION
## Summary

Third and final follow-up in the red-main saga (#1567, #1568). The `visual-testing-macos` shard flaked twice in a row on Desktop Safari `search.spec.ts` tests, both times in the same shape: `page.goto` to the popover fixture stalled until the (now bounded) navigation timeout, and even the in-attempt retry from #1568 stalled — while the fresh-browser test retry passed instantly. Evidence pinned the wedge inside WebKit, not the harness or server:

- The webserver log for the failing shard shows requests being served continuously through the stall window — the server never blocked.
- The failure screenshot shows the fixture page **completely rendered** (text, fonts, images, footnotes) — the document loaded and painted; only the `load` event never fired, i.e. some subresource fetch wedged in WebKit's network process, which a same-browser retry cannot recover.

## Changes

- `quartz/components/tests/search.spec.ts`: pass `"domcontentloaded"` to all three `gotoPage` calls (the beforeEach fixture navigation and the two in-test `/test-page` navigations), so the tests no longer depend on WebKit's wedge-prone `load` event. Readiness is already covered by the spec's own assertions (`#search-container` attached, `#search-icon` visible, search-state checks) plus each screenshot's bounded stability wait (fonts capped at 10s, images-in-scope, double rAF) — the same pattern `popover.spec.ts` uses for the identical fixture.

## Testing

- Full non-screenshot `search.spec.ts` suite passes locally on Desktop Chrome (56 passed) against an offline build with the change in place. Screenshot titles can't run locally (no R2 baselines); their readiness path (`waitForVisualStability`) is unchanged.
- Diagnosis artifacts: webserver log (`webserver-build-log-macos-shard-1`) and failure screenshot from run 28886975972.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R85sN67x5inviYQbhD6ECc)_