### PR TITLE
fix: prevent build crash on slashes adjacent across an inline-element boundary

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -154,7 +154,11 @@ function isHatTipSlash(view: ProseView, slashIdx: number): boolean {
  * Returns true when the slash matched (even if both sides kept their spaces),
  * so the digit-slash rule doesn't double-process it.
  */
-function applyMainSlashRule(view: ProseView, slashIdx: number): boolean {
+function applyMainSlashRule(
+  view: ProseView,
+  slashIdx: number,
+  insertNbsp: (offset: number, bind?: "left" | "right") => void,
+): boolean {
   const text = view.text
   const leftBoundary = view.hasBoundary(slashIdx)
   const spaceBefore = !leftBoundary && text[slashIdx - 1] === " "
@@ -180,14 +184,14 @@ function applyMainSlashRule(view: ProseView, slashIdx: number): boolean {
   }
 
   if (leftBoundary) {
-    view.replace(slashIdx, slashIdx, NBSP, { bind: "right" })
+    insertNbsp(slashIdx, "right")
   } else if (!spaceBefore) {
-    view.replace(slashIdx, slashIdx, NBSP)
+    insertNbsp(slashIdx)
   }
   if (rightBoundary) {
-    view.replace(afterIdx, afterIdx, NBSP, { bind: "left" })
+    insertNbsp(afterIdx, "left")
   } else if (!spaceAfter) {
-    view.replace(afterIdx, afterIdx, NBSP)
+    insertNbsp(afterIdx)
   }
   return true
 }
@@ -214,11 +218,23 @@ function applyNumberSlashRule(view: ProseView, slashIdx: number): void {
 
 function applySlashSpacing(view: ProseView): void {
   const text = view.text
+  // Two adjacent slashes separated only by an inline-element boundary make the
+  // first slash's trailing NBSP and the second slash's leading NBSP target the
+  // same offset. A single NBSP there is the intended spacing, and punctilio
+  // rejects two pure insertions at one offset — so collapse the duplicate.
+  const insertedAt = new Set<number>()
+  const insertNbsp = (offset: number, bind?: "left" | "right"): void => {
+    if (insertedAt.has(offset)) {
+      return
+    }
+    insertedAt.add(offset)
+    view.replace(offset, offset, NBSP, bind ? { bind } : undefined)
+  }
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== "/" || isHatTipSlash(view, i)) {
       continue
     }
-    if (!applyMainSlashRule(view, i)) {
+    if (!applyMainSlashRule(view, i, insertNbsp)) {
       applyNumberSlashRule(view, i)
     }
   }

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -308,6 +308,21 @@ describe("HTMLFormattingImprovement", () => {
     })
   })
 
+  describe("slashes adjacent across an inline-element boundary", () => {
+    // Two slashes separated only by an inline-element boundary make the first
+    // slash's trailing NBSP and the second slash's leading NBSP land at the
+    // same offset; punctilio rejects two pure insertions there. The pass now
+    // collapses the duplicate to a single NBSP instead of crashing the build.
+    it.each([
+      ["<p>a/<em></em>/b</p>", "<p>a / <em></em>/ b</p>"],
+      ["<p><em>x/</em>/y</p>", "<p><em>x /</em>/ y</p>"],
+      ["<p><em>a/</em><em>/b</em></p>", "<p><em>a /</em><em>/ b</em></p>"],
+      ["<p>a/<strong></strong>/b</p>", "<p>a / <strong></strong>/ b</p>"],
+    ])("does not crash on %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+    })
+  })
+
   describe("non-breaking spaces around slashes and ampersands", () => {
     it.each([
       ["dog/cat", `dog${NBSP}/${NBSP}cat`],


### PR DESCRIPTION
## Summary

The site build currently crashes on `main` while parsing `open-source.md`:

```
Failed to process website_content/open-source.md:
Two pure insertions at the same offset 92 are ambiguous; combine them.
  at spacesAroundSlashes (../plugins/transformers/formatting_improvement_html.ts)
```

**Root cause.** The slash-spacing pass (`applyMainSlashRule`) adds an NBSP after one slash and before the next. When two slashes sit adjacent with only an inline-element boundary between them — which the embedded claude-guard README produces via inline-code paths — both NBSPs target the **same** offset. punctilio's `ProseView.commit()` (`prose-view.ts`) deliberately rejects two *pure* insertions at one offset (`bind` does not disambiguate them), so it throws and aborts the entire build. Every PR's merge-ref build fails as a result.

**Fix.** Dedupe NBSP insertions by offset within `applySlashSpacing`: the shared boundary gets a single NBSP (the intended spacing) instead of a duplicate that crashes. Non-adjacent slashes are unaffected — each still targets a distinct offset — so existing behavior is unchanged.

## Reproduction / test

Minimal repros that threw before and now pass, added as a regression test (`slashes adjacent across an inline-element boundary`):

| Input | Output |
| --- | --- |
| `<p>a/<em></em>/b</p>` | `<p>a / <em></em>/ b</p>` |
| `<p><em>x/</em>/y</p>` | `<p><em>x /</em>/ y</p>` |
| `<p><em>a/</em><em>/b</em></p>` | `<p><em>a /</em><em>/ b</em></p>` |
| `<p>a/<strong></strong>/b</p>` | `<p>a / <strong></strong>/ b</p>` |

`formatting_improvement_html.ts` stays at 100% statement/branch/function/line coverage; all 618 tests in the two formatting suites pass; `tsc`, ESLint, and Prettier are clean.

## Lessons learned

- **A transformer must not emit two "pure insertions" at the same offset into a punctilio `ProseView`** — `commit()` rejects them regardless of `bind`. When two adjacent rules can target one boundary offset, dedupe/collapse in the caller. Applies to any downstream repo consuming `punctilio`'s prose-view editing API.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjQ1rd6bcW6mYjTa7WopbM)_