### PR TITLE
style: letterspace acronym small-caps

### DIFF
--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -345,6 +345,18 @@ article[data-use-dropcap="true"] > p:first-of-type .small-caps {
   }
 }
 
+// Letterspace acronym small-caps so the string reads as one settled unit
+// instead of a cramped clump (Bringhurst §2.1.6: space strings of caps and
+// small caps by 5–10% of the type size). Scoped to `.small-caps` alone so it
+// never reaches the dropcap `::first-line` grouped in the rule above. The
+// negative right margin cancels the trailing tracking, keeping a plural suffix
+// rendered outside the abbr (e.g. the "s" in "LLMs") flush against the acronym
+// and leaving word spacing to the following word unchanged.
+.small-caps {
+  letter-spacing: 0.05em;
+  margin-right: -0.05em;
+}
+
 /* Set monospace font for code blocks, inline code, etc. */
 code,
 pre {

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -677,7 +677,7 @@ A footnote reference right after a favicon-ending [same-page link](#external-lin
 
 ## Smallcaps
 
-The NATO alliance met in the USA. SMALLCAPS "capitalization" should be similar to that of normal text (in that a sentence's first letter should be full-height). Here are _italicized SMALLCAPS_.
+The NATO alliance met in the USA. Several LLMs ran on the GPUs. SMALLCAPS "capitalization" should be similar to that of normal text (in that a sentence's first letter should be full-height). Here are _italicized SMALLCAPS_.
 
 <!--spellchecker-disable-->
 


### PR DESCRIPTION
## Summary

- Acronyms set in small-caps (e.g. "AGI" in "Chief AGI Scientist") read as a cramped clump at default tracking — especially noticeable when sandwiched between full-height capitalized words. Standing typographic guidance says to fix this with letterspacing, not by enlarging the small caps (small caps are *meant* to sit shorter than adjacent full capitals).
- Robert Bringhurst, *The Elements of Typographic Style* §2.1.6: "Letterspace all strings of capitals and small caps… The normal value for letterspacing these sequences of small or full caps is 5% to 10% of the type size." Matthew Butterick, *Practical Typography*, gives the same rule for small caps (5–12%).

## Changes

- `quartz/styles/fonts.scss`: add `letter-spacing: 0.05em` to `.small-caps` (Bringhurst's low end, appropriate for a text face). Scoped to `.small-caps` alone so it never reaches the dropcap `::first-line` grouped in the adjacent rule. A compensating `margin-right: -0.05em` cancels the *trailing* tracking so a plural suffix rendered outside the `<abbr>` (the "s" in "LLMs"/"GPUs") stays flush against the acronym, and spacing to the following word is unchanged.
- `website_content/test-page.md`: add a plural-acronym sentence ("Several LLMs ran on the GPUs.") so visual regression captures the trailing-margin behavior.

## Testing

- Rendered the phrase with the site's actual commissioned EB Garamond (`EBGaramond08-Regular.woff2`) at candidate tracking values (0 / 0.03 / 0.05 / 0.08em) to pick 0.05em, then verified the plural-suffix edge case: without compensation, `letter-spacing` detaches the "s" ("LLM s"); `margin-right: -0.05em` restores it flush while preserving internal tracking.
- Pre-commit stylelint passed on the changed SCSS.
- Visual-regression baselines for the small-caps examples will update — expected, handled via the approve-baselines workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1uWcgGqypF7cezmnWeiC1)_