### PR TITLE
fix(transcribe): close caption-injection and empty-VTT gaps

### DIFF
--- a/scripts/tests/test_transcribe_videos.py
+++ b/scripts/tests/test_transcribe_videos.py
@@ -383,16 +383,27 @@ def test_inject_caption_track_stem_not_substring(tmp_path: Path):
 # --- Asset orchestration ---
 
 
+_CUED_VTT = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n"
+
+
 def test_transcribe_video_asset_existing_vtt_skips_but_injects(tmp_path: Path):
     """A pre-existing VTT skips re-transcription without blocking caption
     injection into video blocks written after the original transcription."""
     mp4 = tmp_path / "talk.mp4"
     mp4.write_bytes(b"x")
-    (tmp_path / "talk.vtt").write_text("WEBVTT\n", encoding="utf-8")
+    (tmp_path / "talk.vtt").write_text(_CUED_VTT, encoding="utf-8")
     refs = tmp_path / "content"
     md = _write_md(refs, "post.md", _video_block("talk") + "\n")
     assert transcribe_videos.transcribe_video_asset(mp4, refs) is False
     assert "talk.vtt" in md.read_text(encoding="utf-8")
+
+
+def test_transcribe_video_asset_cueless_existing_vtt_raises(tmp_path: Path):
+    mp4 = tmp_path / "talk.mp4"
+    mp4.write_bytes(b"x")
+    (tmp_path / "talk.vtt").write_text("WEBVTT\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="contains no cues"):
+        transcribe_videos.transcribe_video_asset(mp4, tmp_path)
 
 
 def test_transcribe_video_asset_empty_transcript_raises(tmp_path: Path):

--- a/scripts/tests/test_transcribe_videos.py
+++ b/scripts/tests/test_transcribe_videos.py
@@ -287,6 +287,13 @@ def test_transcript_to_vtt_missing_bounds_raises():
         transcribe_videos.transcript_to_vtt(transcript)
 
 
+@pytest.mark.parametrize("end", [1.0, 0.5])
+def test_transcript_to_vtt_non_positive_duration_raises(end: float):
+    transcript = {"segments": [{"start": 1.0, "end": end, "text": "hi"}]}
+    with pytest.raises(ValueError, match="non-positive duration"):
+        transcribe_videos.transcript_to_vtt(transcript)
+
+
 def test_transcript_to_vtt_escapes_cue_text():
     transcript = {"segments": [{"start": 0.0, "end": 1.0, "text": "a & b < c"}]}
     vtt = transcribe_videos.transcript_to_vtt(transcript)
@@ -385,6 +392,39 @@ def test_transcribe_video_asset_skips_existing_vtt(tmp_path: Path):
     assert transcribe_videos.transcribe_video_asset(mp4, tmp_path) is False
 
 
+def test_transcribe_video_asset_existing_vtt_still_injects(tmp_path: Path):
+    """A pre-existing VTT must not block caption injection into video blocks
+    written after the original transcription."""
+    mp4 = tmp_path / "talk.mp4"
+    mp4.write_bytes(b"x")
+    (tmp_path / "talk.vtt").write_text("WEBVTT\n", encoding="utf-8")
+    refs = tmp_path / "content"
+    md = _write_md(
+        refs,
+        "post.md",
+        '<video controls><source src="static/images/posts/talk.mp4" '
+        'type="video/mp4; codecs=hvc1"></video>\n',
+    )
+    assert transcribe_videos.transcribe_video_asset(mp4, refs) is False
+    assert "talk.vtt" in md.read_text(encoding="utf-8")
+
+
+def test_transcribe_video_asset_empty_transcript_raises(tmp_path: Path):
+    mp4 = tmp_path / "talk.mp4"
+    mp4.write_bytes(b"x")
+    with (
+        mock.patch.object(
+            transcribe_videos, "has_real_audio", return_value=True
+        ),
+        mock.patch.object(
+            transcribe_videos, "transcribe", return_value={"segments": []}
+        ),
+        pytest.raises(RuntimeError, match="no usable cues"),
+    ):
+        transcribe_videos.transcribe_video_asset(mp4, tmp_path)
+    assert not (tmp_path / "talk.vtt").exists()
+
+
 def test_transcribe_video_asset_skips_silent(tmp_path: Path):
     mp4 = tmp_path / "talk.mp4"
     mp4.write_bytes(b"x")
@@ -424,6 +464,12 @@ def test_transcribe_video_asset_happy_path(tmp_path: Path):
 
 
 # --- main() ---
+
+
+def test_main_requires_asset_directory(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["transcribe_videos.py"])
+    with pytest.raises(SystemExit):
+        transcribe_videos.main()
 
 
 def test_main_skips_when_unconfigured(monkeypatch, capsys):

--- a/scripts/tests/test_transcribe_videos.py
+++ b/scripts/tests/test_transcribe_videos.py
@@ -287,7 +287,9 @@ def test_transcript_to_vtt_missing_bounds_raises():
         transcribe_videos.transcript_to_vtt(transcript)
 
 
-@pytest.mark.parametrize("end", [1.0, 0.5])
+# 1.0004 is positive in raw seconds but rounds to the same millisecond cue
+# timestamp as the start, which WebVTT forbids just the same.
+@pytest.mark.parametrize("end", [1.0, 0.5, 1.0004])
 def test_transcript_to_vtt_non_positive_duration_raises(end: float):
     transcript = {"segments": [{"start": 1.0, "end": end, "text": "hi"}]}
     with pytest.raises(ValueError, match="non-positive duration"):
@@ -308,6 +310,14 @@ def _write_md(references_dir: Path, name: str, body: str) -> Path:
     md = references_dir / name
     md.write_text(body, encoding="utf-8")
     return md
+
+
+def _video_block(stem: str) -> str:
+    """A markdown ``<video>`` block with a single MP4 source for *stem*."""
+    return (
+        f'<video controls><source src="static/images/posts/{stem}.mp4" '
+        'type="video/mp4; codecs=hvc1"></video>'
+    )
 
 
 def test_inject_caption_track_adds_track(tmp_path: Path):
@@ -341,10 +351,7 @@ def test_inject_caption_track_idempotent(tmp_path: Path):
 
 def test_inject_caption_track_ignores_other_videos(tmp_path: Path):
     refs = tmp_path / "content"
-    original = (
-        '<video controls><source src="static/images/posts/other.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>\n'
-    )
+    original = _video_block("other") + "\n"
     md = _write_md(refs, "post.md", original)
     transcribe_videos.inject_caption_track(Path("x/talk.mp4"), refs)
     assert md.read_text(encoding="utf-8") == original
@@ -353,14 +360,8 @@ def test_inject_caption_track_ignores_other_videos(tmp_path: Path):
 def test_inject_caption_track_adjacent_blocks(tmp_path: Path):
     """A track lands in the target block without merging the neighbour."""
     refs = tmp_path / "content"
-    other_block = (
-        '<video controls><source src="static/images/posts/other.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>'
-    )
-    talk_block = (
-        '<video controls><source src="static/images/posts/talk.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>'
-    )
+    other_block = _video_block("other")
+    talk_block = _video_block("talk")
     md = _write_md(refs, "post.md", f"{other_block}\n{talk_block}\n")
     transcribe_videos.inject_caption_track(Path("x/talk.mp4"), refs)
     updated = md.read_text(encoding="utf-8")
@@ -373,10 +374,7 @@ def test_inject_caption_track_adjacent_blocks(tmp_path: Path):
 def test_inject_caption_track_stem_not_substring(tmp_path: Path):
     """``bar.mp4`` must not match a ``foobar.mp4`` source (anchored stem)."""
     refs = tmp_path / "content"
-    original = (
-        '<video controls><source src="static/images/posts/foobar.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>\n'
-    )
+    original = _video_block("foobar") + "\n"
     md = _write_md(refs, "post.md", original)
     transcribe_videos.inject_caption_track(Path("x/bar.mp4"), refs)
     assert md.read_text(encoding="utf-8") == original
@@ -385,26 +383,14 @@ def test_inject_caption_track_stem_not_substring(tmp_path: Path):
 # --- Asset orchestration ---
 
 
-def test_transcribe_video_asset_skips_existing_vtt(tmp_path: Path):
-    mp4 = tmp_path / "talk.mp4"
-    mp4.write_bytes(b"x")
-    (tmp_path / "talk.vtt").write_text("WEBVTT\n", encoding="utf-8")
-    assert transcribe_videos.transcribe_video_asset(mp4, tmp_path) is False
-
-
-def test_transcribe_video_asset_existing_vtt_still_injects(tmp_path: Path):
-    """A pre-existing VTT must not block caption injection into video blocks
-    written after the original transcription."""
+def test_transcribe_video_asset_existing_vtt_skips_but_injects(tmp_path: Path):
+    """A pre-existing VTT skips re-transcription without blocking caption
+    injection into video blocks written after the original transcription."""
     mp4 = tmp_path / "talk.mp4"
     mp4.write_bytes(b"x")
     (tmp_path / "talk.vtt").write_text("WEBVTT\n", encoding="utf-8")
     refs = tmp_path / "content"
-    md = _write_md(
-        refs,
-        "post.md",
-        '<video controls><source src="static/images/posts/talk.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>\n',
-    )
+    md = _write_md(refs, "post.md", _video_block("talk") + "\n")
     assert transcribe_videos.transcribe_video_asset(mp4, refs) is False
     assert "talk.vtt" in md.read_text(encoding="utf-8")
 
@@ -441,12 +427,7 @@ def test_transcribe_video_asset_happy_path(tmp_path: Path):
     mp4 = static / "talk.mp4"
     mp4.write_bytes(b"x")
     refs = tmp_path / "content"
-    _write_md(
-        refs,
-        "post.md",
-        '<video controls><source src="static/images/posts/talk.mp4" '
-        'type="video/mp4; codecs=hvc1"></video>\n',
-    )
+    _write_md(refs, "post.md", _video_block("talk") + "\n")
     transcript = {"segments": [{"start": 0, "end": 1, "text": "hi"}]}
     with (
         mock.patch.object(
@@ -468,8 +449,9 @@ def test_transcribe_video_asset_happy_path(tmp_path: Path):
 
 def test_main_requires_asset_directory(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["transcribe_videos.py"])
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as excinfo:
         transcribe_videos.main()
+    assert excinfo.value.code == 2  # argparse usage error, not a clean exit
 
 
 def test_main_skips_when_unconfigured(monkeypatch, capsys):

--- a/scripts/transcribe_videos.py
+++ b/scripts/transcribe_videos.py
@@ -249,6 +249,11 @@ def transcript_to_vtt(transcript: dict) -> str:
             raise ValueError(
                 f"Transcript segment has text but no start/end: {segment}"
             )
+        if segment["end"] <= segment["start"]:
+            raise ValueError(
+                "Transcript segment has a non-positive duration "
+                f"(WebVTT requires end > start): {segment}"
+            )
         start = format_timestamp(segment["start"])
         end = format_timestamp(segment["end"])
         lines.append(f"{start} --> {end}")
@@ -307,12 +312,15 @@ def transcribe_video_asset(mp4_path: Path, references_dir: Path) -> bool:
     """
     Transcribe one ``.mp4`` asset and wire up its captions.
 
-    Returns True when a new VTT was produced; False when the asset was skipped
-    (existing sibling VTT or no real audio).
+    Returns True when a new VTT was produced; False when transcription was
+    skipped (existing sibling VTT or no real audio). A pre-existing VTT still
+    gets its ``<track>`` (re-)injected, so video blocks written after the
+    original transcription pick up captions on the next run.
     """
     vtt_path = mp4_path.with_suffix(".vtt")
     if vtt_path.exists():
         print(f"Skipping {mp4_path.name}: sibling .vtt already exists")
+        inject_caption_track(mp4_path, references_dir)
         return False
     if not has_real_audio(mp4_path):
         print(f"Skipping {mp4_path.name}: no real (non-silent) audio")
@@ -320,7 +328,13 @@ def transcribe_video_asset(mp4_path: Path, references_dir: Path) -> bool:
 
     print(f"Transcribing {mp4_path.name} via Scriberr...")
     transcript = transcribe(mp4_path)
-    vtt_path.write_text(transcript_to_vtt(transcript), encoding="utf-8")
+    vtt = transcript_to_vtt(transcript)
+    if "-->" not in vtt:
+        raise RuntimeError(
+            f"Scriberr returned no usable cues for {mp4_path.name}, which "
+            "has real audio; refusing to write an empty VTT"
+        )
+    vtt_path.write_text(vtt, encoding="utf-8")
     inject_caption_track(mp4_path, references_dir)
     print(f"Wrote captions: {vtt_path.name}")
     return True
@@ -334,6 +348,7 @@ def main() -> None:
     parser.add_argument(
         "--asset-directory",
         type=Path,
+        required=True,
         help="Directory containing video assets to transcribe",
     )
     parser.add_argument(

--- a/scripts/transcribe_videos.py
+++ b/scripts/transcribe_videos.py
@@ -8,8 +8,9 @@ WebVTT file, and injects a ``<track kind="captions">`` into the matching
 markdown ``<video>`` block. The VTT then follows the same R2/CDN lifecycle as
 the ``.mp4``/``.webm`` sources (see ``r2_upload.py``).
 
-GIF-derived autoplay videos have no audio stream and are skipped, as are
-videos that already have a sibling ``.vtt``. Scriberr is the maintainer's
+GIF-derived autoplay videos have no audio stream and are skipped. Videos
+with a sibling ``.vtt`` skip re-transcription but still get their
+``<track>`` (re-)injected. Scriberr is the maintainer's
 private instance; when ``SCRIBERR_BASE_URL`` / ``SCRIBERR_API_KEY`` are unset
 (CI, external contributors) the whole step is skipped with a warning.
 """
@@ -249,7 +250,9 @@ def transcript_to_vtt(transcript: dict) -> str:
             raise ValueError(
                 f"Transcript segment has text but no start/end: {segment}"
             )
-        if segment["end"] <= segment["start"]:
+        # Compare at cue resolution: a positive-but-sub-millisecond duration
+        # still renders as start == end, which WebVTT forbids.
+        if round(segment["end"] * 1000) <= round(segment["start"] * 1000):
             raise ValueError(
                 "Transcript segment has a non-positive duration "
                 f"(WebVTT requires end > start): {segment}"

--- a/scripts/transcribe_videos.py
+++ b/scripts/transcribe_videos.py
@@ -9,8 +9,8 @@ markdown ``<video>`` block. The VTT then follows the same R2/CDN lifecycle as
 the ``.mp4``/``.webm`` sources (see ``r2_upload.py``).
 
 GIF-derived autoplay videos have no audio stream and are skipped. Videos
-with a sibling ``.vtt`` skip re-transcription but still get their
-``<track>`` (re-)injected. Scriberr is the maintainer's
+with a sibling ``.vtt`` skip re-transcription but still get a ``<track>``
+injected into blocks missing one. Scriberr is the maintainer's
 private instance; when ``SCRIBERR_BASE_URL`` / ``SCRIBERR_API_KEY`` are unset
 (CI, external contributors) the whole step is skipped with a warning.
 """
@@ -311,17 +311,32 @@ def inject_caption_track(video_path: Path, references_dir: Path) -> None:
         )
 
 
+def _has_cues(vtt: str) -> bool:
+    """
+    Return True iff *vtt* contains at least one cue timing line.
+
+    Cue text
+    escapes ``>``, so ``-->`` can only come from timings.
+    """
+    return "-->" in vtt
+
+
 def transcribe_video_asset(mp4_path: Path, references_dir: Path) -> bool:
     """
     Transcribe one ``.mp4`` asset and wire up its captions.
 
     Returns True when a new VTT was produced; False when transcription was
     skipped (existing sibling VTT or no real audio). A pre-existing VTT still
-    gets its ``<track>`` (re-)injected, so video blocks written after the
-    original transcription pick up captions on the next run.
+    gets a ``<track>`` injected into blocks missing one, so video blocks
+    written after the original transcription pick up captions on the next run.
     """
     vtt_path = mp4_path.with_suffix(".vtt")
     if vtt_path.exists():
+        if not _has_cues(vtt_path.read_text(encoding="utf-8")):
+            raise RuntimeError(
+                f"Existing {vtt_path.name} contains no cues; delete it to "
+                "re-transcribe"
+            )
         print(f"Skipping {mp4_path.name}: sibling .vtt already exists")
         inject_caption_track(mp4_path, references_dir)
         return False
@@ -332,7 +347,7 @@ def transcribe_video_asset(mp4_path: Path, references_dir: Path) -> bool:
     print(f"Transcribing {mp4_path.name} via Scriberr...")
     transcript = transcribe(mp4_path)
     vtt = transcript_to_vtt(transcript)
-    if "-->" not in vtt:
+    if not _has_cues(vtt):
         raise RuntimeError(
             f"Scriberr returned no usable cues for {mp4_path.name}, which "
             "has real audio; refusing to write an empty VTT"


### PR DESCRIPTION
## Summary
- The video-transcription step had two silent failure modes (a `.vtt` sibling permanently blocked caption injection into later-written video blocks; an empty transcript shipped a cue-less VTT that passed the built-site check) and one silent no-op (missing `--asset-directory`). All now either self-heal or fail loudly.

## Changes
- `transcribe_video_asset`: when the sibling `.vtt` already exists, still run `inject_caption_track` (idempotent) so `<video>` blocks written after the original transcription pick up their `<track>` on the next pipeline run instead of failing `check_video_caption_tracks` with no automated remedy.
- `transcribe_video_asset`: raise `RuntimeError` instead of writing a VTT with zero cues for a video that has real audio — an empty captions file satisfies the built-site check while delivering nothing, and its existence blocks retries.
- `transcript_to_vtt`: raise `ValueError` on segments with non-positive duration (WebVTT requires `end > start`; players drop such cues silently).
- `main`: `--asset-directory` is now required; omitting it previously exited 0 having scanned nothing (`get_files(None)` returns no files).

## Testing
- New unit tests for each behavior: existing-VTT path still injects tracks, empty transcript raises without writing the VTT, non-positive-duration cues raise (parametrized zero/negative), missing `--asset-directory` exits with argparse error.
- `scripts/transcribe_videos.py` remains at 100% line coverage; all 52 tests in `test_transcribe_videos.py` pass; `ruff` and `pylint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017tsJ8fRvwnAsc5VygReUjU)_