### PR TITLE
Fix flaky Welcome page screenshot by mutating DOM inside waitForFunction

### DIFF
--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -158,31 +158,27 @@ test.describe("Test page sections", () => {
   })
 })
 
-// The index page's SPA fires an initial `nav` after load; a bare page.evaluate
-// racing that pass hits a destroyed execution context in Firefox. Poll with
-// waitForFunction (which survives the nav) until webfonts have swapped, then
-// drop every paragraph but the first — retrying once if the nav destroys the
-// context mid-call — so only the dropcap paragraph remains for the screenshot.
+// The index page's SPA can replace the document shortly after load, destroying
+// the execution context (killing any in-flight page.evaluate) and discarding
+// DOM edits made before the swap. waitForFunction survives that: Playwright
+// re-injects the predicate into each new context, so mutating inside the poll
+// guarantees the edit lands in the document that gets screenshotted. Wait for
+// webfonts, drop every paragraph but the dropcap one, and resolve only once
+// that state holds.
 async function keepOnlyFirstParagraph(page: Page): Promise<void> {
-  await page.waitForFunction(() => document.fonts?.status === "loaded", undefined, {
-    timeout: 10_000,
-  })
-  const removeTrailingParagraphs = (): void => {
-    const article = document.querySelector("article")
-    if (!article) return
-    article.querySelectorAll("p").forEach((p, idx) => {
-      if (idx > 0) p.remove()
-    })
-  }
-  try {
-    await page.evaluate(removeTrailingParagraphs)
-  } catch (error: unknown) {
-    if (error instanceof Error && error.message.includes("Execution context was destroyed")) {
-      await page.evaluate(removeTrailingParagraphs)
-    } else {
-      throw error
-    }
-  }
+  await page.waitForFunction(
+    () => {
+      if (document.fonts?.status !== "loaded") return false
+      const article = document.querySelector("article")
+      if (!article) return false
+      article.querySelectorAll("p").forEach((p, idx) => {
+        if (idx > 0) p.remove()
+      })
+      return article.querySelectorAll("p").length === 1
+    },
+    undefined,
+    { timeout: 10_000 },
+  )
 }
 
 test.describe("Unique content around the site", () => {


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `Welcome page (screenshot)` flake in `visual-regression.spec.ts`, which failed again today on `visual-testing-macos (2/2)` (Desktop Safari/WebKit) with:

```
page.evaluate: Execution context was destroyed, most likely because of a navigation
```

## Root cause

The index page's SPA can replace the document shortly after load. `keepOnlyFirstParagraph` handled this with a bare `page.evaluate` plus a single retry on "Execution context was destroyed" — but that pattern has two residual races:

1. The retry itself can hit a second context destruction (the flake was originally observed on Firefox; today's failure shows WebKit races the same way).
2. An `evaluate` that *succeeds* before the document swap has its DOM edits silently discarded, leaving the wrong content in the screenshot.

## Fix

Perform the paragraph removal **inside `page.waitForFunction`**. Playwright re-injects the polled predicate into every new execution context, so a navigation mid-poll just restarts the poll in the fresh document and the mutation is re-applied there. The poll resolves only once the trimmed state (webfonts loaded, exactly one paragraph) actually holds in the final document — eliminating both races instead of retrying around them. The predicate is idempotent, so repeated polling is safe.

Also removes the try/catch retry scaffolding, so the helper is simpler than before.

## Verification

- `tsc --noEmit` clean.
- Prettier clean.
- The test itself is the coverage — it runs across all Playwright projects (desktop + mobile, Chromium/Firefox/WebKit) in the visual-testing workflow, which this PR's paths trigger.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JD1dwXGqTpSRtKZTGS3bJc)_