### PR TITLE
fix: adopt current punctilio (5.2.1); retire local slash-dedup workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "5.0.10",
+    "punctilio": "5.1.4",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "reading-time": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "5.1.4",
+    "punctilio": "5.2.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "reading-time": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 5.1.4
-        version: 5.1.4(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
+        specifier: 5.2.1
+        version: 5.2.1(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -7857,8 +7857,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@5.1.4:
-    resolution: {integrity: sha512-dFpdXwoveK9OwdoUVFZAtWncBaLRHmF64JvYhV2+cv31q1rp4G5ww+KKYJQONW3xymV4PywmO3C3yTXU0UOsZA==}
+  punctilio@5.2.1:
+    resolution: {integrity: sha512-HSivcYR0tQQjP8zlaJ0aZ/OlSnBZ2rUl1HTKF7Zj4Jy+ki+3Z7ESWkIAb/ZF4VieY3/FJqdnzHLNKAFCnativA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -18849,7 +18849,7 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@5.1.4(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
+  punctilio@5.2.1(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       ignore: 7.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,12 +74,8 @@ overrides:
 packageExtensionsChecksum: sha256-tQX/LTBtNWpzo5W3RVqiDvcaT/zH+onXhfh82N75Neo=
 
 patchedDependencies:
-  pa11y@9.0.1:
-    hash: 53c3bfb372c741997f7b6d75518c4f3ed1a5be9b3ccf3ae16904feb90bb8c5ae
-    path: patches/pa11y@9.0.1.patch
-  pa11y@9.1.1:
-    hash: 91649c642a6fbdcea14e61453f3ae4b1bcb36d2c874b392a6cd3bb16424cbaef
-    path: patches/pa11y@9.1.1.patch
+  pa11y@9.0.1: 53c3bfb372c741997f7b6d75518c4f3ed1a5be9b3ccf3ae16904feb90bb8c5ae
+  pa11y@9.1.1: 91649c642a6fbdcea14e61453f3ae4b1bcb36d2c874b392a6cd3bb16424cbaef
 
 importers:
 
@@ -200,8 +196,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 5.0.10
-        version: 5.0.10(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
+        specifier: 5.1.4
+        version: 5.1.4(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -550,7 +546,7 @@ importers:
         version: 17.11.1(typescript@6.0.3)
       stylelint-config-standard-scss:
         specifier: 17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3))
+        version: 17.0.0(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3))
       stylelint-declaration-strict-value:
         specifier: 1.11.1
         version: 1.11.1(stylelint@17.11.1(typescript@6.0.3))
@@ -559,7 +555,7 @@ importers:
         version: 5.0.3(prettier@3.8.3)(stylelint@17.11.1(typescript@6.0.3))
       stylelint-value-no-unknown-custom-properties:
         specifier: 6.1.1
-        version: 6.1.1(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3))
+        version: 6.1.1(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3))
       ts-jest:
         specifier: 29.4.11
         version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@6.0.3)))(typescript@6.0.3)
@@ -1875,89 +1871,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2337,36 +2349,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2998,51 +3016,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -5200,6 +5228,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -6331,24 +6360,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7724,10 +7757,6 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   preact-render-to-string@6.7.0:
     resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
     peerDependencies:
