### PR TITLE
fix: stop mobile prose baseline wobble from subpixel text rendering

### DIFF
--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -108,7 +108,7 @@ jobs:
             public/research.html \
             public/Test-page.html \
             public/posts.html \
-            --formats woff2 --in-place --instance --inline-css --no-recursive --debug
+            --formats woff2 --in-place --instance --inline-css --font-display block --no-recursive --debug
 
       - name: Install Wrangler
         # Local install (not -g): the deploy step below invokes it via

--- a/.github/workflows/preview-audits.yaml
+++ b/.github/workflows/preview-audits.yaml
@@ -108,7 +108,14 @@ jobs:
             public/research.html \
             public/Test-page.html \
             public/posts.html \
-            --formats woff2 --in-place --instance --inline-css --font-display block --no-recursive --debug
+            --formats woff2 --in-place --instance --inline-css --no-recursive --debug
+          ./scripts/block_katex_font_display.sh \
+            public/index.html \
+            public/design.html \
+            public/about.html \
+            public/research.html \
+            public/Test-page.html \
+            public/posts.html
 
       - name: Install Wrangler
         # Local install (not -g): the deploy step below invokes it via

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -36,8 +36,8 @@
   // Engine-default text rendering: fractional horizontal advances with
   // vertically grid-fit (hinted) glyphs. Vertical grid-fitting keeps every
   // glyph on a shared, stable baseline, which matters most for small prose on
-  // high-DPR mobile screens. Kerning and ligatures are enabled explicitly on
-  // the body, independent of this property.
+  // high-DPR mobile screens. Ligatures are enabled explicitly on the body,
+  // independent of this property.
   text-rendering: auto;
 }
 
@@ -185,11 +185,6 @@ body {
     "liga" 1,
     "cv11" 1;
   font-variant-numeric: oldstyle-nums;
-
-  // Pin kerning on explicitly: engines vary in which kern behavior each
-  // text-rendering value implies, and EB Garamond's kern pairs (AV, Wa, To…)
-  // only apply when the feature is affirmatively enabled.
-  font-kerning: normal;
 
   // Code should contain full-height numbers
   & code,

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -33,11 +33,13 @@
     font-size: round(nearest, var(--base-font-size), 1px);
   }
 
-  // Snap glyphs to the pixel grid. geometricPrecision/optimizeLegibility put
-  // Blink into subpixel glyph positioning, which rounds each glyph's vertical
-  // position independently; on high-DPR mobile that reads as a wobbling
-  // baseline in prose. Ligatures and kerning stay on via the body's explicit
-  // font-feature-settings, so they don't depend on this property.
+  // Body prose snaps to the pixel grid. geometricPrecision/optimizeLegibility
+  // put Blink into subpixel glyph positioning, whose independent per-glyph
+  // rounding surfaces as a wobbling baseline in small prose on high-DPR mobile.
+  // Kerning and ligatures are preserved explicitly on the body (font-kerning +
+  // font-feature-settings), so they don't depend on this hint; large display
+  // type opts back into precision below, where subpixel positioning is
+  // imperceptible.
   text-rendering: optimizespeed;
 }
 
@@ -57,6 +59,10 @@ h6,
   margin-bottom: 1rem;
   font-weight: 500;
   line-height: 1.15;
