### PR TITLE
fix(ci): crawl the site for external link checking

### DIFF
--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -149,12 +149,17 @@ jobs:
       # External links go out to the public internet (assets.turntrout.com,
       # github.com). Cloudflare / GitHub can return transient 5xx, so wrap
       # in retry-external. A persistent 4xx still fails after max-attempts.
+      #
+      # Crawl the running site so every page's external links are checked; the
+      # ignore-url allowlist keeps localhost (crawled) plus the two hosts we
+      # control, and drops all other external links. --check-extern is required
+      # for the allowlisted external URLs to be fetched rather than skipped.
       - name: Check external links (with retries)
         uses: ./.github/actions/retry-external
         with:
           command: |
-            uv run linkchecker public/**/*.html \
-              --ignore-url='!^https://(assets\.turntrout\.com|github\.com/alexander-turner/TurnTrout\.com)' \
+            uv run linkchecker http://localhost:8080 \
+              --ignore-url='!^(http://localhost:8080|https://assets\.turntrout\.com|https://github\.com/alexander-turner/TurnTrout\.com)' \
               --check-extern \
               --threads 30 \
               --user-agent "linkchecker" \

--- a/scripts/linkchecker.fish
+++ b/scripts/linkchecker.fish
@@ -7,15 +7,16 @@ set -x no_proxy $LOCAL_SERVER
 linkchecker $LOCAL_SERVER --threads 50 
 set -l INTERNAL_STATUS $status
 
-# Check external links which I control
-set -l GIT_ROOT (git rev-parse --show-toplevel)
-set TARGET_FILES_EXTERNAL $GIT_ROOT/public/**html
-linkchecker $TARGET_FILES_EXTERNAL \
-    --ignore-url="!^https://(assets\.turntrout\.com|github\.com/alexander-turner/TurnTrout\.com)" \
+# Check external links which I control. Crawl the running site so every page's
+# external links are checked; the allowlist keeps localhost (crawled) plus the
+# two hosts I control and drops all other external links. --check-extern makes
+# linkchecker fetch the allowlisted external URLs instead of skipping them.
+linkchecker $LOCAL_SERVER \
+    --ignore-url="!^(http://localhost:8080|https://assets\.turntrout\.com|https://github\.com/alexander-turner/TurnTrout\.com)" \
     --check-extern \
     --threads 30 \
     --user-agent "linkchecker" \
-    --timeout 40 
+    --timeout 40
 set -l EXTERNAL_STATUS $status
 
 # If any of the checks failed, exit with a non-zero status

--- a/scripts/tests/test_linkchecker.py
+++ b/scripts/tests/test_linkchecker.py
@@ -110,15 +110,14 @@ def html_linkchecker_result(test_server_and_files) -> object:
         cwd=str(tmp_dir),
     )
 
-    # External link check
-    public_dir = test_server_and_files["public_dir"]
-    target_files = list(public_dir.glob("**/*.html"))
-
+    # External link check: crawl the running site so every page's external
+    # links are checked, matching the production script. The allowlist keeps
+    # localhost (crawled) plus the two hosts we control.
     external_result = subprocess.run(
         [
             "linkchecker",
-            *[str(f) for f in target_files],
-            "--ignore-url=!^https://(assets\\.turntrout\\.com|github\\.com/alexander-turner/TurnTrout\\.com)",
+            local_server,
+            f"--ignore-url=!^({local_server}|https://assets\\.turntrout\\.com|https://github\\.com/alexander-turner/TurnTrout\\.com)",
             "--check-extern",
             "--threads",
             "30",


### PR DESCRIPTION
## Summary

The external-link CI check never actually checked article pages. It ran linkchecker against the glob `public/**/*.html`, but:

- In CI's bash, `globstar` is **off**, so `**` collapses to a single `*` → the glob resolves to `public/*/*.html` (only files one directory deep).
- Pages are emitted **flat** as `public/<slug>.html` (`contentPage.tsx:99`), so every top-level article page was skipped.

Result: the external step checked ~34 nested pages / 285 links in ~1 second and never verified external links (`assets.turntrout.com` and our own `github.com/alexander-turner/TurnTrout.com` blob URLs) in article bodies. The internal check (`linkchecker http://localhost:8080`) does crawl every page but runs **without** `--check-extern`, so it skips external links entirely. Net: external links in posts were checked on essentially zero pages — which is how the dead `red-line-framework.md` link (fixed in #1621) slipped through every PR.

## Change

Crawl the running site for the external check instead of globbing files, matching how the internal check already works:

```
linkchecker http://localhost:8080 \
  --ignore-url='!^(http://localhost:8080|https://assets\.turntrout\.com|https://github\.com/alexander-turner/TurnTrout\.com)' \
  --check-extern ...
```

The allowlist keeps localhost (so the whole site is crawled) plus the two hosts we control, and drops all other external links. `--check-extern` makes linkchecker fetch the allowlisted URLs rather than skip them. Applied identically to:

- `.github/workflows/site-build-checks.yaml` (CI)
- `scripts/linkchecker.fish` (local)
- `scripts/tests/test_linkchecker.py` (test now exercises the crawl method; assertions unchanged — it still catches the bad asset link)

## Testing

- `uv run pytest scripts/tests/test_linkchecker.py` — 2 passed; the crawl-based external check still catches the invalid `assets.turntrout.com` link.

## Risk / follow-up

The correct behavior now checks every article's external links, including one auto-generated `github.com/.../blob/main/website_content/<slug>.md` source link per post. That's a larger volume of requests to GitHub; the existing `retry-external` wrapper absorbs transient 429/5xx. If GitHub rate-limits persistently under 30 threads, the next lever is lowering the external thread count — will watch this PR's `site-build-checks` run to confirm it stays green.

## Lessons learned

- `**` is only recursive when `globstar` is enabled; in a plain `bash -c` it silently behaves like `*`, so a `**/*` glob can match far fewer files than intended and a "passing" link/file check may be scanning almost nothing. Prefer crawling a served site (or `find`) over shell `**` globs for whole-site coverage, and sanity-check the reported count (links/files scanned) — a check that finishes suspiciously fast with a tiny count is a coverage bug, not a fast pass.
- A CI check that only gates on `pull_request` won't catch problems introduced by direct pushes to a protected branch; verify the offending commit actually went through the gated path before concluding the check is working.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDA17nMNP6kjYBtZ1iD2wG)_