### PR TITLE
refactor(ci): decouple the baseline R2 upload from the PR branch

### DIFF
--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -20,10 +20,11 @@ name: Update visual baselines
 # check-run + deploy verify rerun). One approval click clears both the PR
 # and main.
 #
-# An approval can race an auto-merge that lands mid-run (deleting the head
-# branch, possibly after a lag). Both spots that touch the branch — the
-# checkout and the empty-commit push — re-check the PR's merged state and
-# route down the merged-PR carry-through path instead of failing.
+# The R2 upload — the actual approval — runs entirely from the default
+# branch and never touches the PR branch, so an auto-merge landing mid-run
+# cannot abort it. Only the open-PR retrigger push depends on the branch
+# existing; it detects a merge-deleted branch and defers to the
+# carry-through path above.
 
 on:
   workflow_dispatch:
@@ -93,55 +94,14 @@ jobs:
             core.setOutput('merged', merged);
             core.setOutput('merged_at', mergedAt);
 
-      # Merged PRs skip the branch checkout: the head branch is auto-deleted
-      # on merge, and the carry-through path below only needs the repo
-      # scripts — from the default branch, or, when the merge lands mid-run,
-      # from the already-checked-out PR branch (whose tree is what just
-      # landed on main). An auto-merge can land (and delete the branch)
-      # between the resolve step and this checkout, so a checkout failure is
-      # tolerated here and re-resolved below instead of failing the approval.
-      - name: Checkout target ref
-        id: checkout-branch
-        if: steps.resolve.outputs.ref != '' && steps.resolve.outputs.merged != 'true'
-        continue-on-error: true
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted GITHUB_TOKEN is used by the empty-commit push below
+      # The upload and both carry-through paths only need the repo scripts,
+      # which live on the default branch; the open-PR retrigger fetches and
+      # pushes the PR branch itself from here. Persisted credentials are used
+      # by that push.
+      - name: Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked] the persisted GITHUB_TOKEN is used by the retrigger push below
         with:
-          ref: ${{ steps.resolve.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      # A failed branch checkout is only acceptable when the PR merged after
-      # the resolve step (deleting the branch); in that case the approval
-      # continues down the merged-PR carry-through path. Any other checkout
-      # failure fails the approval loudly.
-      - name: Re-resolve PR after branch checkout failure
-        id: recheck
-        if: steps.checkout-branch.outcome == 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: Number(process.env.PR_NUMBER),
-            });
-            if (!pr.data.merged) {
-              core.setFailed(
-                `Checkout of the PR branch failed but PR #${process.env.PR_NUMBER} ` +
-                'is not merged, so the failure is not a merge-deleted branch.'
-              );
-              return;
-            }
-            core.info(`PR #${process.env.PR_NUMBER} merged after resolve; using the carry-through path.`);
-            core.setOutput('merged', 'true');
-            core.setOutput('merged_at', pr.data.merged_at || '');
-
-      - name: Checkout default branch (main runs and merged PRs)
-        if: steps.resolve.outputs.ref == '' || steps.resolve.outputs.merged == 'true' || steps.recheck.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
       - name: Download Playwright blob reports from the named run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -176,7 +136,7 @@ jobs:
 
       - name: Push empty commit to retrigger visual-testing (open-PR runs only)
         id: push
-        if: steps.resolve.outputs.pr_number != '' && steps.resolve.outputs.merged != 'true' && steps.recheck.outputs.merged != 'true'
+        if: steps.resolve.outputs.pr_number != '' && steps.resolve.outputs.merged != 'true'
         env:
           REF: ${{ steps.resolve.outputs.ref }}
           RUN_ID: ${{ github.event.inputs.run_id }}
@@ -185,11 +145,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # The R2 upload above is the approval; this empty commit only nudges
-          # visual-testing to rerun. A push to the PR branch that lands between
-          # this job's checkout and its push (e.g. a fresh commit on the PR)
-          # would non-fast-forward reject the push and fail the approval even
-          # though the baselines are already live. Reset to the freshest tip
-          # before each attempt so the push is always a fast-forward.
+          # visual-testing to rerun. A concurrent push to the PR branch would
+          # non-fast-forward reject this one, so reset to the freshest tip
+          # before each attempt to keep the push a fast-forward.
           #
           # A merge landing during this job deletes the branch entirely; in
           # that case the retrigger is moot and the merged-PR carry-through
@@ -212,7 +170,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="ci: rerun visual-testing against approved baselines (run $RUN_ID, approved by $APPROVER)"
           for attempt in 1 2 3 4 5; do
-            if ! git fetch origin "$REF"; then
+            # Write the remote-tracking ref explicitly: the checkout is of the
+            # default branch, whose refspec would otherwise leave the PR
+            # branch only in FETCH_HEAD, so origin/$REF must be created here.
+            if ! git fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF"; then
               check_merged_late
               echo "Fetch of $REF failed but PR #$PR_NUMBER is not merged" >&2
               exit 1
@@ -235,27 +196,25 @@ jobs:
           echo "Failed to push retrigger commit after 5 attempts" >&2
           exit 1
 