+
+  // Display type is large enough that subpixel positioning doesn't wobble, so
+  // opt back into geometric precision for its smoother, fractional kerning.
+  text-rendering: geometricprecision;
 }
 
 $heading-sizes: (
@@ -180,6 +186,11 @@ body {
     "liga" 1,
     "cv11" 1;
   font-variant-numeric: oldstyle-nums;
+
+  // Keep kerning independent of text-rendering: the root uses optimizeSpeed to
+  // stop the mobile baseline wobble, and optimizeSpeed would otherwise drop
+  // kerning. This restores it without reintroducing subpixel positioning.
+  font-kerning: normal;
 
   // Code should contain full-height numbers
   & code,

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -33,14 +33,12 @@
     font-size: round(nearest, var(--base-font-size), 1px);
   }
 
-  // Body prose snaps to the pixel grid. geometricPrecision/optimizeLegibility
-  // put Blink into subpixel glyph positioning, whose independent per-glyph
-  // rounding surfaces as a wobbling baseline in small prose on high-DPR mobile.
-  // Kerning and ligatures are preserved explicitly on the body (font-kerning +
-  // font-feature-settings), so they don't depend on this hint; large display
-  // type opts back into precision below, where subpixel positioning is
-  // imperceptible.
-  text-rendering: optimizespeed;
+  // Engine-default text rendering: fractional horizontal advances with
+  // vertically grid-fit (hinted) glyphs. Vertical grid-fitting keeps every
+  // glyph on a shared, stable baseline, which matters most for small prose on
+  // high-DPR mobile screens. Kerning and ligatures are enabled explicitly on
+  // the body, independent of this property.
+  text-rendering: auto;
 }
 
 h1,
@@ -60,8 +58,9 @@ h6,
   font-weight: 500;
   line-height: 1.15;
 
-  // Display type is large enough that subpixel positioning doesn't wobble, so
-  // opt back into geometric precision for its smoother, fractional kerning.
+  // Display type is large enough that unhinted, linear-metric rasterization
+  // stays baseline-stable, and it preserves the face's drawn proportions at
+  // scale.
   text-rendering: geometricprecision;
 }
 
@@ -187,9 +186,9 @@ body {
     "cv11" 1;
   font-variant-numeric: oldstyle-nums;
 
-  // Keep kerning independent of text-rendering: the root uses optimizeSpeed to
-  // stop the mobile baseline wobble, and optimizeSpeed would otherwise drop
-  // kerning. This restores it without reintroducing subpixel positioning.
+  // Pin kerning on explicitly: engines vary in which kern behavior each
+  // text-rendering value implies, and EB Garamond's kern pairs (AV, Wa, To…)
+  // only apply when the feature is affirmatively enabled.
   font-kerning: normal;
 
   // Code should contain full-height numbers

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -33,7 +33,12 @@
     font-size: round(nearest, var(--base-font-size), 1px);
   }
 
-  text-rendering: geometricprecision;
+  // Snap glyphs to the pixel grid. geometricPrecision/optimizeLegibility put
+  // Blink into subpixel glyph positioning, which rounds each glyph's vertical
+  // position independently; on high-DPR mobile that reads as a wobbling
+  // baseline in prose. Ligatures and kerning stay on via the body's explicit
+  // font-feature-settings, so they don't depend on this property.
+  text-rendering: optimizespeed;
 }
 
 h1,

--- a/scripts/block_katex_font_display.sh
+++ b/scripts/block_katex_font_display.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Scope font-display: block to KaTeX @font-face rules in built HTML.
+#
+# subfont injects font-display: swap into every @font-face it inlines. Prose
+# keeps swap (text paints instantly in the fallback serif on cold caches), but
+# math waits for the real font: KaTeX rendered in a fallback face is
+# unpositioned unicode soup, not merely off-brand type. subfont's
+# --font-display flag is global, so the split is applied here instead.
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <html files...>" >&2
+  exit 1
+fi
+
+perl -0777 -pi -e '
+  s{(\@font-face\{[^{}]*KaTeX[^{}]*\})}{
+    my $rule = $1;
+    $rule =~ s/font-display\s*:\s*swap/font-display:block/g;
+    $rule;
+  }ge;
+' "$@"

--- a/scripts/subfont.sh
+++ b/scripts/subfont.sh
@@ -15,7 +15,10 @@ echo "Subsetting fonts in $num_files files"
 # pushed past the previous 6GB cap (mark-compact OOM at ~6.0/6.2GB).
 # Note: this fork only emits woff2 and doesn't support font instancing, so
 # shellcheck disable=SC2086
