### PR TITLE
fix: drop the Similar posts block from search previews

### DIFF
--- a/quartz/components/scripts/content_renderer.ts
+++ b/quartz/components/scripts/content_renderer.ts
@@ -1,5 +1,10 @@
 import { normalizeRelativeURLs, stripSlashes } from "../../util/path"
-import { PREVIEWABLE_CLASS } from "../constants"
+import { PREVIEWABLE_CLASS, similarPostsHeadingId } from "../constants"
+
+// The "Similar posts" block (a heading + `.related-posts` list appended by
+// relatedPosts.ts) is page-bottom navigation, not article content, so it is
+// noise in a search preview and its excerpts shouldn't match search queries.
+const SIMILAR_POSTS_SELECTOR = `#${similarPostsHeadingId}, .related-posts`
 
 interface WindowWithCheckboxStates extends Window {
   __quartz_checkbox_states?: Map<string, boolean>
@@ -95,6 +100,7 @@ export function processPreviewables(html: Document, targetUrl: URL): Element[] {
 
   const tempContainer = document.createElement("div")
   previewables.forEach((el) => tempContainer.appendChild(el.cloneNode(true)))
+  tempContainer.querySelectorAll(SIMILAR_POSTS_SELECTOR).forEach((el) => el.remove())
   restoreCheckboxStates(tempContainer, targetUrl)
 
   return Array.from(tempContainer.children)

--- a/quartz/components/scripts/tests/content_renderer.test.ts
+++ b/quartz/components/scripts/tests/content_renderer.test.ts
@@ -156,6 +156,27 @@ describe("processPreviewables", () => {
     const original = html.querySelector(".previewable p")
     expect(original?.textContent).toBe("Original content")
   })
+
+  it("should strip the Similar posts block from the preview", () => {
+    const html = document.implementation.createHTMLDocument()
+    html.body.innerHTML = `
+      <div class="previewable">
+        <p>Article body</p>
+        <h1 id="similar-posts" class="related-posts-title">Similar posts</h1>
+        <div class="related-posts">
+          <ul><li><a href="/other">Other post</a><span class="related-post-excerpt">Excerpt</span></li></ul>
+        </div>
+      </div>
+    `
+
+    const url = new URL("http://example.com")
+    const elements = processPreviewables(html, url)
+
+    expect(elements.length).toBe(1)
+    expect(elements[0].querySelector("#similar-posts")).toBeNull()
+    expect(elements[0].querySelector(".related-posts")).toBeNull()
+    expect(elements[0].querySelector("p")?.textContent).toBe("Article body")
+  })
 })
 
 describe("modifyElementIds", () => {

--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -146,6 +146,21 @@ test("Search results appear and can be navigated (screenshot)", async ({ page },
   })
 })
 
+test("search preview omits the Similar posts block", async ({ page }) => {
+  test.skip(isMobileViewport(page), "the side preview panel is desktop-only")
+  await search(page, "Definitive Confirmation of Shard Theory")
+
+  const card = page.locator('.result-card[id="shard-theory-confirmed"]')
+  await expect(card).toBeVisible({ timeout: 15_000 })
+  await card.hover()
+
+  // The article preview renders, but its page-bottom "Similar posts" block
+  // (heading + `.related-posts` list) is stripped from the preview.
+  const preview = await waitForArticlePreview(page)
+  await expect(preview.locator("#similar-posts")).toHaveCount(0)
+  await expect(preview.locator(".related-posts")).toHaveCount(0)
+})
+
 test("ArrowDown navigation does not get stuck below the second result", async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
## Summary

- The search preview showed the page-bottom "Similar posts" block. When you hover a result, the preview fetches the full rendered page and displays its previewable article, which includes the "Similar posts" list appended by `relatedPosts.ts`. That block is navigation, not article content, so it's noise in the preview.
- This strips the block from search previews (both the desktop side panel and the mobile card preview, which share the extraction path).

## Changes

- `quartz/components/scripts/content_renderer.ts`: in `processPreviewables` (the search-only extraction path), remove the `#similar-posts` heading and its `.related-posts` list from the cloned preview content. Scoped to search — popovers use a separate render path and are untouched.
- `quartz/components/scripts/tests/content_renderer.test.ts`: unit test that the block is stripped while surrounding article content is kept.
- `quartz/components/tests/search.spec.ts`: end-to-end test that a result's preview renders but contains no similar-posts block.

## Note on the search index

The client search index (`static/contentIndex.json`) already excludes similar posts: its `content` field is `file.data.text`, gathered by a markdown-stage transformer that runs *before* `relatedPosts.ts` injects the block at the HTML stage. Verified against the built index — no page's indexed content contains a neighbor's title or excerpt — so no page matches a search term that only appears in a similar-posts excerpt. No index change was needed.

## Testing

- New unit test and Playwright test pass; the Playwright test was confirmed to fail when the strip is disabled (not vacuous).
- Verified against a fresh local build that `shard-theory-confirmed`'s preview omits the block while the article body still renders.
- tsc, eslint, and prettier clean on the changed files.