### PR TITLE
ci: scope Playwright browser cache key to the installed version

### DIFF
--- a/.github/actions/setup-site/action.yaml
+++ b/.github/actions/setup-site/action.yaml
@@ -123,14 +123,27 @@ runs:
       shell: bash
 
     # ── Browsers ──────────────────────────────────────────────────────────────
+    # Resolve the *installed* Playwright version so it can scope the browser
+    # cache key. Playwright pins one browser build per version, so a bare
+    # runner-os prefix in restore-keys would let a Playwright bump restore the
+    # previous version's browser build (a stale-browser drift source). Runs
+    # after node deps install, so @playwright/test is resolvable on disk.
+    - name: Resolve Playwright version
+      if: inputs.cache-playwright == 'true'
+      id: playwright-version
+      shell: bash
+      run: |
+        version="$(node -e "console.log(require('@playwright/test/package.json').version)")"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Cache Playwright browsers
       if: inputs.cache-playwright == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
-        key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          playwright-${{ runner.os }}-
+          playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-
 
     - name: Cache Puppeteer browsers
       if: inputs.cache-puppeteer == 'true' || inputs.install-puppeteer-chrome == 'true'


### PR DESCRIPTION
## Summary

- The Playwright browser cache in `setup-site` restored via `restore-keys: playwright-<os>-`, a bare prefix that matches caches from *any* Playwright version. On a version bump the exact key misses (the lockfile hash changed) but the prefix can restore a **previous** version's browser build — a latent stale-browser drift source for visual regression.
- Fold the installed `@playwright/test` version into both the exact cache key and the `restore-keys` prefix so a bump can never restore across versions.

## Changes

- `.github/actions/setup-site/action.yaml`:
  - New `Resolve Playwright version` step (gated on `cache-playwright`) that reads the installed version from `@playwright/test/package.json` (runs after node deps install, so it's resolvable on disk) into a step output.
  - `Cache Playwright browsers` key/restore-keys now include the resolved version.

## Testing

- CI exercises this action on every relevant PR (`build-site` / visual-testing call `setup-site` / `setup-visual-testing-env` with `cache-playwright: "true"`). A green run confirms the version resolves and the cache save/restore succeeds. No behavior change on a warm cache with an unchanged version; the only effect is that a version bump now forces a fresh browser cache instead of restoring a stale one.

## Notes

- Does not change any screenshots or baselines.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPsFqfMyiMYNj3kXbKHZKh)_