### PR TITLE
ci: skip CI suite for the automated README-snapshot refresh branch

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -17,7 +17,10 @@ permissions:
 jobs:
   should-run:
     name: a11y-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the always() reporter below marks the required check green.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -39,10 +42,6 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # a11y run.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -39,6 +39,10 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # a11y run.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -93,6 +93,9 @@ jobs:
               - 'scripts/strip_for_spellcheck.py'
             code:
               - 'quartz/**'
+              # External README snapshots are embedded content, not code;
+              # a refresh of them (refresh-readme-snapshots.yaml) needs no lint.
+              - '!quartz/plugins/transformers/.readme-snapshots/**'
               - 'config/javascript/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
@@ -116,6 +119,10 @@ jobs:
               - '!quartz/**/*.test.ts'
               - '!quartz/**/*.test.tsx'
               - '!quartz/**/tests/**'
+              # External README snapshots are embedded content, not source we
+              # author; a refresh of them (refresh-readme-snapshots.yaml) must
+              # not trip source_file_checks and block the automated merge.
+              - '!quartz/plugins/transformers/.readme-snapshots/**'
               - 'scripts/source_file_checks.py'
               - 'config/quartz/**'
               - 'config/constants.json'

--- a/.github/workflows/lint-and-validate.yaml
+++ b/.github/workflows/lint-and-validate.yaml
@@ -93,9 +93,6 @@ jobs:
               - 'scripts/strip_for_spellcheck.py'
             code:
               - 'quartz/**'
-              # External README snapshots are embedded content, not code;
-              # a refresh of them (refresh-readme-snapshots.yaml) needs no lint.
-              - '!quartz/plugins/transformers/.readme-snapshots/**'
               - 'config/javascript/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
@@ -119,10 +116,6 @@ jobs:
               - '!quartz/**/*.test.ts'
               - '!quartz/**/*.test.tsx'
               - '!quartz/**/tests/**'
-              # External README snapshots are embedded content, not source we
-              # author; a refresh of them (refresh-readme-snapshots.yaml) must
-              # not trip source_file_checks and block the automated merge.
-              - '!quartz/plugins/transformers/.readme-snapshots/**'
               - 'scripts/source_file_checks.py'
               - 'config/quartz/**'
               - 'config/constants.json'
@@ -316,8 +309,12 @@ jobs:
     # Run if detect-changes found changes, and not a deepsource PR.
     # update-dates is allowed to be skipped (runs only on push to main by users).
     # always() ensures this runs even when update-dates or autofix are skipped.
+    # The automated README-snapshot refresh (branch automated/readme-snapshots)
+    # only rewrites embedded external READMEs; skip lint so an external README's
+    # content can't trip source_file_checks and block the automated merge.
     if: >
       !startsWith(github.head_ref, 'deepsource-') &&
