### PR TITLE
ci: fix visual-baseline drift root causes and approval reliability

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -136,6 +136,7 @@ jobs:
             ./all-blob-reports --staging-dir "$STAGING_DIR"
 
       - name: Push empty commit to retrigger visual-testing (open-PR runs only)
+        id: retrigger
         if: steps.resolve.outputs.pr_number != '' && steps.resolve.outputs.merged != 'true'
         env:
           REF: ${{ steps.resolve.outputs.ref }}
@@ -148,11 +149,28 @@ jobs:
           # would non-fast-forward reject the push and fail the approval even
           # though the baselines are already live. Reset to the freshest tip
           # before each attempt so the push is always a fast-forward.
+          #
+          # The PR can also merge mid-approval, which auto-deletes the head
+          # branch; the fetch then reports a missing ref. The baselines are
+          # already live, so this is a handoff, not a failure: signal
+          # `branch_gone` and let the merged-PR carry-through steps below
+          # finish the job (mark main's own visual-testing run green).
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="ci: rerun visual-testing against approved baselines (run $RUN_ID, approved by $APPROVER)"
+          fetch_err="$RUNNER_TEMP/fetch-err.txt"
           for attempt in 1 2 3 4 5; do
-            git fetch origin "$REF"
+            if ! git fetch origin "$REF" 2>"$fetch_err"; then
+              cat "$fetch_err" >&2
+              if grep -q "couldn't find remote ref" "$fetch_err"; then
+                echo "Branch $REF is gone (PR merged mid-approval); baselines already uploaded."
+                echo "branch_gone=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Fetch failed for a reason other than a missing branch (attempt $attempt); retrying"
+              sleep 2
+              continue
+            fi
             git reset --hard "origin/$REF"
             git commit --allow-empty -m "$msg"
             if git push origin "HEAD:$REF"; then
@@ -172,13 +190,36 @@ jobs:
       # replacement reports.
       - name: Find post-merge visual-testing run on main
         id: find-main-run
-        if: steps.resolve.outputs.merged == 'true'
+        if: steps.resolve.outputs.merged == 'true' || steps.retrigger.outputs.branch_gone == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MERGED_AT: ${{ steps.resolve.outputs.merged_at }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         with:
           script: |
-            const mergedAt = process.env.MERGED_AT;
+            // On the branch-gone handoff `merged_at` was captured before the
+            // merge, so re-read it from the PR; if the branch vanished for
+            // another reason the PR isn't merged and there's nothing to carry
+            // through, so bail cleanly.
+            let mergedAt = process.env.MERGED_AT;
+            if (!mergedAt && process.env.PR_NUMBER) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(process.env.PR_NUMBER),
+              });
+              mergedAt = pr.data.merged_at || '';
+            }
+            if (!mergedAt) {
+              core.warning(
+                'Head branch is gone but the PR is not merged; ' +
+                'no post-merge main run to carry the approval through to.'
+              );
+              core.setOutput('main_run_id', '');
+              core.setOutput('main_conclusion', '');
+              core.setOutput('shards_ok', '');
+              return;
+            }
             const POLL_INTERVAL_MS = 30_000;
             const MAX_ATTEMPTS = 40; // 40 × 30s = 20 min
             let found = null;
@@ -465,14 +506,19 @@ jobs:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           RUN_ID: ${{ github.event.inputs.run_id }}
           MERGED: ${{ steps.resolve.outputs.merged }}
+          BRANCH_GONE: ${{ steps.retrigger.outputs.branch_gone }}
           MAIN_RUN_ID: ${{ steps.find-main-run.outputs.main_run_id }}
           MAIN_CONCLUSION: ${{ steps.find-main-run.outputs.main_conclusion }}
           COVERED: ${{ steps.cover.outputs.covered }}
           COVER_REASON: ${{ steps.cover.outputs.reason }}
         with:
           script: |
+            // A branch that vanished mid-approval (PR merged) takes the same
+            // carry-through path as a PR that was already merged at dispatch.
+            const carriedThrough =
+              process.env.MERGED === 'true' || process.env.BRANCH_GONE === 'true';
             let body = `Approved baselines from run ${process.env.RUN_ID}`;
