### PR TITLE
feat: make the nightly drift sentinel classification deterministic

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -332,6 +332,7 @@ jobs:
       # the deploy. Merged-PR approvals reach this step with the discovered
       # post-merge main run once the coverage gate above has passed.
       - name: Mark visual-testing passing + retrigger deploy on main
+        id: mark-main
         if: success() && (steps.resolve.outputs.pr_number == '' || steps.cover.outputs.covered == 'true')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -345,6 +346,9 @@ jobs:
               run_id: runId,
             });
             const headSha = original.data.head_sha;
+            // The nightly drift sentinel diffs this commit against main HEAD to
+            // classify its snapshot diffs as environment drift vs. code change.
+            core.setOutput('head_sha', headSha);
             const detailsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const nowIso = new Date().toISOString();
             await github.rest.checks.create({
@@ -439,6 +443,20 @@ jobs:
               `Re-running verify-test-results job ${verifyJob.id} ` +
               `(part of deploy run ${deploy.id})`
             );
+
+      # Record the main commit these baselines are now authoritative for, so
+      # the nightly drift sentinel can deterministically tell environment drift
+      # from a real code change. Only main-run and merged-PR-carry-through
+      # approvals reach here with a head_sha (open-PR approvals don't touch
+      # main), so the recorded SHA is always a commit on main.
+      - name: Record baseline provenance
+        if: steps.mark-main.outputs.head_sha != ''
+        env:
+          HEAD_SHA: ${{ steps.mark-main.outputs.head_sha }}
+          ACCESS_KEY_ID_TURNTROUT_MEDIA: ${{ secrets.ACCESS_KEY_ID_TURNTROUT_MEDIA }}
+          SECRET_ACCESS_TURNTROUT_MEDIA: ${{ secrets.SECRET_ACCESS_TURNTROUT_MEDIA }}
+          S3_ENDPOINT_ID_TURNTROUT_MEDIA: ${{ secrets.S3_ENDPOINT_ID_TURNTROUT_MEDIA }}
+        run: uv run python scripts/visual_drift.py write-provenance --sha "$HEAD_SHA"
 
       - name: Comment success on PR
         if: success() && steps.resolve.outputs.pr_number != ''

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -487,7 +487,12 @@ jobs:
             if [ -n "$sha" ]; then
               args+=(--provenance-sha "$sha")
               if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
-                mapfile -t paths < <(uv run python scripts/visual_drift.py render-paths)
+                # Capture via command substitution (not process substitution)
+                # so a render-paths crash aborts the step under `set -e` rather
+                # than leaving `paths` empty — an empty pathspec would diff ALL
+                # paths and mislabel unrelated changes as rendering-relevant.
+                paths_output="$(uv run python scripts/visual_drift.py render-paths)"
+                mapfile -t paths <<< "$paths_output"
                 git diff --name-only "$sha" HEAD -- "${paths[@]}" > changed-paths.txt
                 args+=(--changed-paths-file changed-paths.txt)
               else

--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -424,6 +424,9 @@ jobs:
         timeout-minutes: 5
         with:
           persist-credentials: false
+          # Full history so the nightly sentinel can diff the recorded
+          # baseline-approval commit against main HEAD (see the provenance step).
+          fetch-depth: 0
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env
@@ -457,6 +460,13 @@ jobs:
       # aggregate-visual-results already downloaded and parsed every shard's
       # `environment=` provenance line into its `environments` output; reuse
       # it here instead of re-downloading the same status artifacts.
+      #
+      # On the nightly schedule the note states the drift verdict
+      # deterministically: it reads the R2-recorded baseline-approval commit
+      # and diffs it against main HEAD over the rendering-relevant paths. No
+      # change there → the diffs are provably environment drift; a change →
+      # some diffs may be code, not drift. Falls back to a hedge when no
+      # provenance is recorded or the approving commit can't be resolved.
       - name: Compose gallery provenance note
         id: provenance
         env:
@@ -465,15 +475,27 @@ jobs:
           # pull_request event is the synthetic `<N>/merge` ref instead.
           REF_NAME: ${{ github.head_ref || github.ref_name }}
           ENVIRONMENTS: ${{ needs.aggregate-visual-results.outputs.environments }}
+          ACCESS_KEY_ID_TURNTROUT_MEDIA: ${{ secrets.ACCESS_KEY_ID_TURNTROUT_MEDIA }}
+          SECRET_ACCESS_TURNTROUT_MEDIA: ${{ secrets.SECRET_ACCESS_TURNTROUT_MEDIA }}
+          S3_ENDPOINT_ID_TURNTROUT_MEDIA: ${{ secrets.S3_ENDPOINT_ID_TURNTROUT_MEDIA }}
         run: |
           set -euo pipefail
-          note="trigger: ${EVENT_NAME} on ${REF_NAME}"
+          args=(--event-name "$EVENT_NAME" --ref-name "$REF_NAME"
+                --environments "$ENVIRONMENTS")
           if [ "$EVENT_NAME" = "schedule" ]; then
-            note="nightly drift sentinel (diffs below are usually environment drift, unless main changed since the last baseline approval) · ${note}"
+            sha="$(uv run python scripts/visual_drift.py read-provenance)"
+            if [ -n "$sha" ]; then
+              args+=(--provenance-sha "$sha")
+              if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+                mapfile -t paths < <(uv run python scripts/visual_drift.py render-paths)
+                git diff --name-only "$sha" HEAD -- "${paths[@]}" > changed-paths.txt
+                args+=(--changed-paths-file changed-paths.txt)
+              else
+                args+=(--changed-unknown)
+              fi
+            fi
           fi
-          if [ -n "$ENVIRONMENTS" ]; then
-            note="${note} · ${ENVIRONMENTS}"
-          fi
+          note="$(uv run python scripts/visual_drift.py compose-note "${args[@]}")"
           echo "note=${note}" >> "$GITHUB_OUTPUT"
 
       # Build a single-page screenshot gallery alongside the Playwright

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -58,6 +58,13 @@ def rclone(args: Sequence[str], config_path: Path) -> None:
     subprocess.run(cmd, check=True)
 
 
+def rclone_output(args: Sequence[str], config_path: Path) -> str:
+    """Run ``rclone`` and return its captured stdout, raising on failure."""
+    cmd = ["rclone", f"--config={config_path}", *args]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return result.stdout
+
+
 @contextlib.contextmanager
 def rclone_config() -> Iterator[Path]:
     """Yield the path to a freshly-written, temporary rclone config."""

--- a/scripts/tests/test_r2_sync.py
+++ b/scripts/tests/test_r2_sync.py
@@ -49,6 +49,22 @@ def test_rclone_invokes_subprocess(tmp_path: Path) -> None:
     )
 
 
