### PR TITLE
test(visual): mock tagged-page count on dynamic listing screenshots

### DIFF
--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -226,10 +226,19 @@ test.describe("Unique content around the site", () => {
         const childrenToRemove = Array.from(children).slice(0, numToRemove)
         childrenToRemove.forEach((child) => listElement.removeChild(child))
 
-        // Update the number of posts displayed
-        const listingText = listElement.querySelector(".page-listing > p")
-        if (listingText) {
-          listingText.textContent = `Showing ${numKeepOldest} of ${numTotalChildren} posts.`
+        // Mock the total-count paragraph so the screenshot stays stable as
+        // posts/tagged pages are added. The all-posts ("recent") page renders
+        // it as "This site has N blog posts."; tag pages render it as
+        // "N items with this tag." Replace the count with the number of items
+        // actually shown so the text stays consistent with the trimmed list.
+        const countParagraph =
+          document.querySelector("#center-content article > p") ??
+          document.querySelector("#center-content .page-listing > p")
+        if (countParagraph?.textContent) {
+          countParagraph.textContent = countParagraph.textContent.replace(
+            /\d+/,
+            String(numKeepOldest),
+          )
         }
       }, numOldest)
 


### PR DESCRIPTION
## Summary

The `tags/personal (screenshot)` visual-regression test (and the sibling `recent (screenshot)` test) captured a count paragraph that changes whenever content is added, forcing needless baseline churn:

- Tag pages render `N items with this tag.` (`TagContent.tsx`, at `.page-listing > p`).
- The all-posts / "recent" page renders `This site has N blog posts.` (`AllPosts.tsx`, at `article > p`).

The existing mock only trimmed the list items to the oldest 5. Its attempt to rewrite the count queried `.page-listing > p` **scoped to the `<ul>`** (`listElement.querySelector(...)`), which never matches the count paragraph (it lives outside the list), so the count was never actually mocked — every new personal-tagged page shifted the number and invalidated the snapshot.

## Change

Query the count paragraph from `#center-content` (covering both the tag-page and all-posts layouts) and normalize its number to the count of items actually shown, so the screenshot stays stable as posts/tagged pages are added.

## Testing

- `tsc --noEmit` and Prettier pass on the changed file.
- The `tags/personal` and `recent` visual baselines will show a one-time diff (the count now reads a fixed value) for the maintainer to approve via the usual diff-gallery flow.