### PR TITLE
fix(favicons): fail loudly on real CDN errors during favicon existence check

### DIFF
--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -227,10 +227,19 @@ describe("findFaviconPath", () => {
     expect(fetchSpy).toHaveBeenCalledWith(specialFaviconPaths.turntrout)
   })
 
-  it("returns null when CDN fetch throws", async () => {
+  it("throws when the CDN fetch fails with a network error", async () => {
     jest.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"))
-    expect(await favicons.findFaviconPath(hostname)).toBeNull()
-  })
+    await expect(favicons.findFaviconPath(hostname)).rejects.toThrow("Network error")
+  }, 15000)
+
+  it("throws when the CDN returns a server error after exhausting retries", async () => {
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false, status: 503 } as Response)
+    await expect(favicons.findFaviconPath(hostname)).rejects.toThrow(/HTTP 503/)
+    // Initial attempt plus the two configured retries.
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+  }, 15000)
 
   it("retries on server error then succeeds", async () => {
     const fetchSpy = jest
@@ -239,7 +248,7 @@ describe("findFaviconPath", () => {
       .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
     expect(await favicons.findFaviconPath(hostname)).toBe(expectedPath)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
-  })
+  }, 15000)
 })
 
 describe("readFaviconCounts", () => {

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -2,7 +2,7 @@ import type { Element, Parent, Root, Text } from "hast"
 
 import fs from "fs"
 import mime from "mime-types"
-import pRetry, { AbortError } from "p-retry"
+import pRetry from "p-retry"
 import { visit } from "unist-util-visit"
 import { visitParents } from "unist-util-visit-parents"
 
@@ -112,20 +112,22 @@ export function transformUrl(faviconPath: string): string {
  */
 async function checkCdnSvg(svgPath: string): Promise<boolean> {
   const url = svgPath.startsWith("http") ? svgPath : `${cdnBaseUrl}${svgPath}`
-  try {
-    return await pRetry(
-      async () => {
-        const response = await fetch(url)
-        if (response.ok) return true
-        if (response.status >= 400 && response.status < 500)
-          throw new AbortError(`${response.status}`)
-        throw new Error(`Server error ${response.status}`)
-      },
-      { retries: 2, minTimeout: 1000 },
-    )
-  } catch {
-    return false
-  }
+  return await pRetry(
+    async () => {
+      const response = await fetch(url)
+      if (response.ok) return true
+      // A 4xx is a definitive "absent" answer: findFaviconPath probes the
+      // normalized path first and falls back to the unnormalized one on a
+      // miss, so report the favicon missing without retrying.
+      if (response.status >= 400 && response.status < 500) return false
+      // A 5xx (or a rejected `fetch`, i.e. a network failure) is a transient
+      // real failure. Silently dropping the favicon would shift glyph layout
+      // on every page linking this domain, so throw after retries and let the
+      // build fail loudly rather than encode a degraded layout into the site.
+      throw new Error(`Favicon existence check failed for ${url}: HTTP ${response.status}`)
+    },
+    { retries: 2, minTimeout: 1000 },
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

- `checkCdnSvg` does a build-time `fetch` per external domain to confirm the favicon exists on the CDN. Its `catch` returned `false` for **any** failure, so a transient network blip or a 5xx from the CDN silently dropped the favicon. A missing favicon shifts glyph layout on every page linking that domain and churns visual baselines — a latent drift source.
- A genuine **404** is still a legitimate "absent" answer (`findFaviconPath` relies on it to probe the normalized path, then fall back to the unnormalized one).
- Distinguish the two failure modes and fail loudly on the real ones.

## Changes

- `quartz/plugins/transformers/favicons.ts`:
  - `checkCdnSvg`: a **4xx** returns `false` (absent, no retry); a **5xx or a rejected `fetch`** (network failure) throws after the existing 2 retries, so the build fails loudly instead of encoding a degraded layout.
  - Dropped the now-unused `AbortError` import.
- `quartz/plugins/transformers/favicons.test.ts`: the former "returns null when CDN fetch throws" test asserted the old silent-swallow behavior; replaced it with two tests asserting the new fail-loud contract (network error rejects; 503 rejects after exactly 3 attempts). The existing 404/`ok:false` "absent" tests and the "retry-then-succeed" test are unchanged.

## Testing

- `favicons.test.ts`: 315 passing; `favicons.ts` at 100% stmt/branch/func/line coverage.
- `pnpm check` + eslint clean.
- **Offline builds unaffected**: `AddFavicons` short-circuits to `[]` (no `fetch`) when `ctx.argv.offline` is set, so the documented offline-build path never reaches `checkCdnSvg`.

## Notes

- No screenshot/baseline changes. This makes a previously-silent build degradation fail loudly instead; the existing retries absorb genuinely-transient CDN blips before the throw.

## Lessons learned

- **What**: When a build-time network check's failure silently changes rendered output, distinguish "definitively absent" (4xx) from "transient failure" (5xx/network) and throw on the latter rather than catching-all to a falsy default.
- **Where**: `quartz/plugins/transformers/favicons.ts` (`checkCdnSvg`); pattern generalizes to any build-time existence probe.
- **Why**: A catch-all `return false` turned CDN flakiness into invisible layout drift and baseline churn instead of a loud, diagnosable build failure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPsFqfMyiMYNj3kXbKHZKh)_