### PR TITLE
fix(navbar): make paused video timestamp restore buffer-aware

### DIFF
--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -133,8 +133,12 @@ function restorePausedTimestamp(
     videoElement
       .play()
       .then(() => videoElement.pause())
-      .catch(() => {
-        // AbortError is expected if pause() races with play() — harmless
+      .catch((error: Error) => {
+        // AbortError is expected when pause() interrupts the play() request;
+        // anything else is a real playback failure worth surfacing.
+        if (error.name !== "AbortError") {
+          console.debug("[restorePausedTimestamp] Nudge play failed:", error)
+        }
       })
   }
 

--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -84,6 +84,46 @@ function handleVideoToggle(): void {
   }
 }
 
+// A seek is close enough when the playhead lands within this many seconds of
+// the target. Kept under the 0.5s tolerance the timestamp tests assert.
+const SEEK_LANDING_TOLERANCE_S = 0.4
+
+function isTimestampBuffered(videoElement: HTMLVideoElement, target: number): boolean {
+  const { buffered } = videoElement
+  for (let i = 0; i < buffered.length; i++) {
+    if (buffered.start(i) <= target && target <= buffered.end(i)) return true
+  }
+  return false
+}
+
+// WebKit clamps a seek past the buffered range back to 0 and fires `seeked` as
+// if it succeeded, and a paused video may not apply currentTime until a
+// play/pause cycle nudges it through the decode pipeline. On a fresh reload the
+// saved position is often not buffered yet, so seek only once the buffer reaches
+// it, then nudge — re-checking as the buffer fills until the playhead lands.
+function restorePausedTimestamp(
+  videoElement: HTMLVideoElement,
+  target: number,
+  signal: AbortSignal,
+): void {
+  const applySeek = () => {
+    if (Math.abs(videoElement.currentTime - target) <= SEEK_LANDING_TOLERANCE_S) return
+    if (!isTimestampBuffered(videoElement, target)) return
+    videoElement.currentTime = target
+    videoElement
+      .play()
+      .then(() => videoElement.pause())
+      .catch(() => {
+        // AbortError is expected if pause() races with play() — harmless
+      })
+  }
+
+  videoElement.addEventListener("progress", applySeek, { signal })
+  videoElement.addEventListener("canplay", applySeek, { signal })
+  videoElement.addEventListener("seeked", applySeek, { signal })
+  applySeek()
+}
+
 function setupPondVideo(): void {
   // Clean up listeners from previous invocations to prevent accumulation
   if (pondVideoCleanupController) {
@@ -111,25 +151,17 @@ function setupPondVideo(): void {
   const restoreVideoState = () => {
     console.debug("[restoreVideoState] Running, readyState:", videoElement.readyState)
 
-    // Restore timestamp first (safe while paused)
-    if (savedTime) {
-      videoElement.currentTime = parseFloat(savedTime)
-    }
-
-    // Then start playback if autoplay enabled
     if (autoplayEnabled) {
+      // Restore timestamp first (safe while paused), then resume playback.
+      if (savedTime) {
+        videoElement.currentTime = parseFloat(savedTime)
+      }
       playVideoWithWatchdog(videoElement)
     } else if (savedTime && parseFloat(savedTime) > 0) {
-      // Safari/WebKit may not apply currentTime on paused videos reliably.
-      // A brief play/pause cycle forces the seek through the video pipeline.
-      // Only do this for non-zero timestamps — seeking to 0 doesn't need the
-      // workaround and would briefly advance the video (breaking visual tests).
-      videoElement
-        .play()
-        .then(() => videoElement.pause())
-        .catch(() => {
-          // AbortError is expected if pause() races with play() — harmless
-        })
+      // Seeking to 0 doesn't need the buffer-aware restore and would briefly
+      // advance the video (breaking visual tests), so only restore non-zero
+      // positions.
+      restorePausedTimestamp(videoElement, parseFloat(savedTime), signal)
     }
   }
 

--- a/quartz/components/scripts/navbar.inline.ts
+++ b/quartz/components/scripts/navbar.inline.ts
@@ -87,6 +87,9 @@ function handleVideoToggle(): void {
 // A seek is close enough when the playhead lands within this many seconds of
 // the target. Kept under the 0.5s tolerance the timestamp tests assert.
 const SEEK_LANDING_TOLERANCE_S = 0.4
+// WebKit can report a buffered range covering the target yet still clamp the
+// applied seek, so the retry loop is bounded rather than trusting the buffer.
+const MAX_SEEK_ATTEMPTS = 5
 
 function isTimestampBuffered(videoElement: HTMLVideoElement, target: number): boolean {
   const { buffered } = videoElement
@@ -96,19 +99,36 @@ function isTimestampBuffered(videoElement: HTMLVideoElement, target: number): bo
   return false
 }
 
-// WebKit clamps a seek past the buffered range back to 0 and fires `seeked` as
-// if it succeeded, and a paused video may not apply currentTime until a
-// play/pause cycle nudges it through the decode pipeline. On a fresh reload the
-// saved position is often not buffered yet, so seek only once the buffer reaches
-// it, then nudge — re-checking as the buffer fills until the playhead lands.
+function seekLanded(videoElement: HTMLVideoElement, target: number): boolean {
+  return Math.abs(videoElement.currentTime - target) <= SEEK_LANDING_TOLERANCE_S
+}
+
+// Browsers that honor an in-buffer seek land immediately and leave the video
+// paused on the restored frame — no playback, so visual snapshots stay stable.
+// WebKit instead clamps a seek past the buffered range back to 0 and only
+// applies a paused seek after a play/pause nudge, so retry as the buffer fills.
+// A dedicated controller stops the retries the moment the playhead lands, so a
+// later autoplay or loop restart can't drag it back to the restored position.
 function restorePausedTimestamp(
   videoElement: HTMLVideoElement,
   target: number,
-  signal: AbortSignal,
+  parentSignal: AbortSignal,
 ): void {
+  videoElement.currentTime = target
+  if (seekLanded(videoElement, target)) return
+
+  const controller = new AbortController()
+  const { signal } = controller
+  parentSignal.addEventListener("abort", () => controller.abort(), { once: true, signal })
+
+  let attempts = 0
   const applySeek = () => {
-    if (Math.abs(videoElement.currentTime - target) <= SEEK_LANDING_TOLERANCE_S) return
+    if (seekLanded(videoElement, target) || attempts >= MAX_SEEK_ATTEMPTS) {
+      controller.abort()
+      return
+    }
     if (!isTimestampBuffered(videoElement, target)) return
+    attempts += 1
     videoElement.currentTime = target
     videoElement
       .play()
@@ -121,7 +141,12 @@ function restorePausedTimestamp(
   videoElement.addEventListener("progress", applySeek, { signal })
   videoElement.addEventListener("canplay", applySeek, { signal })
   videoElement.addEventListener("seeked", applySeek, { signal })
-  applySeek()
+
+  // A paused, autoplay-off video may stall at HAVE_METADATA without buffering to
+  // the target; force loading so the events above can fire.
+  if (videoElement.networkState !== HTMLMediaElement.NETWORK_LOADING) {
+    videoElement.load()
+  }
 }
 
 function setupPondVideo(): void {


### PR DESCRIPTION
## Summary

- The "Video timestamp is preserved during refresh" Playwright test was intermittently timing out on Desktop Safari (WebKit), failing the `playwright-tests-macos` shard.
- Root cause is production restore logic, not the test: on a full page reload the pond video's buffer resets, and the restore seeked to the saved timestamp (~2.5s) exactly once. When that position wasn't buffered yet, WebKit clamps the seek back to 0 and fires `seeked` as if it succeeded, so the playhead never reached the saved position — and the one-shot restore never retried, so the test's 45s wait timed out.
- The paused-timestamp restore is now buffer-aware and deterministic, so this race can no longer make the test hang.

## Changes

All in `quartz/components/scripts/navbar.inline.ts`:

- Added `isTimestampBuffered`, `seekLanded`, and `restorePausedTimestamp` helpers. Restore now:
  - seeks directly first and returns if it lands, so the already-buffered case (Chromium/Firefox) restores with **no** play/pause playback and the video stays strictly paused on the restored frame (keeps visual snapshots stable);
  - otherwise re-applies the seek as the buffer fills (`progress`/`canplay`/`seeked`), nudging the paused video through WebKit's decode pipeline until the playhead lands within tolerance;
  - stops its retry listeners via a dedicated `AbortController` the moment the playhead lands, so a later autoplay or loop restart can't drag the video back to the restored position;
  - bounds the retries (`MAX_SEEK_ATTEMPTS`) so a buffer that reports coverage while WebKit still clamps the seek can't spin indefinitely;
  - forces `load()` when the video has stalled at `HAVE_METADATA` without buffering to the target (guarded on `networkState` so it can't double-load an in-flight loader).
- Restructured `restoreVideoState` so the autoplay branch keeps its immediate seek-then-play behavior and the paused branch delegates to the buffer-aware helper.
- The restore nudge now logs non-`AbortError` play failures instead of swallowing every rejection.

## Testing

- `pnpm check` (tsc), eslint, and prettier pass for the changed file.
- The fix mirrors the "wait for the target to be buffered before seeking" pattern the test's own setup helper already relies on, applying it to the production restore path. The SPA-navigation restore path is unaffected: it preserves the live video element (and its `currentTime`) across DOM morphs, so only a full refresh resets the buffer.
- No timeouts, poll budgets, or test expectations were changed.

## Lessons learned

- **What**: When fixing a flaky Playwright media test, check whether the flake exposes a real production bug rather than patching the test. Here the test correctly asserted a behavior the production restore couldn't reliably deliver on WebKit; the durable fix was in the client code, not the test.
- **Where**: general test-triage discipline.
- **Why**: Raising the test timeout or loosening the assertion would have hidden a genuine user-facing bug (paused video failing to restore its position after refresh on Safari).
