### PR TITLE
fix: triplicate search label

### DIFF
--- a/quartz/components/Navbar.tsx
+++ b/quartz/components/Navbar.tsx
@@ -93,15 +93,7 @@ const darkMode = (
 const searchHTML = (
   <div className="search" id="nav-searchbar">
     <div className="no-select" id="search-icon">
-      <svg
-        tabIndex={-1}
-        aria-labelledby="search-svg-title search-svg-desc"
-        role="img"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 19.9 19.7"
-      >
-        <title id="search-svg-title">Search</title>
-        <desc id="search-svg-desc">Search</desc>
+      <svg tabIndex={-1} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19.9 19.7">
         <g className="search-path" fill="none">
           <path strokeLinecap="square" d="M18.5 18.3l-5.4-5.4" />
           <circle cx="8" cy="8" r="7" />


### PR DESCRIPTION
The Search icon was labeled with with both a "Search" title and a "Search" description, along with the literal text "Search" rendered into the page. I noticed this because of how CloudFlare converts the page to Markdown:

```markdown
[](#center-content)

SearchSearch

Search
```

... but this is also an accessibility problem since a screen reader will read each of these separately.

The correct thing to do when an icon is purely decorative and described by the text is to render it with no alt text or description and let the text stand alone.