### PR TITLE
fix(ci): survive an auto-merge racing a baseline approval

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -94,8 +94,10 @@ jobs:
             core.setOutput('merged_at', mergedAt);
 
       # Merged PRs skip the branch checkout: the head branch is auto-deleted
-      # on merge, and the carry-through path below only needs the scripts on
-      # the default branch. An auto-merge can land (and delete the branch)
+      # on merge, and the carry-through path below only needs the repo
+      # scripts — from the default branch, or, when the merge lands mid-run,
+      # from the already-checked-out PR branch (whose tree is what just
+      # landed on main). An auto-merge can land (and delete the branch)
       # between the resolve step and this checkout, so a checkout failure is
       # tolerated here and re-resolved below instead of failing the approval.
       - name: Checkout target ref
@@ -193,7 +195,10 @@ jobs:
           # that case the retrigger is moot and the merged-PR carry-through
           # below takes over, keyed off the merged_late output.
           check_merged_late() {
-            merged_at=$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt // empty')
+            if ! merged_at=$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt // empty'); then
+              echo "gh pr view failed while checking merged state of PR #$PR_NUMBER" >&2
+              exit 1
+            fi
             if [ -n "$merged_at" ]; then
               echo "PR #$PR_NUMBER merged mid-approval; deferring to the carry-through path"
               {
@@ -214,7 +219,11 @@ jobs:
             fi
             git reset --hard "origin/$REF"
             git commit --allow-empty -m "$msg"
-            if git push origin "HEAD:$REF"; then
+            # The lease makes the push a compare-and-swap against the tip we
+            # just fetched: a plain push to a merge-deleted ref would
+            # silently recreate the branch, while the lease rejects it and
+            # the next iteration's fetch routes to check_merged_late.
+            if git push --force-with-lease="refs/heads/$REF:origin/$REF" origin "HEAD:$REF"; then
               echo "Pushed retrigger commit on attempt $attempt"
               exit 0
             fi
@@ -224,6 +233,29 @@ jobs:
           echo "Failed to push retrigger commit after 5 attempts" >&2
           exit 1
 
+      # Single source of truth for whether the PR is merged, however that
+      # was discovered: at resolve time, at branch checkout (recheck), or at
+      # the retrigger push (merged_late).
+      - name: Consolidate effective merge state
+        id: merged-state
+        if: steps.resolve.outputs.pr_number != ''
+        env:
+          RESOLVE_MERGED: ${{ steps.resolve.outputs.merged }}
+          RECHECK_MERGED: ${{ steps.recheck.outputs.merged }}
+          PUSH_MERGED_LATE: ${{ steps.push.outputs.merged_late }}
+          RESOLVE_MERGED_AT: ${{ steps.resolve.outputs.merged_at }}
+          RECHECK_MERGED_AT: ${{ steps.recheck.outputs.merged_at }}
+          PUSH_MERGED_AT: ${{ steps.push.outputs.merged_at }}
+        run: |
+          merged=false
+          if [ "$RESOLVE_MERGED" = "true" ] || [ "$RECHECK_MERGED" = "true" ] || [ "$PUSH_MERGED_LATE" = "true" ]; then
+            merged=true
+          fi
+          {
+            echo "merged=$merged"
+            echo "merged_at=${RESOLVE_MERGED_AT:-${RECHECK_MERGED_AT:-$PUSH_MERGED_AT}}"
+          } >> "$GITHUB_OUTPUT"
+
       # Carry-through for merged PRs: the approved diffs are the ones
       # re-failing main's own visual-testing run, so find that run and (after
       # the safety checks below) give it the main-run treatment. Waits out
@@ -232,10 +264,10 @@ jobs:
       # replacement reports.
       - name: Find post-merge visual-testing run on main
         id: find-main-run
-        if: steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true' || steps.push.outputs.merged_late == 'true'
+        if: steps.merged-state.outputs.merged == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          MERGED_AT: ${{ steps.resolve.outputs.merged_at || steps.recheck.outputs.merged_at || steps.push.outputs.merged_at }}
+          MERGED_AT: ${{ steps.merged-state.outputs.merged_at }}
         with:
           script: |
             const mergedAt = process.env.MERGED_AT;
@@ -524,7 +556,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           RUN_ID: ${{ github.event.inputs.run_id }}
-          MERGED: ${{ (steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true' || steps.push.outputs.merged_late == 'true') && 'true' || 'false' }}
+          MERGED: ${{ steps.merged-state.outputs.merged }}
           MAIN_RUN_ID: ${{ steps.find-main-run.outputs.main_run_id }}
           MAIN_CONCLUSION: ${{ steps.find-main-run.outputs.main_conclusion }}
           COVERED: ${{ steps.cover.outputs.covered }}

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -21,9 +21,9 @@ name: Update visual baselines
 # and main.
 #
 # An approval can race an auto-merge that lands mid-run (deleting the head
-# branch). Both spots that touch the branch — the checkout and the
-# empty-commit push — detect the deletion, confirm the PR merged, and route
-# down the merged-PR carry-through path instead of failing.
+# branch, possibly after a lag). Both spots that touch the branch — the
+# checkout and the empty-commit push — re-check the PR's merged state and
+# route down the merged-PR carry-through path instead of failing.
 
 on:
   workflow_dispatch:
@@ -129,7 +129,7 @@ jobs:
             if (!pr.data.merged) {
               core.setFailed(
                 `Checkout of the PR branch failed but PR #${process.env.PR_NUMBER} ` +
-                'is still open, so the failure is not a merge-deleted branch.'
+                'is not merged, so the failure is not a merge-deleted branch.'
               );
               return;
             }
@@ -214,16 +214,18 @@ jobs:
           for attempt in 1 2 3 4 5; do
             if ! git fetch origin "$REF"; then
               check_merged_late
-              echo "Fetch of $REF failed but PR #$PR_NUMBER is still open" >&2
+              echo "Fetch of $REF failed but PR #$PR_NUMBER is not merged" >&2
               exit 1
             fi
             git reset --hard "origin/$REF"
             git commit --allow-empty -m "$msg"
             # The lease makes the push a compare-and-swap against the tip we
-            # just fetched: a plain push to a merge-deleted ref would
-            # silently recreate the branch, while the lease rejects it and
+            # just fetched; a merge-deleted remote ref fails the lease, and
             # the next iteration's fetch routes to check_merged_late.
             if git push --force-with-lease="refs/heads/$REF:origin/$REF" origin "HEAD:$REF"; then
+              # Branch auto-deletion lags the merge, so a successful push
+              # alone does not prove the PR is still open.
+              check_merged_late
               echo "Pushed retrigger commit on attempt $attempt"
               exit 0
             fi

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -19,6 +19,11 @@ name: Update visual baselines
 # screenshots — applies the main-run treatment (synthetic passing
 # check-run + deploy verify rerun). One approval click clears both the PR
 # and main.
+#
+# An approval can race an auto-merge that lands mid-run (deleting the head
+# branch). Both spots that touch the branch — the checkout and the
+# empty-commit push — detect the deletion, confirm the PR merged, and route
+# down the merged-PR carry-through path instead of failing.
 
 on:
   workflow_dispatch:
@@ -90,16 +95,48 @@ jobs:
 
       # Merged PRs skip the branch checkout: the head branch is auto-deleted
       # on merge, and the carry-through path below only needs the scripts on
-      # the default branch.
+      # the default branch. An auto-merge can land (and delete the branch)
+      # between the resolve step and this checkout, so a checkout failure is
+      # tolerated here and re-resolved below instead of failing the approval.
       - name: Checkout target ref
+        id: checkout-branch
         if: steps.resolve.outputs.ref != '' && steps.resolve.outputs.merged != 'true'
+        continue-on-error: true
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted GITHUB_TOKEN is used by the empty-commit push below
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # A failed branch checkout is only acceptable when the PR merged after
+      # the resolve step (deleting the branch); in that case the approval
+      # continues down the merged-PR carry-through path. Any other checkout
+      # failure fails the approval loudly.
+      - name: Re-resolve PR after branch checkout failure
+        id: recheck
+        if: steps.checkout-branch.outcome == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            if (!pr.data.merged) {
+              core.setFailed(
+                `Checkout of the PR branch failed but PR #${process.env.PR_NUMBER} ` +
+                'is still open, so the failure is not a merge-deleted branch.'
+              );
+              return;
+            }
+            core.info(`PR #${process.env.PR_NUMBER} merged after resolve; using the carry-through path.`);
+            core.setOutput('merged', 'true');
+            core.setOutput('merged_at', pr.data.merged_at || '');
+
       - name: Checkout default branch (main runs and merged PRs)
-        if: steps.resolve.outputs.ref == '' || steps.resolve.outputs.merged == 'true'
+        if: steps.resolve.outputs.ref == '' || steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -136,11 +173,14 @@ jobs:
             ./all-blob-reports --staging-dir "$STAGING_DIR"
 
       - name: Push empty commit to retrigger visual-testing (open-PR runs only)
-        if: steps.resolve.outputs.pr_number != '' && steps.resolve.outputs.merged != 'true'
+        id: push
+        if: steps.resolve.outputs.pr_number != '' && steps.resolve.outputs.merged != 'true' && steps.recheck.outputs.merged != 'true'
         env:
           REF: ${{ steps.resolve.outputs.ref }}
           RUN_ID: ${{ github.event.inputs.run_id }}
           APPROVER: ${{ github.actor }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # The R2 upload above is the approval; this empty commit only nudges
           # visual-testing to rerun. A push to the PR branch that lands between
@@ -148,11 +188,30 @@ jobs:
           # would non-fast-forward reject the push and fail the approval even
           # though the baselines are already live. Reset to the freshest tip
           # before each attempt so the push is always a fast-forward.
+          #
+          # A merge landing during this job deletes the branch entirely; in
+          # that case the retrigger is moot and the merged-PR carry-through
+          # below takes over, keyed off the merged_late output.
+          check_merged_late() {
+            merged_at=$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt // empty')
+            if [ -n "$merged_at" ]; then
+              echo "PR #$PR_NUMBER merged mid-approval; deferring to the carry-through path"
+              {
+                echo "merged_late=true"
+                echo "merged_at=$merged_at"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          }
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="ci: rerun visual-testing against approved baselines (run $RUN_ID, approved by $APPROVER)"
           for attempt in 1 2 3 4 5; do
-            git fetch origin "$REF"
+            if ! git fetch origin "$REF"; then
+              check_merged_late
+              echo "Fetch of $REF failed but PR #$PR_NUMBER is still open" >&2
+              exit 1
+            fi
             git reset --hard "origin/$REF"
             git commit --allow-empty -m "$msg"
             if git push origin "HEAD:$REF"; then
@@ -161,6 +220,7 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); refetching $REF and retrying"
           done
+          check_merged_late
           echo "Failed to push retrigger commit after 5 attempts" >&2
           exit 1
 
@@ -172,10 +232,10 @@ jobs:
       # replacement reports.
       - name: Find post-merge visual-testing run on main
         id: find-main-run
-        if: steps.resolve.outputs.merged == 'true'
+        if: steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true' || steps.push.outputs.merged_late == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          MERGED_AT: ${{ steps.resolve.outputs.merged_at }}
+          MERGED_AT: ${{ steps.resolve.outputs.merged_at || steps.recheck.outputs.merged_at || steps.push.outputs.merged_at }}
         with:
           script: |
             const mergedAt = process.env.MERGED_AT;
@@ -464,7 +524,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           RUN_ID: ${{ github.event.inputs.run_id }}
-          MERGED: ${{ steps.resolve.outputs.merged }}
+          MERGED: ${{ (steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true' || steps.push.outputs.merged_late == 'true') && 'true' || 'false' }}
           MAIN_RUN_ID: ${{ steps.find-main-run.outputs.main_run_id }}
           MAIN_CONCLUSION: ${{ steps.find-main-run.outputs.main_conclusion }}
           COVERED: ${{ steps.cover.outputs.covered }}


### PR DESCRIPTION
## Summary

- Approving visual baselines from a PR's diff gallery while auto-merge lands the PR killed the approval before the R2 upload, forcing a second approval from main's own gallery. The workflow decided open-vs-merged once, at resolve time, and a merge landing after that decision deleted the head branch out from under it.
- Both branch-touching steps now detect the deletion, confirm the PR actually merged, and route down the existing merged-PR carry-through path — so one approval click still clears both the PR and main, even when it races the merge.

Observed in run [29982130322](https://github.com/alexander-turner/TurnTrout.com/actions/runs/29982130322): approval dispatched at 05:26:01Z, PR #1655 auto-merged at 05:26:08Z, checkout of the deleted branch failed after retries, and every later step — including the R2 upload — was skipped. The 14 gdm-signature baselines were never uploaded, so main's post-merge run re-surfaced the same diffs.

## Changes

- **`Checkout target ref`**: `continue-on-error: true` so a merge-deleted branch no longer kills the run at checkout.
- **`Re-resolve PR after branch checkout failure`** (new step): re-queries the PR when the branch checkout fails. Merged → emits `merged`/`merged_at` outputs and the run continues down the carry-through path; still open → fails loudly (a genuine checkout failure).
- **`Checkout default branch`**: also runs for the re-resolved-merged case so the upload scripts are present.
- **`Push empty commit`**: the retrigger push now distinguishes "branch deleted because the PR merged mid-approval" (emits `merged_late`, defers to carry-through) from a genuine fetch/push failure (still fails). Covers the wider race window — a merge landing during Python setup, rclone install, or the R2 upload.
- **Carry-through + PR comment steps**: keyed off the effective merge state (`resolve` ∥ `recheck` ∥ `push.merged_late`) instead of the resolve-time snapshot.

## Testing

- YAML parses; `zizmor --offline` reports no findings; `actionlint` with shellcheck integration passes.
- Failure-path behavior verified against the logs of run 29982130322 (the observed race): with this change, the failed branch fetch would re-resolve, find PR #1655 merged, and continue to the upload + carry-through instead of skipping to the failure comment.

## Lessons Learned

- **What**: In workflows dispatched against a PR, never cache "is the PR merged/open" from a single early lookup — re-check at each step that depends on the PR's branch existing, and treat "branch gone + PR merged" as a routing signal rather than a failure.
- **Where**: any workflow that checks out or pushes to a PR head branch (here `.github/workflows/update-visual-baselines.yaml`).
- **Why**: auto-merge can land (and auto-delete the branch) at any point during the run; a resolve-time snapshot made the approval fail before its real work (the R2 upload) ever ran.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaRmhB58bKNb5s1K72ofDQ)_