+def test_rclone_output_returns_stdout(tmp_path: Path) -> None:
+    cfg = tmp_path / "rclone.conf"
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="hello\n", stderr=""
+    )
+    with mock.patch.object(subprocess, "run", return_value=completed) as run:
+        out = r2_sync.rclone_output(["cat", "r2:bucket/obj"], cfg)
+    assert out == "hello\n"
+    run.assert_called_once_with(
+        ["rclone", f"--config={cfg}", "cat", "r2:bucket/obj"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_rclone_config_context_manager(env_vars: None) -> None:
     with r2_sync.rclone_config() as config:
         assert config.exists()

--- a/scripts/tests/test_visual_drift.py
+++ b/scripts/tests/test_visual_drift.py
@@ -1,0 +1,302 @@
+"""Tests for scripts/visual_drift.py."""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scripts import visual_drift
+
+
+@contextlib.contextmanager
+def _fake_config() -> Iterator[Path]:
+    yield Path("/tmp/rclone.conf")
+
+
+# --- compose_note (pure) ----------------------------------------------------
+
+
+def test_compose_note_non_schedule_has_no_sentinel_prefix() -> None:
+    note = visual_drift.compose_note(
+        event_name="push",
+        ref_name="main",
+        environments="linux: pinned",
+        provenance_sha=None,
+        changed_paths=None,
+    )
+    assert note == "trigger: push on main · linux: pinned"
+    assert "sentinel" not in note
+
+
+def test_compose_note_non_schedule_without_environments() -> None:
+    note = visual_drift.compose_note(
+        event_name="pull_request",
+        ref_name="my-branch",
+        environments="",
+        provenance_sha="abc",
+        changed_paths=[],
+    )
+    assert note == "trigger: pull_request on my-branch"
+
+
+def test_compose_note_schedule_no_provenance_hedges() -> None:
+    note = visual_drift.compose_note(
+        event_name="schedule",
+        ref_name="main",
+        environments="",
+        provenance_sha=None,
+        changed_paths=None,
+    )
+    assert "no baseline-approval provenance recorded yet" in note
+    assert note.endswith("trigger: schedule on main")
+
+
+def test_compose_note_schedule_unresolved_commit_hedges() -> None:
+    note = visual_drift.compose_note(
+        event_name="schedule",
+        ref_name="main",
+        environments="linux: pinned",
+        provenance_sha="deadbeefcafe",
+        changed_paths=None,
+    )
+    assert "couldn't resolve the baseline-approval commit deadbeef" in note
+    assert note.endswith("· linux: pinned")
+
+
+def test_compose_note_schedule_no_change_is_deterministic_drift() -> None:
+    note = visual_drift.compose_note(
+        event_name="schedule",
+        ref_name="main",
+        environments="",
+        provenance_sha="deadbeefcafe1234",
+        changed_paths=[],
+    )
+    assert "main is unchanged in rendering-relevant paths" in note
+    assert "approved at deadbeef" in note
+    assert "every diff below is environment drift" in note
+
+
+def test_compose_note_schedule_single_change_singular_wording() -> None:
+    note = visual_drift.compose_note(
+        event_name="schedule",
+        ref_name="main",
+        environments="",
+        provenance_sha="deadbeefcafe1234",
+        changed_paths=["quartz/foo.ts"],
+    )
+    assert "1 rendering-relevant file," in note
+    assert "e.g. quartz/foo.ts" in note
+    assert "may be code changes" in note
+
+
+def test_compose_note_schedule_multiple_changes_plural_wording() -> None:
+    note = visual_drift.compose_note(
+        event_name="schedule",
+        ref_name="main",
+        environments="macos",
+        provenance_sha="deadbeefcafe1234",
+        changed_paths=["website_content/a.md", "quartz/b.ts"],
+    )
+    assert "2 rendering-relevant files," in note
+    assert "e.g. website_content/a.md" in note
+    assert note.endswith("· macos")
+
+
+# --- read_provenance_sha ----------------------------------------------------
+
+
+def test_read_provenance_sha_success() -> None:
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(
+            visual_drift.r2_sync,
+            "rclone_output",
+            return_value='{"sha": "abc123"}',
+        ),
+    ):
+        assert visual_drift.read_provenance_sha() == "abc123"
+
+
+def test_read_provenance_sha_missing_object_returns_none(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    err = subprocess.CalledProcessError(1, ["rclone"])
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(
+            visual_drift.r2_sync, "rclone_output", side_effect=err
+        ),
+    ):
+        assert visual_drift.read_provenance_sha() is None
+    assert "hedge" in capsys.readouterr().err
+
+
+def test_read_provenance_sha_malformed_json_returns_none(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(
+            visual_drift.r2_sync, "rclone_output", return_value="not json"
+        ),
+    ):
+        assert visual_drift.read_provenance_sha() is None
+    assert "malformed" in capsys.readouterr().err
+
+
+def test_read_provenance_sha_non_object_json_returns_none() -> None:
+    # A bare JSON array has no .get -> AttributeError branch.
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(
+            visual_drift.r2_sync, "rclone_output", return_value="[1, 2]"
+        ),
+    ):
+        assert visual_drift.read_provenance_sha() is None
+
+
+@pytest.mark.parametrize("raw", ['{"sha": ""}', '{"sha": 5}', "{}"])
+def test_read_provenance_sha_bad_sha_returns_none(
+    raw: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(
+            visual_drift.r2_sync, "rclone_output", return_value=raw
+        ),
+    ):
+        assert visual_drift.read_provenance_sha() is None
+    assert "no 'sha'" in capsys.readouterr().err
+
+
+# --- write_provenance_sha ---------------------------------------------------
+
+
+def test_write_provenance_sha_uploads_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        mock.patch.object(visual_drift.r2_sync, "rclone_config", _fake_config),
+        mock.patch.object(visual_drift.r2_sync, "rclone") as rclone,
+    ):
+        visual_drift.write_provenance_sha("abc123")
+    args, _ = rclone.call_args
+    argv, _config = args
+    assert argv[0] == "copyto"
+    assert argv[2] == visual_drift._remote_object()
+    written = Path(argv[1])
+    # File is cleaned up after the temp dir closes; assert on the call shape.
+    assert written.name == "provenance.json"
+    assert "Recorded baseline provenance: abc123" in capsys.readouterr().out
+
+
+def test_write_provenance_sha_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="empty provenance"):
+        visual_drift.write_provenance_sha("")
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_read_provenance_prints_sha(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with mock.patch.object(
+        visual_drift, "read_provenance_sha", return_value="abc123"
+    ):
+        visual_drift.main(["read-provenance"])
+    assert capsys.readouterr().out == "abc123\n"
+
+
+def test_cli_read_provenance_prints_nothing_when_absent(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with mock.patch.object(
+        visual_drift, "read_provenance_sha", return_value=None
+    ):
+        visual_drift.main(["read-provenance"])
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_write_provenance_delegates() -> None:
+    with mock.patch.object(visual_drift, "write_provenance_sha") as write:
+        visual_drift.main(["write-provenance", "--sha", "abc123"])
+    write.assert_called_once_with("abc123")
+
+
+def test_cli_render_paths_prints_all(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    visual_drift.main(["render-paths"])
+    out = capsys.readouterr().out.splitlines()
+    assert out == list(visual_drift.RENDERING_RELEVANT_PATHS)
+
+
+def test_cli_compose_note_with_changed_file(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    changed = tmp_path / "changed.txt"
+    changed.write_text(
+        "quartz/a.ts\n\nwebsite_content/b.md\n", encoding="utf-8"
+    )
+    visual_drift.main(
+        [
+            "compose-note",
+            "--event-name",
+            "schedule",
+            "--ref-name",
+            "main",
+            "--provenance-sha",
+            "deadbeefcafe",
+            "--changed-paths-file",
+            str(changed),
+        ]
+    )
+    out = capsys.readouterr().out
+    # Blank lines are dropped -> two real paths.
+    assert "2 rendering-relevant files," in out
+
+
+def test_cli_compose_note_changed_unknown_overrides_file(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    changed = tmp_path / "changed.txt"
+    changed.write_text("quartz/a.ts\n", encoding="utf-8")
+    visual_drift.main(
+        [
+            "compose-note",
+            "--event-name",
+            "schedule",
+            "--ref-name",
+            "main",
+            "--provenance-sha",
+            "deadbeefcafe",
+            "--changed-paths-file",
+            str(changed),
+            "--changed-unknown",
+        ]
+    )
+    assert "couldn't resolve" in capsys.readouterr().out
+
+
+def test_cli_compose_note_no_provenance(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    visual_drift.main(
+        [
+            "compose-note",
+            "--event-name",
+            "schedule",
+            "--ref-name",
+            "main",
+        ]
+    )
+    assert (
+        "no baseline-approval provenance recorded yet"
+        in capsys.readouterr().out
+    )

--- a/scripts/visual_drift.py
+++ b/scripts/visual_drift.py
@@ -96,11 +96,13 @@ def write_provenance_sha(sha: str) -> None:
     if not sha:
         raise ValueError("Refusing to write empty provenance SHA")
     payload = json.dumps({"sha": sha}) + "\n"
-    with r2_sync.rclone_config() as config:
-        with tempfile.TemporaryDirectory() as tmp:
-            local = Path(tmp) / "provenance.json"
-            local.write_text(payload, encoding="utf-8")
-            r2_sync.rclone(["copyto", str(local), _remote_object()], config)
+    with (
+        r2_sync.rclone_config() as config,
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        local = Path(tmp) / "provenance.json"
+        local.write_text(payload, encoding="utf-8")
+        r2_sync.rclone(["copyto", str(local), _remote_object()], config)
     print(f"Recorded baseline provenance: {sha}")
 
 

--- a/scripts/visual_drift.py
+++ b/scripts/visual_drift.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Deterministic drift classification for the nightly visual-testing sentinel.
+
+The nightly (``schedule``) visual-testing run re-renders ``main`` against the
+R2 baselines. Whether a snapshot diff it reports is *environment drift* (runner
+image or browser rotation) or a *real code change* is a deterministic fact: it
+depends only on whether ``main``'s rendering-relevant source moved since the
+baselines were last approved.
+
+This module owns:
+
+  * the R2 provenance object (``visual-baselines/.provenance.json``) that records
+    the ``main`` commit the current baselines were approved against, and
+  * composition of the gallery provenance note shown under the diff-gallery
+    header, which states the drift verdict without hedging when provenance is
+    available.
+
+The provenance SHA is written by ``update-visual-baselines.yaml`` each time an
+approval makes the baselines authoritative for a ``main`` commit, and read by
+``visual-testing.yaml`` when it composes the sentinel note.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+try:
+    from . import r2_baselines, r2_sync
+except ImportError:  # pragma: no cover - script-style invocation
+    import r2_baselines
+    import r2_sync
+
+# Object holding the approving commit, stored next to the baselines in R2.
+PROVENANCE_KEY = f"{r2_baselines.R2_PREFIX}/.provenance.json"
+
+# Paths whose changes can move rendered pixels. Kept in sync with the
+# ``should-run`` ci-gate filter in ``.github/workflows/visual-testing.yaml``;
+# the sentinel diffs the approving commit against ``main`` HEAD over exactly
+# these paths to decide drift-vs-code.
+RENDERING_RELEVANT_PATHS: tuple[str, ...] = (
+    "quartz",
+    "website_content",
+    "config/quartz",
+    "config/constants.json",
+    "config/playwright",
+    "tests/visual-baselines",
+    "package.json",
+    "pnpm-lock.yaml",
+    ".github/actions",
+)
+
+
+def _remote_object() -> str:
+    return f"r2:{r2_sync.R2_BUCKET}/{PROVENANCE_KEY}"
+
+
+def read_provenance_sha() -> str | None:
+    """
+    Return the recorded approving commit SHA, or ``None`` when no provenance
+    object exists yet (or it can't be read/parsed).
+
+    A missing or unreadable object is not fatal: the sentinel degrades to its
+    hedged note rather than failing the run. The reason is logged to stderr.
+    """
+    with r2_sync.rclone_config() as config:
+        try:
+            raw = r2_sync.rclone_output(["cat", _remote_object()], config)
+        except subprocess.CalledProcessError:
+            print(
+                "No baseline provenance object in R2 (or it was unreadable); "
+                "the sentinel note will hedge.",
+                file=sys.stderr,
+            )
+            return None
+    try:
+        sha = json.loads(raw).get("sha")
+    except (json.JSONDecodeError, AttributeError):
+        print("Baseline provenance object is malformed JSON.", file=sys.stderr)
+        return None
+    if not isinstance(sha, str) or not sha:
+        print("Baseline provenance object has no 'sha'.", file=sys.stderr)
+        return None
+    return sha
+
+
+def write_provenance_sha(sha: str) -> None:
+    """Record ``sha`` as the commit the current baselines were approved
+    against."""
+    if not sha:
+        raise ValueError("Refusing to write empty provenance SHA")
+    payload = json.dumps({"sha": sha}) + "\n"
+    with r2_sync.rclone_config() as config:
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "provenance.json"
+            local.write_text(payload, encoding="utf-8")
+            r2_sync.rclone(["copyto", str(local), _remote_object()], config)
+    print(f"Recorded baseline provenance: {sha}")
+
+
+def _sentinel_prefix(
+    provenance_sha: str | None,
+    changed_paths: Sequence[str] | None,
+) -> str:
+    """Build the drift verdict shown before the trigger line on nightly runs."""
+    if provenance_sha is None:
+        return (
+            "nightly drift sentinel (no baseline-approval provenance recorded "
+            "yet; diffs below are environment drift unless main changed since "
+            "the last approval)"
+        )
+    short = provenance_sha[:8]
+    if changed_paths is None:
+        return (
+            "nightly drift sentinel (couldn't resolve the baseline-approval "
+            f"commit {short} in history; diffs below are environment drift "
+            "unless main changed since the last approval)"
+        )
+    if not changed_paths:
+        return (
+            "nightly drift sentinel · main is unchanged in rendering-relevant "
+            f"paths since baselines were approved at {short} — every diff "
+            "below is environment drift, not a code change"
+        )
+    count = len(changed_paths)
+    plural = "" if count == 1 else "s"
+    return (
+        "nightly drift sentinel · main changed since baselines were approved "
+        f"at {short} ({count} rendering-relevant file{plural}, e.g. "
+        f"{changed_paths[0]}) — some diffs below may be code changes, not drift"
+    )
+
+
+def compose_note(
+    *,
+    event_name: str,
+    ref_name: str,
+    environments: str,
+    provenance_sha: str | None,
+    changed_paths: Sequence[str] | None,
+) -> str:
+    """
+    Build the gallery provenance note.
+
+    ``changed_paths`` is the rendering-relevant diff between the approving
+    commit and ``main`` HEAD: an empty sequence means "determined: nothing
+    changed", while ``None`` means "couldn't determine" (no provenance, or the
+    commit wasn't resolvable). On non-``schedule`` triggers the sentinel prefix
+    is omitted entirely.
+    """
+    note = f"trigger: {event_name} on {ref_name}"
+    if event_name == "schedule":
+        note = f"{_sentinel_prefix(provenance_sha, changed_paths)} · {note}"
+    if environments:
+        note = f"{note} · {environments}"
+    return note
+
+
+def _cmd_read_provenance(_args: argparse.Namespace) -> None:
+    sha = read_provenance_sha()
+    if sha:
+        print(sha)
+
+
+def _cmd_write_provenance(args: argparse.Namespace) -> None:
+    write_provenance_sha(args.sha)
+
+
+def _cmd_render_paths(_args: argparse.Namespace) -> None:
+    for path in RENDERING_RELEVANT_PATHS:
+        print(path)
+
+
+def _cmd_compose_note(args: argparse.Namespace) -> None:
+    if args.changed_unknown:
+        changed_paths: list[str] | None = None
+    elif args.changed_paths_file is not None:
+        text = Path(args.changed_paths_file).read_text(encoding="utf-8")
+        changed_paths = [line for line in text.splitlines() if line]
+    else:
+        changed_paths = None
+    print(
+        compose_note(
+            event_name=args.event_name,
+            ref_name=args.ref_name,
+            environments=args.environments,
+            provenance_sha=args.provenance_sha or None,
+            changed_paths=changed_paths,
+        )
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    read_p = sub.add_parser(
+        "read-provenance",
+        help="Print the recorded approving commit SHA (empty line if none).",
+    )
+    read_p.set_defaults(func=_cmd_read_provenance)
+
+    write_p = sub.add_parser(
+        "write-provenance",
+        help="Record the commit the current baselines were approved against.",
+    )
+    write_p.add_argument("--sha", required=True)
+    write_p.set_defaults(func=_cmd_write_provenance)
+
+    paths_p = sub.add_parser(
+        "render-paths",
+        help="Print the rendering-relevant path list, one per line.",
+    )
+    paths_p.set_defaults(func=_cmd_render_paths)
+
+    note_p = sub.add_parser(
+        "compose-note", help="Compose the gallery provenance note."
+    )
+    note_p.add_argument("--event-name", required=True)
+    note_p.add_argument("--ref-name", required=True)
+    note_p.add_argument("--environments", default="")
+    note_p.add_argument("--provenance-sha", default="")
+    note_p.add_argument(
+        "--changed-paths-file",
+        default=None,
+        help="File of newline-separated changed paths (empty file = no "
+        "rendering-relevant change).",
+    )
+    note_p.add_argument(
+        "--changed-unknown",
+        action="store_true",
+        help="Mark the diff as undeterminable (overrides --changed-paths-file).",
+    )
+    note_p.set_defaults(func=_cmd_compose_note)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary

- The nightly (`schedule`) visual-testing sentinel re-renders `main` against the R2 baselines, then labelled every snapshot diff with a hedge: *"diffs below are usually environment drift, unless main changed since the last baseline approval."* Whether main changed since the last approval is a **deterministic** fact, so the sentinel shouldn't have to guess.
- This records the approving `main` commit to R2 and has the sentinel diff it against `main` HEAD over the rendering-relevant paths, replacing the hedge with a definite verdict.

## Changes

- **`scripts/visual_drift.py`** (new): owns the R2 provenance object (`visual-baselines/.provenance.json`, recording the `main` commit the current baselines were approved against) and composition of the gallery note. `compose-note` states the verdict deterministically:
  - no rendering-relevant change since approval → *"every diff below is environment drift, not a code change"*
  - main moved → *"main changed since baselines approved at &lt;short-sha&gt; (N rendering-relevant files…) — some diffs may be code changes"*
  - falls back to the old hedge only when no provenance is recorded yet or the approving commit can't be resolved in history.
- **`.github/workflows/update-visual-baselines.yaml`**: after an approval becomes authoritative for a `main` commit (main-run or merged-PR carry-through), writes that commit's SHA to R2 as the new provenance. Open-PR approvals don't touch `main`, so the recorded SHA is always a `main` commit → always an ancestor of the nightly HEAD.
- **`.github/workflows/visual-testing.yaml`**: the "Compose gallery provenance note" step now reads the provenance SHA, diffs it against `main` HEAD over the rendering-relevant paths (canonical list owned by `visual_drift.py render-paths`, kept in sync with the `should-run` ci-gate filter), and calls `compose-note`. The `publish-visual-report` checkout gains `fetch-depth: 0` so the ancestor commit resolves. `render-paths` is captured via command substitution so a crash aborts the step rather than silently diffing all paths.
- **`scripts/r2_sync.py`**: added `rclone_output()` to capture stdout (for reading the small provenance object).

The hedge already only appeared on `schedule` runs — a merge-into-`main` (a `push` event) never showed it — so this only changes the nightly message.

## Testing

- New `scripts/tests/test_visual_drift.py` covers `compose_note` (every branch: non-schedule, no-provenance, unresolved-commit, no-change, single/plural change), `read_provenance_sha` (success, missing object, malformed JSON, non-object JSON, bad/empty SHA), `write_provenance_sha`, and the CLI subcommands. 100% line coverage on the new module.
- `test_r2_sync.py` covers the new `rclone_output`.
- `uv run ruff format` / `ruff check` / `pylint` clean.