### PR TITLE
Kern spaced separator slashes with right-side margin

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -44,6 +44,7 @@ import {
   ITALIC_TAGS,
   replaceRegex,
   urlRegexNonGlobal,
+  wrapCharsInSpan,
 } from "./utils"
 
 /**
@@ -241,6 +242,48 @@ export function spacesAroundSlashes(input: string | ProseView): string | void {
   applySlashSpacing(input)
   input.commit()
   return undefined
+}
+
+// Whitespace that flanks a separator slash once slash spacing has run: an
+// authored plain space or the NBSP the slash rules glue on.
+const SLASH_FLANK_SPACES: ReadonlySet<string> = new Set([" ", NBSP])
+
+/**
+ * Wrap each spaced separator slash in a `<span class="slash-gap-after">` so CSS
+ * can widen the gap on its right. The forward lean of "/" crowds the following
+ * glyph, so a symmetric space reads as tight after the slash; a right-side
+ * margin opens it without inserting a character (find-in-page stays intact).
+ *
+ * Only a slash flanked by whitespace on both sides within its own text node is
+ * a separator — URL and fraction slashes are unspaced and never match. Slashes
+ * inside links are skipped so an underline runs past them unbroken.
+ */
+export function kernSpacedSlashes(tree: Root): void {
+  const ops: { parent: Parent; node: Text; offsets: number[] }[] = []
+  visitParents(tree, "text", (node: Text, ancestors) => {
+    if (!node.value.includes("/")) return
+    // A text node is never itself a skip element, so inspecting ancestors is
+    // enough. Links are skipped so an underline runs past the slash unbroken.
+    if (ancestors.some((a) => toSkip(a as Element) || (a as Element).tagName === "a")) return
+
+    const { value } = node
+    const offsets: number[] = []
+    for (let i = 0; i < value.length; i++) {
+      if (
+        value[i] === "/" &&
+        SLASH_FLANK_SPACES.has(value[i - 1]) &&
+        SLASH_FLANK_SPACES.has(value[i + 1])
+      ) {
+        offsets.push(i)
+      }
+    }
+    if (offsets.length > 0) {
+      ops.push({ parent: ancestors[ancestors.length - 1] as Parent, node, offsets })
+    }
+  })
+  for (const { parent, node, offsets } of ops) {
+    wrapCharsInSpan(parent, node, offsets, "slash-gap-after")
+  }
 }
 
 /**
@@ -1136,6 +1179,8 @@ export const improveFormatting = (
     formatOrdinalSuffixes(tree)
     // After rearrangeLinkPunctuation, so a colon pulled into a link is seen.
     kernItalicBeforePunctuation(tree)
+    // After slash spacing, so every separator slash is flanked and wrappable.
+    kernSpacedSlashes(tree)
     removeSpaceBeforeFootnotes(tree)
   }
 }

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -1,4 +1,4 @@
-import type { Element, ElementContent, Node, Parent, Text } from "hast"
+import type { Element, Node, Parent, Text } from "hast"
 import type { Plugin } from "unified"
 
 import escapeStringRegexp from "escape-string-regexp"
@@ -19,6 +19,7 @@ import {
   looksLikeWorkTitle,
   replaceRegex,
   shouldCapitalizeNodeText,
+  wrapCharsInSpan,
 } from "./utils"
 
 /** Validates if string matches Roman numeral pattern with optional trailing punctuation */
@@ -470,7 +471,6 @@ const SMALLCAPS_LEFT_OVERHANG_INITIALS: ReadonlySet<string> = new Set(["j", "J"]
 
 interface BracketGap {
   parent: Parent
-  index: number
   prevText: Text
 }
 
@@ -488,23 +488,10 @@ export function spaceSmallcapsAfterOpenBracket(tree: Node): void {
     const index = parent.children.indexOf(node)
     const prev = parent.children[index - 1]
     if (prev?.type !== "text" || !OPEN_BRACKET_BEFORE_SMALLCAPS.test(prev.value)) return
-    ops.push({ parent, index, prevText: prev })
+    ops.push({ parent, prevText: prev })
   })
