### PR TITLE
fix: let monospace arrows inherit link color

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -1820,6 +1820,7 @@ maximizers
 maxmin
 MaxPool2D
 maxpools
+Mayrhofer
 Mazeika
 MC1
 MC2
@@ -2530,6 +2531,7 @@ relatedly
 RELU
 ReLU
 ReLUs
+René
 renegotiations
 renormalized
 renormalizing

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -1168,6 +1168,18 @@ test.describe("Link color states", () => {
       })
     })
   }
+
+  test("monospace arrow inside a link inherits the link color", async ({ page }) => {
+    const arrowLink = page.locator("a:has(.monospace-arrow)").first()
+    await arrowLink.scrollIntoViewIfNeeded()
+    await expect(arrowLink).toBeVisible()
+
+    const arrow = arrowLink.locator(".monospace-arrow").first()
+    const linkColor = await arrowLink.evaluate((el) => getComputedStyle(el).color)
+    const arrowColor = await arrow.evaluate((el) => getComputedStyle(el).color)
+
+    expect(arrowColor).toEqual(linkColor)
+  })
 })
 
 test.describe("List alignment", () => {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1029,7 +1029,6 @@ iframe {
 // EG ← looks better in FiraCode
 .monospace-arrow {
   font-family: var(--font-monospace);
-  color: var(--foreground);
 }
 
 // Specific graph in design doc has too much whitespace in light

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -636,9 +636,9 @@ Your company is trying to make and then supply the best AI in the world to a mil
 
 That looks a damn lot like "support the development of lethal autonomous weapons" to me.
 
-What should a pledge-signer do? I see three honest options: explain publicly how staying is consistent with the pledge, say plainly that you no longer hold it and why, or quit.[^rene] Wearing the pledge while saying nothing isn't one of them.
+What should a pledge-signer do? I see three honest options: explain publicly how staying is consistent with the pledge, say plainly that you no longer hold it and why, or quit.[^rene-mayrhofer] Wearing the pledge while saying nothing isn't one of them.
 
-[^rene]: I know of exactly one other person who left over the deal: René Mayrhofer, a director for Android platform security. "Management has lost its moral compass", [he stated](https://www.businessinsider.com/google-director-resigned-pentagon-ai-deal-military-artificial-intelligence-gemini-2026-6). He apparently will serve his notice period from mid-June until August. Brave.
+[^rene-mayrhofer]: I know of exactly one other person who left over the deal: René Mayrhofer, a director for Android platform security. "Management has lost its moral compass", [he stated](https://www.businessinsider.com/google-director-resigned-pentagon-ai-deal-military-artificial-intelligence-gemini-2026-6). He apparently will serve his notice period from mid-June until August. Brave.
 
 ### Keeping a seat at the table
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -607,6 +607,8 @@ Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium dolor
 
 -> and --> should be EB Garamond, but ←, ↑, ↓, and ↗ should be Fira Code.
 
+A [link with a → arrow](https://npmjs.com) should color the arrow like the rest of the link.
+
 # Math
 
 Inline math: $e^{i\pi} + 1 = 0$.


### PR DESCRIPTION
## What

Unicode arrows (`←→↑↓↗↘↖↙`) are wrapped in `<span class="monospace-arrow">` by `wrapUnicodeArrowsWithMonospaceStyle`. That class hardcoded `color: var(--foreground)`, which is a **no-op in body prose** (body text is already `--foreground`) but **overrode the inherited link color** whenever an arrow appeared inside a link — rendering it in dark body-text color instead of the link blue.

Reported on [/disagreements-with-list-of-lethalities](https://turntrout.com/some-of-my-disagreements-with-list-of-lethalities): the `→` in the linked phrase `(evolution) → (human values)` rendered dark while the surrounding link text was blue.

## Change

- Drop the `color: var(--foreground)` declaration from `.monospace-arrow` (`quartz/styles/custom.scss`). The `font-family` (FiraCode) and `vertical-align` are kept. Arrows now inherit their context color: link color inside links, body color in prose (unchanged there).
- Add a `→`-in-a-link example to the `# Arrows` section of `test-page.md` so visual regression captures the corrected coloring.
- Add a focused test in "Link color states" asserting a `.monospace-arrow` inside a link has the same computed color as its enclosing link.

## Scope check

Swept all SCSS for other inline span classes emitted by the transformers that hardcode a text `color` and could land inside link text (small-caps, ordinals, fractions, dates, version numbers, highlights, favicons). None of the automatically-emitted spans set a text color, so no other instance of this bug exists in the transformer path. Two author-applied classes (`.dropcap` → `var(--foreground)`, `.gold-script` → `var(--gold)`) share the same structure but aren't emitted into links automatically; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK66T8TfGexm6274H2GEko)_