-NODE_OPTIONS="--max-old-space-size=12288" pnpm exec subfont --root public/ $html_files --in-place --inline-css --no-recursive --debug
+# font-display: block — first paint waits (≤3s) for the preloaded subsets, so
+# text never renders in a fallback face on a cold cache. Math is the acute
+# case: KaTeX in a fallback font is unpositioned unicode soup.
+NODE_OPTIONS="--max-old-space-size=12288" pnpm exec subfont --root public/ $html_files --in-place --inline-css --font-display block --no-recursive --debug
 
 # Refresh config/font_stats.md from the just-emitted subset woff2s so the
 # design page picks up current sizes on the next build.

--- a/scripts/subfont.sh
+++ b/scripts/subfont.sh
@@ -15,10 +15,13 @@ echo "Subsetting fonts in $num_files files"
 # pushed past the previous 6GB cap (mark-compact OOM at ~6.0/6.2GB).
 # Note: this fork only emits woff2 and doesn't support font instancing, so
 # shellcheck disable=SC2086
-# font-display: block — first paint waits (≤3s) for the preloaded subsets, so
-# text never renders in a fallback face on a cold cache. Math is the acute
-# case: KaTeX in a fallback font is unpositioned unicode soup.
-NODE_OPTIONS="--max-old-space-size=12288" pnpm exec subfont --root public/ $html_files --in-place --inline-css --font-display block --no-recursive --debug
+# Prose keeps subfont's default font-display: swap (instant paint in the
+# fallback serif on cold caches); KaTeX faces are switched to block afterward,
+# since math in a fallback font is illegible rather than merely off-brand.
+NODE_OPTIONS="--max-old-space-size=12288" pnpm exec subfont --root public/ $html_files --in-place --inline-css --no-recursive --debug
+
+# shellcheck disable=SC2086
+./scripts/block_katex_font_display.sh $html_files
 
 # Refresh config/font_stats.md from the just-emitted subset woff2s so the
 # design page picks up current sizes on the next build.


### PR DESCRIPTION
## What

Two first-load font-rendering fixes in one theme: text should look right the first time a page paints.

**1. Mobile baseline wobble** — `quartz/styles/fonts.scss`:
- `:root` prose → `text-rendering: auto` (engine default: fractional horizontal advances + vertically grid-fit glyphs).
- headings (`h1`–`.h6`) → keep `text-rendering: geometricPrecision` (unhinted linear-metric rendering is baseline-stable at display sizes).

**2. Cold-cache unicode-math flash** — `scripts/subfont.sh`, `scripts/block_katex_font_display.sh` (new), `.github/workflows/preview-audits.yaml`:
- subfont injects `font-display: swap` into every inlined `@font-face`, which painted first-visit math in fallback fonts as raw, unpositioned unicode until the KaTeX subsets arrived. A post-pass now rewrites only the KaTeX `@font-face` rules to `font-display: block`: math waits (bounded ~3s, typically ~200ms since the subsets are preloaded) for the real font, while prose keeps `swap`'s instant paint. Applied in both the main build and the Lighthouse audit path so CI measures what production ships.

## Why (wobble)

On mobile, EB Garamond body prose rendered with a subtly wobbling baseline — individual glyphs nudged up/down by a device pixel or two — while desktop looked fine.

`geometricPrecision`'s distinguishing payload is **disabling vertical grid-fitting (hinting) in exchange for linear metrics**. Unhinted glyphs rasterized at fractional device-pixel baselines lose the shared alignment zones that keep x-height letters visually level; at small sizes on mobile FreeType platforms that surfaces as a bouncing baseline. Desktop rasterization (larger glyphs, different platform font params) hides it.

There is no `text-rendering` value that explicitly requests "fractional horizontal + hinted vertical" — but that combination is exactly what `auto` delivers on modern engines (e.g. FreeType "slight" hinting on Android: vertical-only grid fit, horizontal advances stay linear). So `auto` keeps spacing geometrically fluid *and* baselines stable.

## Measurements

Controlled comparisons in headless Chromium (FreeType — same rasterizer family as Android Chrome), using the site's EB Garamond woff2 at 18px:

