### PR TITLE
fix(test): bound overflow-settle font wait so WebKit /posts can't hang

### DIFF
--- a/quartz/components/tests/overflow.spec.ts
+++ b/quartz/components/tests/overflow.spec.ts
@@ -110,19 +110,17 @@ const SETTLE_FRAMES = 3
 // counter resets, which is correct: a recreated context is a fresh page to
 // settle). A standalone `page.evaluate` has no such resilience and loses that
 // race. The predicate is self-contained (serialized into the page, so it can
-// reference only DOM globals): true once webfonts have swapped and the
-// client-side pass has wrapped wide tables/KaTeX into scroll containers —
-// measuring before that lands reports them as overflow. The frame count is
-// tracked on `window` so consecutive `raf`-polled evaluations can require the
-// predicate to hold stably rather than for a single lucky frame.
+// reference only DOM globals): true once the client-side pass has wrapped wide
+// tables/KaTeX into scroll containers — measuring before that lands reports them
+// as overflow. Font readiness is awaited separately in `settle` (bounded, since
+// WebKit can hang on it). The frame count is tracked on `window` so consecutive
+// `raf`-polled evaluations can require the predicate to hold stably rather than
+// for a single lucky frame.
 /* istanbul ignore next -- executed in the browser, not under Jest */
 function settledForFrames(requiredFrames: number): boolean {
-  const fontsReady = !document.fonts || document.fonts.status === "loaded"
   const scrollables = Array.from(document.querySelectorAll(".table-container, .katex-display"))
   const settled =
-    fontsReady &&
-    (scrollables.length === 0 ||
-      scrollables.every((el) => el.closest(".scroll-indicator") !== null))
+    scrollables.length === 0 || scrollables.every((el) => el.closest(".scroll-indicator") !== null)
 
   const state = window as unknown as { __overflowSettledFrames?: number }
   if (!settled) {
@@ -139,8 +137,23 @@ function describeOffenders(offenders: readonly Offender[]): string {
     .join("\n  ")
 }
 
+// WebKit's `document.fonts.status`/`.ready` can stay pending indefinitely when a
+// `@font-face` request never settles, so gating on font readiness must be bounded
+// or it burns the whole test timeout (the `/posts` listing has no scrollables, so
+// the settle predicate reduces to font readiness alone there). Pages that do
+// settle load their fonts well within this budget; where WebKit hangs, we proceed
+// and measure against the currently painted font.
+const FONTS_READY_TIMEOUT_MS = 10_000
+
 async function settle(page: Page, url: string) {
   await gotoPage(page, url)
+  await page.evaluate(async (timeoutMs) => {
+    if (!document.fonts) return
+    await Promise.race([
+      document.fonts.ready,
+      new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+    ])
+  }, FONTS_READY_TIMEOUT_MS)
   await page.waitForFunction(settledForFrames, SETTLE_FRAMES, {
     timeout: 10_000,
     polling: "raf",


### PR DESCRIPTION
## Summary

The `/posts` overflow probes (`no horizontal page scroll` / `no clipped overflow`) time out on the macOS/WebKit shard (`playwright-tests-macos 1/3`), while every Linux shard and the other WebKit pages pass. Root cause:

- The `/posts` listing (AllPosts → PageList) renders only titles, dates, and tags — **no `.table-container` or `.katex-display`**. So `settle()`'s predicate reduces to a single gate: `document.fonts.status === "loaded"`.
- On WebKit that status can stay pending **indefinitely** when a `@font-face` request never settles — a hazard already documented in this repo (`quartz/components/tests/visual_utils.ts:147`, where the visual tests bound the wait instead of gating on it).
- With no scrollables to satisfy the other half of the predicate, the 10 s `waitForFunction` runs out and both `/posts` probes fail. It reproduces deterministically (both the shard's internal retries and a manual re-run failed identically).

## Fix

Mirror the repo's existing WebKit-aware pattern:

- Await font readiness in `settle()` with a **bounded** `Promise.race([document.fonts.ready, timeout])` before measuring, so a stuck WebKit font load can't consume the whole test budget.
- Drop the indefinite `document.fonts.status === "loaded"` term from the polled predicate; the frame-stable scroll-wrapping check remains the real gate.

Pages that genuinely load fonts still await the swap (via `document.fonts.ready`, which resolves well under the budget) exactly as before — only the pathological WebKit hang is now bounded. The overflow assertions themselves are unchanged; this is a determinism fix, not a timeout increase.

## Testing

- `pnpm tsc` and ESLint clean on the changed file.

## Lessons learned

- A Playwright "settle" helper that gates on `document.fonts.status === "loaded"` (or awaits `document.fonts.ready` unbounded) can hang forever on WebKit when a `@font-face` request never settles. Always bound font-readiness waits with a `Promise.race` timeout; rely on a separate deterministic signal (frame-stable layout, two-equal-frames screenshot) as the real gate. This is browser-agnostic advice for any WebKit-targeting Playwright suite.
- When a probe combines multiple AND-ed conditions, verify which one actually fails on the target page before "fixing" — here the page had zero scrollables, so the failure could only be the font gate, which pinned the diagnosis precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3aZJrwKGCsnCUXPnygYnm)_