### PR TITLE
fix: keep "newsletter & rss" together when the subscription line wraps

### DIFF
--- a/quartz/components/tests/afterArticle.spec.ts
+++ b/quartz/components/tests/afterArticle.spec.ts
@@ -16,4 +16,22 @@ test.describe("After-article components", () => {
       elementToScreenshot: afterArticle,
     })
   })
+
+  test("newsletter & RSS links share a line when the sentence wraps", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 800 })
+    await gotoPage(page, AFTER_ARTICLE_URL)
+
+    const paragraph = page.locator("#subscription-and-contact p").first()
+    const newsletterBox = await paragraph
+      .locator('a[href="https://turntrout.substack.com/subscribe"]')
+      .boundingBox()
+    const rssBox = await paragraph.locator("#rss-link").boundingBox()
+    if (!newsletterBox || !rssBox) {
+      throw new Error("newsletter or RSS link is not visible")
+    }
+
+    const newsletterMidY = newsletterBox.y + newsletterBox.height / 2
+    expect(rssBox.y).toBeLessThan(newsletterMidY)
+    expect(rssBox.y + rssBox.height).toBeGreaterThan(newsletterMidY)
+  })
 })

--- a/quartz/components/tests/afterArticle.spec.ts
+++ b/quartz/components/tests/afterArticle.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures"
-import { gotoPage, takeRegressionScreenshot } from "./visual_utils"
+import { gotoPage, requireBoundingBox, takeRegressionScreenshot } from "./visual_utils"
 
 const AFTER_ARTICLE_URL = "http://localhost:8080/after-article-fixture"
 
@@ -22,13 +22,10 @@ test.describe("After-article components", () => {
     await gotoPage(page, AFTER_ARTICLE_URL)
 
     const paragraph = page.locator("#subscription-and-contact p").first()
-    const newsletterBox = await paragraph
-      .locator('a[href="https://turntrout.substack.com/subscribe"]')
-      .boundingBox()
-    const rssBox = await paragraph.locator("#rss-link").boundingBox()
-    if (!newsletterBox || !rssBox) {
-      throw new Error("newsletter or RSS link is not visible")
-    }
+    const newsletterBox = await requireBoundingBox(
+      paragraph.locator('a[href="https://turntrout.substack.com/subscribe"]'),
+    )
+    const rssBox = await requireBoundingBox(paragraph.locator("#rss-link"))
 
     const newsletterMidY = newsletterBox.y + newsletterBox.height / 2
     expect(rssBox.y).toBeLessThan(newsletterMidY)

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test"
 
 import { expect, routeCdnAssetStubs, test } from "./fixtures"
-import { gotoPage, reloadPage } from "./visual_utils"
+import { gotoPage, reloadPage, requireBoundingBox } from "./visual_utils"
 
 // Helper to get collapsible admonitions
 const getCollapsibles = (page: Page) => page.locator(".admonition.is-collapsible")
@@ -38,17 +38,6 @@ async function spaNavigateToAbout(page: Page): Promise<void> {
   await page.evaluate(() => window.spaNavigate(new URL("/about", window.location.origin)))
   await page.waitForURL("**/about")
   await expect(page.locator('body[data-slug="about"]')).toBeAttached()
-}
-
-/** Resolves a locator's bounding box, throwing if it's not visible/attached. */
-async function requireBoundingBox(
-  locator: import("@playwright/test").Locator,
-): Promise<{ x: number; y: number; width: number; height: number }> {
-  const box = await locator.boundingBox()
-  if (!box) {
-    throw new Error(`Expected a visible bounding box for locator: ${locator}`)
-  }
-  return box
 }
 
 async function goBackToTestPage(page: Page): Promise<void> {

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -429,6 +429,19 @@ export async function getNextElementMatchingSelector(
   throw new Error("No next element found")
 }
 
+/** Return a locator's bounding box, throwing if the element isn't laid out.
+ *  Keeps the null-check out of test bodies (`playwright/no-conditional-in-test`)
+ *  while giving callers a non-nullable box. */
+export async function requireBoundingBox(
+  locator: Locator,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const box = await locator.boundingBox()
+  if (!box) {
+    throw new Error(`Expected a visible bounding box for locator: ${locator}`)
+  }
+  return box
+}
+
 /** Open the search UI by clicking the search icon.
  *
  *  Waits for search event handlers to be fully registered (signalled by

--- a/quartz/plugins/transformers/afterArticle.ts
+++ b/quartz/plugins/transformers/afterArticle.ts
@@ -3,7 +3,7 @@ import { h } from "hastscript"
 import { visit } from "unist-util-visit"
 import { VFile } from "vfile"
 
-import { EXTERNAL_LINK_REL } from "../../components/constants"
+import { EXTERNAL_LINK_REL, NBSP } from "../../components/constants"
 import { type QuartzTransformerPlugin } from "../types"
 import { type QuartzPluginData } from "../vfile"
 import { createSequenceLinksComponent } from "./sequenceLinks"
@@ -18,8 +18,18 @@ const newsletterElement = h("a", { href: "https://turntrout.substack.com/subscri
 export const rssElement = h("a", { href: "https://turntrout.com/rss.xml", id: "rss-link" }, [
   h("abbr", { class: "small-caps" }, "rss"),
 ])
+// NBSPs glue "newsletter & rss" into one line-break atom so narrow viewports
+// wrap before "newsletter" instead of stranding "& rss" on its own line.
 const subscriptionElement = h("div", { className: "centered" }, [
-  h("div", h("p", ["Find out when I post more content: ", newsletterElement, " & ", rssElement])),
+  h(
+    "div",
+    h("p", [
+      "Find out when I post more content: ",
+      newsletterElement,
+      `${NBSP}&${NBSP}`,
+      rssElement,
+    ]),
+  ),
 ])
 
 const mailLink = h("a", { href: "mailto:alex@turntrout.com" }, ["alex@turntrout.com"])


### PR DESCRIPTION
## Summary

On narrow (mobile) viewports, the subscription line under each article — "Find out when I post more content: newsletter & rss" — could wrap so that "& rss" was stranded on its own line, leaving a lonely "& rss".

This glues the two links to the ampersand with non-breaking spaces (`` `${NBSP}&${NBSP}` ``) so "newsletter & rss" behaves as a single line-break atom. A narrow screen now breaks *before* "newsletter" and keeps the whole "newsletter & rss" unit on one line.

## Why not a punctilio fix?

punctilio can't reach this text. In the Quartz pipeline (`config/quartz/quartz.config.ts`), `AfterArticle()` — which injects this subscription element — runs *after* `HTMLFormattingImprovement()` (the punctilio pass). The element is added to the tree after punctilio has already run, so its NBSP logic never sees "newsletter & rss". The gluing has to be done at construction time in `afterArticle.ts`.

## Changes

- `quartz/plugins/transformers/afterArticle.ts`: use the shared `NBSP` constant to bind the newsletter/RSS links to the ampersand.
- `quartz/components/tests/afterArticle.spec.ts`: add a Playwright test at a 320px viewport asserting the two links share a visual line when the sentence wraps.

## Verification

Built the site offline with `INCLUDE_FIXTURES=true` and ran the new test against the fixture page. At 320px the paragraph wraps to two lines and the newsletter and RSS links share the second line (identical `y`), confirming the break falls before "newsletter" rather than stranding "& rss".

---
_Generated by [Claude Code](https://claude.ai/code/session_012rs4bauxnjxSdv3Runy5UB)_