### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__ci-truth-serum__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__ci-truth-serum__main__README.md
@@ -77,6 +77,7 @@ lints that catch two kinds of lie a green check can hide:
 | `check-cron-comment`         | Catches a schedule comment that contradicts its cron. Example: the comment says "daily" but the cron runs weekly, so the job runs 1/7th as often as everyone thinks. Pairs a cadence word (`hourly`/`daily`/`weekly`/`monthly`/`every N minutes\|hours\|days`) in a comment on or within 3 lines above a `cron:` line with the expression, and fails only on a clear contradiction — lists, ranges, and exotic crons always pass. Opt out with `# cron-comment-ok`.                                                                                                                                    |
 | `check-toolchain-skips`      | Catches a test that skips itself when a tool is missing (`skipif(shutil.which("node") is None)`), which silently drops all coverage of the guarded scripts on a runner without that tool while the suite stays green. Flags `pytest.mark.skipif`/`pytest.importorskip` conditions that probe for a binary (`shutil.which`, `which(`, `find_executable`) with no CI guard — in CI the skip must instead FAIL: `shutil.which("node") is None and not os.environ.get("CI")`. Only test files are scanned. Opt out with `# toolchain-skip-ok: <reason>`.                                                   |
 | `check-env-symmetry`         | Catches a half-finished env-var rename: the var was changed where it's **set** but not where it's **read** (or vice-versa), so the reader just sees an unset value and falls back to a default. Scans the whole tracked tree for every var matching a `--prefix` (e.g. `GLOVEBOX_`) and flags any that is written-but-never-read or read-but-never-written. Dynamically-built names are skipped; an out-of-band var opts out with `# env-symmetry-ok: <VARNAME> <reason>`. Needs `args: [--prefix, <PREFIX>]`; not part of a tier aggregate.                                                           |
+| `check-stray-tool-markup`    | Catches an agent's leaked file-authoring scaffolding — a bare closing `content`/`invoke` tag (or an `antml:`-prefixed variant) committed onto its own line in a doc, where it renders as literal garbage that only a human caught. Flags a line that is _entirely_ a stray tool-call tag (`</invoke>`, an opening `invoke`/`parameter` tag, `<function_calls>`, a bare closing `content` tag); inline mentions, inline-code spans, and fenced code blocks are never flagged. Suppress a genuine case with `allow-stray-markup: <reason>` on the line above.                                            |
 
 ## Usage
 
@@ -96,7 +97,7 @@ the only prerequisite.
 ```yaml
 repos:
   - repo: https://github.com/AlexanderMattTurner/ci-truth-serum
-    rev: v0.1.0 # pin to a tag
+    rev: v0.2.0 # the release tag; matches the package version (vX.Y.Z)
     hooks:
       # ── Tier 1 · Honesty (default-on) ──
       - id: check-workflow-pipefail
@@ -105,7 +106,7 @@ repos:
       - id: check-substitution-exit-swallow
       - id: check-pr-paths
       - id: check-pipefail-grep-pipe
-      - id: check-frozen-head-sha       # ban frozen event head.sha in diff-range/checkout steps
+      - id: check-frozen-head-sha # ban frozen event head.sha in diff-range/checkout steps
       # ── Tier 1 · Identity (default-on) ──
       - id: check-pinned-base-images
       - id: check-pinned-downloads
@@ -147,6 +148,7 @@ repos:
       # - id: check-toolchain-skips      # which()-gated pytest skips must fail (not skip) in CI
       # - id: check-env-symmetry         # prefixed env vars must be both written and read
       #   args: [--prefix, GLOVEBOX_]    # required: only <PREFIX>… vars are checked
+      # - id: check-stray-tool-markup    # ban leaked tool-call tags (</invoke>, </content>) committed into a file
 ```
 
 `pre-commit run --all-files` sweeps the whole repo (handy on first adoption).
@@ -160,7 +162,7 @@ are picked up with **no change to your config**:
 ```yaml
 repos:
   - repo: https://github.com/AlexanderMattTurner/ci-truth-serum
-    rev: v0.1.0 # pin to a tag
+    rev: v0.2.0 # the release tag; matches the package version (vX.Y.Z)
     hooks:
       - id: check-tier1 # all honesty + identity checks (the safe default-on set)
       # - id: check-tier2   # all opinionated checks: assumes the decide-gate + reporter architecture
@@ -184,7 +186,7 @@ standalone hook with normal pre-commit `files:`/`exclude:` filters:
 
 ```yaml
 - repo: https://github.com/AlexanderMattTurner/ci-truth-serum
