### PR TITLE
test(visual): guard the engine→OS baseline-naming invariant

### DIFF
--- a/config/playwright/engineOsGuard.test.ts
+++ b/config/playwright/engineOsGuard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "@jest/globals"
+
+import { assertEngineOsMapping, type Engine, ENGINE_TO_PLATFORM } from "./engineOsGuard"
+
+describe("assertEngineOsMapping", () => {
+  it("is a no-op when enforcement is off, even for a mismatched engine/OS pair", () => {
+    expect(() => assertEngineOsMapping(["webkit"], "linux", false)).not.toThrow()
+  })
+
+  it.each([
+    ["chromium", "linux"],
+    ["firefox", "linux"],
+    ["webkit", "darwin"],
+  ] as const)("allows %s on its expected platform %s", (engine, platform) => {
+    expect(() => assertEngineOsMapping([engine], platform, true)).not.toThrow()
+  })
+
+  it("allows the full Linux engine set on Linux", () => {
+    expect(() => assertEngineOsMapping(["chromium", "firefox"], "linux", true)).not.toThrow()
+  })
+
+  it.each([
+    ["webkit", "linux"],
+    ["chromium", "darwin"],
+    ["firefox", "darwin"],
+  ] as const)("throws for %s scheduled on %s", (engine, platform) => {
+    expect(() => assertEngineOsMapping([engine], platform, true)).toThrow(
+      new RegExp(`engine "${engine}" must render on platform "${ENGINE_TO_PLATFORM[engine]}"`),
+    )
+  })
+
+  it("throws on the first mismatched engine in a mixed list", () => {
+    const engines: Engine[] = ["chromium", "webkit"]
+    expect(() => assertEngineOsMapping(engines, "linux", true)).toThrow(/engine "webkit"/)
+  })
+})

--- a/config/playwright/engineOsGuard.ts
+++ b/config/playwright/engineOsGuard.ts
@@ -1,0 +1,48 @@
+// Visual baselines are named by browser engine (Playwright's `project.name`),
+// not by OS, so the single global R2 baseline set is collision-free only while
+// each engine renders on exactly one OS: WebKit on macOS, Chromium and Firefox
+// in the Linux container. This guard enforces that mapping on CI test shards,
+// so a future config change that schedules (say) WebKit on Linux can't silently
+// overwrite the macOS WebKit baselines with same-named Linux captures.
+
+export type Engine = "chromium" | "firefox" | "webkit"
+
+// The OS (`process.platform`) each engine is allowed to render baselines on.
+export const ENGINE_TO_PLATFORM: Readonly<Record<Engine, NodeJS.Platform>> = {
+  chromium: "linux",
+  firefox: "linux",
+  webkit: "darwin",
+}
+
+/**
+ * Throws if any engine is scheduled to run on an OS other than the one its
+ * baselines belong to.
+ *
+ * @param engines - Engines this process will run (derived from the per-OS
+ *   `PLAYWRIGHT_BROWSERS` selection).
+ * @param platform - The runner's `process.platform`.
+ * @param enforce - True only for a real CI test shard (`CI` set and a
+ *   `PLAYWRIGHT_BROWSERS` selection present). Off it — a local run, or the
+ *   report-merge job that loads the config without running tests — this is a
+ *   no-op, since no baselines are written.
+ */
+export function assertEngineOsMapping(
+  engines: readonly Engine[],
+  platform: NodeJS.Platform,
+  enforce: boolean,
+): void {
+  if (!enforce) return
+  for (const engine of engines) {
+    const expectedPlatform = ENGINE_TO_PLATFORM[engine]
+    if (platform !== expectedPlatform) {
+      throw new Error(
+        `Visual baseline safety: engine "${engine}" must render on platform ` +
+          `"${expectedPlatform}" because baselines are named by engine, not OS. ` +
+          `This CI shard reports platform "${platform}", so running "${engine}" here ` +
+          `would overwrite the "${expectedPlatform}" baselines with same-named ` +
+          `captures. Add an OS token to the baseline name (getScreenshotName / ` +
+          `snapshotPathTemplate) before running an engine on a second OS.`,
+      )
+    }
+  }
+}

