### PR TITLE
Point RSS subscribe link at production feed

### DIFF
--- a/quartz/plugins/transformers/afterArticle.ts
+++ b/quartz/plugins/transformers/afterArticle.ts
@@ -13,7 +13,9 @@ const newsletterElement = h("a", { href: "https://turntrout.substack.com/subscri
   "newsletter",
 ])
 
-export const rssElement = h("a", { href: "/rss.xml", id: "rss-link" }, [
+// Absolute production URL so preview/dev deploys point subscribers at the
+// canonical feed instead of their own draft-laden rss.xml.
+export const rssElement = h("a", { href: "https://turntrout.com/rss.xml", id: "rss-link" }, [
   h("abbr", { class: "small-caps" }, "rss"),
 ])
 const subscriptionElement = h("div", { className: "centered" }, [


### PR DESCRIPTION
## What

The after-article "rss" subscribe link previously used a root-relative `href="/rss.xml"`. On preview and `dev` deploys that resolved to the preview/dev site's own `rss.xml`, advertising a draft-laden feed to anyone who clicked subscribe.

This changes the link to the absolute production URL `https://turntrout.com/rss.xml`, so **every** deploy — production, `dev`, and PR previews — points subscribers at the single canonical feed.

## Why this approach

The site build is shared by commit SHA and always uses `baseUrl: turntrout.com`, so there's no reliable per-branch signal inside the cached build. Making the link unconditionally absolute is the simplest robust fix and is semantically identical on `main` (where `/rss.xml` and `https://turntrout.com/rss.xml` are the same resource). Dev keeps emitting a valid `public/rss.xml`, so the Python `check_rss_file_for_issues` validation keeps passing everywhere — no gating needed.

## Safety notes

- `isExternalLink("https://…")` classifies the link as **external**, so it is not flagged by `check_invalid_internal_links` (which only inspects `class="internal"` links).
- The favicon transformer force-applies the `rss` favicon for any href ending in `/rss.xml` and returns early, so the link keeps its RSS icon with no generic external-link icon.
- `countFavicons` still matches the absolute href (`endsWith("/rss.xml")`).
- The only behavioral change is that the link now opens in a new tab (external `target`/`rel`), which is appropriate for a feed link.

## Tests

- `afterArticle.test.ts` (9 passed, 100% file coverage) and `favicons.test.ts` (258 passed) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Rok7sm4ShVZprgEJgSreP)_