### PR TITLE
fix: clear DeepSource findings on main

### DIFF
--- a/.claude/hooks/safe-launch-parse.py
+++ b/.claude/hooks/safe-launch-parse.py
@@ -14,22 +14,28 @@ import os
 import sys
 
 
+def _extract_path(tool_input: dict, name: str) -> str:
+    path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+    if path or name != "MultiEdit":
+        return path
+    # MultiEdit carries an array of edits; use the first entry's file_path.
+    edits = tool_input.get("edits") or []
+    if edits and isinstance(edits, list) and isinstance(edits[0], dict):
+        return edits[0].get("file_path") or ""
+    return ""
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         return 0
     project_dir = sys.argv[1]
     try:
-        data = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, ValueError):
+        data = json.load(sys.stdin)
+    except ValueError:
         return 0
     name = data.get("tool_name", "") or ""
     tool_input = data.get("tool_input", {}) or {}
-    path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
-    # MultiEdit carries an array of edits; use the first entry's file_path.
-    if not path and name == "MultiEdit":
-        edits = tool_input.get("edits") or []
-        if edits and isinstance(edits, list) and isinstance(edits[0], dict):
-            path = edits[0].get("file_path") or ""
+    path = _extract_path(tool_input, name)
     if path and not os.path.isabs(path):
         path = os.path.join(project_dir, path)
     print(name)

--- a/.github/actions/restore-site-cache/action.yaml
+++ b/.github/actions/restore-site-cache/action.yaml
@@ -1,0 +1,37 @@
+name: "Restore built site from cache"
+description: >-
+  Restores the public/ site-build cache, retrying once on a transient
+  cache-service failure (GitHub's cache CDN occasionally aborts a hit
+  mid-download) rather than failing the job outright. A genuine cache miss
+  still fails after the retry, since that indicates the upstream build job
+  never saved the artifact.
+
+inputs:
+  key:
+    description: "Cache key to restore."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore built site from cache (attempt 1)
+      id: restore-1
+      continue-on-error: true
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: public/
+        key: ${{ inputs.key }}
+        fail-on-cache-miss: true
+
+    - name: Wait before retrying cache restore
+      if: steps.restore-1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+
+    - name: Restore built site from cache (retry)
+      if: steps.restore-1.outcome == 'failure'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: public/
+        key: ${{ inputs.key }}
+        fail-on-cache-miss: true

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -73,11 +73,9 @@ jobs:
           install-puppeteer-chrome: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       - name: Start server
         id: server

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,11 +93,9 @@ jobs:
           install-system-deps: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       # --- PR preview: deploy immediately without subfont ---
       - name: Deploy PR preview to Cloudflare Pages

--- a/.github/workflows/playwright-flake-check.yaml
+++ b/.github/workflows/playwright-flake-check.yaml
@@ -79,11 +79,9 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download section fixtures
         uses: ./.github/actions/download-section-fixtures
@@ -194,11 +192,9 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download section fixtures
         uses: ./.github/actions/download-section-fixtures

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -106,11 +106,9 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download section fixtures
         uses: ./.github/actions/download-section-fixtures
@@ -219,11 +217,9 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download section fixtures
         uses: ./.github/actions/download-section-fixtures

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -89,11 +89,9 @@ jobs:
           install-puppeteer-chrome: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       # subfont is pinned to @turntrout/subfont@1.8.1 in package.json and
       # installed by setup-site's `pnpm install`, so we run it via

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -89,11 +89,9 @@ jobs:
           install-system-deps: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       - name: Check CSS variables
         run: |
@@ -130,11 +128,9 @@ jobs:
         uses: ./.github/actions/setup-site
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       - name: Start server
         id: server

--- a/.github/workflows/subfont-bisect.yaml
+++ b/.github/workflows/subfont-bisect.yaml
@@ -54,11 +54,9 @@ jobs:
           install-system-deps: "true"
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-false
-          fail-on-cache-miss: true
 
       - name: Install subfont fork at ${{ inputs.fork_ref }}
         env:

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -104,11 +104,9 @@ jobs:
         run: pnpm run install-browsers
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download visual baselines from R2
         env:
