### PR TITLE
feat(punctilio): scroll box for long input/output

### DIFF
--- a/quartz/components/styles/punctilioDemo.scss
+++ b/quartz/components/styles/punctilioDemo.scss
@@ -4,6 +4,7 @@ $panel-border: 1px solid var(--midground-faint);
 $panel-bg-readonly: color-mix(in srgb, var(--foreground) 4%, var(--background));
 $hover-bg: color-mix(in srgb, var(--foreground) 5%, transparent);
 $panel-min-height: 200px;
+$panel-max-height: 60vh;
 
 #punctilio-demo {
   margin-top: calc(2 * $base-margin);
@@ -49,6 +50,7 @@ $panel-min-height: 200px;
     white-space: pre-wrap;
     width: 100%;
     min-height: $panel-min-height;
+    max-height: $panel-max-height;
     padding: $base-margin calc(2 * $base-margin);
     border: 1px solid var(--midground-faint);
     border-radius: $border-radius;
@@ -81,6 +83,7 @@ $panel-min-height: 200px;
     box-sizing: border-box;
     width: 100%;
     min-height: $panel-min-height;
+    max-height: $panel-max-height;
     padding: $base-margin calc(2 * $base-margin);
     border: 1px solid var(--midground-faint);
     border-radius: $border-radius;

--- a/quartz/components/tests/punctilio-demo.spec.ts
+++ b/quartz/components/tests/punctilio-demo.spec.ts
@@ -436,6 +436,30 @@ test.describe("Output monospace styling", () => {
   })
 })
 
+test.describe("Long-content scroll box", () => {
+  const LONG_TEXT = Array.from({ length: 60 }, (_, i) => `"Line ${i}" is long text ---`).join("\n")
+
+  test("input scrolls within a bounded box for long text", async ({ page }) => {
+    const input = page.locator("#punctilio-input")
+    await input.fill(LONG_TEXT)
+
+    const overflows = await input.evaluate(
+      (el: HTMLTextAreaElement) => el.scrollHeight > el.clientHeight + 1,
+    )
+    expect(overflows).toBe(true)
+  })
+
+  test("output scrolls within a bounded box for long text", async ({ page }) => {
+    await page.locator("#punctilio-input").fill(LONG_TEXT)
+    // Wait for the debounced transform to populate the output
+    await expect(page.locator(`${OUTPUT_CONTENT} .diff-insert`).first()).toBeAttached()
+
+    const output = page.locator(OUTPUT_CONTENT)
+    const overflows = await output.evaluate((el) => el.scrollHeight > el.clientHeight + 1)
+    expect(overflows).toBe(true)
+  })
+})
+
 test.describe("Mode button navigation", () => {
   test("clicking the already-active mode does not clear input", async ({ page }) => {
     const input = page.locator("#punctilio-input")


### PR DESCRIPTION
## Summary

The punctilio demo's input textarea and output panel had a `min-height` but no `max-height`, so pasting a long document grew the panels unboundedly down the page instead of scrolling within a fixed box.

This adds `max-height: 60vh` (via a new `$panel-max-height` SCSS variable) to both `#punctilio-demo textarea` and `.punctilio-output-content`. Both already had overflow handling (`overflow: auto` / `overflow-y: auto`), so capping the height turns them into bounded scroll boxes for long content. Short content (including the ghost-placeholder default state used by the visual-regression baselines) is unaffected since it never reaches the cap.

## Changes

- `quartz/components/styles/punctilioDemo.scss`: add `$panel-max-height: 60vh` and apply it to the input textarea and output panel.
- `quartz/components/tests/punctilio-demo.spec.ts`: add a "Long-content scroll box" describe block asserting that both the input and output overflow (scroll) within their box when filled with long text.

## Testing

- `pnpm exec stylelint` and `prettier --check` pass on the changed files.
- New Playwright specs cover both mobile/desktop via the shared fixtures, verifying `scrollHeight > clientHeight` for input and output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019gLFeLbvi8tfX5pR8CLC82)_