### PR TITLE
fix: capitalize sentence-leading acronyms after a closing quote/bracket

### DIFF
--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -261,9 +261,14 @@ export function shouldSkipNode(node: Text, ancestors: Parent[]): boolean {
   return hasClass(parent, "elvish") || parent.tagName === "abbr"
 }
 
+// Closing quotes/brackets that can sit between sentence-ending punctuation and
+// the following whitespace (e.g. `escalation.” IASEAI`). Straight quotes are
+// omitted because PUNCTUATION_BEFORE_MATCH already strips them upstream.
+const sentenceEndCloser = "[’”)\\]}]?"
+
 // If text comes after sentence ending, capitalize the first letter
 export const capitalizeAfterEnding = new RegExp(
-  `(?<prefix>^\\s*|\\n|[.!?](?<!e\\.g\\.|i\\.e\\.)\\s+)(?<letter>[${upperCapsChars}])$`,
+  `(?<prefix>^\\s*|\\n|[.!?](?<!e\\.g\\.|i\\.e\\.)${sentenceEndCloser}\\s+)(?<letter>[${upperCapsChars}])$`,
   "iu",
 )
 

--- a/quartz/plugins/transformers/tests/tagSmallcaps.test.ts
+++ b/quartz/plugins/transformers/tests/tagSmallcaps.test.ts
@@ -929,6 +929,15 @@ describe("capitalizeAfterEnding regex", () => {
     [".   C"], // Multiple spaces after period
     ["!    É"], // Multiple spaces after exclamation with accent
     ["?.   Ô"], // Multiple punctuation with spaces
+
+    // Closing quote/bracket between sentence-ender and whitespace
+    ["escalation.” I"], // Curly double quote
+    ["cool.’ N"], // Curly single quote
+    ["done!” A"], // Exclamation then curly quote
+    ["really?” B"], // Question then curly quote
+    ["(see below.) C"], // Closing paren
+    ["item.] D"], // Closing bracket
+    ["block.} E"], // Closing brace
   ]
 
   const invalidCases = [
@@ -960,6 +969,13 @@ describe("capitalizeAfterEnding regex", () => {
     ".A", // Just punctuation and capital
     "?A", // Just punctuation and capital
     "!A", // Just punctuation and capital
+
+    // Closing punctuation without a preceding sentence-ender
+    "mid” B", // Curly quote with no sentence-ender before it
+    "list) C", // Closing paren after a non-terminal word
+    "e.g.” D", // "e.g." stays excluded even with a closing quote
+    "i.e.) E", // "i.e." stays excluded even with a closing paren
+    ".”A", // Closing quote but no whitespace before the capital
   ]
 
   it.each(validCases)("should match end of sentence with capital: %s", (text) => {
@@ -1004,6 +1020,9 @@ describe("capitalizeMatch", () => {
     ["only punctuation and spaces before", ".  NASA", 3, true],
     ["period without space", "First.NASA", 6, false],
     ["multiple sentences", "First. Second. NASA", 15, true],
+    ["curly quote after period", "escalation.” NASA seemed built", 13, true],
+    ["closing paren after period", "(see below.) NASA is cool", 13, true],
+    ["curly quote mid-sentence", "the “model” NASA program", 12, false],
 
     // Test each punctuation character from PUNCTUATION_BEFORE_MATCH
     ...punctuationChars.map(


### PR DESCRIPTION
## Summary

A sentence-leading acronym renders with a full-height initial cap (e.g. `Iaseai` under `font-variant: small-caps`) instead of all small caps. This relies on `capitalizeAfterEnding` in `quartz/plugins/transformers/tagSmallcaps.ts` recognizing the acronym as sentence-initial.

That regex only matched when the sentence-ending punctuation `.!?` was **immediately** followed by whitespace. In `escalation.” IASEAI seemed built…` the period is followed by a curly closing quote (inserted by the `HTMLFormattingImprovement` pass, which runs before `TagSmallcaps`), so the boundary went undetected and `IASEAI` rendered entirely in small caps with no full-height `I`.

## Change

- Allow an optional closing quote/bracket (`’ ” ) ] }`) between the sentence-ending punctuation and the whitespace in `capitalizeAfterEnding`. Straight quotes are intentionally omitted — `PUNCTUATION_BEFORE_MATCH` already strips them upstream, so only curly closers and brackets needed adding.
- The `e.g.` / `i.e.` negative lookbehind is preserved, so those stay excluded even when followed by a closing quote.
- Added tests covering the new valid cases (curly quotes, brackets, `!`/`?` enders) and guard cases (closing punctuation with no preceding sentence-ender, no trailing whitespace).

## False-positive check

A scan of all `website_content/*.md` for `[.!?]` + closing-quote/bracket + whitespace + a real acronym (2+ caps) returns **exactly one** occurrence — the `IASEAI` case this fixes. The looser single-capital variant (458 hits) is all ordinary sentence-openers (`The`, `I`, …) that never trigger small-caps. No false positives.

## Testing

- `pnpm test -- quartz/plugins/transformers/tests/tagSmallcaps.test.ts` — 760 passed, `tagSmallcaps.ts` at 100% coverage.