- **Shaping is identical across `geometricPrecision` / `optimizeSpeed` / `auto`** with the site's config: identical DOM layout widths (303.734px for a 38-char probe string) and identical screenshot ink widths at DPR 3. Current Blink retains fractional advances under every value (repeated-glyph advance mean 29.32 device px, std 0.11px in all modes) — MDN's "optimizeSpeed disables kerning/ligatures, geometricPrecision changes spacing" describes legacy semantics that Blink no longer implements positionally. Desktop rendering is therefore unchanged by this PR.
- **`font-kerning` is irrelevant for this font**: `fontTools` inspection shows the font's GPOS `kern` feature contains only bracket/punctuation pairs (`(J`, `T)`, `),` …) and contextual rules — no letter-letter pairs exist, and engines apply kerning by default anyway. An earlier revision of this PR added `font-kerning: normal` based on a screenshot ink-extent measurement (−4 device px) that direct DOM layout-width measurement disproved; the override was removed as a no-op. (Control validating the harness: with the fallback system serif, `font-kerning: none` widens the probe by 16.8px — the pipeline detects kerning when it exists.)
- The wobble itself does not reproduce on desktop-class renderers under any `text-rendering` value, consistent with it being a platform hinting behavior. On-device verification: compare production against the PR preview (`pr-1645.turntrout.pages.dev`) on a phone.
- The KaTeX post-pass was verified against deployed production HTML: 12/12 KaTeX `@font-face` rules switch to `block`, all 15 non-KaTeX rules keep `swap`.

## Why (font-display)

Production HTML inspection: subfont inlines the `@font-face` CSS and preloads the per-family subset woff2s, but the font *bytes* are still network fetches, and every inlined face carried `font-display: swap` (subfont's default) — including the KaTeX faces, whose upstream CSS intentionally omits `font-display` (≈ `block`). So the flash was a subfont-injected downgrade.

Scoping decisions: a global `--font-display block` was tried first and rejected — hiding all text until fonts arrive reads as a flash of invisible content on cold caches. Math-only block is the right split because fallback-rendered math is *illegible*, not merely off-brand, while fallback prose is perfectly readable during the swap window. `optional` was rejected (commits to the fallback face on slow loads); inlining font bytes as data URIs was rejected (fork doesn't support it; would add ~120–160 KB to every page and defeat cross-page subset caching).

## Scope / review note

The `text-rendering` change affects rasterization on platforms where hinting differs (mobile) and churns visual-regression baselines on CI renderers; the diff gallery shows the expected signature (glyph-level antialiasing changes, zero layout movement) and the snapshot diffs are yours to approve. The `font-display` change affects only cold-cache first paint (CI screenshots wait for font load, so baselines don't move from it).

## Lessons learned

- `text-rendering` effects are engine- **and platform-**specific; MDN's descriptions reflect legacy semantics. Current Blink shows zero shaping/positioning difference between values on desktop, while the mobile wobble comes from `geometricPrecision` disabling vertical hinting. The "fractional horizontal + hinted vertical" hybrid cannot be requested explicitly in CSS — it is what `auto` already does on modern engines. Reserve `geometricPrecision` for large display type.
- Measure layout effects with DOM layout widths (`getBoundingClientRect`), not screenshot ink extents — antialiased ink edges add ±1–2px noise per edge, enough to fabricate a "finding." Validate the probe with a positive control (an effect known to exist) and a negative control before trusting a delta, and `await document.fonts.load(...)` for the specific face — `document.fonts.ready` can resolve before any element has triggered the webfont, silently measuring the fallback font.
- Before attributing a typographic effect to CSS, check the font file itself (`fontTools`): EB Garamond 08 ships no letter-pair kerning, so `font-kerning` toggles can't affect prose regardless of CSS.
- Tools that rewrite `@font-face` (subfont, font pipelines) can silently override upstream `font-display` intent; when debugging FOUT/FOIT, inspect the *deployed* CSS, not the source CSS.
- `font-display` deserves per-family policy, not a global one: block for content that is illegible in fallback (math, icon fonts), swap for content that is readable in fallback (prose). A global value optimizes the wrong thing on one side or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)