### PR TITLE
Allow temporary caption waiver for the leaving-DeepMind video

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -3029,6 +3029,19 @@ def _should_skip_video(video: Tag) -> bool:
     return not isinstance(video, Tag) or video.get("id") == "pond-video"
 
 
+def _is_pa11y_hidden(video: Tag) -> bool:
+    """
+    True for a ``<video>`` carrying the ``ignore-pa11y`` a11y-waiver class.
+
+    ``ignore-pa11y`` (see ``config/pa11y/.pa11yci`` ``hideElements``) removes an
+    element from the axe/htmlcs audit, so the built-site caption gate honors the
+    same marker: waiving one accessibility gate while the other still fails would
+    be contradictory. Removing the class re-enables both gates at once.
+    """
+    classes = video.get("class") or []
+    return "ignore-pa11y" in classes
+
+
 def check_video_source_order_and_match(soup: BeautifulSoup) -> list[str]:
     """Check <video> elements have the MP4 <source> tag first, then the WEBM
     <source> tag, with matching base src."""
@@ -3093,11 +3106,15 @@ def check_video_caption_tracks(soup: BeautifulSoup) -> list[str]:
     Every audio-bearing ``<video>`` must carry a real captions track.
 
     Skips ``#pond-video`` and inline looping muted GIF replacements, which have
-    no audio.
+    no audio, and any ``<video>`` bearing the ``ignore-pa11y`` a11y-waiver class.
     """
     issues: list[str] = []
     for video in _tags_only(soup.find_all("video")):
-        if _should_skip_video(video) or _is_gif_replacement(video):
+        if (
+            _should_skip_video(video)
+            or _is_gif_replacement(video)
+            or _is_pa11y_hidden(video)
+        ):
             continue
         issue = _video_caption_issue(video)
         if issue is not None:

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -5115,6 +5115,19 @@ _NO_CAPTIONS_ISSUE = (
             '<source src="https://cdn/pond.mp4"></video>',
             [],
         ),
+        # A video waived from the a11y audit (ignore-pa11y) is skipped so the
+        # caption gate cannot contradict the axe/htmlcs suppression.
+        (
+            '<video controls class="ignore-pa11y">'
+            '<source src="https://cdn/talk.mp4"></video>',
+            [],
+        ),
+        # ignore-pa11y among other classes is still honored.
+        (
+            '<video controls class="foo ignore-pa11y bar">'
+            '<source src="https://cdn/talk.mp4"></video>',
+            [],
+        ),
         # A non-captions track does not satisfy the requirement.
         (
             '<video controls><source src="https://cdn/talk.mp4">'

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -203,7 +203,7 @@ I was surprised. Stuart said "It seems like \[taking the same stand\] is up to t
 
 The next question from a conference attendee asked whether IASEAI would take positions on current issues. As the session wrapped, IASEAI's interim executive director Mark Nitzberg took the stage.
 
-<video controls playsinline aria-label="A speaker at a conference addresses an audience, asking for a show of hands to gauge support for an organization statement regarding Anthropic. After the audience responds with a mass of raised hands, the speaker discusses the process for formalizing organizational member opinions."><source src="https://assets.turntrout.com/static/images/posts/Why I left Google DeepMind-06242026-1.mp4" type="video/mp4; codecs=hvc1"/><source src="https://assets.turntrout.com/static/images/posts/Why I left Google DeepMind-06242026-1.webm" type="video/webm"/></video>
+<video controls playsinline class="ignore-pa11y" aria-label="A speaker at a conference addresses an audience, asking for a show of hands to gauge support for an organization statement regarding Anthropic. After the audience responds with a mass of raised hands, the speaker discusses the process for formalizing organizational member opinions."><source src="https://assets.turntrout.com/static/images/posts/Why I left Google DeepMind-06242026-1.mp4" type="video/mp4; codecs=hvc1"/><source src="https://assets.turntrout.com/static/images/posts/Why I left Google DeepMind-06242026-1.webm" type="video/webm"/></video>
 
 Figure: Mark asks for a show-of-hands. "We will be asking the opinions of members... and if you're not a member, go to the member desk."
 


### PR DESCRIPTION
## What

Lets the leaving-Google-DeepMind page publish before its embedded IASEAI video has a real captions track, without weakening the caption gate for every other video.

The embedded `<video>` at line 206 has audio but no `<track kind="captions">` yet (the real captions are being prepared separately). That currently fails two accessibility gates:

- `check_video_caption_tracks` in `scripts/built_site_checks.py` (built-site-checks / site-build-checks)
- axe's `video-caption` rule via pa11y (a11y)

## How

Reuse the site's existing a11y-waiver marker, `ignore-pa11y` (already in `config/pa11y/.pa11yci` `hideElements`):

- Add `class="ignore-pa11y"` to the one video. pa11y already skips `ignore-pa11y` elements, so axe no longer flags it.
- Teach `check_video_caption_tracks` to skip any `<video>` carrying `ignore-pa11y`, so the built-site caption gate can't contradict the axe/htmlcs suppression. No video currently uses `ignore-pa11y`, so no existing caption coverage is lost.

Removing the class re-enables **both** gates at once when the real captions land — a single, greppable toggle.

The marker carries no CSS, so the video's appearance is unchanged. Source-order/accessibility-label checks still apply.

## Tests

- Added two `check_video_caption_tracks` cases: an `ignore-pa11y` video (and one with `ignore-pa11y` among other classes) produces no issue.
- Full `test_built_site_checks.py` suite passes; new code fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVF5nzJeSt5zHZKNhQ5jWH)_