### PR TITLE
Grant pull-requests: write so baseline-approval PR comments post

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -28,7 +28,9 @@ permissions:
   actions: write # re-run deploy on main
   checks: write # post a synthetic passing visual-testing check-run on main
   contents: write
-  pull-requests: read
+  # PR conversation comments (issues.createComment on a PR) require
+  # pull-requests: write, not issues: write.
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

Every `update-visual-baselines` run since **July 6** has concluded red. Pulling the July 11 run's logs (`29160571013`) shows the actual failure is at the end of the job:

```
##[error]Unhandled error: HttpError: Resource not accessible by integration
  - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

Both `issues.createComment` steps (the "approved" comment at line 249 and the failure comment at line 264) hit this. **Commenting on a PR conversation via `issues.createComment` is gated by the `pull-requests` permission — the workflow's `issues: write` does not cover it**, and it only granted `pull-requests: read`.

Notably, the *useful* work in those runs succeeded: the R2 upload completed ("Uploaded 18 baseline(s) to R2" — the per-file rclone 501s were retried internally, rclone exited 0) and the empty retrigger commit was pushed. Only the comment step failed the job, making the approve-button flow look broken when it mostly wasn't.

## Change

One-line permission bump in `.github/workflows/update-visual-baselines.yaml`: `pull-requests: read` → `pull-requests: write`, with a comment stating the constraint. All other API calls in the workflow (`pulls.get`, `checks.create`, `actions.*`) were already covered by existing grants.

## Verification

- Traced both failing `createComment` calls in the workflow to the two `Unhandled error` entries in the failed run's log.
- Confirmed no other REST calls in the workflow need additional permissions.
- Full verification requires the next real approve-baselines dispatch (workflow permissions only take effect from the ref the dispatch runs on, i.e. after this merges to `main`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JD1dwXGqTpSRtKZTGS3bJc)_