-      # Single source of truth for whether the PR is merged, however that
-      # was discovered: at resolve time, at branch checkout (recheck), or at
-      # the retrigger push (merged_late).
+      # Single source of truth for whether the PR is merged, whether that was
+      # known at resolve time or discovered when the retrigger push found the
+      # branch gone (merged_late).
       - name: Consolidate effective merge state
         id: merged-state
         if: steps.resolve.outputs.pr_number != ''
         env:
           RESOLVE_MERGED: ${{ steps.resolve.outputs.merged }}
-          RECHECK_MERGED: ${{ steps.recheck.outputs.merged }}
           PUSH_MERGED_LATE: ${{ steps.push.outputs.merged_late }}
           RESOLVE_MERGED_AT: ${{ steps.resolve.outputs.merged_at }}
-          RECHECK_MERGED_AT: ${{ steps.recheck.outputs.merged_at }}
           PUSH_MERGED_AT: ${{ steps.push.outputs.merged_at }}
         run: |
           merged=false
-          if [ "$RESOLVE_MERGED" = "true" ] || [ "$RECHECK_MERGED" = "true" ] || [ "$PUSH_MERGED_LATE" = "true" ]; then
+          if [ "$RESOLVE_MERGED" = "true" ] || [ "$PUSH_MERGED_LATE" = "true" ]; then
             merged=true
           fi
           {
             echo "merged=$merged"
-            echo "merged_at=${RESOLVE_MERGED_AT:-${RECHECK_MERGED_AT:-$PUSH_MERGED_AT}}"
+            echo "merged_at=${RESOLVE_MERGED_AT:-$PUSH_MERGED_AT}"
           } >> "$GITHUB_OUTPUT"
 
       # Carry-through for merged PRs: the approved diffs are the ones

--- a/.github/workflows/update-visual-baselines.yaml
+++ b/.github/workflows/update-visual-baselines.yaml
@@ -170,9 +170,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="ci: rerun visual-testing against approved baselines (run $RUN_ID, approved by $APPROVER)"
           for attempt in 1 2 3 4 5; do
-            # Write the remote-tracking ref explicitly: the checkout is of the
-            # default branch, whose refspec would otherwise leave the PR
-            # branch only in FETCH_HEAD, so origin/$REF must be created here.
+            # The default-branch checkout tracks only the default branch, so
+            # write the PR branch's remote-tracking ref explicitly to make
+            # origin/$REF resolvable for the reset and lease below.
             if ! git fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF"; then
               check_merged_late
               echo "Fetch of $REF failed but PR #$PR_NUMBER is not merged" >&2


### PR DESCRIPTION
## Summary

- The visual-baseline approval workflow checked out the PR branch *before* the R2 upload, so an auto-merge deleting that branch mid-run aborted the whole job before the upload ran — the approved screenshots were never adopted and `main`'s post-merge run re-surfaced the same diffs (observed on PR #1655, fixed reactively in #1656).
- #1656 patched each branch-touching step to re-check merged state — a symptom fix. This addresses the root cause instead: the upload (the actual approval) never needs the PR branch, so it shouldn't depend on it.

## Changes

- **Single `Checkout default branch` step** (with persisted push credentials) replaces the tolerant PR-branch checkout + re-resolve step. The upload and both carry-through paths run from the default branch, which is where the repo scripts live and which a merge can't delete.
- **The retrigger push is now the only branch-dependent step**: it fetches the PR branch, makes the empty commit, and pushes with `--force-with-lease`; finding the branch gone, it defers to the merged-PR carry-through via `check_merged_late`.
- **Removed** the `continue-on-error` checkout, the `recheck` re-resolve step, and the three-way merged-state consolidation (now just resolve ∥ push.merged_late).
- Because the checkout is now of the default branch, the retrigger fetch writes the PR branch's remote-tracking ref explicitly (`+refs/heads/$REF:refs/remotes/origin/$REF`) so `origin/$REF` resolves for the reset and the lease.

Net: ~40 fewer lines, and the race can no longer touch the approval — only the best-effort retrigger, which already handles it.

## Testing

- YAML parses; `zizmor --offline` reports no findings; `actionlint` with shellcheck integration passes.
- Traced the failure path against run 29982130322 (the original race): with this change the upload runs unconditionally from the default branch, so the mid-run merge that previously aborted before upload no longer can.

## Lessons Learned

- **What**: When a job's core side effect doesn't need a mutable resource (here the PR branch, which an auto-merge can delete mid-run), don't check that resource out on the critical path — isolate the dependency to the one step that genuinely needs it, so racing state changes can't abort the important work.
- **Where**: any workflow that both performs a durable action and pushes to a PR head branch (here `.github/workflows/update-visual-baselines.yaml`).
- **Why**: the prior design gated the R2 upload behind a PR-branch checkout, so a mid-run merge aborted the approval before it did anything; decoupling makes the upload race-immune and confines the fragile part to a best-effort step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaRmhB58bKNb5s1K72ofDQ)_