### PR TITLE
fix(tweet): scope no-formatting to tweet body only

### DIFF
--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -187,8 +187,13 @@ describe("buildTweetCard", () => {
     expect(render(buildTweetCard(baseSnapshot))).toContain('aria-label="View post on X"')
   })
 
-  it("marks the card no-formatting so typography passes leave the quote verbatim", () => {
-    expect(render(buildTweetCard(baseSnapshot))).toContain('class="tweet-card no-formatting"')
+  it("marks only the body no-formatting so typography passes leave the quote verbatim", () => {
+    const html = render(buildTweetCard(baseSnapshot))
+    // The body carries no-formatting; the card as a whole does not, so the date
+    // line and engagement counts still get normal typography.
+    expect(html).toContain('class="tweet-body no-formatting"')
+    expect(html).toContain('class="tweet-card"')
+    expect(html).not.toContain('class="tweet-card no-formatting"')
   })
 
   it("shows the verified badge only when verified", () => {

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -359,7 +359,11 @@ function quotedCard(quoted: QuotedTweet, outerDate: string): Element {
     authorNameRow(quoted.author, profileUrl),
     externalAnchor(profileUrl, [`@${quoted.author.handle}`], "tweet-handle"),
   ])
-  const body = h("div", { className: "tweet-body" }, linkifyTweetText(quoted.text, quoted.urls))
+  const body = h(
+    "div",
+    { className: "tweet-body no-formatting" },
+    linkifyTweetText(quoted.text, quoted.urls),
+  )
   const children: Element[] = [header, body, ...mediaGrid(quoted.media)]
   const formattedDate = formatTweetDate(quoted.createdAt)
   if (formattedDate && formattedDate !== outerDate) {
@@ -398,7 +402,18 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
     ),
   ])
 
-  const body = h("div", { className: "tweet-body" }, linkifyTweetText(snapshot.text, snapshot.urls))
+  // `no-formatting` exempts the quoted text from HTMLFormattingImprovement
+  // (which runs later in the pipeline): a tweet body is a verbatim quote of
+  // someone else's words, so the site's typography rewrites must not touch it.
+  // Without this, slash spacing pads the slashes in a shortened display URL
+  // ("futureoflife.org / open-letter / le…") and other passes would silently
+  // alter the quoted text. It stays on the body alone so the card's own chrome
+  // (the date line, engagement counts) still gets normal typography.
+  const body = h(
+    "div",
+    { className: "tweet-body no-formatting" },
+    linkifyTweetText(snapshot.text, snapshot.urls),
+  )
 
   const children: Element[] = []
   if (retweetedBy) children.push(retweetContext(retweetedBy))
@@ -414,17 +429,7 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
   // TweetEmbed runs after the global Twemoji pass, so the card's text (names,
   // body, quoted text) is built too late to be picked up. Twemojify it here so
   // emoji in a tweet render as inline images like the rest of the site.
-  //
-  // `no-formatting` exempts the card from HTMLFormattingImprovement (which runs
-  // later in the pipeline): a tweet is a verbatim quote of someone else's words,
-  // so the site's typography rewrites must not touch it. Without this, slash
-  // spacing pads the slashes in a shortened display URL ("futureoflife.org /
-  // open-letter / le…") and other passes would silently alter the quoted text.
-  const article = h(
-    "article",
-    { className: "tweet-card no-formatting", "data-tweet-id": snapshot.id },
-    children,
-  )
+  const article = h("article", { className: "tweet-card", "data-tweet-id": snapshot.id }, children)
   return processTree(article) as Element
 }
 


### PR DESCRIPTION
## Summary

Tweet embeds previously carried `no-formatting` on the entire `<article class="tweet-card">`, which exempted the whole card—including the site's own chrome—from the HTMLFormattingImprovement typography pass. This meant the post date and engagement counts (reply/like numbers) never received the site's typographic treatment.

This moves `no-formatting` off the article and onto the `tweet-body` divs (both the main body and the quoted-tweet body). Now:

- The **scraped quote text** stays exactly verbatim (the reason `no-formatting` exists—display-URL slash spacing and other rewrites must not touch someone else's words).
- The card's own **date line and engagement counts** get normal site typography like the rest of the page.

## Changes

- `quartz/plugins/transformers/tweetCard.ts`: apply `no-formatting` to the `tweet-body` elements instead of the `tweet-card` article; relocate the explanatory comment to the body.
- `quartz/plugins/transformers/tests/tweetCard.test.ts`: assert `no-formatting` is on the body and not on the card.

## Testing

- `tweetCard.test.ts` — 75 passing, `tweetCard.ts` at 100% coverage.

Styling is unaffected: the `.tweet-body` SCSS selectors still match since `no-formatting` is purely additive.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJM53dPtY7dHaTg8A6qYGD)_