-            if (process.env.MERGED !== 'true') {
+            if (!carriedThrough) {
               body += ' and pushed an empty commit to retrigger visual-testing.';
             } else if (!process.env.MAIN_RUN_ID) {
               body +=

--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -46,6 +46,23 @@ const rafPollingSyntax = [
   },
 ]
 
+// A hast node built once at module scope is shared across every page's tree.
+// Later HTML plugins (InlineCodeSpacing, Favicons, ...) mutate the tree in
+// place, so each page's edits accumulate onto the one shared node — output
+// becomes a function of page count and processing order (e.g. the after-article
+// contact line grew one hair space per page, drifting the visual baselines).
+// Build injected nodes fresh inside a function so each page gets its own copy.
+const moduleScopeHastSyntax = {
+  selector: [
+    "Program > VariableDeclaration > VariableDeclarator > CallExpression[callee.name='h']",
+    "Program > VariableDeclaration > VariableDeclarator > TSAsExpression > CallExpression[callee.name='h']",
+    "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > CallExpression[callee.name='h']",
+    "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > TSAsExpression > CallExpression[callee.name='h']",
+  ].join(", "),
+  message:
+    "Do not build hast nodes (`h(...)`) at module scope: the single node is shared across every page and accumulates in-place mutations from later pipeline plugins. Build it fresh inside a function so each page gets its own copy.",
+}
+
 // Every built page embeds the looping navbar pond video, whose continuous
 // range requests can hold the `load` event open indefinitely in WebKit, so a
 // load-event gate is a latent shard-flaking timeout. Fixture documents
@@ -133,6 +150,17 @@ export default [
   {
     rules: {
       "no-restricted-syntax": ["error", noReexportSyntax],
+    },
+  },
+
+  // Pipeline plugins mutate the hast tree in place, so nodes they inject must be
+  // built per page — never shared from module scope. (Barrel index.ts files are
+  // re-enabled to "off" below; this block precedes them so that override wins.)
+  {
+    files: ["quartz/plugins/**/*.ts"],
+    ignores: ["**/*.test.ts", "**/*.spec.ts"],
+    rules: {
+      "no-restricted-syntax": ["error", noReexportSyntax, moduleScopeHastSyntax],
     },
   },
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -660,9 +660,9 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
  *
  * `pauseMediaElements` seeks videos to currentTime 0, but `paused`/`currentTime
  * === 0` are satisfied even when the engine (notably WebKit) has presented no
- * frame yet. requestVideoFrameCallback fires only on a real paint, which is the
- * signal we actually need — and a fresh sub-frame seek forces a presentation,
- * so the callback fires even when frame 0 was already on screen.
+ * frame yet. A fresh sub-frame seek forces a presentation even when frame 0 was
+ * already on screen, and two independent signals report it: rVFC (a real paint,
+ * but never delivered by WebKit while paused) and "seeked" + double rAF.
  *
  * A video that never paints within budget throws instead of letting the
  * screenshot proceed: a blank-video capture that gets approved poisons the
@@ -697,17 +697,18 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
           }
           const waitForPaint = () => {
             videoEl.pause()
+            // Race both presentation signals; `finish` is idempotent so the
+            // first to fire wins. WebKit never delivers video-frame callbacks
+            // while the video is paused, so it completes via "seeked" + double
+            // rAF; Chromium and Firefox fire rVFC on the paused seek itself.
             if (typeof videoEl.requestVideoFrameCallback === "function") {
               videoEl.requestVideoFrameCallback(finish)
-            } else {
-              // Engines without rVFC: "seeked" + double rAF is the closest
-              // available paint signal (mirrors pauseMediaElements).
-              videoEl.addEventListener(
-                "seeked",
-                () => requestAnimationFrame(() => requestAnimationFrame(finish)),
-                { once: true },
-              )
             }
+            videoEl.addEventListener(
+              "seeked",
+              () => requestAnimationFrame(() => requestAnimationFrame(finish)),
+              { once: true },
+            )
             // Seek to a sub-frame offset (or back to 0 if already nudged): an
             // actual position change runs the full seek algorithm in every
             // engine, forcing the compositor to present frame 0 whether or not

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -660,9 +660,13 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
  *
  * `pauseMediaElements` seeks videos to currentTime 0, but `paused`/`currentTime
  * === 0` are satisfied even when the engine (notably WebKit) has presented no
- * frame yet. Screenshotting that blank, never-painted state diffs against the
- * painted baseline — the source of the flake. requestVideoFrameCallback fires
- * only on a real paint, which is the signal we actually need.
+ * frame yet. requestVideoFrameCallback fires only on a real paint, which is the
+ * signal we actually need — and a fresh sub-frame seek forces a presentation,
+ * so the callback fires even when frame 0 was already on screen.
+ *
+ * A video that never paints within budget throws instead of letting the
+ * screenshot proceed: a blank-video capture that gets approved poisons the
+ * shared R2 baselines for every later run.
  */
 async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
   for (const video of await scope.locator("video").all()) {
@@ -670,29 +674,46 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
     if (!handle) throw new Error("Could not get element handle for video")
     await handle.evaluate(
       (el, dataTimeoutMs) =>
-        new Promise<void>((resolve) => {
+        new Promise<void>((resolve, reject) => {
           const videoEl = el as HTMLVideoElement & {
             requestVideoFrameCallback?: (cb: () => void) => number
           }
-          const timers: ReturnType<typeof setTimeout>[] = []
           let settled = false
+          const timer = setTimeout(() => {
+            if (settled) return
+            settled = true
+            reject(
+              new Error(
+                `Video never painted within ${dataTimeoutMs}ms ` +
+                  `(readyState=${videoEl.readyState}): ${videoEl.currentSrc || "<no src>"}`,
+              ),
+            )
+          }, dataTimeoutMs)
           const finish = () => {
             if (settled) return
             settled = true
-            timers.forEach(clearTimeout)
+            clearTimeout(timer)
             resolve()
           }
           const waitForPaint = () => {
             videoEl.pause()
-            if (videoEl.currentTime !== 0) videoEl.currentTime = 0
-            if (typeof videoEl.requestVideoFrameCallback !== "function") {
-              finish()
-              return
+            if (typeof videoEl.requestVideoFrameCallback === "function") {
+              videoEl.requestVideoFrameCallback(finish)
+            } else {
+              // Engines without rVFC: "seeked" + double rAF is the closest
+              // available paint signal (mirrors pauseMediaElements).
+              videoEl.addEventListener(
+                "seeked",
+                () => requestAnimationFrame(() => requestAnimationFrame(finish)),
+                { once: true },
+              )
             }
-            videoEl.requestVideoFrameCallback(finish)
-            // Fallback for the case where frame 0 is already on screen: no new
-            // frame is presented, so rVFC would never fire.
-            timers.push(setTimeout(finish, 1500))
+            // Seek to a sub-frame offset (or back to 0 if already nudged): an
+            // actual position change runs the full seek algorithm in every
+            // engine, forcing the compositor to present frame 0 whether or not
+            // it was already on screen. That presentation fires the callback
+            // registered above.
+            videoEl.currentTime = videoEl.currentTime === 0 ? 1e-4 : 0
           }
           if (videoEl.readyState >= 2) {
             // HAVE_CURRENT_DATA or better: a frame is decodable now.
@@ -703,9 +724,6 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
             // data at all; for HAVE_METADATA the decode is already in flight.
             if (videoEl.readyState === 0) videoEl.load()
           }
-          // Never hang on a video whose data never arrives (e.g. a broken
-          // source); let the screenshot proceed and fail on its own terms.
-          timers.push(setTimeout(finish, dataTimeoutMs))
         }),
       VIDEO_PAINT_TIMEOUT_MS,
     )

--- a/scripts/r2_baselines.py
+++ b/scripts/r2_baselines.py
@@ -27,6 +27,13 @@ except ImportError:
 R2_PREFIX = "visual-baselines"
 LOCAL_DIR = Path("tests/visual-baselines")
 
+# Cloudflare R2 intermittently answers object transfers with
+# ``501 NotImplemented`` ("Failed to copy"). rclone's default three whole-run
+# retries usually absorb a lone blip, but a cluster of 501s across a
+# multi-file sync can exhaust them and fail an otherwise-good baseline
+# push/pull. Raise the ceiling so transient R2 errors can't sink the sync.
+_R2_RETRY_FLAGS = ["--retries=10", "--low-level-retries=20"]
+
 
 def _write_rclone_config(config_path: Path) -> None:
     """Thin alias for the shared rclone-config writer (see ``r2_sync``)."""
@@ -61,6 +68,7 @@ def download(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *_R2_RETRY_FLAGS,
             ],
             config,
         )
@@ -90,6 +98,7 @@ def upload(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *_R2_RETRY_FLAGS,
             ],
             config,
         )


### PR DESCRIPTION
## Why

You reported having to intervene on almost every merge to keep `main` green. I traced the treadmill end-to-end:

1. **The `main` deploy is gated on the `visual-testing` check** (`deploy.yaml` `verify-test-results` polls the `visual-testing` check-run; `deploy` only runs when it succeeds). A red visual check literally holds the production deploy.
2. **`visual-testing` goes red on *any* snapshot diff**, not just real failures (the gate checks `has-any-failures`). Baselines were drifting on nearly every merge, so the deploy was routinely blocked.
3. **The "Approve baselines" button failed ~half the time — often *falsely*.** The R2 upload (the actual approval) succeeded, but the run was still marked failed and posted `Approve-baselines failed` on the PR, so the approval got redone by hand even though it had worked.

This PR fixes the concrete defects behind #3 and closes the remaining structural holes behind #2's drift.

## Root causes of the drift (investigated via the nightly drift sentinel)

The nightly `schedule` run re-renders `main` against current baselines with zero code change, so its diffs isolate what actually moves. The last five nightlies decompose cleanly — Jul 18 green; Jul 19 red (27 typography/description-list diffs on all engines = PR #1628's kerning change landing without baseline approval); Jul 20 red (the identical 27 — same stale baselines, second night); Jul 21 red (a single `section-video-in-dark-mode` Desktop Safari diff — genuine capture nondeterminism); Jul 22 red (contact line = #1646's fix landing after that morning's baselines were approved from a pre-fix build, plus a blank-pond poisoned baseline). Two independent cause classes:

- **Shared hast nodes accumulating mutations** (fixed in #1646; now enforced by lint here). The after-article subscription/contact elements were module-level constants shared across every page's tree. `InlineCodeSpacing` appended one hair space to "Email me at " *per page processed*, so the centered contact line's width — and every glyph position on it — was a function of the page set (count and processing order), not of the page's own content. The build itself is deterministic, so this is **not** per-rebuild noise: the line rendered with a fixed, wrong gap that shifted whenever the page set changed or the code did. Concretely, the Jul 22 nightly's contact-line diff was **#1646's own fix landing (06:42) *after* that morning's baselines were approved (06:02) from a pre-fix build** — a real change catching up to stale baselines, not that-night nondeterminism. A codebase sweep found no other module-scope shared-node sites (`renderPage` clones before transclusion; `sequenceLinks`, `trout_hr`, `populateContainers` build fresh or clone), and the new lint (below) keeps it that way.

- **Silent blank/partway video captures poisoning baselines** (fixed in this PR). This is the recurring, engine-specific drift signal: the Jul 21 nightly's only diff was a WebKit video frame (baseline had the reward bar empty; the capture had it filled), and the Jul 22 pond diff traced to a blank capture that had been approved into R2. `waitForVideosPainted` timed out silently and let the screenshot proceed against whatever frame happened to be on screen. Forcing a deterministic paint (below) removes the nondeterminism at the source.

## What changed

**1. Merge-race false-failure (`update-visual-baselines.yaml`).** The retrigger step reads the PR's merged state once at dispatch, then pushes an empty commit to the head branch. When the PR merges mid-approval, GitHub auto-deletes the branch, so `git fetch` reports a missing ref and the step exits 128 — even though the baselines are already live. The step now detects the missing-ref case, signals `branch_gone`, and hands off to the existing merged-PR carry-through path (which marks `main`'s own post-merge `visual-testing` run green) instead of failing:

- `Find post-merge visual-testing run on main` also fires on `branch_gone`, and re-reads `merged_at` from the PR (the early capture predates the merge). If the branch vanished for some other reason and the PR isn't merged, it bails cleanly.
- The success comment reports the carry-through rather than the wrong "pushed an empty commit" message.

**2. R2 `501 NotImplemented` resilience (`scripts/r2_baselines.py`).** Cloudflare R2 intermittently returns `501 NotImplemented` on object transfers (observed recovering on rclone's 2nd of 3 default retries). Raised `--retries`/`--low-level-retries` on the baseline copy so a cluster of transient 501s can't exhaust the default budget and sink a sync. Applies to both upload and download.

**3. Fail loudly on unpainted videos (`quartz/components/tests/visual_utils.ts`).** `waitForVideosPainted` now forces a fresh frame presentation via a sub-frame seek and throws when no paint arrives within budget. Two independent presentation signals race, first one wins: `requestVideoFrameCallback` (a real paint — but WebKit never delivers it while the video is paused, which this PR's first iteration learned the hard way on the macOS shards) and `seeked` + double rAF (WebKit's completion path). The timeout failure surfaces as a real test error (shard red, per `classify_visual_failures.py`), not a snapshot diff, so a blank capture can never reach the approve-baselines path again.

**4. Lint the shared-node footgun (`config/javascript/eslint.config.js`).** A `no-restricted-syntax` rule flags module-scope `h(...)` initializers under `quartz/plugins/**` — the exact pattern behind #1646, where a hast node built once at module scope is shared across every page and accumulates in-place mutations from later pipeline plugins. Verified it catches all six module-scope nodes in the pre-fix `afterArticle.ts` and stays clean on current source (barrel `index.ts` files remain exempt). Reintroducing the shared-node bug now fails lint instead of silently drifting the baselines.

## Testing

- `uv run pytest scripts/tests/test_r2_baselines.py scripts/tests/test_r2_sync.py scripts/tests/test_r2_upload.py` — 60 passed, coverage holds.
- `tsc --noEmit` and `eslint` clean on `visual_utils.ts`.
- The new lint rule: verified it errors on both `const x = h(...)` and `export const x = h(...) as Element` at module scope, catches all six such nodes in the pre-#1646 `afterArticle.ts`, and leaves current `quartz/plugins/**` clean.
- Workflow YAML validated; embedded retrigger script is shellcheck-clean.
- This PR touches `quartz/**`, so the full visual suite (Linux Chromium + Firefox, macOS WebKit) runs on it — and it caught the WebKit paused-video rVFC starvation in the first iteration of the paint-wait, now fixed by the signal race.

## Lessons learned

- **A CI step that reports failure after its side effect already succeeded is worse than a hard failure** — it trains the human to redo work that was actually done. When a workflow performs an irreversible action (an upload, a publish) and *then* does a cosmetic follow-up (a retrigger commit, a notification), a failure in the follow-up must not mark the whole run failed. Detect the expected terminal states (here: branch auto-deleted on merge) and treat them as handoffs, not errors.
- **State read once at job start goes stale in long-running jobs.** A PR's `merged`/`merged_at` captured at dispatch can be wrong by the time a later step runs; re-read mutable remote state at point of use.
- **Never share AST/DOM nodes across documents when any pass mutates in place, and enforce it with lint.** A node inserted into N trees accumulates N rounds of every mutating transform, making output a function of document count and processing order. This isn't random per-rebuild flakiness — a deterministic build yields the same wrong output every time and only *moves* when the document set or the code changes, which is why it masquerades as "baseline drift on merges" rather than an obvious bug. Build injected nodes fresh per document (or deep-clone at the insertion point), and add a lint rule so the footgun fails CI instead of silently poisoning output (this PR adds one for module-scope `h(...)` in `quartz/plugins/**`).
- **A test helper that times out into "proceed anyway" converts a transient failure into a silently wrong artifact.** In snapshot pipelines the wrong artifact can then be *approved as the new expected state*, poisoning every later comparison. Wait-helpers guarding capture correctness should throw on timeout, not resolve — a loud real failure is recoverable; a quietly-approved bad baseline is a standing defect.
- **Browser-event contracts differ per engine even for "standard" APIs — never gate a cross-engine wait on a single signal.** WebKit supports `requestVideoFrameCallback` but never delivers it while the video is paused; Chromium/Firefox fire it on a paused seek. A wait that picks one signal by feature detection starves on the engine whose delivery semantics differ. Register every equivalent completion signal and race them with an idempotent finisher — feature *presence* is not delivery *semantics*.
- **When a "flaky" signal recurs, diff the actual artifacts, not just the pass/fail bits.** The two causes here were separated by pixel-diffing the failing screenshots: one diff localized to a single centered line (→ width as a function of page set → shared-node mutation), the other to a media region on one engine (→ unpainted-video capture on WebKit). The failure *shape* — and *which* nightly it appeared on relative to a code change — identified each root cause and its attribution; run-level statuses alone never would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)