### PR TITLE
fix(ofm): preserve source spacing in admonition titles before inline links

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -144,6 +144,7 @@ const createAdmonitionTitleInner = (
   useDefaultTitle: boolean,
   capitalizedTypeString: string,
   titleContent: string,
+  titleSeparator: string,
   remainingChildren: ElementContent[],
 ): Element => ({
   type: "element",
@@ -160,7 +161,7 @@ const createAdmonitionTitleInner = (
     {
       type: "text",
       /* istanbul ignore next -- admonition title formatting edge case */
-      value: useDefaultTitle ? capitalizedTypeString : `${titleContent} `,
+      value: useDefaultTitle ? capitalizedTypeString : `${titleContent}${titleSeparator}`,
     },
     ...remainingChildren,
   ],
@@ -186,6 +187,7 @@ const createAdmonitionTitle = (
   useDefaultTitle: boolean,
   capitalizedTypeString: string,
   titleContent: string,
+  titleSeparator: string,
   remainingChildren: ElementContent[],
   collapse: boolean,
   noSmallcaps: boolean,
@@ -195,6 +197,7 @@ const createAdmonitionTitle = (
       useDefaultTitle,
       capitalizedTypeString,
       titleContent,
+      titleSeparator,
       remainingChildren,
     ),
   ]
@@ -343,7 +346,13 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
   const collapse = collapseChar === "+" || collapseChar === "-"
   recordAdmonitionIcons(file, admonitionType, collapse)
   const defaultState = collapseChar === "-" ? "collapsed" : "expanded"
-  const titleContent = firstLine.slice(admonitionDirective.length).trim()
+  const rawTitle = firstLine.slice(admonitionDirective.length)
+  const titleContent = rawTitle.trim()
+  // Preserve the source spacing between the plain-text title and any following
+  // inline child (e.g. a link). Appending a space unconditionally would insert
+  // one after a trailing opening delimiter, turning "remarks ([video])" into
+  // "remarks ( video)".
+  const titleSeparator = /\s$/u.test(rawTitle) ? " " : ""
   /* istanbul ignore next -- admonition title detection edge case */
   const useDefaultTitle = titleContent === "" && firstChild.children.length === 1
   const capitalizedTypeString = typeString.charAt(0).toUpperCase() + typeString.slice(1)
@@ -363,6 +372,7 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
     useDefaultTitle,
     capitalizedTypeString,
     titleContent,
+    titleSeparator,
     firstChild.children.slice(1) as ElementContent[],
     collapse,
     noSmallcaps,

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -323,30 +323,37 @@ const createPlaylistEmbed = (playlistId: string): Properties => ({
   src: `https://www.youtube.com/embed/videoseries?list=${playlistId}`,
 })
 
-/** Processes blockquotes and converts them to admonitions. */
-const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
-  if (node.children.length === 0) return
+/** Parsed metadata from an admonition's `[!type]±` directive. */
+interface AdmonitionHeader {
+  admonitionDirective: string
+  typeString: string
+  collapse: boolean
+  defaultState: "collapsed" | "expanded"
+  admonitionType: string
+}
 
-  const firstChild = node.children[0]
-  if (firstChild.type !== "paragraph" || firstChild.children[0]?.type !== "text") {
-    return
-  }
-
-  const text = firstChild.children[0].value
-  const [firstLine, ...remainingLines] = text.split("\n")
-  const remainingText = remainingLines.join("\n")
-
+/** Parses the `[!type]±` directive from an admonition's first line. */
+const parseAdmonitionHeader = (firstLine: string): AdmonitionHeader | null => {
   const match = admonitionRegex.exec(firstLine)
-  if (!match?.groups) return
+  if (!match?.groups) return null
 
-  const admonitionDirective = match[0]
-  const typeString = match.groups.type
   const collapseChar = match.groups.collapse
-  const admonitionType = canonicalizeAdmonition(typeString.toLowerCase())
-  const collapse = collapseChar === "+" || collapseChar === "-"
-  recordAdmonitionIcons(file, admonitionType, collapse)
-  const defaultState = collapseChar === "-" ? "collapsed" : "expanded"
-  const rawTitle = firstLine.slice(admonitionDirective.length)
+  return {
+    admonitionDirective: match[0],
+    typeString: match.groups.type,
+    collapse: collapseChar === "+" || collapseChar === "-",
+    defaultState: collapseChar === "-" ? "collapsed" : "expanded",
+    admonitionType: canonicalizeAdmonition(match.groups.type.toLowerCase()),
+  }
+}
+
+/** Builds the title element from an admonition's first paragraph. */
+const buildAdmonitionTitle = (
+  firstChild: Paragraph,
+  firstLine: string,
+  header: AdmonitionHeader,
+): BlockContent => {
+  const rawTitle = firstLine.slice(header.admonitionDirective.length)
   const titleContent = rawTitle.trim()
   // Preserve the source spacing between the plain-text title and any following
   // inline child (e.g. a link). Appending a space unconditionally would insert
@@ -355,7 +362,9 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
   const titleSeparator = /\s$/u.test(rawTitle) ? " " : ""
   /* istanbul ignore next -- admonition title detection edge case */
   const useDefaultTitle = titleContent === "" && firstChild.children.length === 1
-  const capitalizedTypeString = typeString.charAt(0).toUpperCase() + typeString.slice(1)
+  const capitalizedTypeString =
+    header.typeString.charAt(0).toUpperCase() + header.typeString.slice(1)
+  const remainingChildren = firstChild.children.slice(1)
 
   // An admonition title that already reads as a title-cased work name (a
   // cited article, a named act) should not render its acronyms as
@@ -364,20 +373,23 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
   // work title, and an empty string is vacuously "title-cased" by the Hamming
   // check, so guard on non-empty text first.
   const fullTitleText = `${titleContent} ${collectInlineText(
-    firstChild.children.slice(1) as PhrasingContent[],
+    remainingChildren as PhrasingContent[],
   )}`.trim()
   const noSmallcaps = fullTitleText !== "" && isEffectivelyTitleCased(fullTitleText)
 
-  const admonitionTitle = createAdmonitionTitle(
+  return createAdmonitionTitle(
     useDefaultTitle,
     capitalizedTypeString,
     titleContent,
     titleSeparator,
-    firstChild.children.slice(1) as ElementContent[],
-    collapse,
+    remainingChildren as ElementContent[],
+    header.collapse,
     noSmallcaps,
   ) as unknown as BlockContent
+}
 
+/** Builds the content node holding the body after an admonition's first line. */
+const buildAdmonitionContentNode = (node: Blockquote, remainingText: string): Element | null => {
   /* istanbul ignore next -- admonition content handling edge case */
   const contentChildren = [
     ...(remainingText.trim() !== ""
@@ -391,18 +403,16 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
     ...node.children.slice(1),
   ]
 
-  const contentNode = createAdmonitionContent(contentChildren as ElementContent[])
+  return createAdmonitionContent(contentChildren as ElementContent[])
+}
 
-  node.children = [admonitionTitle]
-  if (contentNode) {
-    node.children.push(contentNode as unknown as BlockContent)
-  }
-
-  const classNames = ["admonition", admonitionType]
-  if (collapse) {
+/** Applies admonition classes and data attributes to the blockquote node. */
+const setAdmonitionProperties = (node: Blockquote, header: AdmonitionHeader): void => {
+  const classNames = ["admonition", header.admonitionType]
+  if (header.collapse) {
     classNames.push("is-collapsible")
   }
-  if (defaultState === "collapsed") {
+  if (header.defaultState === "collapsed") {
     classNames.push("is-collapsed")
   }
 
@@ -411,10 +421,36 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
     hProperties: {
       ...(node.data?.hProperties ?? {}),
       className: classNames.join(" "),
-      "data-admonition": admonitionType,
-      "data-admonition-fold": collapse,
+      "data-admonition": header.admonitionType,
+      "data-admonition-fold": header.collapse,
     },
   }
+}
+
+/** Processes blockquotes and converts them to admonitions. */
+const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
+  if (node.children.length === 0) return
+
+  const firstChild = node.children[0]
+  if (firstChild.type !== "paragraph" || firstChild.children[0]?.type !== "text") {
+    return
+  }
+
+  const [firstLine, ...remainingLines] = firstChild.children[0].value.split("\n")
+  const header = parseAdmonitionHeader(firstLine)
+  if (!header) return
+
+  recordAdmonitionIcons(file, header.admonitionType, header.collapse)
+
+  const admonitionTitle = buildAdmonitionTitle(firstChild, firstLine, header)
+  const contentNode = buildAdmonitionContentNode(node, remainingLines.join("\n"))
+
+  node.children = [admonitionTitle]
+  if (contentNode) {
+    node.children.push(contentNode as unknown as BlockContent)
+  }
+
+  setAdmonitionProperties(node, header)
 }
 
 /** Configuration options for the OFM transformer. */

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -390,6 +390,9 @@ const buildAdmonitionTitle = (
 
 /** Builds the content node holding the body after an admonition's first line. */
 const buildAdmonitionContentNode = (node: Blockquote, remainingText: string): Element | null => {
+  // The body is the title line's trailing text (any lines the user typed under
+  // the title, minus the title line itself) followed by the blockquote's
+  // remaining block children — the first block held the title and is dropped.
   /* istanbul ignore next -- admonition content handling edge case */
   const contentChildren = [
     ...(remainingText.trim() !== ""
@@ -427,24 +430,36 @@ const setAdmonitionProperties = (node: Blockquote, header: AdmonitionHeader): vo
   }
 }
 
-/** Processes blockquotes and converts them to admonitions. */
+/**
+ * Converts an Obsidian callout blockquote (`> [!type] Title`) into an
+ * admonition: a `<div class="admonition …">` wrapping a title node and, when
+ * there is body text, a content node. Mutates `node` in place. Runs on every
+ * blockquote, so a blockquote that isn't a callout is left untouched.
+ */
 const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
   if (node.children.length === 0) return
 
+  // A callout always opens with a paragraph whose first child is the plain-text
+  // `[!type]` marker. Any other shape is an ordinary blockquote.
   const firstChild = node.children[0]
   if (firstChild.type !== "paragraph" || firstChild.children[0]?.type !== "text") {
     return
   }
 
+  // The marker text node also carries body text typed on lines beneath the
+  // title: textTransform injects a newline after the title, so the first line
+  // is the directive + title and the rest is leading body content.
   const [firstLine, ...remainingLines] = firstChild.children[0].value.split("\n")
   const header = parseAdmonitionHeader(firstLine)
-  if (!header) return
+  if (!header) return // Not a `[!type]` directive — an ordinary blockquote.
 
   recordAdmonitionIcons(file, header.admonitionType, header.collapse)
 
   const admonitionTitle = buildAdmonitionTitle(firstChild, firstLine, header)
   const contentNode = buildAdmonitionContentNode(node, remainingLines.join("\n"))
 
+  // Swap the blockquote's children for the title (+ content when present); the
+  // admonition classes/data attributes go on the blockquote element itself.
   node.children = [admonitionTitle]
   if (contentNode) {
     node.children.push(contentNode as unknown as BlockContent)

--- a/quartz/plugins/transformers/tests/ofm.test.ts
+++ b/quartz/plugins/transformers/tests/ofm.test.ts
@@ -179,6 +179,20 @@ describe("markdownPlugins", () => {
       expectedContent: ['<div class="admonition-title">'],
       notExpectedContent: ["no-smallcaps"],
     },
+    {
+      name: "title link abutting an opening paren gets no inserted space",
+      input: "> [!quote] Stuart Russell's closing remarks ([video](https://example.com))",
+      expectedClass: "admonition quote",
+      expectedContent: ['closing remarks (<a href="https://example.com">video</a>)'],
+      notExpectedContent: ["remarks ( "],
+    },
+    {
+      name: "title with a space before a link keeps the separating space",
+      input: "> [!note] See the [docs](https://example.com) for details",
+      expectedClass: "admonition note",
+      expectedContent: ['See the <a href="https://example.com">docs</a>'],
+      notExpectedContent: ["See the<a"],
+    },
   ]
 
   it.each(admonitionCases)(


### PR DESCRIPTION
## Summary

- Admonition titles containing trailing inline content (e.g. a link) rendered a spurious space after a trailing opening delimiter — `> [!quote] Stuart Russell's closing remarks ([video](url))` came out as `( video)` instead of `(video)`.
- Root cause: `createAdmonitionTitleInner` in `ofm.ts` unconditionally appended a space to the plain-text portion of the title to separate it from the following inline node. When the plain text ended with `(`, that space landed between the paren and the link.

## Changes

- `quartz/plugins/transformers/ofm.ts`: derive the title separator from the original source spacing (`/\s$/` on the raw pre-trim title) instead of always appending a space. An abutting delimiter now stays glued to the following link; genuinely space-separated titles keep their space. Threaded a `titleSeparator` argument through `createAdmonitionTitle` / `createAdmonitionTitleInner`.
- `quartz/plugins/transformers/tests/ofm.test.ts`: added two cases — a title link abutting an opening paren (no inserted space) and a title with a real space before a link (space preserved).

## Testing

- Jest run of `ofm.test.ts`: 153/153 pass, including the two new cases (both branches of the new separator logic covered).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTASYv4u2fmjqL53MJwdx4)_