### PR TITLE
fix: correct dead raw-Markdown link in military red lines article

### DIFF
--- a/website_content/military-red-lines.md
+++ b/website_content/military-red-lines.md
@@ -25,7 +25,7 @@ date_updated: *id001
 ---
 
 > [!note] Historical context-
-> I [wrote this document in my personal time and had it reviewed by experts in military and surveillance law](/why-i-left-google-deepmind#the-art-of-the-deal). You can also read [the raw Markdown for this document](https://github.com/alexander-turner/TurnTrout.com/blob/main/website_content/red-line-framework.md).
+> I [wrote this document in my personal time and had it reviewed by experts in military and surveillance law](/why-i-left-google-deepmind#the-art-of-the-deal). You can also read [the raw Markdown for this document](https://github.com/alexander-turner/TurnTrout.com/blob/main/website_content/military-red-lines.md).
 
 This Framework contains two parts. First, the red lines expressed by Standards 1 and 2. Second, a Review Body which advises on contracts relative to Standards 1 and 2. The Body cannot block contracts. Instead, it assesses whether contracts comply with defined Standards, ensuring key decision-makers can track the ethical implications of those contracts. The Body manufactures justified trust by releasing a yearly transparency report to all AI employees. The report notes how many times leadership overrode a non-compliance finding. Leadership cannot quietly dismantle the Body.
 


### PR DESCRIPTION
## Summary

The "You can also read the raw Markdown for this document" link in the military red lines article pointed at `.../blob/main/website_content/red-line-framework.md`, but that file does not exist — the article's file is `military-red-lines.md` (`red-line-framework` is only its `permalink` slug). The URL 404'd. This points the link at the real filename.

- `red-line-framework.md → 404`
- `military-red-lines.md → 200`

## Why it wasn't caught by linkchecker

The link has been dead since the article was first committed (`301e9ba "feat: military article"`). The `linkchecker` external-link check (`site-build-checks.yaml`) *does* check `github.com/alexander-turner/TurnTrout.com` links and would have flagged this 404 — but only the `pull_request:` trigger is a blocking gate. That commit was pushed directly to the branch rather than through a PR, so the blocking gate never evaluated it. On direct pushes the check still runs but can't gate a commit that's already landed.

Note: the page's *auto-generated* raw-Markdown link (`ContentMeta.tsx`, built from the real `relativePath`) was already correct — only the hand-written in-prose link was wrong.

## Testing

- Confirmed the corrected URL returns HTTP 200 and the old one returns 404 via `curl`.

## Lessons learned

- A repo can have a blocking CI check that only gates one trigger (`pull_request`). Content committed directly to a protected branch bypasses that gate entirely, so "the check exists" ≠ "the check ran on this change." When a link/lint check "should have caught" something, first verify the offending commit actually went through the gated path (PR) rather than a direct push.