### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -18,7 +18,7 @@ _Disclaimer: I'm an AI professional but not a security professional. I welcome i
 [![pytest + bash config](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fvalidate-config.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/validate-config.yaml)
 [![hadolint](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fhadolint.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/hadolint.yaml)
 [![actionlint + zizmor](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Flint-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/lint-checks.yaml)
-[![isolation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fdevcontainer-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/devcontainer-checks.yaml)
+[![isolation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsbx-live-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/sbx-live-checks.yaml)
 
 <!-- END GENERATED: status badges -->
 
@@ -87,7 +87,7 @@ Here are just a few of the things things which `glovebox` has and auto-mode does
 
 ### Why not just the built-in sandbox?
 
-Claude Code's built-in `sandbox` confines only Bash subprocesses with OS-level primitives that share the host kernel: it doesn't cover WebFetch, MCP, or the main agent process, and a single kernel exploit escapes it. This repo's stack instead contains the _entire_ session behind a VM / userspace-kernel boundary (Kata/gVisor on Linux; the OrbStack Linux VM on macOS) and a network-layer firewall, so neither a kernel LPE nor a non-Bash path to send data out gets a free pass.
+Claude Code's built-in `sandbox` confines only Bash subprocesses with OS-level primitives that share the host kernel: it doesn't cover WebFetch, MCP, or the main agent process, and a single kernel exploit escapes it. This repo's stack instead contains the _entire_ session behind the Docker `sbx` microVM's hypervisor boundary and a network-layer firewall, so neither a kernel LPE nor a non-Bash path to send data out gets a free pass.
 
 ### Help — it's broken and I just need to code
 
@@ -160,7 +160,7 @@ flowchart TB
 
 - **It can't read files outside your project.** The agent runs in a container that mounts only your project directory. The rest of your home folder, your SSH and cloud keys, your browser profile, your other repos — none of it is _present_ inside the sandbox, so there's nothing to read in the first place (this is stronger than a per-file blocklist: unmounted files don't exist for it). Credential-shaped environment variables are stripped from its shells, too.
 - **It can't change your computer.** By default the agent works on a throwaway copy of your project and hands its edits back as a reviewable `glovebox/*` git branch you merge yourself — nothing it writes touches your real files until you approve. Inside the box it runs as an unprivileged user, on a read-only system filesystem, with no path to `root`, so it can't quietly rewrite the container or its own guardrails either.
-- **It can't break out or send your data off the machine.** The whole session — not just shell commands, but web fetches, connectors, and the agent process itself — runs inside a virtual machine (a microVM, or a userspace kernel where hardware virtualization isn't available), so even a kernel-level exploit stays contained. All network traffic is blocked except an [allowlist](https://github.com/AlexanderMattTurner/agent-glovebox/blob/main/sandbox-policy/domain-allowlist.json), so a compromised agent has no route to upload your code or reach an arbitrary server.
+- **It can't break out or send your data off the machine.** The whole session — not just shell commands, but web fetches, connectors, and the agent process itself — runs inside a hardware-isolated microVM, so even a kernel-level exploit stays contained. All network traffic is blocked except an [allowlist](https://github.com/AlexanderMattTurner/agent-glovebox/blob/main/sandbox-policy/domain-allowlist.json), so a compromised agent has no route to upload your code or reach an arbitrary server.
 
 On top of those two walls sit **best-effort filters**. They raise the bar but a determined or hijacked agent can sometimes slip past one, so the safety argument never _rests_ on them — they're extra layers, not the boundary:
 
@@ -246,12 +246,12 @@ Charts re-render on every merge to `main` and update in place.
 <!-- prettier-ignore -->
 | Category | Lines | Share |
 | ---: | :---: | :--- |
-| Tests | 203,243 | `████████████░░░░░░░░` 61% |
-| CI/CD | 21,736 | `█░░░░░░░░░░░░░░░░░░░` 7% |
-| Docs | 10,089 | `█░░░░░░░░░░░░░░░░░░░` 3% |
-| Config | 12,986 | `█░░░░░░░░░░░░░░░░░░░` 4% |
-| Source | 82,061 | `█████░░░░░░░░░░░░░░░` 25% |
-| **Total** | **330,115** | |
+| Tests | 204,103 | `████████████░░░░░░░░` 61% |
+| CI/CD | 21,741 | `█░░░░░░░░░░░░░░░░░░░` 7% |
+| Docs | 10,111 | `█░░░░░░░░░░░░░░░░░░░` 3% |
+| Config | 12,993 | `█░░░░░░░░░░░░░░░░░░░` 4% |
+| Source | 82,789 | `█████░░░░░░░░░░░░░░░` 25% |
+| **Total** | **331,737** | |
 
 <sub>Generated by `.github/scripts/codebase-breakdown.py`. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` -> Tests; `.github/` -> CI/CD; `*.md`/`docs/`/`changelog.d/` -> Docs; manifests/lockfiles/dotfiles -> Config; everything else -> Source.</sub>
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.