### PR TITLE
fix: don't crash the build when an embedded README asset 404s

### DIFF
--- a/quartz/plugins/transformers/assetDimensions.ts
+++ b/quartz/plugins/transformers/assetDimensions.ts
@@ -14,6 +14,7 @@ import type { BuildCtx } from "../../util/ctx"
 
 import { createWinstonLogger } from "../../util/log"
 import { isDraftPath } from "../filters/draft"
+import { EXTERNAL_README_CLASS } from "./populateExternalMarkdown"
 
 export const logger = createWinstonLogger("assetDimensions")
 
@@ -388,12 +389,15 @@ class AssetProcessor {
    * @param currentDimensionsCache - The current dimensions cache
    * @param retries - Number of retry attempts for remote assets
    * @param offline - If true, skip remote fetches and use cached dimensions only
+   * @param tolerateRemoteFailure - If true, a failed remote fetch is logged and
+   *   skipped instead of aborting the build (used for third-party README assets)
    */
   public async processAsset(
     assetInfo: { node: Element; src: string },
     currentDimensionsCache: AssetDimensionMap,
     retries = numRetries,
     offline = false,
+    tolerateRemoteFailure = false,
   ): Promise<void> {
     const { node, src } = assetInfo
     let dims = currentDimensionsCache[src]
@@ -404,7 +408,18 @@ class AssetProcessor {
         logger.debug(`Skipping remote asset in offline mode: ${src}`)
         return
       }
-      const fetchedDims = await AssetProcessor.fetchAndParseAssetDimensions(src, retries)
+      let fetchedDims: AssetDimensions | null
+      try {
+        fetchedDims = await AssetProcessor.fetchAndParseAssetDimensions(src, retries)
+      } catch (error) {
+        if (tolerateRemoteFailure && AssetProcessor.isRemoteUrl(src)) {
+          logger.warn(
+            `Skipping dimensions for external README asset ${src}: ${(error as Error).message}`,
+          )
+          return
+        }
+        throw error
+      }
       if (fetchedDims) {
         dims = fetchedDims
         currentDimensionsCache[src] = fetchedDims
@@ -501,6 +516,24 @@ export function constrainSliderHeight(tree: Root): void {
 }
 
 /**
+ * Collects every element inside a `div.external-readme` wrapper (produced by
+ * `wrapExternalReadme`). Assets embedded from a third-party README point at URLs
+ * we don't author, so a fetch failure there must degrade gracefully rather than
+ * abort the whole site build.
+ */
+export function collectExternalReadmeNodes(tree: Root): ReadonlySet<Element> {
+  const external = new Set<Element>()
+  visit(tree, "element", (node: Element) => {
+    const classes = node.properties?.className
+    if (!(Array.isArray(classes) && classes.includes(EXTERNAL_README_CLASS))) return
+    visit(node, "element", (descendant: Element) => {
+      external.add(descendant)
+    })
+  })
+  return external
+}
+
+/**
  * Creates a Quartz plugin that adds width, height, and aspect-ratio CSS to image and video elements.
  * In offline mode, uses cached dimensions only and skips remote asset fetches.
  */
@@ -520,6 +553,7 @@ export const addAssetDimensionsFromSrc = () => {
             }
             const currentDimensionsCache = await assetProcessor.maybeLoadDimensionCache()
             const assetsToProcess = assetProcessor.collectAssetNodes(tree)
+            const externalReadmeNodes = collectExternalReadmeNodes(tree)
 
             for (const assetInfo of assetsToProcess) {
               await assetProcessor.processAsset(
@@ -527,6 +561,7 @@ export const addAssetDimensionsFromSrc = () => {
                 currentDimensionsCache,
                 numRetries,
                 offline,
+                externalReadmeNodes.has(assetInfo.node),
               )
             }
             if (assetProcessor["needToSaveCache"]) {

--- a/quartz/plugins/transformers/tests/assetDimensions.test.ts
+++ b/quartz/plugins/transformers/tests/assetDimensions.test.ts
@@ -32,6 +32,7 @@ import {
   addAssetDimensionsFromSrc,
   type AssetDimensionMap,
   AssetProcessor,
+  collectExternalReadmeNodes,
   constrainSliderHeight,
   findWidestAspectRatio,
   assetProcessor as globalAssetProcessor,
@@ -41,6 +42,7 @@ import {
   paths,
   prependStyles,
 } from "../assetDimensions"
+import { EXTERNAL_README_CLASS } from "../populateExternalMarkdown"
 import { mockFetchNetworkError, mockFetchResolve } from "./test-utils"
 
 // Create a minimal valid PNG file with IHDR chunk
@@ -1026,6 +1028,73 @@ describe("Asset Dimensions Plugin", () => {
       expect(node.properties?.style).toBe(`aspect-ratio: ${mockImageWidth} / ${mockImageHeight};`)
       expect(assetProcessor["needToSaveCache"]).toBe(true)
     })
+
+    it("tolerates a failed remote fetch for an external README asset", async () => {
+      mockFetchResolve(mockedFetch, null, 404, {}, "Not Found")
+      const loggerWarnSpy = jest.spyOn(logger, "warn").mockImplementation((() => logger) as never)
+      const currentDimensionsCache: AssetDimensionMap = {}
+      const node = h("img", { src: imageUrl }) as Element
+
+      await expect(
+        assetProcessor.processAsset(
+          { node, src: imageUrl },
+          currentDimensionsCache,
+          1,
+          false,
+          true,
+        ),
+      ).resolves.toBeUndefined()
+
+      expect(node.properties?.width).toBeUndefined()
+      expect(node.properties?.height).toBeUndefined()
+      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining(imageUrl))
+      loggerWarnSpy.mockRestore()
+    })
+
+    it("still throws for a non-remote asset even when tolerating remote failures", async () => {
+      const localSrc = "asset_staging/does-not-exist.png"
+      const fetchSpy = jest
+        .spyOn(AssetProcessor, "fetchAndParseAssetDimensions")
+        .mockRejectedValue(new Error("local read failed"))
+      const currentDimensionsCache: AssetDimensionMap = {}
+      const node = h("img", { src: localSrc }) as Element
+
+      await expect(
+        assetProcessor.processAsset(
+          { node, src: localSrc },
+          currentDimensionsCache,
+          1,
+          false,
+          true,
+        ),
+      ).rejects.toThrow("local read failed")
+
+      fetchSpy.mockRestore()
+    })
+  })
+
+  describe("collectExternalReadmeNodes", () => {
+    it("collects descendants of an external-readme wrapper", () => {
+      const img = h("img", { src: "https://assets.turntrout.com/readme.png" }) as Element
+      const wrapper = h("div", { className: [EXTERNAL_README_CLASS] }, [img]) as Element
+      const tree: Root = { type: "root", children: [wrapper] }
+
+      const external = collectExternalReadmeNodes(tree)
+
+      expect(external.has(img)).toBe(true)
+    })
+
+    it("ignores assets outside an external-readme wrapper", () => {
+      const img = h("img", { src: "https://assets.turntrout.com/first-party.png" }) as Element
+      const tree: Root = {
+        type: "root",
+        children: [h("div", { className: ["some-other-class"] }, [img]) as Element],
+      }
+
+      const external = collectExternalReadmeNodes(tree)
+
+      expect(external.has(img)).toBe(false)
+    })
   })
 
   describe("addAssetDimensionsFromUrl Plugin (Integration)", () => {
@@ -1141,6 +1210,31 @@ describe("Asset Dimensions Plugin", () => {
 
       expect(tree.children).toHaveLength(0)
       expect(mockedFetch).not.toHaveBeenCalled()
+    })
+
+    it("does not abort the build when an external README asset 404s", async () => {
+      const readmeImgSrc = "https://assets.turntrout.com/static/images/missing-readme-asset.png"
+      const img = h("img", { src: readmeImgSrc }) as Element
+      const tree: Root = {
+        type: "root",
+        children: [h("div", { className: [EXTERNAL_README_CLASS] }, [img]) as Element],
+      }
+      assetProcessor.setDirectCache({})
+      const fetchSpy = jest
+        .spyOn(AssetProcessor, "fetchAndParseAssetDimensions")
+        .mockRejectedValue(new Error(`Failed to fetch asset ${readmeImgSrc}: 404 Not Found`))
+      const loggerWarnSpy = jest.spyOn(logger, "warn").mockImplementation((() => logger) as never)
+
+      const pluginInstance = addAssetDimensionsFromSrc()
+      const mockCtx = { argv: { offline: false } } as BuildCtx
+      const transformer = pluginInstance.htmlPlugins(mockCtx)[0]()
+
+      await expect(transformer(tree, makeNonDraftFile())).resolves.toBeUndefined()
+
+      expect(img.properties?.width).toBeUndefined()
+      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining(readmeImgSrc))
+      fetchSpy.mockRestore()
+      loggerWarnSpy.mockRestore()
     })
 
     it("should handle tree with no images", async () => {


### PR DESCRIPTION
## Why main was failing

Every check on `main`'s latest commit (`347bf11`) that depends on a successful site build was red: **Site build checks, Playwright Tests, Accessibility, Deploy to Cloudflare, Visual Testing, and Preview audits**. They all cascade from a single root cause.

The build aborted with a fatal error:

```
Failed to process `website_content/open-source.md`: Failed to fetch asset
https://assets.turntrout.com/static/images/glovebox.png?v=1: 404 Not Found
    at Function.getRemoteAssetDimensions (assetDimensions.ts:268)
```

The open-source page embeds third-party READMEs (`claude-guard`, `punctilio`, `ci-truth-serum`, `agent-input-sanitizer`) fetched from GitHub **at build time** via `populate-markdown-*` placeholders. The `claude-guard` README referenced an image that returned 404. `assetDimensions` threw, and because markdown parsing runs in a worker pool, that single failure killed the whole Quartz build — taking every downstream check with it.

(The upstream README has since been repointed from `glovebox.png` → `glovebox.jpg`, which now returns 200, but the build should never have been this brittle: any future edit to any embedded README that references a missing asset would break `main` the same way.)

## The fix

Asset-dimension fetches for images inside a `div.external-readme` wrapper now degrade gracefully — the failure is logged via `logger.warn` and the image ships without precomputed dimensions, rather than aborting the build. First-party assets still fail loudly, since those are authoring errors we control.

- `collectExternalReadmeNodes(tree)` gathers every element inside an `external-readme` wrapper.
- `processAsset` gains a `tolerateRemoteFailure` flag; on a failed **remote** fetch it logs and skips instead of throwing.
- The plugin passes the flag per-asset based on wrapper membership.

## Tests

Added coverage for the new branches in `assetDimensions.test.ts`:
- `processAsset` tolerates a failed remote fetch for an external-README asset (logs, skips, no throw).
- `processAsset` still throws for a non-remote asset even when tolerating remote failures.
- `collectExternalReadmeNodes` collects wrapper descendants and ignores assets outside the wrapper.
- Plugin-level: a 404 on an external-README asset no longer aborts the transform.

All 92 tests in the file pass; `tsc` and Prettier are clean.

## Lessons learned

- A static site build that embeds **external content fetched at build time** (READMEs, remote assets) must treat failures in that content as non-fatal. A 404 in a third-party dependency should degrade gracefully, never hard-crash the whole build and cascade across every downstream CI check. Keep loud failures for first-party content you author and control; make the pipeline resilient to sources you don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVGVqs7FTkUE7fGWHZW6HD)_