### PR TITLE
fix(tweets): exempt embedded tweets from typography transforms

### DIFF
--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -187,6 +187,10 @@ describe("buildTweetCard", () => {
     expect(render(buildTweetCard(baseSnapshot))).toContain('aria-label="View post on X"')
   })
 
+  it("marks the card no-formatting so typography passes leave the quote verbatim", () => {
+    expect(render(buildTweetCard(baseSnapshot))).toContain('class="tweet-card no-formatting"')
+  })
+
   it("shows the verified badge only when verified", () => {
     expect(render(buildTweetCard(baseSnapshot))).toContain("tweet-verified")
     const unverified = { ...baseSnapshot, author: { ...baseSnapshot.author, verified: false } }

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -414,7 +414,17 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
   // TweetEmbed runs after the global Twemoji pass, so the card's text (names,
   // body, quoted text) is built too late to be picked up. Twemojify it here so
   // emoji in a tweet render as inline images like the rest of the site.
-  const article = h("article", { className: "tweet-card", "data-tweet-id": snapshot.id }, children)
+  //
+  // `no-formatting` exempts the card from HTMLFormattingImprovement (which runs
+  // later in the pipeline): a tweet is a verbatim quote of someone else's words,
+  // so the site's typography rewrites must not touch it. Without this, slash
+  // spacing pads the slashes in a shortened display URL ("futureoflife.org /
+  // open-letter / le…") and other passes would silently alter the quoted text.
+  const article = h(
+    "article",
+    { className: "tweet-card no-formatting", "data-tweet-id": snapshot.id },
+    children,
+  )
   return processTree(article) as Element
 }
 


### PR DESCRIPTION
## Summary

On [why-i-left-google-deepmind](https://turntrout.com/why-i-left-google-deepmind), the shortened display URL inside an embedded tweet rendered with padded slashes — `futureoflife.org / open-letter / le…` — because the tweet card's text was being run through `HTMLFormattingImprovement`'s slash-spacing pass like ordinary prose.

A tweet card is a **verbatim quote** of someone else's words, so none of the site's typography rewrites (slash spacing, curly quotes, dash gluing, a.m./p.m. normalization, `github`→`GitHub`, …) should touch it. I mark the card element `no-formatting`, the existing skip class honored by every pass in `formatting_improvement_html.ts` (via `toSkip`), so the whole card subtree — body, names, quoted tweet — is left as authored.

### Why this class and not a narrower fix

The pipeline already protects link text from slash mangling via `shouldSkipLinkUrlText`, but only when the visible text equals the `href`. Tweet display URLs are shortened (visible `futureoflife.org/open-letter/le…` ≠ expanded `href`), so they slip through. Rather than special-casing that one pass, `no-formatting` matches the semantics: the embed is a quote, not our prose.

### Elsewhere

Ordinary blockquotes still receive full typography transforms — they're not treated as verbatim. The only prior verbatim exemptions are `code`/`pre`, the `no-formatting`/`elvish`/`bad-handwriting` classes, footnote refs, and URL-text links. Tweet embeds now join the `no-formatting` set because they reproduce external content exactly.

## Changes

- `quartz/plugins/transformers/tweetCard.ts`: add `no-formatting` to the `article.tweet-card` class list, with a comment explaining the verbatim-quote rationale.
- `quartz/plugins/transformers/tests/tweetCard.test.ts`: assert the card carries `no-formatting`.

## Testing

- `tweetCard.test.ts` and `tweetEmbed.test.ts` pass (110 tests). The `no-formatting` skip behavior itself is already covered by `formatting_improvement_html.test.ts`.
- Verified on the PR preview: the tweet URL now renders `futureoflife.org/open-letter/le…` with unspaced slashes.