-  rev: v0.1.0
+  rev: v0.2.0
   hooks:
     - id: check-tier1
       args: [--skip, check_exit_suppression] # drop from aggregate...
@@ -196,7 +198,7 @@ standalone hook with normal pre-commit `files:`/`exclude:` filters:
 `--skip` is repeatable: pass one `--skip <name>` pair per check to drop.
 **An unknown name is a hard error** (to catch typos that would silently
 re-include the check). Module names use underscores and match the TIERS
-registry in `hooks/run_tier.py` (e.g., `check_exit_suppression`, not
+registry in `ci_truth_serum/run_tier.py` (e.g., `check_exit_suppression`, not
 `check-exit-suppression`).
 
 The key property is preserved: any new check added to the tier upstream still

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -162,7 +162,7 @@ What the hard boundaries buy you:
 On top of those walls sit **best-effort filters** — they raise the bar, but a determined or hijacked agent can sometimes slip past one, so the safety argument never _rests_ on them:
 
 - **Auto mode** (`--permission-mode auto`) — Claude Code's built-in gating that blocks destructive and external tool calls.
-- **A trusted monitor** — a cheap second model in a separate container that reviews tool calls and [push-notifies your phone](https://ntfy.sh) on genuine misalignment, halting the agent until you return.
+- **A trusted monitor** — a cheap second model running on your machine, outside the sandbox, that reviews tool calls and [push-notifies your phone](https://ntfy.sh) on genuine misalignment, halting the agent until you return.
 - **Input/output sanitization** — strips hidden-content injection (payload-capable invisible Unicode, ANSI escapes, human-invisible HTML) from tool output and fetched pages before either model reads them, via the first-party [`agent-input-sanitizer`](https://github.com/AlexanderMattTurner/agent-input-sanitizer).
 
 Sessions are **ephemeral by default**: attackers can't lay landmines in the system state which are hard for monitors to spot. Claude's work is backed out fine, but the rest of the session state is lost. That'd normally be annoying (e.g. re-login to every service) but I did some fancy mitigations.
@@ -205,7 +205,7 @@ All modes are sandboxed and pass extra args through to the real `claude` binary.
 
 Researchers run experiments on remote GPU pods, where the sandbox's outbound firewall can't easily be reproduced. Rather than tunnelling a local `claude` out to the pod, `glovebox remote` ships the hardened image **to** the compute and runs `claude` natively on it, so the controls travel with the job. The rendered app runs a networked **setup** phase (clone/install/secrets) and then a locked-down **agent** phase with setup secrets scrubbed; the boundary there is the provider's isolation (gVisor) plus Claude Code's native sandbox, so the agent never runs with `--dangerously-skip-permissions`.
 
-**[Modal](https://modal.com), [RunPod](https://www.runpod.io), and [Lambda](https://lambdalabs.com) are wired up today.** See [`docs/remote-execution.md`](docs/remote-execution.md) for the operator guide and [`docs/remote-execution-design.md`](docs/remote-execution-design.md) for the design rationale.
+**[Modal](https://modal.com), [RunPod](https://www.runpod.io), and [Lambda](https://lambdalabs.com) are wired up today but may not work reliably. This is an important area for future testing.** See [`docs/remote-execution.md`](docs/remote-execution.md) for the operator guide and [`docs/remote-execution-design.md`](docs/remote-execution-design.md) for the design rationale.
 
 ### Apollo Watcher integration
 
@@ -223,6 +223,8 @@ The launch box's **Monitor** row shows the resolved posture. Opt-in only, and on
 An agent with shell access can hurt you in at least seven distinct ways: tampering with its own guardrails, sending your data out, acting outside your intent, breaking out of the sandbox, being hijacked by prompt injection, leaking your code to the inference provider, and (this isn't something `glovebox` protects against yet) subtly sabotaging the work itself. [`SECURITY.md`](SECURITY.md) organizes the defense into layers — **hard boundaries** a model cannot talk its way past versus **best-effort filters** a creative adversary can sometimes bypass — with the full per-layer threat model, trust boundaries, and known limitations.
 
 ## Configuration
+
+[`docs/feature-guide.md`](docs/feature-guide.md) is a plain-language "if you want X, use feature Y" index that maps common goals to the command, flag, or file that gets you there.
 
 See [`docs/configuration.md`](docs/configuration.md) for the full reference: wrapper environment variables and flags, the `--dangerously-*` security levels, privacy-routing knobs, and how to expand network access for a specific workflow.
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.