--- a/config/playwright/playwright.config.ts
+++ b/config/playwright/playwright.config.ts
@@ -3,6 +3,8 @@ import { defineConfig, devices } from "@playwright/test"
 import { dirname, resolve } from "path"
 import { fileURLToPath } from "url"
 
+import { assertEngineOsMapping } from "./engineOsGuard"
+
 // Playwright resolves a relative `webServer.command` path against
 // `webServer.cwd`, which defaults to this config file's directory. The built
 // site lives at the repo root (`public/`), so pin the server's cwd there.
@@ -66,6 +68,16 @@ const playwrightBrowsersEnv = process.env.PLAYWRIGHT_BROWSERS
 const browsers: Browser[] = playwrightBrowsersEnv
   ? allBrowsers.filter((b) => playwrightBrowsersEnv.split(",").includes(b.engine))
   : allBrowsers
+
+// Enforce the engine→OS mapping only for a real CI test shard: `CI` is set and
+// a per-OS PLAYWRIGHT_BROWSERS selection is present. The report-merge job loads
+// this config on Linux without that selection and runs no tests, so it stays
+// exempt (no baselines are written there).
+assertEngineOsMapping(
+  browsers.map((b) => b.engine),
+  process.platform,
+  Boolean(process.env.CI) && playwrightBrowsersEnv !== undefined,
+)
 
 /**
  * Remove or adjust device options that are not supported by a given browser engine.


### PR DESCRIPTION
## Summary

- Visual baselines are named by browser engine (`project.name`, e.g. "Desktop Safari") with **no OS token**. The single global R2 baseline set is collision-free only because WebKit runs exclusively on macOS and Chromium/Firefox exclusively in the Linux container. If an engine ever ran on a second OS, same-named baselines would silently overwrite across platforms.
- Per the chosen approach (lightweight guard, not a full rename-everything migration), add an assertion that enforces the engine→OS mapping on CI test shards and fails loudly on a violation.

## Changes

- `config/playwright/engineOsGuard.ts` (new): `ENGINE_TO_PLATFORM` (`chromium`/`firefox` → `linux`, `webkit` → `darwin`) and `assertEngineOsMapping(engines, platform, enforce)`.
- `config/playwright/playwright.config.ts`: call the guard at config load with the configured engines, `process.platform`, and `enforce = CI && PLAYWRIGHT_BROWSERS is set`.
- `config/playwright/engineOsGuard.test.ts` (new): full unit coverage.

## Why the `enforce` gate

The guard is a no-op unless `CI` is set **and** a per-OS `PLAYWRIGHT_BROWSERS` selection is present — i.e. a real test shard that writes baselines. The `publish-visual-report` job loads this config on Linux (via `playwright merge-reports`) with no `PLAYWRIGHT_BROWSERS`, running no tests; enforcing there would wrongly trip on the default all-engines list. Local runs (`CI` unset) are also exempt, since they don't write the authoritative R2 baselines.

## Testing

- `engineOsGuard.test.ts`: 9 passing; module at 100% coverage.
- Verified end-to-end: the config loads clean with no env; `CI=true PLAYWRIGHT_BROWSERS=webkit` on Linux throws the guard error at config load.
- `pnpm check` + eslint clean.

## Notes

- No screenshot/baseline changes. All current CI shards satisfy the invariant, so this is inert until someone changes the engine/OS pairing.

## Lessons learned

- **What**: When a shared artifact's identity omits a dimension it silently depends on (here: baselines keyed by engine but implicitly per-OS), add a loud invariant check at the point the dimension is chosen, rather than relying on the current config staying correct.
- **Where**: `config/playwright/engineOsGuard.ts`, called from the Playwright config; pattern applies to any keyed-artifact naming scheme.
- **Why**: The engine→OS mapping is load-bearing but implicit; a future config edit running an engine on a second OS would clobber baselines with no error otherwise.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPsFqfMyiMYNj3kXbKHZKh)_