+      github.head_ref != 'automated/readme-snapshots' &&
       (needs.detect-changes.outputs.content == 'true' ||
        needs.detect-changes.outputs.code == 'true' ||
        needs.detect-changes.outputs.styles == 'true' ||

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -47,6 +47,10 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # Jest run.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "config/quartz/**"
               - "config/constants.json"
               - "config/javascript/**"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,10 @@ permissions:
 jobs:
   should-run:
     name: node-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the gated build job's test steps skip and the required check passes.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -47,10 +50,6 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # Jest run.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "config/quartz/**"
               - "config/constants.json"
               - "config/javascript/**"

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -39,6 +39,10 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # browser run.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "config/quartz/**"
               - "config/constants.json"
               - "config/playwright/**"

--- a/.github/workflows/playwright-tests.yaml
+++ b/.github/workflows/playwright-tests.yaml
@@ -19,7 +19,10 @@ jobs:
   # Otherwise yields run=true and full browser coverage (chromium,firefox + macOS).
   should-run:
     name: playwright-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the always() reporter below marks the required check green.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -39,10 +42,6 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # browser run.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "config/quartz/**"
               - "config/constants.json"
               - "config/playwright/**"

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -19,7 +19,10 @@ permissions:
 jobs:
   should-run:
     name: lighthouse-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the gated build/deploy/audit jobs skip and the required checks pass.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -41,10 +44,6 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # lighthouse run.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               # Console-clean spec runs against the preview URL in this
               # workflow, so changes to it must still trigger a run despite the
               # broad spec/tests exclusions above.

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -41,6 +41,10 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # lighthouse run.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               # Console-clean spec runs against the preview URL in this
               # workflow, so changes to it must still trigger a run despite the
               # broad spec/tests exclusions above.

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -53,6 +53,11 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # site-build-checks run. The post-merge deploy build still
+              # exercises the embed.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"

--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -31,7 +31,10 @@ permissions:
 jobs:
   should-run:
     name: site-checks-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the always() reporter below marks the required check green.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -53,11 +56,6 @@ jobs:
               - "!quartz/**/*.test.ts"
               - "!quartz/**/*.test.tsx"
               - "!quartz/**/tests/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # site-build-checks run. The post-merge deploy build still
-              # exercises the embed.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -21,7 +21,10 @@ jobs:
   # Otherwise yields run=true and full browser coverage (chromium,firefox + macOS).
   should-run:
     name: visual-should-run
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-')
+    # Skip the automated README-snapshot refresh (branch automated/readme-snapshots):
+    # it only rewrites embedded external READMEs, not code under test. should-run is
+    # skipped, so the always() reporter below marks the required check green.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'deepsource-') && github.head_ref != 'automated/readme-snapshots'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -41,10 +44,6 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
-              # External README snapshots are embedded content, not code under
-              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
-              # visual run.
-              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -41,6 +41,10 @@ jobs:
           filters: |
             relevant:
               - "quartz/**"
+              # External README snapshots are embedded content, not code under
+              # test; a refresh of them (refresh-readme-snapshots.yaml) needs no
+              # visual run.
+              - "!quartz/plugins/transformers/.readme-snapshots/**"
               - "website_content/**"
               - "config/quartz/**"
               - "config/constants.json"


### PR DESCRIPTION
## Summary

The daily `refresh-readme-snapshots.yaml` workflow opens an auto-merge PR from the fixed branch `automated/readme-snapshots` whenever an external README snapshot changes. Those snapshots (`quartz/plugins/transformers/.readme-snapshots/`) are embedded content, not code under test — but they live under `quartz/**`, so every gated CI workflow ran the full browser + visual + a11y + lighthouse + build matrix on the refresh. That's wasted CI, and a flaky macOS-WebKit shard (as on #1614) leaves a required check red so the workflow's own auto-merge never fires.

This skips the entire suite for that automated branch, using the idiom the repo **already** uses for `dependabot` / `renovate` / `deepsource-` PRs: skip by branch, not by path.

## Approach (and why not path exclusion)

The obvious first idea — add `!quartz/plugins/transformers/.readme-snapshots/**` to each `dorny/paths-filter` — does **not** work here. dorny/paths-filter combines a filter's patterns with OR (`predicate-quantifier: some`), so a `!` pattern matches *every file that isn't a snapshot*, making the filter match essentially everything (verified in the gate log: all workflow files matched `relevant`, forcing `run=true`). It also can't achieve the goal, since a real snapshot file still matches the positive `quartz/**`. Path negation is the wrong tool for an OR-combined filter with a positive parent glob.

Instead, each gate's `should-run` job now also skips `github.head_ref == 'automated/readme-snapshots'`, exactly like the existing dependabot/deepsource skips. When `should-run` is skipped, the gated jobs skip and the existing `if: always()` reporter (`playwright-tests`, `visual-testing`, `a11y`, `site-build-checks`) exits 0 — or the gated build/deploy/audit jobs report `skipped`, which branch protection treats as passing. This is the proven dependabot path.

## Changes

`&& github.head_ref != 'automated/readme-snapshots'` added to the `should-run` gate of:

- `playwright-tests.yaml` — Linux Chromium/Firefox + macOS WebKit
- `visual-testing.yaml` — visual regression
- `a11y.yml` — accessibility
- `preview-audits.yaml` — Lighthouse / console-clean
- `site-build-checks.yaml` — built-site checks + linkchecker
- `node.js.yml` — Jest

And to the `lint` job's condition in `lint-and-validate.yaml`, so an external README's content can't trip `source_file_checks.py` and block the automated merge.

`python-tests.yaml` already only matches `scripts/**`, so it needs no change.

## Scope note

This targets the automated refresh branch specifically (matching how the repo already gates dependabot/deepsource), not any hand-edited snapshot change on another branch — the automated refresh is the only producer of these commits.

## Testing

- All seven edited workflows parse (`yaml.safe_load`).
- The skip mirrors the established, working dependabot/deepsource branch-skip: `should-run` skipped → gated jobs skip → `if: always()` reporter marks the required check green.
- This PR touches `.github/workflows/**`, so CI's own `workflow-lint` (actionlint + zizmor) validates the changed files. Because the PR itself is workflow-only (no `quartz/**`), the playwright/visual/node gates correctly return `run=false` and skip.

## Lessons learned

- **`dorny/paths-filter` with `predicate-quantifier: some` cannot exclude a sub-path by adding a `!` pattern.** Patterns are OR-combined, so a lone negation matches every non-matching file and the filter matches almost everything; and a positive parent glob (`quartz/**`) still matches the sub-path you tried to exclude. Confirm a gate's decision in its job log (`Filter <name> = true` + matched files) before trusting a negation.
- **To exempt a class of automated PRs from CI, gate on branch/actor, not path.** When a bot commits generated content into a code tree, the robust skip is `github.head_ref`/`github.actor` at the `should-run` job — the same mechanism the repo already uses for dependabot/deepsource — because a downstream `if: always()` reporter still reports the required check green while the expensive jobs skip.