-  // Splice from the highest index down so earlier rewrites don't shift the
-  // positions recorded for later ones.
-  ops.sort((a, b) => b.index - a.index)
-  for (const { parent, index, prevText } of ops) {
-    const head = prevText.value.slice(0, -1)
-    const bracket = prevText.value.slice(-1)
-    const replacement: ElementContent[] = []
-    if (head) replacement.push({ type: "text", value: head })
-    replacement.push({
-      type: "element",
-      tagName: "span",
-      properties: { className: ["smallcaps-gap-before"] },
-      children: [{ type: "text", value: bracket }],
-    })
-    parent.children.splice(index - 1, 1, ...replacement)
+  for (const { parent, prevText } of ops) {
+    wrapCharsInSpan(parent, prevText, [prevText.value.length - 1], "smallcaps-gap-before")
   }
 }
 

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -89,6 +89,11 @@ function applyPassToNodes(pass: (view: ProseView) => void, values: string[]): st
 }
 
 describe("HTMLFormattingImprovement", () => {
+  // A separator slash is wrapped for right-side kerning in the full HTML
+  // pipeline (not in the standalone string pass).
+  const SLASH_GAP_SPAN = '<span class="slash-gap-after">/</span>'
+  const withSlashGaps = (html: string): string => html.replace(/ \/ /g, ` ${SLASH_GAP_SPAN} `)
+
   describe("Quotes", () => {
     // Handle HTML inputs
     it.each([
@@ -229,22 +234,22 @@ describe("HTMLFormattingImprovement", () => {
       "should add spaces around '/' in an HTML context: %s",
       (input: string, expected: string) => {
         const processedHtml = testHtmlFormattingImprovement(`<p>${input}</p>`)
-        expect(normalizeNbsp(processedHtml)).toBe(`<p>${expected}</p>`)
+        expect(normalizeNbsp(processedHtml)).toBe(`<p>${withSlashGaps(expected)}</p>`)
       },
     )
 
     it.each([
-      ["<p><em>dog/cat</em></p>", "<p><em>dog / cat</em></p>"],
-      ["<p><strong>dog/cat</strong></p>", "<p><strong>dog / cat</strong></p>"],
-      ["<p><em>dog</em>/cat</p>", "<p><em>dog</em> / cat</p>"],
+      ["<p><em>dog/cat</em></p>", `<p><em>dog ${SLASH_GAP_SPAN} cat</em></p>`],
+      ["<p><strong>dog/cat</strong></p>", `<p><strong>dog ${SLASH_GAP_SPAN} cat</strong></p>`],
+      ["<p><em>dog</em>/cat</p>", `<p><em>dog</em> ${SLASH_GAP_SPAN} cat</p>`],
       // Code kerning is different
       [
         "<p><code>cat</code> / <code>unknown</code> classifier</p>",
-        "<p><code>cat</code> / <code>unknown</code> classifier</p>",
+        `<p><code>cat</code> ${SLASH_GAP_SPAN} <code>unknown</code> classifier</p>`,
       ],
       [
         "<p>raw <code>red</code> / <code>green</code> / <code>blue</code> colors</p>",
-        "<p>raw <code>red</code> / <code>green</code> / <code>blue</code> colors</p>",
+        `<p>raw <code>red</code> ${SLASH_GAP_SPAN} <code>green</code> ${SLASH_GAP_SPAN} <code>blue</code> colors</p>`,
       ],
       [
         '<p>(<strong>NAFTA</strong> <a href="x">/ˈnæftə/</a> <a href="y"><em>NAF-tə</em></a>; Spanish)</p>',
@@ -252,11 +257,11 @@ describe("HTMLFormattingImprovement", () => {
       ],
       [
         "<p>upweight the sycophantic <code>A</code>/<code>B</code> token</p>",
-        "<p>upweight the sycophantic <code>A</code> / <code>B</code> token</p>",
+        `<p>upweight the sycophantic <code>A</code> ${SLASH_GAP_SPAN} <code>B</code> token</p>`,
       ],
       [
         "<p>the <code>A</code>/<code>B</code> token</p>",
-        "<p>the <code>A</code> / <code>B</code> token</p>",
+        `<p>the <code>A</code> ${SLASH_GAP_SPAN} <code>B</code> token</p>`,
       ],
       // Asymmetric: only the left side is a skipped-element boundary. The
       // captured leftSpace must stay outside the marker (i.e. the trailing
@@ -264,7 +269,7 @@ describe("HTMLFormattingImprovement", () => {
       // node — otherwise the rendered output reads "of the<code>unknown</code>".
       [
         "<p>volumetric properties of the <code>unknown</code>/non-<code>unknown</code> portions.</p>",
-        "<p>volumetric properties of the <code>unknown</code> / non-<code>unknown</code> portions.</p>",
+        `<p>volumetric properties of the <code>unknown</code> ${SLASH_GAP_SPAN} non-<code>unknown</code> portions.</p>`,
       ],
     ])(
       "should add spaces around '/' even near other HTML tags: %s",
@@ -306,9 +311,17 @@ describe("HTMLFormattingImprovement", () => {
     it("still transforms <a> text when it differs from href", () => {
       const inputElement = '<p><a href="https://example.com/abc">dog/cat</a></p>'
       const processedHtml = testHtmlFormattingImprovement(inputElement)
+      // Slash spacing runs on link text, but the kern span is skipped inside a
+      // link so the underline runs through the slash unbroken.
       expect(normalizeNbsp(processedHtml)).toBe(
         '<p><a href="https://example.com/abc">dog / cat</a></p>',
       )
+    })
+
+    it("does not wrap a spaced slash authored inside <code>", () => {
+      const inputElement = "<p><code>cat / dog</code></p>"
+      const processedHtml = testHtmlFormattingImprovement(inputElement)
+      expect(normalizeNbsp(processedHtml)).toBe(inputElement)
     })
   })
 
@@ -318,10 +331,16 @@ describe("HTMLFormattingImprovement", () => {
     // bound insertions into different nodes (v5.1+), so the build no longer
     // aborts with "Two pure insertions at the same offset ... ambiguous".
     it.each([
-      ["<p>a/<em></em>/b</p>", "<p>a / <em></em> / b</p>"],
-      ["<p><em>x/</em>/y</p>", "<p><em>x /</em> / y</p>"],
-      ["<p><em>a/</em><em>/b</em></p>", "<p><em>a /</em><em>/ b</em></p>"],
-      ["<p>a/<strong></strong>/b</p>", "<p>a / <strong></strong> / b</p>"],
+      ["<p>a/<em></em>/b</p>", `<p>a ${SLASH_GAP_SPAN} <em></em> ${SLASH_GAP_SPAN} b</p>`],
+      ["<p><em>x/</em>/y</p>", `<p><em>x ${SLASH_GAP_SPAN}</em> ${SLASH_GAP_SPAN} y</p>`],
+      [
+        "<p><em>a/</em><em>/b</em></p>",
+        `<p><em>a ${SLASH_GAP_SPAN}</em><em>${SLASH_GAP_SPAN} b</em></p>`,
+      ],
+      [
+        "<p>a/<strong></strong>/b</p>",
+        `<p>a ${SLASH_GAP_SPAN} <strong></strong> ${SLASH_GAP_SPAN} b</p>`,
+      ],
     ])("does not crash on %s", (input: string, expected: string) => {
       expect(normalizeNbsp(testHtmlFormattingImprovement(input))).toBe(expected)
     })

--- a/quartz/plugins/transformers/tests/utils.test.ts
+++ b/quartz/plugins/transformers/tests/utils.test.ts
@@ -15,6 +15,7 @@ import {
   type ReplaceFnResult,
   replaceRegex,
   shouldCapitalizeNodeText,
+  wrapCharsInSpan,
 } from "../utils"
 
 const acceptAll = () => false
@@ -360,6 +361,61 @@ describe("gatherTextBeforeIndex", () => {
     },
   ])("should handle $description", ({ parent, index, expected }) => {
     expect(gatherTextBeforeIndex(parent, index)).toBe(expected)
+  })
+})
+
+describe("wrapCharsInSpan", () => {
+  const span = (ch: string): Element => ({
+    type: "element",
+    tagName: "span",
+    properties: { className: ["kern"] },
+    children: [{ type: "text", value: ch }],
+  })
+
+  it("lifts a mid-node character into its own span, splitting the text", () => {
+    const node: Text = { type: "text", value: "a / b" }
+    const parent: Element = { type: "element", tagName: "p", properties: {}, children: [node] }
+    wrapCharsInSpan(parent, node, [2], "kern")
+    expect(parent.children).toEqual([
+      { type: "text", value: "a " },
+      span("/"),
+      { type: "text", value: " b" },
+    ])
+  })
+
+  it("wraps multiple characters in one pass, ascending offsets", () => {
+    const node: Text = { type: "text", value: "a / b / c" }
+    const parent: Element = { type: "element", tagName: "p", properties: {}, children: [node] }
+    wrapCharsInSpan(parent, node, [2, 6], "kern")
+    expect(parent.children).toEqual([
+      { type: "text", value: "a " },
+      span("/"),
+      { type: "text", value: " b " },
+      span("/"),
+      { type: "text", value: " c" },
+    ])
+  })
+
+  it("emits no leading or trailing text when the char is the whole node", () => {
+    const node: Text = { type: "text", value: "/" }
+    const parent: Element = { type: "element", tagName: "p", properties: {}, children: [node] }
+    wrapCharsInSpan(parent, node, [0], "kern")
+    expect(parent.children).toEqual([span("/")])
+  })
+
+  it("is a no-op when offsets is empty", () => {
+    const node: Text = { type: "text", value: "a / b" }
+    const parent: Element = { type: "element", tagName: "p", properties: {}, children: [node] }
+    wrapCharsInSpan(parent, node, [], "kern")
+    expect(parent.children).toEqual([node])
+  })
+
+  it("is a no-op when the text node is not a child of the parent", () => {
+    const node: Text = { type: "text", value: "a / b" }
+    const other: Text = { type: "text", value: "elsewhere" }
+    const parent: Element = { type: "element", tagName: "p", properties: {}, children: [other] }
+    wrapCharsInSpan(parent, node, [2], "kern")
+    expect(parent.children).toEqual([other])
   })
 })
 

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -313,7 +313,7 @@ export function wrapCharsInSpan(
   offsets: readonly number[],
   className: string,
 ): void {
-  const nodeIndex = parent.children.indexOf(textNode as unknown as ElementContent)
+  const nodeIndex = parent.children.indexOf(textNode)
   if (nodeIndex === -1 || offsets.length === 0) return
 
   const { value } = textNode

--- a/quartz/plugins/transformers/utils.ts
+++ b/quartz/plugins/transformers/utils.ts
@@ -298,6 +298,45 @@ export function spliceAndWrapLastChars(
   return createNowrapSpan(lastChars, elementToWrap)
 }
 
+/**
+ * Lift the characters at `offsets` out of `textNode` (a child of `parent`),
+ * each into its own `<span class={className}>`, splitting the surrounding text
+ * around them. Lets CSS hang a per-glyph kerning margin on a single character
+ * without altering the document's text content (so find-in-page is unaffected).
+ *
+ * `offsets` must be ascending and in range; an empty list or a detached node is
+ * a no-op.
+ */
+export function wrapCharsInSpan(
+  parent: Parent,
+  textNode: Text,
+  offsets: readonly number[],
+  className: string,
+): void {
+  const nodeIndex = parent.children.indexOf(textNode as unknown as ElementContent)
+  if (nodeIndex === -1 || offsets.length === 0) return
+
+  const { value } = textNode
+  const replacement: ElementContent[] = []
+  let cursor = 0
+  for (const offset of offsets) {
+    if (offset > cursor) {
+      replacement.push({ type: "text", value: value.slice(cursor, offset) })
+    }
+    replacement.push({
+      type: "element",
+      tagName: "span",
+      properties: { className: [className] },
+      children: [{ type: "text", value: value.charAt(offset) }],
+    })
+    cursor = offset + 1
+  }
+  if (cursor < value.length) {
+    replacement.push({ type: "text", value: value.slice(cursor) })
+  }
+  parent.children.splice(nodeIndex, 1, ...replacement)
+}
+
 // Does node have a class that includes the given className?
 export function hasClass(node: Element, className: string): boolean {
   // Check both className and class properties (hastscript uses class)

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -360,7 +360,7 @@ article[data-use-dropcap="true"] > p:first-of-type .small-caps {
 // (headings and subtitles run larger). The margin is inert at a line end, so a
 // slash that wraps to a line start stays flush.
 .slash-gap-after {
-  margin-right: 0.1em;
+  margin-right: 0.125em;
 }
 
 /* Set monospace font for code blocks, inline code, etc. */

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -354,6 +354,15 @@ article[data-use-dropcap="true"] > p:first-of-type .small-caps {
   margin-right: calc(0.25 * $base-margin);
 }
 
+// A separator slash ("cat / dog") leans forward, crowding the glyph after it,
+// so an equal space reads as tight on the right. This margin opens the right
+// side to match the optical left gap. Set in em so it tracks the font size
+// (headings and subtitles run larger). The margin is inert at a line end, so a
+// slash that wraps to a line start stays flush.
+.slash-gap-after {
+  margin-right: 0.1em;
+}
+
 /* Set monospace font for code blocks, inline code, etc. */
 code,
 pre {

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -715,6 +715,7 @@ The NATO alliance met in the USA. SMALLCAPS "capitalization" should be similar t
 | In context | the staff(s) called if’d a “buff” (Wolf) |
 | In context | (Jeff) met (John) in (July) about the (JSON) API |
 | In context | the clipping (probably) happened (just) quickly |
+| separator slash + glyph | cat / dog / DoD / Write / Avenue / Total / Value / other |
 
 ## Numbers and units
 


### PR DESCRIPTION
## Summary

Add optical kerning for separator slashes by wrapping spaced slashes in a `<span class="slash-gap-after">` with a right-side margin. The forward lean of "/" crowds the following glyph, so equal spacing reads as tight on the right; a CSS margin opens the right side without inserting a character (preserving find-in-page functionality).

## Changes

- **New utility function `wrapCharsInSpan()`** in `utils.ts`: lifts characters at specified offsets out of a text node into individual `<span>` elements, splitting surrounding text. Enables per-glyph kerning without altering document text content.

- **New transformer `kernSpacedSlashes()`** in `formatting_improvement_html.ts`: identifies separator slashes (flanked by whitespace on both sides within their text node), skips those in links (to keep underlines unbroken) and skip elements like `<code>`, and wraps them with the new utility.

- **CSS styling** in `fonts.scss`: `.slash-gap-after { margin-right: 0.1em; }` opens the right gap optionally at font size (headings/subtitles scale automatically). Margin is inert at line ends.

- **Refactored `spaceSmallcapsAfterOpenBracket()`** in `tagSmallcaps.ts`: now uses `wrapCharsInSpan()` instead of inline splicing logic, reducing duplication.

- **Comprehensive test coverage**: 
  - Unit tests for `wrapCharsInSpan()` covering mid-node splits, multiple characters, edge cases (whole node, empty offsets, detached nodes)
  - Integration tests in `formatting_improvement_html.test.ts` verifying slash kerning in various contexts (inline elements, code blocks, links, asymmetric boundaries)
  - Test helper `withSlashGaps()` to normalize expected output

## Implementation details

- Offsets must be ascending and in range; empty offset list or detached node is a no-op
- Slashes inside `<a>` tags are skipped so underlines run unbroken
- Slashes in skip elements (e.g., `<code>`) are never wrapped
- Only slashes with whitespace (space or NBSP) on both sides within the same text node are considered separators—URL and fraction slashes remain unspaced and never match

https://claude.ai/code/session_016fyqkitTRStz7NQ4scowZj