### PR TITLE
fix: build after-article subscription nodes fresh per page

### DIFF
--- a/quartz/plugins/transformers/afterArticle.ts
+++ b/quartz/plugins/transformers/afterArticle.ts
@@ -9,49 +9,56 @@ import { type QuartzPluginData } from "../vfile"
 import { createSequenceLinksComponent } from "./sequenceLinks"
 import { troutContainerId } from "./trout_hr"
 
-const newsletterElement = h("a", { href: "https://turntrout.substack.com/subscribe" }, [
-  "newsletter",
-])
+// These elements are built fresh for every page: later HTML plugins (e.g.
+// InlineCodeSpacing, Favicons) mutate the tree in place, so a node shared
+// across pages would accumulate one page's edits into every other page.
+function createSubscriptionElement(): Element {
+  const newsletterElement = h("a", { href: "https://turntrout.substack.com/subscribe" }, [
+    "newsletter",
+  ])
 
-// Absolute production URL so preview/dev deploys point subscribers at the
-// canonical feed instead of their own draft-laden rss.xml.
-export const rssElement = h("a", { href: "https://turntrout.com/rss.xml", id: "rss-link" }, [
-  h("abbr", { class: "small-caps" }, "rss"),
-])
-// NBSPs glue "newsletter & rss" into one line-break atom so narrow viewports
-// wrap before "newsletter" instead of stranding "& rss" on its own line.
-const subscriptionElement = h("div", { className: "centered" }, [
-  h(
-    "div",
-    h("p", [
-      "Find out when I post more content: ",
-      newsletterElement,
-      `${NBSP}&${NBSP}`,
-      rssElement,
+  // Absolute production URL so preview/dev deploys point subscribers at the
+  // canonical feed instead of their own draft-laden rss.xml.
+  const rssElement = h("a", { href: "https://turntrout.com/rss.xml", id: "rss-link" }, [
+    h("abbr", { class: "small-caps" }, "rss"),
+  ])
+  // NBSPs glue "newsletter & rss" into one line-break atom so narrow viewports
+  // wrap before "newsletter" instead of stranding "& rss" on its own line.
+  return h("div", { className: "centered" }, [
+    h(
+      "div",
+      h("p", [
+        "Find out when I post more content: ",
+        newsletterElement,
+        `${NBSP}&${NBSP}`,
+        rssElement,
+      ]),
+    ),
+  ])
+}
+
+function createContactElement(): Element {
+  const mailLink = h("a", { href: "mailto:alex@turntrout.com" }, ["alex@turntrout.com"])
+
+  const pgpLink = h(
+    "a",
+    {
+      href: "https://keys.openpgp.org/search?q=alex%40turntrout.com",
+      rel: EXTERNAL_LINK_REL,
+      target: "_blank",
+    },
+    [h("abbr", { className: "small-caps" }, "pgp")],
+  )
+  return h("div", [
+    h("div", { className: "centered" }, [
+      "Thoughts? Email me at ",
+      h("code", {}, [mailLink]),
+      " (",
+      pgpLink,
+      ")",
     ]),
-  ),
-])
-
-const mailLink = h("a", { href: "mailto:alex@turntrout.com" }, ["alex@turntrout.com"])
-
-const pgpLink = h(
-  "a",
-  {
-    href: "https://keys.openpgp.org/search?q=alex%40turntrout.com",
-    rel: EXTERNAL_LINK_REL,
-    target: "_blank",
-  },
-  [h("abbr", { className: "small-caps" }, "pgp")],
-)
-const contactMe = h("div", [
-  h("div", { className: "centered" }, [
-    "Thoughts? Email me at ",
-    h("code", {}, [mailLink]),
-    " (",
-    pgpLink,
-    ")",
-  ]),
-])
+  ])
+}
 
 /**
  * Inserts components after the ornament node (trout container) in the tree
@@ -83,7 +90,12 @@ function afterArticleTransform(tree: Root, file: VFile) {
 
   // If frontmatter doesn't say to avoid it
   if (!file.data.frontmatter?.hideSubscriptionLinks) {
-    components.push(h("div", { id: "subscription-and-contact" }, [subscriptionElement, contactMe]))
+    components.push(
+      h("div", { id: "subscription-and-contact" }, [
+        createSubscriptionElement(),
+        createContactElement(),
+      ]),
+    )
   }
 
   const sequenceLinksComponent = createSequenceLinksComponent(file.data as QuartzPluginData)

--- a/quartz/plugins/transformers/tests/afterArticle.test.ts
+++ b/quartz/plugins/transformers/tests/afterArticle.test.ts
@@ -180,6 +180,23 @@ describe("AfterArticle plugin", () => {
       expect((mockTree.children[0] as Element).properties?.id).toBe("some-other-div")
     })
 
+    it("should build fresh subscription nodes per page so later plugins can mutate them safely", () => {
+      const firstTree = createMockTree()
+      const secondTree = createMockTree([createOrnamentNode()])
+
+      transformer(firstTree, createMockFile())
+      transformer(secondTree, createMockFile())
+
+      const firstSubscription = expectAfterArticleComponentsAdded(firstTree, 1)
+        .children[0] as Element
+      const secondSubscription = (secondTree.children[1] as Element).children[0] as Element
+
+      expect(firstSubscription).toEqual(secondSubscription)
+      expect(firstSubscription).not.toBe(secondSubscription)
+      expect(firstSubscription.children[0]).not.toBe(secondSubscription.children[0])
+      expect(firstSubscription.children[1]).not.toBe(secondSubscription.children[1])
+    })
+
     it("should call createSequenceLinksComponent with file data", () => {
       // This test verifies the function is called and works with real sequence data
       const mockTree = createMockTree()


### PR DESCRIPTION
## Summary

- The contact line under articles rendered with a wide gap before the email address ("Email me at    alex@turntrout.com"). The live HTML contained 22 consecutive hair spaces (U+200A) between "at" and the `<code>` element.
- Root cause: `afterArticle.ts` built the subscription/contact block as module-level hast constants, so every page's tree contained the *same* node objects. Mutating HTML plugins — `InlineCodeSpacing` appends a hair space to the word before inline code, `Favicons` appends icon spans to links — edited those shared nodes once per processed page, accumulating one hair space per page into the shared text node.

## Changes

- `quartz/plugins/transformers/afterArticle.ts`: replaced the module-level `subscriptionElement` / `contactMe` constants with `createSubscriptionElement()` / `createContactElement()` factories invoked per page, so each page gets its own nodes to mutate.
- `quartz/plugins/transformers/tests/afterArticle.test.ts`: added a regression test asserting the subscription components inserted into two different trees are structurally equal but not the same object references.

## Testing

- `jest quartz/plugins/transformers/tests/afterArticle.test.ts` — 10/10 pass, including the new regression test.
- `tsc --noEmit` — clean.

## Lessons Learned

- **What**: Never insert module-level hast/AST constant nodes into per-file trees in a unified/rehype pipeline; use factory functions (or deep-clone) so each file owns its nodes.
- **Where**: Any transformer that injects prebuilt elements into per-page trees (here `quartz/plugins/transformers/afterArticle.ts`).
- **Why**: Downstream plugins mutate trees in place; a shared node accumulates every page's edits (here, one U+200A hair space per page baked into the site-wide contact line).

---
_Generated by [Claude Code](https://claude.ai/code/session_019V6cp68FxFY9CssEiaWA2c)_