### PR TITLE
fix: keep short hyphenated compounds from wrapping at their hyphens

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -24,6 +24,7 @@ import {
   InvertInDarkMode,
   Latex,
   LinkContexts,
+  NonBreakingHyphens,
   NotFoundPage,
   ObsidianFlavoredMarkdown,
   PopulateContainers,
@@ -165,6 +166,10 @@ const config: QuartzConfig = {
       rehypeCustomSpoiler(),
       TagSmallcaps(),
       AutoCode(),
+      // After TagSmallcaps (and AutoCode) so acronyms are already wrapped in
+      // <abbr>: gluing a word joiner into "GPT-4" earlier would split the
+      // small-caps match. Glues short hyphenated compounds so they don't wrap.
+      NonBreakingHyphens(),
       AfterArticle(),
       RelatedPosts(),
       AddFavicons(),

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -339,11 +339,13 @@ const isAlnum = (char: string | undefined): boolean =>
 // compounds ("state-of-the-art") keep their break opportunities.
 //
 // The join fires when the hyphen sits between two alphanumerics and either a
-// digit flanks it (numeric compounds: "GPT-4", "COVID-19", "3-D", "9-to-5") or
-// one of the two joined segments is a single character (single-letter affixes:
-// "T-shirt", "X-ray", "e-mail"). Number ranges are already en dashes by this
-// point, so digit-digit hyphens never reach here. Idempotent: after a pass the
-// character following the hyphen is the word joiner, which fails the alnum test.
+// digit flanks it (numeric compounds and identifiers: "GPT-4", "COVID-19",
+// "3-D", "9-to-5", "1-2-3", "Qwen1.5-1.8") or one of the two joined segments is
+// a single character (single-letter affixes: "T-shirt", "X-ray", "e-mail").
+// Two-segment numeric ranges have already become en dashes upstream; a hyphen
+// that survives to here belongs to a compound worth keeping whole. Idempotent:
+// after a pass the character following the hyphen is the word joiner, which
+// fails the alphanumeric test.
 const hyphenWordJoinerPass = definePass(/-/g, (match, view) => {
   const idx = match.index
   const { text } = view

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -346,19 +346,23 @@ const isAlnum = (char: string | undefined): boolean =>
 // that survives to here belongs to a compound worth keeping whole. Idempotent:
 // after a pass the character following the hyphen is the word joiner, which
 // fails the alphanumeric test.
+//
+// Applied by NonBreakingHyphens, a late plugin (see below): running after
+// TagSmallcaps means acronyms are already wrapped in <abbr>, so gluing "gpt-4"
+// inside the finished element keeps it both small-capped and unbreakable
+// instead of splitting the acronym match.
 const hyphenWordJoinerPass = definePass(/-/g, (match, view) => {
   const idx = match.index
   const { text } = view
   const left = text[idx - 1]
   const right = text[idx + 1]
 
-  // Only an intra-word hyphen whose neighbors both live in this node qualifies.
+  // Only an intra-word hyphen qualifies. `glueHyphens` feeds one text node at a
+  // time, so a hyphen at a node edge has an undefined neighbor and is skipped.
   if (!isAlnum(left) || !isAlnum(right)) return null
-  if (view.hasBoundary(idx) || view.hasBoundary(idx + 1)) return null
 
-  const leftSegmentIsSingle = idx - 1 === 0 || view.hasBoundary(idx - 1) || !isAlnum(text[idx - 2])
-  const rightSegmentIsSingle =
-    idx + 2 === text.length || view.hasBoundary(idx + 2) || !isAlnum(text[idx + 2])
+  const leftSegmentIsSingle = idx - 1 === 0 || !isAlnum(text[idx - 2])
+  const rightSegmentIsSingle = idx + 2 === text.length || !isAlnum(text[idx + 2])
 
   const shouldGlue =
     /\d/.test(left) || /\d/.test(right) || leftSegmentIsSingle || rightSegmentIsSingle
@@ -1051,10 +1055,6 @@ export const improveFormatting = (
           ...activeUncheckedTransformers,
           // Runs after dash conversion so freshly created dashes get glued.
           dashWordJoinerPass,
-          // Runs after dash conversion so surviving hyphens (number ranges are
-          // now en dashes) get their short-compound joins. Skipped in display
-          // headings, which wrap naturally like nbspTransform is skipped there.
-          ...(inDisplayHeading ? [] : [hyphenWordJoinerPass]),
         ]
 
         // Don't replace slashes in fractions or link text; loose runs are neither.
@@ -1108,6 +1108,45 @@ export const StripInlineBoundaryWhitespace: QuartzTransformerPlugin = () => {
     name: "stripInlineBoundaryWhitespace",
     htmlPlugins() {
       return [() => stripInlineBoundaryWhitespace]
+    },
+  }
+}
+
+/**
+ * Applies {@link hyphenWordJoinerPass} to prose text nodes, gluing short
+ * hyphenated compounds so they don't wrap at their hyphens. Skips code and
+ * display headings (which wrap naturally, like nbspTransform is skipped there).
+ *
+ * Each text node is processed on its own; a hyphen at a node edge has no
+ * in-node neighbor and is left alone, matching the boundary-skip the pass
+ * applies within a multi-node run.
+ */
+export function glueHyphens(tree: Root): void {
+  visitParents(tree, "text", (node: Text, ancestors: Parent[]) => {
+    const parent = ancestors[ancestors.length - 1] as Element
+    // istanbul ignore next
+    if (!parent) return
+    if (hasAncestor(parent, toSkip, ancestors)) return
+    if (isDisplayHeading(parent) || hasAncestor(parent, isDisplayHeading, ancestors)) return
+    node.value = hyphenWordJoinerPass(node.value)
+  })
+}
+
+/**
+ * Quartz plugin gluing short hyphenated compounds ("1-on-1", "GPT-4") so they
+ * never wrap at a hyphen.
+ *
+ * Runs *after* ``TagSmallcaps``: acronyms are already wrapped in
+ * ``<abbr class="small-caps">`` by then, so the word joiner lands inside the
+ * finished element and keeps the acronym both small-capped and unbreakable. A
+ * joiner injected earlier would split the acronym match and drop trailing
+ * segments (e.g. the "XL" of "GPT-2-XL") out of the small-caps run.
+ */
+export const NonBreakingHyphens: QuartzTransformerPlugin = () => {
+  return {
+    name: "nonBreakingHyphens",
+    htmlPlugins() {
+      return [() => glueHyphens]
     },
   }
 }

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -329,6 +329,42 @@ const dashWordJoinerPass = definePass(/[–—]/gu, (match, view) => {
   return `${WORD_JOINER}${match[0]}`
 })
 
+const isAlnum = (char: string | undefined): boolean =>
+  char !== undefined && /[\p{L}\p{N}]/u.test(char)
+
+// A hyphen (U+002D) is a break-after opportunity, so a hyphenated token can
+// wrap right after any of its hyphens ("1-on-1" splitting to "1-" / "on-1").
+// For short, identifier-like compounds this reads badly. Glue a word joiner
+// after such a hyphen so the unit stays whole, while long descriptive
+// compounds ("state-of-the-art") keep their break opportunities.
+//
+// The join fires when the hyphen sits between two alphanumerics and either a
+// digit flanks it (numeric compounds: "GPT-4", "COVID-19", "3-D", "9-to-5") or
+// one of the two joined segments is a single character (single-letter affixes:
+// "T-shirt", "X-ray", "e-mail"). Number ranges are already en dashes by this
+// point, so digit-digit hyphens never reach here. Idempotent: after a pass the
+// character following the hyphen is the word joiner, which fails the alnum test.
+const hyphenWordJoinerPass = definePass(/-/g, (match, view) => {
+  const idx = match.index
+  const { text } = view
+  const left = text[idx - 1]
+  const right = text[idx + 1]
+
+  // Only an intra-word hyphen whose neighbors both live in this node qualifies.
+  if (!isAlnum(left) || !isAlnum(right)) return null
+  if (view.hasBoundary(idx) || view.hasBoundary(idx + 1)) return null
+
+  const leftSegmentIsSingle = idx - 1 === 0 || view.hasBoundary(idx - 1) || !isAlnum(text[idx - 2])
+  const rightSegmentIsSingle =
+    idx + 2 === text.length || view.hasBoundary(idx + 2) || !isAlnum(text[idx + 2])
+
+  const shouldGlue =
+    /\d/.test(left) || /\d/.test(right) || leftSegmentIsSingle || rightSegmentIsSingle
+  if (!shouldGlue) return null
+
+  return `-${WORD_JOINER}`
+})
+
 // Simple find-and-replace transforms local to this site (punctilio handles the rest)
 const checkedTextTransformers = [massTransformText, plusToAmpersand, timeTransform]
 
@@ -1013,6 +1049,10 @@ export const improveFormatting = (
           ...activeUncheckedTransformers,
           // Runs after dash conversion so freshly created dashes get glued.
           dashWordJoinerPass,
+          // Runs after dash conversion so surviving hyphens (number ranges are
+          // now en dashes) get their short-compound joins. Skipped in display
+          // headings, which wrap naturally like nbspTransform is skipped there.
+          ...(inDisplayHeading ? [] : [hyphenWordJoinerPass]),
         ]
 
         // Don't replace slashes in fractions or link text; loose runs are neither.

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -10,6 +10,7 @@ export { AddFavicons } from "./favicons"
 export { FixFootnotes } from "./fixFootnotes"
 export {
   HTMLFormattingImprovement,
+  NonBreakingHyphens,
   StripInlineBoundaryWhitespace,
 } from "./formatting_improvement_html"
 export { TextFormattingImprovement } from "./formatting_improvement_text"

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -26,12 +26,14 @@ import {
 import {
   applyTextTransforms,
   arrowsToWrap,
+  glueHyphens,
   HTMLFormattingImprovement,
   identifyLinkNode,
   improveFormatting,
   lPRegex,
   massTransformText,
   moveQuotesBeforeLink,
+  NonBreakingHyphens,
   rearrangeLinkPunctuation,
   replaceFractions,
   spacesAroundSlashes,
@@ -40,6 +42,7 @@ import {
   timeTransform,
 } from "../formatting_improvement_html"
 import { FRACTION_SKIP_TAGS, SKIP_CLASSES, SKIP_TAGS, toSkip } from "../formatting_improvement_html"
+import { rehypeTagSmallcaps } from "../tagSmallcaps"
 
 const MULTIPLICATION = "\u00D7" // ×
 
@@ -747,10 +750,16 @@ describe("HTMLFormattingImprovement", () => {
     ])("em dashes never start a wrapped line: %s", (input: string, expected: string) => {
       expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
     })
+  })
 
-    // A word joiner after a hyphen removes the break-after opportunity, keeping
-    // short numeric / single-letter compounds on one line.
+  describe("glueHyphens (NonBreakingHyphens)", () => {
     const wj = WORD_JOINER
+    function runGlueHyphens(html: string): string {
+      const processor = rehype().data("settings", { fragment: true })
+      processor.use(() => glueHyphens)
+      return processor.processSync(html).toString()
+    }
+
     it.each([
       // Numeric compound: a digit flanks each hyphen.
       ["<p>a 1-on-1 chat</p>", `<p>a 1-${wj}on-${wj}1 chat</p>`],
@@ -759,8 +768,7 @@ describe("HTMLFormattingImprovement", () => {
       ["<p>COVID-19 era</p>", `<p>COVID-${wj}19 era</p>`],
       ["<p>a 3-D render</p>", `<p>a 3-${wj}D render</p>`],
       ["<p>mid-1990s music</p>", `<p>mid-${wj}1990s music</p>`],
-      // Multi-segment / decimal numerics keep ASCII hyphens (only two-segment
-      // ranges become en dashes), so they reach this pass and stay whole.
+      // Multi-segment / decimal numerics keep ASCII hyphens, so they stay whole.
       ["<p>call 1-2-3 now</p>", `<p>call 1-${wj}2-${wj}3 now</p>`],
       ["<p>Qwen1.5-1.8 model</p>", `<p>Qwen1.5-${wj}1.8 model</p>`],
       // Single-letter segment on the left.
@@ -779,27 +787,38 @@ describe("HTMLFormattingImprovement", () => {
       // Non-alphanumeric neighbor: not an intra-word hyphen, left untouched.
       ["<p>foo- bar</p>", "<p>foo- bar</p>"],
       ["<p>-foo bar</p>", "<p>-foo bar</p>"],
-    ])("glues short hyphenated compounds: %s", (input: string, expected: string) => {
-      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
-    })
-
-    it.each([
-      // An element boundary sits on the hyphen itself: no join.
+      // A hyphen at a text-node edge has no in-node neighbor: left alone.
       ["<p>T<em>-shirt</em></p>", "<p>T<em>-shirt</em></p>"],
-      // An element boundary sits right after the hyphen: no join.
       ["<p>T-<em>shirt</em></p>", "<p>T-<em>shirt</em></p>"],
-      // A node boundary isolates the left segment to one character: join.
+      // A node edge isolates one segment to a single character: join.
       ["<p>ab<em>c-d</em> x</p>", `<p>ab<em>c-${wj}d</em> x</p>`],
-      // A node boundary isolates the right segment to one character: join.
       ["<p>x ab-c<em>d</em></p>", `<p>x ab-${wj}c<em>d</em></p>`],
-    ])("handles hyphens near element boundaries: %s", (input: string, expected: string) => {
-      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+      // Skipped inside code and display headings (which wrap naturally).
+      ["<p><code>1-on-1</code></p>", "<p><code>1-on-1</code></p>"],
+      ['<p class="subtitle">GPT-2-XL</p>', '<p class="subtitle">GPT-2-XL</p>'],
+      ["<h2>1-on-1</h2>", "<h2>1-on-1</h2>"],
+    ])("glues short hyphenated compounds: %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(runGlueHyphens(input))).toBe(expected)
     })
 
-    it("is idempotent for hyphen word joiners", () => {
-      const once = testHtmlFormattingImprovement("<p>a 1-on-1 T-shirt</p>")
-      const twice = testHtmlFormattingImprovement(once)
-      expect(twice).toBe(once)
+    it("is idempotent", () => {
+      const once = runGlueHyphens("<p>a 1-on-1 T-shirt</p>")
+      expect(runGlueHyphens(once)).toBe(once)
+    })
+
+    // Running after TagSmallcaps keeps an acronym both small-capped AND
+    // unbreakable: the joiner lands inside the finished <abbr> rather than
+    // splitting the acronym match (which would drop "XL" out of the small-caps).
+    it.each([
+      ["<p>I use GPT-4 daily</p>", `gpt-${wj}4</abbr>`],
+      ["<p>the GPT-2-XL model</p>", `gpt-${wj}2-${wj}xl</abbr>`],
+    ])("composes with smallcaps: %s", (input: string, expectedFragment: string) => {
+      const processor = rehype().data("settings", { fragment: true })
+      processor.use(improveFormatting, { skipFirstLetter: true })
+      processor.use(rehypeTagSmallcaps)
+      processor.use(() => glueHyphens)
+      const out = normalizeNbsp(processor.processSync(input).toString())
+      expect(out).toContain(expectedFragment)
     })
   })
 
@@ -2228,6 +2247,23 @@ describe("HTMLFormattingImprovement plugin", () => {
     const plugin = HTMLFormattingImprovement()
     const ctx = {} as Parameters<NonNullable<typeof plugin.htmlPlugins>>[0]
     expect(plugin.htmlPlugins?.(ctx)).toEqual([improveFormatting])
+  })
+
+  it("NonBreakingHyphens plugin glues hyphens via rehype", () => {
+    const plugin = NonBreakingHyphens()
+    const { htmlPlugins } = plugin
+    if (!htmlPlugins) {
+      throw new Error("htmlPlugins is undefined")
+    }
+
+    const mockCtx = {} as unknown
+    const plugins = htmlPlugins(mockCtx as Parameters<typeof htmlPlugins>[0])
+    const processor = rehype().data("settings", { fragment: true })
+    for (const p of plugins) {
+      processor.use(p as never)
+    }
+    const result = normalizeNbsp(processor.processSync("<p>a 1-on-1 chat</p>").toString())
+    expect(result).toBe(`<p>a 1-${WORD_JOINER}on-${WORD_JOINER}1 chat</p>`)
   })
 
   it("StripInlineBoundaryWhitespace plugin trims boundary whitespace via rehype", () => {

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -747,6 +747,56 @@ describe("HTMLFormattingImprovement", () => {
     ])("em dashes never start a wrapped line: %s", (input: string, expected: string) => {
       expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
     })
+
+    // A word joiner after a hyphen removes the break-after opportunity, keeping
+    // short numeric / single-letter compounds on one line.
+    const wj = WORD_JOINER
+    it.each([
+      // Numeric compound: a digit flanks each hyphen.
+      ["<p>a 1-on-1 chat</p>", `<p>a 1-${wj}on-${wj}1 chat</p>`],
+      ["<p>a 9-to-5 job</p>", `<p>a 9-${wj}to-${wj}5 job</p>`],
+      ["<p>GPT-4 model</p>", `<p>GPT-${wj}4 model</p>`],
+      ["<p>COVID-19 era</p>", `<p>COVID-${wj}19 era</p>`],
+      ["<p>a 3-D render</p>", `<p>a 3-${wj}D render</p>`],
+      ["<p>mid-1990s music</p>", `<p>mid-${wj}1990s music</p>`],
+      // Single-letter segment on the left.
+      ["<p>a T-shirt</p>", `<p>a T-${wj}shirt</p>`],
+      ["<p>an X-ray</p>", `<p>an X-${wj}ray</p>`],
+      ["<p>send e-mail</p>", `<p>send e-${wj}mail</p>`],
+      // Left segment is a single character starting the prose (idx-1 === 0).
+      ["<p>e-mail me</p>", `<p>e-${wj}mail me</p>`],
+      // Single-letter segment on the right, at end of prose (idx+2 === length).
+      ["<p>a grade-A</p>", `<p>a grade-${wj}A</p>`],
+      // Long descriptive compounds keep their break opportunities (no join).
+      ["<p>state-of-the-art</p>", "<p>state-of-the-art</p>"],
+      ["<p>cost-benefit analysis</p>", "<p>cost-benefit analysis</p>"],
+      // Only the qualifying hyphen is glued in a mixed compound.
+      ["<p>a T-shirt-wearing crowd</p>", `<p>a T-${wj}shirt-wearing crowd</p>`],
+      // Non-alphanumeric neighbor: not an intra-word hyphen, left untouched.
+      ["<p>foo- bar</p>", "<p>foo- bar</p>"],
+      ["<p>-foo bar</p>", "<p>-foo bar</p>"],
+    ])("glues short hyphenated compounds: %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+    })
+
+    it.each([
+      // An element boundary sits on the hyphen itself: no join.
+      ["<p>T<em>-shirt</em></p>", "<p>T<em>-shirt</em></p>"],
+      // An element boundary sits right after the hyphen: no join.
+      ["<p>T-<em>shirt</em></p>", "<p>T-<em>shirt</em></p>"],
+      // A node boundary isolates the left segment to one character: join.
+      ["<p>ab<em>c-d</em> x</p>", `<p>ab<em>c-${wj}d</em> x</p>`],
+      // A node boundary isolates the right segment to one character: join.
+      ["<p>x ab-c<em>d</em></p>", `<p>x ab-${wj}c<em>d</em></p>`],
+    ])("handles hyphens near element boundaries: %s", (input: string, expected: string) => {
+      expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
+    })
+
+    it("is idempotent for hyphen word joiners", () => {
+      const once = testHtmlFormattingImprovement("<p>a 1-on-1 T-shirt</p>")
+      const twice = testHtmlFormattingImprovement(once)
+      expect(twice).toBe(once)
+    })
   })
 
   describe("stripInlineBoundaryWhitespace", () => {

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -759,6 +759,10 @@ describe("HTMLFormattingImprovement", () => {
       ["<p>COVID-19 era</p>", `<p>COVID-${wj}19 era</p>`],
       ["<p>a 3-D render</p>", `<p>a 3-${wj}D render</p>`],
       ["<p>mid-1990s music</p>", `<p>mid-${wj}1990s music</p>`],
+      // Multi-segment / decimal numerics keep ASCII hyphens (only two-segment
+      // ranges become en dashes), so they reach this pass and stay whole.
+      ["<p>call 1-2-3 now</p>", `<p>call 1-${wj}2-${wj}3 now</p>`],
+      ["<p>Qwen1.5-1.8 model</p>", `<p>Qwen1.5-${wj}1.8 model</p>`],
       // Single-letter segment on the left.
       ["<p>a T-shirt</p>", `<p>a T-${wj}shirt</p>`],
       ["<p>an X-ray</p>", `<p>an X-${wj}ray</p>`],

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -732,6 +732,14 @@ This solution is 2/3 water, mixed on 01/01/2024. Even more complicated fractions
 
 He came in 1st but I came in 5,300,251st. :( _Emphasized "21st"._ October 5th, 1993.
 
+## Non-breaking hyphens
+
+Short hyphenated compounds stay whole instead of breaking at the hyphen. The column below is deliberately narrow, so each term is forced onto its own line rather than splitting across two:
+
+<div id="non-breaking-hyphens-demo" style="width: 6rem; border: 2px var(--midground) solid; border-radius: 5px; padding: 0.5rem;">
+We held a 1-on-1 with GPT-4 about the 9-to-5 grind, X-ray goggles, and the mid-1990s.
+</div>
+
 ## Dropcaps
 
 <span id="single-letter-dropcap" class="dropcap" data-first-letter="T">T</span>his paragraph demonstrates a dropcap.


### PR DESCRIPTION
## Summary

- An ASCII hyphen (`-`, U+002D) is a break-after opportunity, so hyphenated terms like "1-on-1" could wrap into "1-" / "on-1" at the end of a line — the exact bug reported.
- Adds a `NonBreakingHyphens` transformer that glues a [word joiner](https://en.wikipedia.org/wiki/Word_joiner) (U+2060) after intra-word hyphens in short, identifier-like compounds, so the unit stays on one line while long descriptive compounds keep their break opportunities.
- Mirrors the existing `dashWordJoinerPass` approach already used for em/en dashes.

## Changes

- `quartz/plugins/transformers/formatting_improvement_html.ts`:
  - New `hyphenWordJoinerPass` + `glueHyphens`, exported as the `NonBreakingHyphens` transformer plugin. It joins a hyphen only when it sits between two alphanumerics and either:
    - a digit flanks it — numeric compounds/identifiers like `GPT-4`, `COVID-19`, `3-D`, `9-to-5`, `mid-1990s`, `1-2-3`, `Qwen1.5-1.8`; or
    - one of the two joined segments is a single character — single-letter affixes like `T-shirt`, `X-ray`, `e-mail`, `grade-A`.
  - Long descriptive compounds (`state-of-the-art`, `cost-benefit`) are left free to wrap.
  - Skipped in display headings, which wrap naturally.
  - The pass is idempotent (after a join, the character following the hyphen is the word joiner, which fails the alphanumeric test) and Unicode-aware (IPA like `NAF-tə` is not misread as a single-character segment).
- `config/quartz/quartz.config.ts`: runs `NonBreakingHyphens()` **after** `TagSmallcaps()` and `AutoCode()`. Injecting a word joiner into `GPT-4` before smallcaps runs would split the acronym match; running it afterward glues the compound without disturbing acronym detection.
- `quartz/plugins/transformers/index.ts`: exports `NonBreakingHyphens`.
- `quartz/plugins/transformers/tests/formatting_improvement_html.test.ts`: parametrized coverage for numeric/single-letter joins, multi-segment/decimal numerics, non-joins on long compounds, non-alphanumeric neighbors, element-boundary cases, idempotency, display-heading skips, the plugin factory, and composition with smallcaps (`GPT-4` → `<abbr>gpt-4</abbr>`).
- `website_content/test-page.md`: a narrow forced-wrap demo block so visual regression captures that these compounds stay whole in a constrained column.

## Testing

- `pnpm check` (tsc + prettier + stylelint) and eslint pass on the changed files.
- Full `formatting_improvement_html.test.ts` suite passes (649 tests) at 100% statement/branch/function/line coverage for the changed file.

## Lessons Learned

- **What**: When gluing non-breaking behavior onto punctuation between "segments", detect segment membership with Unicode letter/number classes (`\p{L}\p{N}`), not ASCII `[A-Za-z0-9]` — otherwise adjacent combining/IPA/accented characters make a real multi-character segment look single-character and trigger false positives.
- **Where**: text-transformation passes such as `quartz/plugins/transformers/formatting_improvement_html.ts`.
- **Why**: An initial ASCII-only check mis-classified `NAF-tə` (the schwa `ə` reads as non-alphanumeric) as a single-letter segment and glued it, breaking an existing test.
- **Ordering matters for text passes that inject invisible characters**: a word joiner glued into `GPT-4` before the small-caps acronym matcher runs silently breaks acronym detection, because the matcher's separator class doesn't include U+2060. Run such gluing passes **after** any downstream matcher that scans the same runs of text, rather than teaching every matcher about the injected character.