### PR TITLE
style: use lining numerals for tweet handles and display names

### DIFF
--- a/quartz/components/styles/tweet.scss
+++ b/quartz/components/styles/tweet.scss
@@ -59,6 +59,10 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  // Handles and display names read as identifiers, not prose, so digits sit on
+  // the baseline as lining figures instead of the site's default oldstyle nums.
+  font-variant-numeric: lining-nums;
 }
 
 // The display-name link and the verified seal share a row; the seal is a sibling


### PR DESCRIPTION
## Summary

Tweet embed handles (`@user123`) and display names now render digits as **lining numerals** instead of the site's default oldstyle figures.

Handles and display names read as identifiers rather than prose, so their digits should sit on the baseline as uniform-height lining figures — matching how X itself renders them and how other identifier-like UI in this repo (TOC, popover, list markers) already uses `lining-nums`.

## Changes

- `quartz/components/styles/tweet.scss`: add `font-variant-numeric: lining-nums` to the shared `.tweet-name-link, .tweet-handle` rule.

## Testing

CSS-only change. Existing `(screenshot)` visual-regression tests for the single tweet, thread, and quote-tweet cards (`quartz/components/tests/tweetEmbed.spec.ts`) capture the rendered numerals.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc6LhMDLjZQCNDVwcV6YZR)_