### PR TITLE
fix(checks): stop built-site checks from flagging closing tags & fill-in-the-blank underscores

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -483,14 +483,17 @@ def check_invalid_anchors(soup: BeautifulSoup, base_dir: Path) -> list[str]:
 # because it probably needed a newline before it
 def check_blockquote_elements(soup: BeautifulSoup) -> list[str]:
     r"""Check for blockquote elements ending with ">" as long as they don't end
-    in a "<\w+>" pattern."""
+    in a "</?\w+>" pattern (an opening or closing tag, e.g. a literal
+    ``<analysis>``/``</analysis>`` shown in a code span)."""
     problematic_blockquotes: list[str] = []
     blockquotes = soup.find_all("blockquote")
     for blockquote in blockquotes:
         contents = list(blockquote.stripped_strings)
         if contents:
             last_part = contents[-1].strip()
-            if last_part.endswith(">") and not re.search(r"<\w+>$", last_part):
+            if last_part.endswith(">") and not re.search(
+                r"</?\w+>$", last_part
+            ):
                 _append_to_list(
                     problematic_blockquotes,
                     " ".join(contents),
@@ -1307,6 +1310,12 @@ EMPHASIS_ELEMENTS_TO_SEARCH = (
     *(f"h{i}" for i in range(1, 7)),
 )
 
+# A standalone run of three or more underscores is a fill-in-the-blank (e.g.
+# ``the "21 of the ___" construction`` or ``works for at least one X vector ___
+# %``), not unrendered emphasis. Requiring non-alphanumeric neighbors keeps a
+# genuinely unrendered ``___word___`` flagged.
+_FILL_IN_THE_BLANK = re.compile(r"(?<![A-Za-z0-9])_{3,}(?![A-Za-z0-9])")
+
 
 def check_unrendered_emphasis(soup: BeautifulSoup) -> list[str]:
     """
@@ -1330,8 +1339,9 @@ def check_unrendered_emphasis(soup: BeautifulSoup) -> list[str]:
         # Get text excluding code and KaTeX elements
         stripped_text = script_utils.get_non_code_text(text_elt)
 
-        if stripped_text and (
-            re.search(rf"\*|\_(?!\_*[ {NBSP}]+\%)", stripped_text)
+        text_to_check = _FILL_IN_THE_BLANK.sub("", stripped_text)
+        if text_to_check and (
+            re.search(rf"\*|\_(?!\_*[ {NBSP}]+\%)", text_to_check)
         ):
             _append_to_list(
                 problematic_texts,

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -707,6 +707,31 @@ def test_complicated_blockquote(tmp_path):
     ]
 
 
+@pytest.mark.parametrize(
+    "html,expected",
+    [
+        # Bare trailing ">" (merged quote marker) is flagged
+        (
+            "<blockquote><p>broken quote &gt;</p></blockquote>",
+            ["Problematic blockquote: broken quote >"],
+        ),
+        # An opening tag ending the blockquote is fine
+        ("<blockquote><p>fine <code>&lt;BOS&gt;</code></p></blockquote>", []),
+        # A closing tag ending the blockquote is also fine
+        (
+            "<blockquote><p>momentum</p>"
+            "<p><code>&lt;/analysis&gt;</code></p></blockquote>",
+            [],
+        ),
+    ],
+)
+def test_check_blockquote_elements(html, expected):
+    """Opening/closing tags may legitimately end a blockquote; a bare ">" may
+    not."""
+    soup = BeautifulSoup(html, "html.parser")
+    assert built_site_checks.check_blockquote_elements(soup) == expected
+
+
 def test_check_file_for_issues_with_redirect(tmp_path):
     file_path = tmp_path / "public" / "test.html"
     file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1422,6 +1447,14 @@ def test_check_problematic_paragraphs_comprehensive(html, expected):
         ("<p>Text with ___ % coverage</p>", []),
         # Percentage with non-breaking space (should also be ignored)
         (f"<p>Text with ___{NBSP}% coverage</p>", []),
+        # Standalone fill-in-the-blank runs (not a percentage) are ignored
+        ('<p>completing the "21 of the ___" construction</p>', []),
+        ("<p>fill in the ____ blank</p>", []),
+        # Underscores adjacent to letters are still flagged (real emphasis)
+        (
+            "<p>this is ___word___ text</p>",
+            ["Unrendered emphasis: this is ___word___ text"],
+        ),
         # Mixed cases
         (
             "<p>Mixed *emphasis* with _100% value_</p>",


### PR DESCRIPTION
## Summary

The `Deploy to Cloudflare` build on `main` ([run 29046391779](https://github.com/alexander-turner/TurnTrout.com/actions/runs/29046391779)) failed in the built-site content check with two **false positives** on the correctly-rendered `natural-language-autoencoder-robustness` page:

```
Issues found in .../public/natural-language-autoencoder-robustness.html:
  trailing_blockquotes:
    - Problematic blockquote: Claude's metaphor-filled response ... <analysis> List-completion moment
  unrendered_emphasis:
    - Unrendered emphasis: he ___" construction, requiring a specific retail category ...
```

Both are legitimately authored, correctly-rendered content that landed just outside each check's existing narrow exemption. No page content is changed — the checks are made precise.

## Changes

- **`check_blockquote_elements`**: a `[!quote]` callout ends with a literal `` `</analysis>` `` code span. Opening tags (`<BOS>`, `<analysis>`) were already exempt via `<\w+>$`; the closing tag `</analysis>` was not. Widened to `</?\w+>$` so a closing tag may end a blockquote, while a bare trailing `>` (a merged markdown quote marker — the bug this check exists for) is still flagged.
- **`check_unrendered_emphasis`**: the quote contains the fill-in-the-blank `"21 of the ___"`. Only the `___ %` variant was exempt (used by the maze-solving page). Added a narrow exemption for a standalone run of 3+ underscores (`(?<[A-Za-z0-9])_{3,}(?[A-Za-z0-9])`), so a fill-in-the-blank not followed by `%` passes while a genuinely unrendered `___word___` (underscores adjacent to letters) is still flagged.

## Tests

- New `test_check_blockquote_elements`: bare `>` flagged; opening and closing tag endings pass.
- Extended `test_check_unrendered_emphasis`: fill-in-the-blank runs (with and without `%`) pass; `___word___` still flagged.
- Full `test_built_site_checks.py` suite: 998 passed, 100% coverage maintained.

## Lessons learned

- **Heuristic content-guards need symmetric exemptions.** When a guard exempts one shape of a legitimate pattern (an opening `<tag>`, or a `___ %` fill-in-the-blank), the mirror shape (the closing `</tag>`, the same fill-in-the-blank without the `%`) will eventually appear in real content and break the build. When adding or reviewing such an exemption, cover the symmetric case up front and pin both the exempt and still-flagged variants with tests so the guard stays precise without going silent on real bugs.


---
_Generated by [Claude Code](https://claude.ai/code/session_017MqxyFyRd38tdUQeP2Xoo9)_