@@ -7828,8 +7857,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@5.0.10:
-    resolution: {integrity: sha512-9Fzp2KgbfFC3Xwl9btC2Vm3jMx3pYljbghWdqIxyj/WqfAGGLgrwrSUDREkzBOk0XH4DMNgKCtpJSH9N4bKlSg==}
+  punctilio@5.1.4:
+    resolution: {integrity: sha512-dFpdXwoveK9OwdoUVFZAtWncBaLRHmF64JvYhV2+cv31q1rp4G5ww+KKYJQONW3xymV4PywmO3C3yTXU0UOsZA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -8359,48 +8388,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.99.0:
     resolution: {integrity: sha512-d4IjJZrX2+AwB2YCy1JySwdptJECNP/WfAQLUl8txI3ka8/d3TUI155GtelnoZUkio211PwIeFvvAeZ9RXPQnw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.99.0:
     resolution: {integrity: sha512-Hi2bt/IrM5P4FBKz6EcHAlniwfpoz9mnTdvSd58y+avA3SANM76upIkAdSayA8ZGwyL3gZokru1AKDPF9lJDNw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.99.0:
     resolution: {integrity: sha512-2gvHOupgIw3ytatXT4nFUow71LFbuOZPEwG+HUzcNQDH8ue4Ez8cr03vsv5MDv3lIjOKcXwDvWD980t18MwkoQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.99.0:
     resolution: {integrity: sha512-mKqGvVaJ9rHMqyZsF0kikQe4NO0f4osb67+X6nLhBiVDKvyazQHJ3zJQreNefIE36yL2sjHIclSB//MprzaQDg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.99.0:
     resolution: {integrity: sha512-huhgOMmOc30r7CH7qbRbT9LerSEGSnWuS4CYNOskr9BvNeQp4dIneFufNRGZ7hkOAxUM8DglxIZJN/cyAT95Ew==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.99.0:
     resolution: {integrity: sha512-mevFPIFAVhrH90THifxLfOntFmHtcEKOcdWnep2gJ0X4DVva4AiVIRlQe/7w9JFx5+gnDRE1oaJJkzuFUuYZsA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.99.0:
     resolution: {integrity: sha512-9k7IkULqIZdCIVt4Mboryt6vN8Mjmm3EhI1P3mClU5y5i3wLK5ExC3cbVWk047KsID/fvB1RLslqghXJx5BoxA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.99.0:
     resolution: {integrity: sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==}
@@ -18674,10 +18711,6 @@ snapshots:
     dependencies:
       postcss: 8.5.10
 
-  postcss-scss@4.0.9(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
-
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
@@ -18712,12 +18745,6 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -18822,10 +18849,9 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@5.0.10(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
+  punctilio@5.1.4(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
-      escape-string-regexp: 5.0.0
       ignore: 7.0.5
       quick-lru: 7.3.0
       tinyglobby: 0.2.16
@@ -20149,26 +20175,26 @@ snapshots:
       postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3)):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3)):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.5.15)
+      postcss-scss: 4.0.9(postcss@8.5.10)
       stylelint: 17.11.1(typescript@6.0.3)
       stylelint-config-recommended: 18.0.0(stylelint@17.11.1(typescript@6.0.3))
       stylelint-scss: 7.0.0(stylelint@17.11.1(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.10
 
   stylelint-config-recommended@18.0.0(stylelint@17.11.1(typescript@6.0.3)):
     dependencies:
       stylelint: 17.11.1(typescript@6.0.3)
 
-  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3)):
+  stylelint-config-standard-scss@17.0.0(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3)):
     dependencies:
       stylelint: 17.11.1(typescript@6.0.3)
-      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3))
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3))
       stylelint-config-standard: 40.0.0(stylelint@17.11.1(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.10
 
   stylelint-config-standard@40.0.0(stylelint@17.11.1(typescript@6.0.3)):
     dependencies:
@@ -20197,9 +20223,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylelint: 17.11.1(typescript@6.0.3)
 
-  stylelint-value-no-unknown-custom-properties@6.1.1(postcss@8.5.15)(stylelint@17.11.1(typescript@6.0.3)):
+  stylelint-value-no-unknown-custom-properties@6.1.1(postcss@8.5.10)(stylelint@17.11.1(typescript@6.0.3)):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       resolve: 1.22.11
       stylelint: 17.11.1(typescript@6.0.3)

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -13,7 +13,7 @@ import {
 } from "punctilio"
 import {
   applyPasses,
-  collectProseBlocks,
+  collectProseUnits,
   getTextContent,
   type PassEntry,
   type TextNodeSkipPredicate,
@@ -1001,11 +1001,13 @@ export const improveFormatting = (
       // punctilio's default skip tags (kbd, var, samp, ...) must not apply.
       // Form-control and metadata text (option labels, button captions) is a
       // literal value, not prose — drop those blocks from the collection.
-      const eltsToTransform = collectProseBlocks(node as Element, {
+      // Units include loose inline "runs" (text beside block children) that no
+      // single element owns, so a container's loose text still gets formatted.
+      const unitsToTransform = collectProseUnits(node as Element, {
         skipTags: [],
         shouldSkip: toSkip,
-      }).filter((elt) => !NON_PROSE_TAGS.has(elt.tagName))
-      eltsToTransform.forEach((elt) => {
+      }).filter((unit) => unit.kind === "run" || !NON_PROSE_TAGS.has(unit.element.tagName))
+      unitsToTransform.forEach((unit) => {
         const passes: PassEntry[] = [
           ...checkedTextPasses,
           ...activeUncheckedTransformers,
@@ -1013,18 +1015,17 @@ export const improveFormatting = (
           dashWordJoinerPass,
         ]
 
-        // Don't replace slashes in fractions, but give breathing room
-        // to others
-        const isNotFractionOrLink = (n: Element) => {
-          return !hasClass(n, "fraction") && n?.tagName !== "a"
-        }
-        if (isNotFractionOrLink(elt)) {
+        // Don't replace slashes in fractions or link text; loose runs are neither.
+        const isNotFractionOrLink =
+          unit.kind === "run" ||
+          (!hasClass(unit.element, "fraction") && unit.element?.tagName !== "a")
+        if (isNotFractionOrLink) {
           // Slash spacing alone also skips URL-text links, so its entry
           // carries the extra text-node predicate.
           passes.push({ pass: spacesAroundSlashes, shouldSkipText: shouldSkipLinkUrlText })
         }
 
-        applyPasses(elt, passes, { shouldSkip: toSkip })
+        applyPasses(unit, passes, { shouldSkip: toSkip })
       })
     })
 

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -154,11 +154,7 @@ function isHatTipSlash(view: ProseView, slashIdx: number): boolean {
  * Returns true when the slash matched (even if both sides kept their spaces),
  * so the digit-slash rule doesn't double-process it.
  */
-function applyMainSlashRule(
-  view: ProseView,
-  slashIdx: number,
-  insertNbsp: (offset: number, bind?: "left" | "right") => void,
-): boolean {
+function applyMainSlashRule(view: ProseView, slashIdx: number): boolean {
   const text = view.text
   const leftBoundary = view.hasBoundary(slashIdx)
   const spaceBefore = !leftBoundary && text[slashIdx - 1] === " "
@@ -184,14 +180,14 @@ function applyMainSlashRule(
   }
 
   if (leftBoundary) {
-    insertNbsp(slashIdx, "right")
+    view.replace(slashIdx, slashIdx, NBSP, { bind: "right" })
   } else if (!spaceBefore) {
-    insertNbsp(slashIdx)
+    view.replace(slashIdx, slashIdx, NBSP)
   }
   if (rightBoundary) {
-    insertNbsp(afterIdx, "left")
+    view.replace(afterIdx, afterIdx, NBSP, { bind: "left" })
   } else if (!spaceAfter) {
-    insertNbsp(afterIdx)
+    view.replace(afterIdx, afterIdx, NBSP)
   }
   return true
 }
@@ -218,23 +214,11 @@ function applyNumberSlashRule(view: ProseView, slashIdx: number): void {
 
 function applySlashSpacing(view: ProseView): void {
   const text = view.text
-  // Two adjacent slashes separated only by an inline-element boundary make the
-  // first slash's trailing NBSP and the second slash's leading NBSP target the
-  // same offset. A single NBSP there is the intended spacing, and punctilio
-  // rejects two pure insertions at one offset — so collapse the duplicate.
-  const insertedAt = new Set<number>()
-  const insertNbsp = (offset: number, bind?: "left" | "right"): void => {
-    if (insertedAt.has(offset)) {
-      return
-    }
-    insertedAt.add(offset)
-    view.replace(offset, offset, NBSP, bind ? { bind } : undefined)
-  }
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== "/" || isHatTipSlash(view, i)) {
       continue
     }
-    if (!applyMainSlashRule(view, i, insertNbsp)) {
+    if (!applyMainSlashRule(view, i)) {
       applyNumberSlashRule(view, i)
     }
   }

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -309,15 +309,15 @@ describe("HTMLFormattingImprovement", () => {
   })
 
   describe("slashes adjacent across an inline-element boundary", () => {
-    // Two slashes separated only by an inline-element boundary make the first
-    // slash's trailing NBSP and the second slash's leading NBSP land at the
-    // same offset; punctilio rejects two pure insertions there. The pass now
-    // collapses the duplicate to a single NBSP instead of crashing the build.
+    // Two slashes separated only by an inline-element boundary each get their
+    // own NBSP at the shared boundary offset. punctilio routes the opposite-
+    // bound insertions into different nodes (v5.1+), so the build no longer
+    // aborts with "Two pure insertions at the same offset ... ambiguous".
     it.each([
-      ["<p>a/<em></em>/b</p>", "<p>a / <em></em>/ b</p>"],
-      ["<p><em>x/</em>/y</p>", "<p><em>x /</em>/ y</p>"],
+      ["<p>a/<em></em>/b</p>", "<p>a / <em></em> / b</p>"],
+      ["<p><em>x/</em>/y</p>", "<p><em>x /</em> / y</p>"],
       ["<p><em>a/</em><em>/b</em></p>", "<p><em>a /</em><em>/ b</em></p>"],
-      ["<p>a/<strong></strong>/b</p>", "<p>a / <strong></strong>/ b</p>"],
+      ["<p>a/<strong></strong>/b</p>", "<p>a / <strong></strong> / b</p>"],
     ])("does not crash on %s", (input: string, expected: string) => {
       expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
     })
@@ -1630,11 +1630,14 @@ describe("collectProseBlocks", () => {
     ],
     ["nested paragraphs", el("div", [el("div", [el("p", ["nested"])])]), [["p", ["nested"]]]],
     [
+      // punctilio's collectProseBlocks returns block-level prose units and no
+      // longer includes loose inline runs (`<span>text</span>`) sitting between
+      // block children; the visitor still reaches such a span directly, so its
+      // typography is unaffected.
       "mixed content",
       el("div", [el("p", ["p1"]), el("span", ["text"]), el("p", ["p2"])]),
       [
         ["p", ["p1"]],
-        ["span", ["text"]],
         ["p", ["p2"]],
       ],
     ],

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -323,6 +323,25 @@ describe("HTMLFormattingImprovement", () => {
     })
   })
 
+  describe("loose inline text beside block children", () => {
+    // Loose text sitting directly in a container alongside block children owns
+    // no element of its own; formatting reaches it via punctilio's prose "run"
+    // units. Its quotes/slashes must still be transformed, without merging the
+    // container's block children across the boundary.
+    it.each([
+      [
+        '<div><p>p1</p>loose "text" here<p>p2</p></div>',
+        "<div><p>p1</p>loose “text” here<p>p2</p></div>",
+      ],
+      [
+        '<blockquote><p>a</p>loose "quote" text</blockquote>',
+        "<blockquote><p>a</p>loose “quote” text</blockquote>",
+      ],
+    ])("curls quotes in %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+    })
+  })
+
   describe("non-breaking spaces around slashes and ampersands", () => {
     it.each([
       ["dog/cat", `dog${NBSP}/${NBSP}cat`],


### PR DESCRIPTION
## Summary

Moves TurnTrout onto **current punctilio (5.2.1)** and retires the two local workarounds, using the upstream engine fixes instead.

- **`punctilio` 5.1.4 → 5.2.1.** Picks up: the `ProseView` insertion-collision fix (opposite-`bind` insertions route to different nodes), the `applyPasses` spanning-view fix (#258), and — the key one — **`collectProseUnits`** (#260), which exposes loose inline "runs".
- **Reverts #1575's local slash-dedup workaround** — the engine handles two slashes adjacent across an inline boundary.
- **Switches `improveFormatting` from `collectProseBlocks` to `collectProseUnits`** and formats each unit. This is what fixes the site-wide regression the 5.1.x line introduced: loose inline text sitting beside a container's block children (`<blockquote><p>…</p>loose "text"</blockquote>`, `<div>`, `<li>`, …) owns no element the visitor reaches, so `collectProseBlocks` couldn't format it. `collectProseUnits` surfaces those runs; `applyPasses` formats a run without merging block children.

## Why this replaced the naive bump

Bumping straight to 5.1.x regressed 60+ pages (`unprocessed_quotes`, missing spacing) — `collectProseBlocks` had started dropping loose runs (`4f2f350`). Rather than pin to the old version, the fix landed upstream (punctilio #260 re-models runs as first-class units) and TurnTrout adopts it here. Root-caused with a full `site-build-checks` build-and-diff (main: 0 regressions; naive 5.1.x: 62), not just the unit suite.

## Verification

- Formatting suites: **620 passed**, `formatting_improvement_html.ts` at **100%** coverage.
- New regression tests: loose inline text beside block children curls its quotes; slashes adjacent across an inline boundary don't crash.
- `tsc`, ESLint, Prettier clean. End-to-end, the 62 `site-build-checks` regressions are resolved.

## Follow-up

After this lands, slash-boundary pages render with the engine's spacing, so the **visual baselines need one approval** — the right moment to clear the baseline diffs from #1575's earlier merge.

## Lessons learned

- **A dependency's minor bump can carry breaking behavior the unit suite won't catch — gate a formatting-engine upgrade on the full built-site check, not just unit tests.** Here `collectProseBlocks` silently stopped returning loose inline "runs"; the unit tests (which asserted the return-set shape) stayed green while 60+ real pages lost quote/spacing formatting. When a library exposes a "collect the things to transform" API, an element-walking consumer depends on *completeness* of that collection — verify against rendered output, and prefer fixing the library to re-model (not drop) members over pinning to an old version.