@@ -179,11 +177,9 @@ jobs:
         run: xattr -cr ~/Library/Caches/ms-playwright
 
       - name: Restore built site from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/restore-site-cache
         with:
-          path: public/
           key: site-build-${{ github.sha }}-fixtures-true
-          fail-on-cache-miss: true
 
       - name: Download visual baselines from R2
         env:

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -27,6 +27,7 @@ import {
 } from "./pages/AllTagsContent"
 import PageShellConstructor from "./PageShell"
 // @ts-expect-error Not a module but a bundled inline script string
+// skipcq: JS-W1028 -- inline script has no named exports to import instead
 import contentIndexLoaderScript from "./scripts/contentIndex.inline"
 import { type QuartzComponent, type QuartzComponentProps } from "./types"
 

--- a/quartz/components/scripts/contentIndexLoader.ts
+++ b/quartz/components/scripts/contentIndexLoader.ts
@@ -57,6 +57,7 @@ export function getContentIndex(forceRefresh = false): Promise<ContentIndexData 
  */
 export function refreshContentIndexOnVisible(): void {
   if (!document.hidden && !indexLoaded) {
+    // skipcq: JS-0098 — fire-and-forget; void marks the intentionally floating promise
     void getContentIndex(true)
   }
 }

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -473,6 +473,10 @@ test("Video toggle changes autoplay behavior", async ({ page }) => {
 
 test("Video autoplay preference persists across page reloads", async ({ page }) => {
   test.skip(!isDesktopViewport(page), "Desktop-only test")
+  // Video decode after a fresh reload competes with other parallel Playwright
+  // workers for CPU, so a contended CI runner can leave readyState at 0 well
+  // past a tight deadline even though the video eventually buffers.
+  test.slow()
 
   const { video, autoplayToggle, playIcon, pauseIcon } = getVideoElements(page)
 
@@ -499,7 +503,7 @@ test("Video autoplay preference persists across page reloads", async ({ page }) 
             `Video failed to reach playable state: readyState=${videoElement.readyState}, paused=${videoElement.paused}, currentTime=${videoElement.currentTime}`,
           ),
         )
-      }, 15_000)
+      }, 30_000)
 
       const checkPlayable = () => {
         if (videoElement.readyState >= 3 && !videoElement.paused && videoElement.currentTime > 0) {

--- a/quartz/components/tests/search-index-recovery.spec.ts
+++ b/quartz/components/tests/search-index-recovery.spec.ts
@@ -27,6 +27,7 @@ test.describe("search index self-heals after the prefetch hangs", () => {
       calls += 1
       if (calls === 1) {
         // Simulate the prefetch started in a since-frozen tab: it never settles.
+        // skipcq: JS-0321 -- intentional no-op: executor deliberately never resolves
         await new Promise<void>(() => {})
         return
       }

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -346,6 +346,7 @@ export function removeClass(node: Element, className: string): void {
 
     const next = { ...node.properties }
     if (kept.length === 0) {
+      // skipcq: JS-0320 -- key is one of the literal "className"/"class" tuple values above, not attacker-controlled
       delete next[key]
     } else {
       next[key] = typeof existing === "string" ? kept.join(" ") : kept


### PR DESCRIPTION
## Summary

- `main` had 7 outstanding DeepSource findings (4 JavaScript/TypeScript, 3 Python) that were making the DeepSource lint checks red.
- Fixes them by addressing genuine issues where present, and suppressing confirmed false positives with the same `skipcq` convention already used throughout the codebase.
- Also hardens CI against two flakes observed live in this PR's own run (see "CI hardening" below).

## Changes

### DeepSource fixes

- `.claude/hooks/safe-launch-parse.py`:
  - Use `json.load(sys.stdin)` instead of `json.loads(sys.stdin.read())` (PY-W0078).
  - Drop the redundant `except (json.JSONDecodeError, ValueError)` in favor of `except ValueError` — `JSONDecodeError` is already a `ValueError` subclass, so the two-exception tuple was flagged as overlapping (PYL-W0714).
  - Extract MultiEdit path resolution into a `_extract_path` helper to reduce `main()`'s cyclomatic complexity (PY-R1000).
- `quartz/components/renderPage.tsx`: suppress JS-W1028 on the default import of the bundled inline script (it has no module exports to import instead), matching the existing suppression on the React import three lines above.
- `quartz/components/scripts/contentIndexLoader.ts`: suppress JS-0098 on the intentional fire-and-forget `void getContentIndex(true)`, using the identical comment already applied at this pattern's other call sites.
- `quartz/plugins/transformers/utils.ts`: suppress JS-0320 on `delete next[key]`, where `key` is bound only to the literal `["className", "class"]` tuple — never attacker-controlled.
- `quartz/components/tests/search-index-recovery.spec.ts`: suppress JS-0321 on a promise executor that intentionally never resolves (simulates a hung fetch), matching the same pattern already suppressed elsewhere in the test suite.

### CI hardening

- Added `.github/actions/restore-site-cache`, a composite action that retries `actions/cache/restore` once on a transient cache-service failure. This PR's own `playwright-tests-linux (7/8)` job hit exactly this: a cache hit that aborted mid-download (`Failed to restore: The operation was aborted`) while every sibling shard restoring the identical cache entry succeeded. A genuine cache miss still fails after the retry. Routed all 12 "Restore built site from cache" call sites (across 9 workflows) through it instead of duplicating retry logic per file.
- `navbar.spec.ts`: gave "Video autoplay preference persists across page reloads" more headroom — this PR's `playwright-tests-macos (1/3)` job showed the video's `readyState` stuck at 0 (no data loaded at all) past the prior 15s deadline, consistent with decode contention from other parallel Playwright workers on a busy CI runner. Bumped the internal wait to 30s and added `test.slow()` so Playwright's own test timeout doesn't fire first.

## Testing

- `pnpm eslint . --config config/javascript/eslint.config.js --max-warnings 0` — clean
- `pnpm exec tsc --noEmit -p config/typescript/tsconfig.json` — clean
- `pnpm exec stylelint --config config/stylelint/.stylelintrc.json "quartz/**/*.scss"` — clean
- Full Jest suite (`pnpm test`, coverage disabled for speed): 99 suites / 4784 tests passing
- `uv run pyright`, `uvx ruff format --check`, `uvx ruff check`, `uv run pylint` on the changed Python file — all clean
- `deepsource issues --default-branch --analyzer javascript/python --output json` confirmed these were the only 7 findings on `main` before the fix; `deepsource issues --pr 1572 --output json` now returns zero findings, and DeepSource's PR check confirms Grade A / all analyzers passed
- Manually exercised `safe-launch-parse.py`'s stdin parsing (valid Edit payload, valid MultiEdit payload, invalid JSON, payload with no path) to confirm the refactor preserves behavior
- Validated all touched workflow/action YAML parses correctly and that the new composite action's `actions/cache/restore` reference stays SHA-pinned (matches this repo's own `check-action-pins` CI gate)

## Lessons learned

- **What**: When a workflow's `actions/cache/restore` step sets `fail-on-cache-miss: true` and the CDN aborts a hit mid-download, the step hard-fails identically to a genuine miss — GitHub gives no distinct signal. Wrapping the restore in a composite action that retries once (via `continue-on-error` + `if: steps.<id>.outcome == 'failure'` on a second identical step) absorbs the transient case while still failing loudly on a real miss.
- **Where**: Any workflow using `actions/cache/restore` with `fail-on-cache-miss: true` — a `.github/actions/<name>` composite action wrapping the restore-and-retry pattern.
- **Why**: Observed live in CI: 7 of 8 parallel shards restoring the identical cache entry succeeded; the 8th aborted mid-download and hard-failed the job with no automatic recovery, even though the artifact was genuinely present.