### PR TITLE
Deflake video-timestamp and popover-checkbox Playwright tests

### DIFF
--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -552,13 +552,18 @@ test("Video autoplay works correctly after SPA navigation", async ({ page }) => 
   )
 })
 
-async function getTimestampAfterNavigation(page: Page): Promise<number> {
+async function getTimestampAfterNavigation(page: Page, expectedTimestamp: number): Promise<number> {
+  // The muted navbar video can autoplay from 0 before the sessionStorage
+  // restore applies, so a bare "currentTime > 0" can sample the pre-restore
+  // playhead. Wait until the playhead is within the assertion's tolerance of
+  // the saved timestamp; a restore that never applies hits the timeout and
+  // fails loudly.
   const handle = await page.waitForFunction(
-    (id) => {
+    ({ id, expected }) => {
       const videoEl = document.querySelector<HTMLVideoElement>(`#${id}`)
-      return videoEl && videoEl.currentTime > 0 ? videoEl.currentTime : null
+      return videoEl && Math.abs(videoEl.currentTime - expected) < 0.5 ? videoEl.currentTime : null
     },
-    pondVideoId,
+    { id: pondVideoId, expected: expectedTimestamp },
     { timeout: 45_000 },
   )
   return (await handle.jsonValue()) as number
@@ -573,7 +578,10 @@ test("Video timestamp is preserved during SPA navigation", async ({ page }) => {
   const localLink = page.locator("a:not(.skip-to-content)").first()
   await triggerAndWaitForSPANav(page, () => localLink.click())
 
-  const timestampAfterNavigation = await getTimestampAfterNavigation(page)
+  const timestampAfterNavigation = await getTimestampAfterNavigation(
+    page,
+    timestampBeforeNavigation,
+  )
   expect(timestampAfterNavigation).toBeCloseTo(timestampBeforeNavigation, 0)
 })
 
@@ -587,6 +595,6 @@ test("Video timestamp is preserved during refresh", async ({ page }) => {
 
   await reloadPage(page)
 
-  const timestampAfterRefresh = await getTimestampAfterNavigation(page)
+  const timestampAfterRefresh = await getTimestampAfterNavigation(page, timestampBeforeRefresh)
   expect(timestampAfterRefresh).toBeCloseTo(timestampBeforeRefresh, 0)
 })

--- a/quartz/components/tests/popover.spec.ts
+++ b/quartz/components/tests/popover.spec.ts
@@ -921,9 +921,16 @@ test.describe("Popover checkbox state preservation", () => {
     await testPageLink.scrollIntoViewIfNeeded()
     await expect(testPageLink).toBeVisible()
 
-    await testPageLink.hover()
+    // Popovers are suppressed until a real mousemove fires after navigation,
+    // and a single hover can race the nav listeners attaching (or be a no-op
+    // when the pointer is already on the link). Re-hover from a safe position
+    // until the popover mounts.
     const popover = page.locator(".popover")
-    await expect(popover).toBeVisible()
+    await expect(async () => {
+      await moveMouseToSafePosition(page)
+      await testPageLink.hover()
+      await expect(popover).toBeVisible({ timeout: 3_000 })
+    }).toPass({ timeout: 30_000 })
 
     const popoverCheckbox = popover.locator(baseSelector).first()
     const popoverChecked = await isElementChecked(popoverCheckbox)


### PR DESCRIPTION
## Summary

Surveying the last two days of red `playwright-tests` runs turned up two more distinct flaky tests (each "1 flaky, passed on retry", each failing its shard since flaky = failure here):

- **Jul 12, `main` (run 29211892970):** `navbar.spec.ts › Video timestamp is preserved during refresh` (Desktop Chrome) — `expect(received).toBeCloseTo(expected)` mismatch.
- **Jul 11, punctilio PR (run 29163357079):** `popover.spec.ts › Popover preserves checkbox state` (Desktop Safari) — `toBeVisible()` 5s timeout.

## Root causes and fixes

**Video timestamp tests** (`navbar.spec.ts`): `getTimestampAfterNavigation` waited for any `currentTime > 0`. The muted navbar video can autoplay from 0 before the sessionStorage restore applies, so the first nonzero sample can be the *pre-restore* playhead (~0.2s) instead of the restored ~2.5s — exactly the observed `toBeCloseTo` failure. The helper now takes the expected timestamp and polls until the playhead is within the assertion's 0.5s tolerance; a restore that never applies hits the 45s timeout and fails loudly. Both the SPA-nav and refresh tests use the helper, so both are covered. The final `toBeCloseTo` assertions are unchanged.

**Popover checkbox test** (`popover.spec.ts`): popovers are suppressed until a real `mousemove` fires after navigation (`mouseMovedSinceNav` in `popover.inline.ts`), and the single `hover()` right after `gotoPage` can race the nav listeners attaching — or be a no-op if the pointer is already on the link. The test now re-hovers from a safe position inside `expect(...).toPass()`, the same idiom this spec already documents and uses for search previews (line ~344). The `toBeVisible` requirement is unchanged, just retried.

Neither change weakens an assertion — both convert one-shot racy waits into bounded retries whose timeout still surfaces genuine breakage.

## Verification

- `tsc --noEmit` clean, prettier clean.
- Root causes traced from the actual CI failure logs of both runs (not reproduced-by-guess); the video race mechanism matches the restore path in `navbar.inline.ts` (restore sets `currentTime` after load while Chrome autoplays muted video from 0).

## Related

Part of the flakiness sweep with #1583 (Welcome-page screenshot), #1584 (approve-baselines permissions), #1585 (artifact-upload retry).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JD1dwXGqTpSRtKZTGS3bJc)_