### PR TITLE
test(navbar): fix cold-start buffering race in SPA-navigation autoplay test

### DIFF
--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -530,6 +530,10 @@ test("Video autoplay preference persists across page reloads", async ({ page }) 
 
 test("Video autoplay works correctly after SPA navigation", async ({ page }) => {
   test.skip(!isDesktopViewport(page), "Desktop-only test")
+  // Video decode competes with other parallel Playwright workers for CPU, so a
+  // contended CI runner can leave readyState below 3 past a tight deadline even
+  // though the video eventually buffers.
+  test.slow()
 
   const { video, autoplayToggle } = getVideoElements(page)
 

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -530,17 +530,18 @@ test("Video autoplay preference persists across page reloads", async ({ page }) 
 
 test("Video autoplay works correctly after SPA navigation", async ({ page }) => {
   test.skip(!isDesktopViewport(page), "Desktop-only test")
-  // Video decode competes with other parallel Playwright workers for CPU, so a
-  // contended CI runner can leave readyState below 3 past a tight deadline even
-  // though the video eventually buffers.
-  test.slow()
 
   const { video, autoplayToggle } = getVideoElements(page)
 
   await autoplayToggle.click()
+  // The pond video only begins loading when play() runs (the click above), so
+  // assert on actual playback — the playhead advancing — rather than look-ahead
+  // buffer depth. currentTime > 0 confirms autoplay works as soon as the first
+  // frame renders, independent of how long the CDN takes to buffer future data
+  // (readyState >= 3), which under CI contention can lag far behind playback.
   await page.waitForFunction((id) => {
     const videoElement = document.querySelector<HTMLVideoElement>(`#${id}`)
-    return videoElement && !videoElement.paused && videoElement.readyState >= 3
+    return videoElement && !videoElement.paused && videoElement.currentTime > 0
   }, pondVideoId)
 
   await page.evaluate(() => window.spaNavigate(new URL("/design", window.location.origin)))


### PR DESCRIPTION
## Summary

The `playwright-tests` check went red on PR #1596 (and would on any PR) because of a **pre-existing flaky test on `main`**, unrelated to that PR's content:

```
[Desktop Safari] › quartz/components/tests/navbar.spec.ts:531 › Video autoplay works correctly after SPA navigation
Test timeout of 90000ms exceeded.
  page.waitForFunction((id) => { … !videoElement.paused && videoElement.readyState >= 3 }, pondVideoId)
```

## Root cause

Not a logic bug — a **cold-start buffering race**:

1. These tests run against the real CDN (`test.use({ stubCdnAssets: false })`) because they assert on genuine `readyState`/`currentTime`.
2. On a fresh page with autoplay disabled (the default) and no saved timestamp, `setupPondVideo` never calls `load()` — that kick is gated on `if (savedTime && !autoplayEnabled)` (`navbar.inline.ts:142`). The pond video only begins loading when `play()` runs on the toggle click.
3. The assertion then required `readyState >= 3` (**HAVE_FUTURE_DATA**), which needs the CDN to buffer look-ahead data. On a contended macOS/WebKit runner (3 parallel workers competing for CPU + network), that look-ahead buffering occasionally exceeded the 90 s deadline — even though playback itself had already started.

It passed on retry, confirming latency (not a stuck state).

## Fix

Assert **`currentTime > 0`** (the playhead is advancing) instead of `readyState >= 3`. The advancing playhead proves autoplay works as soon as the first frame renders, which requires strictly less buffered data than HAVE_FUTURE_DATA and is decoupled from CDN cold-start latency. No production behavior changed, no timeout bumped, and the assertion now tests the thing the test name actually claims (autoplay *plays* the video).

## Changes

- `quartz/components/tests/navbar.spec.ts`: swap the readiness wait from `readyState >= 3` to `currentTime > 0` in `Video autoplay works correctly after SPA navigation`.

## Testing

- `tsc`, `prettier`, `eslint` clean on the changed file. (A local run isn't possible here — the test is WebKit + real-CDN; CI reproduces exactly the failing scenario.)

## Lessons learned

- **Assert on the behavior, not a buffer level.** A Playwright wait for `readyState >= 3` on a real (un-stubbed) video couples the test to CDN cold-start buffering; under CI worker contention the look-ahead buffer lags playback and blows the deadline, even though the video is already playing. Assert `currentTime > 0` (playhead advancing) to prove real playback without depending on how far ahead the buffer has filled.

## Note on PR #1596's other red check

`visual-testing` on #1596 is **expected snapshot churn** from its new `test-page.md` demo row (`Visual diffs present (new or updated screenshots)`), not a code defect — it clears via the approve-baselines button, which only the maintainer can press.