### PR TITLE
Retry critical Playwright log upload before failing the shard

### DIFF
--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -126,16 +126,30 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
-      # Critical log: surface upload failures (don't swallow with
-      # continue-on-error) so a missing log is visible on the shard.
+      # Critical log: a missing log must stay visible on the shard, but the
+      # artifact service intermittently times out (ETIMEDOUT on
+      # CreateArtifact), so give the upload one retry before letting the
+      # failure surface.
       - name: Upload Playwright logs
+        id: upload-playwright-log
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-log-linux-shard-${{ env.SANITIZED_SHARD }}
           path: playwright-run.log
           if-no-files-found: warn
           retention-days: 1
+
+      - name: Upload Playwright logs (retry)
+        if: always() && steps.upload-playwright-log.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-log-linux-shard-${{ env.SANITIZED_SHARD }}
+          path: playwright-run.log
+          if-no-files-found: warn
+          retention-days: 1
+          overwrite: true
 
       - name: Upload Winston logs
         if: steps.playwright.outcome == 'failure'
@@ -237,16 +251,30 @@ jobs:
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
 
-      # Critical log: surface upload failures (don't swallow with
-      # continue-on-error) so a missing log is visible on the shard.
+      # Critical log: a missing log must stay visible on the shard, but the
+      # artifact service intermittently times out (ETIMEDOUT on
+      # CreateArtifact), so give the upload one retry before letting the
+      # failure surface.
       - name: Upload Playwright logs
+        id: upload-playwright-log
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-log-macos-shard-${{ env.SANITIZED_SHARD }}
           path: playwright-run.log
           if-no-files-found: warn
           retention-days: 1
+
+      - name: Upload Playwright logs (retry)
+        if: always() && steps.upload-playwright-log.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-log-macos-shard-${{ env.SANITIZED_SHARD }}
+          path: playwright-run.log
+          if-no-files-found: warn
+          retention-days: 1
+          overwrite: true
 
       - name: Upload Winston logs
         if: steps.playwright.outcome == 'failure'


### PR DESCRIPTION
## Summary

On PR #1583, `playwright-tests-linux (2/8)` went red even though **all 376 tests passed** — the shard died at the very last step on a GitHub artifact-service timeout:

```
##[error]Failed to CreateArtifact: Unable to make request: ETIMEDOUT
```

The `playwright-run.log` upload is deliberately fatal (per the in-workflow comment: a missing critical log must be visible on the shard), so per the zero-flakiness policy the fix is to make the pipeline resilient to the external service rather than swallow the failure.

## Change

In `.github/workflows/playwright-tests.yaml`, for both the Linux and macOS shard jobs:

- First "Upload Playwright logs" attempt gets `continue-on-error: true` and an `id`.
- A new "(retry)" step runs only when the first attempt's `outcome == 'failure'`, with `overwrite: true` (in case the first attempt partially created the artifact), and **without** `continue-on-error` — so if both attempts fail, the shard still fails and the missing log stays visible.

Net semantics: one transient artifact-service hiccup no longer kills a green shard; a persistent upload failure still does.

## Verification

- Root-caused from the failed job log of run `29211985535` (376 passed, 14 skipped, then `Failed to CreateArtifact: ETIMEDOUT` on this exact step).
- `steps.<id>.outcome` is the pre-`continue-on-error` result, so the retry gate fires exactly when attempt 1 failed.
- The diagnostic uploads (Winston logs, webserver logs, traces) already have `continue-on-error: true` and are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JD1dwXGqTpSRtKZTGS3bJc)_