### PR TITLE
test(visual): prevent media playback in screenshot specs

### DIFF
--- a/.github/workflows/site-build-checks.yaml
+++ b/.github/workflows/site-build-checks.yaml
@@ -166,6 +166,7 @@ jobs:
         with:
           command: |
             uv run linkchecker http://localhost:8080 \
+              --config config/linkchecker/linkcheckerrc \
               --ignore-url='!^(http://localhost:8080|https://assets\.turntrout\.com|https://github\.com/alexander-turner/TurnTrout\.com)' \
               --check-extern \
               --threads 30 \

--- a/config/linkchecker/linkcheckerrc
+++ b/config/linkchecker/linkcheckerrc
@@ -1,0 +1,4 @@
+[filtering]
+# GitHub throttles CI runners crawling github.com links (HTTP 429). A
+# rate-limited response is not a broken link; real 4xx/5xx still error.
+ignorewarnings=http-rate-limited

--- a/quartz/components/tests/section-fixtures.spec.ts
+++ b/quartz/components/tests/section-fixtures.spec.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { expect, test } from "./fixtures"
-import { gotoPage, setTheme, takeRegressionScreenshot } from "./visual_utils"
+import { gotoPage, preventMediaPlayback, setTheme, takeRegressionScreenshot } from "./visual_utils"
 
 const THEMES = ["light", "dark"] as const
 
@@ -35,6 +35,7 @@ test.describe("Test page section fixtures", () => {
   for (const slug of sectionSlugs) {
     for (const theme of THEMES) {
       test(`section ${slug} in ${theme} mode (screenshot)`, async ({ page }, testInfo) => {
+        await preventMediaPlayback(page)
         await gotoPage(page, `http://localhost:8080/test-section-${slug}`)
         // Fail loudly if the fixture page didn't build (404s to "Page Not
         // Found") instead of silently screenshotting the 404 page as a diff.

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -16,6 +16,7 @@ import {
   isElementChecked,
   isFirefox,
   moveMouseToSafePosition,
+  preventMediaPlayback,
   reloadPage,
   setTheme,
   takeRegressionScreenshot,
@@ -50,6 +51,8 @@ test.beforeEach(async ({ page }) => {
   })
 
   page.on("pageerror", (err) => console.error(err))
+
+  await preventMediaPlayback(page)
 
   // Use domcontentloaded instead of load — Firefox can stall on subresource
   // loads (images, fonts) in CI, causing 30s timeout in beforeEach.

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -369,13 +369,21 @@ test.describe("preventMediaPlayback", () => {
       canvas.height = 32
       const ctx = canvas.getContext("2d")
       if (!ctx) throw new Error("canvas 2d context unavailable")
-      ctx.fillStyle = "red"
-      ctx.fillRect(0, 0, 32, 32)
+      // captureStream only emits frames when the canvas repaints, so keep
+      // redrawing until the listener pauses the video — otherwise the sole
+      // initial frame can slip past before the video starts consuming the
+      // stream and nothing is ever presented.
+      const redraw = setInterval(() => {
+        ctx.fillStyle = "red"
+        ctx.fillRect(0, 0, 32, 32)
+      }, 20)
       const video = document.createElement("video")
       video.id = "prevent-playback-video-probe"
       video.muted = true
+      video.playsInline = true
       video.srcObject = canvas.captureStream(30)
       document.body.appendChild(video)
+      video.addEventListener("pause", () => clearInterval(redraw), { once: true })
       video.play().catch(() => {
         // The listener's pause() rejects the pending play() promise; that
         // rejection is this helper working as intended.

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -329,33 +329,75 @@ test.describe("visual_utils functions", () => {
 })
 
 test.describe("preventMediaPlayback", () => {
-  test("pauses a video at frame 0 the moment playback starts", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await preventMediaPlayback(page)
     // Fresh navigation so the init script is installed in the document.
     await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
+  })
 
+  test("pauses audio at time 0 the moment playback starts", async ({ page }) => {
     await page.evaluate(() => {
-      const video = document.createElement("video")
-      video.id = "prevent-playback-probe"
-      document.body.appendChild(video)
+      const audio = document.createElement("audio")
+      audio.id = "prevent-playback-audio-probe"
+      document.body.appendChild(audio)
       // No source is attached, so play() flips `paused` and queues the "play"
       // event task without needing any media data.
-      video.play().catch(() => {
+      audio.play().catch(() => {
         // The listener's pause() rejects the pending play() promise; that
         // rejection is this helper working as intended.
       })
     })
 
     // The "play" event is dispatched from a queued task, so the prevention
-    // listener pauses the video one task after play() returns.
+    // listener pauses the media one task after play() returns.
     await expect
       .poll(() =>
         page.evaluate(() => {
-          const video = document.getElementById("prevent-playback-probe") as HTMLVideoElement
-          return { paused: video.paused, currentTime: video.currentTime }
+          const audio = document.getElementById("prevent-playback-audio-probe") as HTMLAudioElement
+          return { paused: audio.paused, currentTime: audio.currentTime }
         }),
       )
       .toEqual({ paused: true, currentTime: 0 })
+  })
+
+  test("pauses a video on its first presented frame", async ({ page }) => {
+    await page.evaluate(() => {
+      // A canvas capture stream supplies real presentable frames without any
+      // network fetch, so the rVFC pause-on-first-frame path runs.
+      const canvas = document.createElement("canvas")
+      canvas.width = 32
+      canvas.height = 32
+      const ctx = canvas.getContext("2d")
+      if (!ctx) throw new Error("canvas 2d context unavailable")
+      ctx.fillStyle = "red"
+      ctx.fillRect(0, 0, 32, 32)
+      const video = document.createElement("video")
+      video.id = "prevent-playback-video-probe"
+      video.muted = true
+      video.srcObject = canvas.captureStream(30)
+      document.body.appendChild(video)
+      video.play().catch(() => {
+        // The listener's pause() rejects the pending play() promise; that
+        // rejection is this helper working as intended.
+      })
+    })
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const video = document.getElementById("prevent-playback-video-probe") as HTMLVideoElement
+          return video.paused
+        }),
+      )
+      .toBe(true)
+
+    // The pause lands on the first presented frame, so the clock has advanced
+    // by at most a frame or two — never seconds of playback.
+    const currentTime = await page.evaluate(() => {
+      const video = document.getElementById("prevent-playback-video-probe") as HTMLVideoElement
+      return video.currentTime
+    })
+    expect(currentTime).toBeLessThan(0.5)
   })
 })
 

--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -10,6 +10,7 @@ import {
   gotoPage,
   isDesktopViewport,
   pauseMediaElements,
+  preventMediaPlayback,
   setTheme,
   takeRegressionScreenshot,
   waitForImagesInElement,
@@ -324,6 +325,37 @@ test.describe("visual_utils functions", () => {
       expect(parseFloat(finalOpacity)).toBeCloseTo(0, 1)
       expect(finalTransform).toContain("100")
     })
+  })
+})
+
+test.describe("preventMediaPlayback", () => {
+  test("pauses a video at frame 0 the moment playback starts", async ({ page }) => {
+    await preventMediaPlayback(page)
+    // Fresh navigation so the init script is installed in the document.
+    await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
+
+    await page.evaluate(() => {
+      const video = document.createElement("video")
+      video.id = "prevent-playback-probe"
+      document.body.appendChild(video)
+      // No source is attached, so play() flips `paused` and queues the "play"
+      // event task without needing any media data.
+      video.play().catch(() => {
+        // The listener's pause() rejects the pending play() promise; that
+        // rejection is this helper working as intended.
+      })
+    })
+
+    // The "play" event is dispatched from a queued task, so the prevention
+    // listener pauses the video one task after play() returns.
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const video = document.getElementById("prevent-playback-probe") as HTMLVideoElement
+          return { paused: video.paused, currentTime: video.currentTime }
+        }),
+      )
+      .toEqual({ paused: true, currentTime: 0 })
   })
 })
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -588,6 +588,29 @@ export async function search(page: Page, term: string) {
   await expect(page.locator(".result-card").first()).toBeVisible({ timeout: 15_000 })
 }
 
+/**
+ * Keeps every `<video>`/`<audio>` on frame 0 for the life of the page by
+ * pausing it inside a capture-phase "play" listener, which runs before the
+ * media clock advances. Screenshot determinism requires frame 0 on the
+ * compositor at capture time; once playback advances, restoring frame 0
+ * depends on WebKit presenting a seeked frame, which it does not reliably do.
+ * Must be called before navigation so the listener exists when autoplay
+ * first fires. Only for specs that never assert real playback.
+ */
+export async function preventMediaPlayback(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    document.addEventListener(
+      "play",
+      (event) => {
+        const media = event.target as HTMLMediaElement
+        media.pause()
+        if (media.currentTime !== 0) media.currentTime = 0
+      },
+      { capture: true },
+    )
+  })
+}
+
 // skipcq: JS-0098
 export async function pauseMediaElements(page: Page, scope?: Locator): Promise<void> {
   const mediaScope = scope ?? page

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -589,22 +589,38 @@ export async function search(page: Page, term: string) {
 }
 
 /**
- * Keeps every `<video>`/`<audio>` on frame 0 for the life of the page by
- * pausing it inside a capture-phase "play" listener, which runs before the
- * media clock advances. Screenshot determinism requires frame 0 on the
- * compositor at capture time; once playback advances, restoring frame 0
- * depends on WebKit presenting a seeked frame, which it does not reliably do.
- * Must be called before navigation so the listener exists when autoplay
- * first fires. Only for specs that never assert real playback.
+ * Freezes every `<video>`/`<audio>` on frame 0 for the life of the page.
+ * Screenshot determinism requires frame 0 on the compositor at capture time,
+ * and WebKit only reliably presents a frame *during playback* — a paused
+ * video may never paint (seeked frames are not reliably presented, and a
+ * never-played video can stay blank). So each play attempt is allowed to
+ * present exactly its first frame: playback starts at the current position,
+ * `requestVideoFrameCallback` fires on that first presentation (mediaTime 0
+ * for a fresh start), and the video is paused right there with its clock
+ * snapped back to 0 before any drift accumulates. Audio, and media with no
+ * data to present, are paused immediately. Must be called before navigation
+ * so the listener exists when autoplay first fires. Only for specs that
+ * never assert real playback.
  */
 export async function preventMediaPlayback(page: Page): Promise<void> {
   await page.addInitScript(() => {
     document.addEventListener(
       "play",
       (event) => {
-        const media = event.target as HTMLMediaElement
-        media.pause()
-        if (media.currentTime !== 0) media.currentTime = 0
+        const media = event.target as HTMLMediaElement & {
+          requestVideoFrameCallback?: (cb: () => void) => number
+        }
+        const isPresentableVideo =
+          media instanceof HTMLVideoElement && typeof media.requestVideoFrameCallback === "function"
+        if (!isPresentableVideo) {
+          media.pause()
+          if (media.currentTime !== 0) media.currentTime = 0
+          return
+        }
+        media.requestVideoFrameCallback?.(() => {
+          media.pause()
+          if (media.currentTime !== 0) media.currentTime = 0
+        })
       },
       { capture: true },
     )

--- a/scripts/linkchecker.fish
+++ b/scripts/linkchecker.fish
@@ -12,6 +12,7 @@ set -l INTERNAL_STATUS $status
 # two hosts I control and drops all other external links. --check-extern makes
 # linkchecker fetch the allowlisted external URLs instead of skipping them.
 linkchecker $LOCAL_SERVER \
+    --config config/linkchecker/linkcheckerrc \
     --ignore-url="!^(http://localhost:8080|https://assets\.turntrout\.com|https://github\.com/alexander-turner/TurnTrout\.com)" \
     --check-extern \
     --threads 30 \


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `section-video` visual flake (most recently on PR #1659's visual run, Desktop Safari): the diff showed the autoplay gridworld video captured on a **mid-play frame** (progress bar filled, agents moved) instead of frame 0.

## Diagnosis

Every prior fix was reactive — pause after autoplay started, seek back to 0, and wait for the paint behind fallback timers (buffered-seek `42b4390`, play-retry `a31022d`/`88495ee`, paint-based waits `b0bdd55`/`dc62b2f`). The remaining hole: WebKit does not reliably present a *seeked* frame while paused, so after seconds of autoplay the seek back to 0 can leave a stable stale mid-play frame on the compositor that passes the two-identical-captures gate and screenshots as a diff.

Fully preventing playback doesn't work either — WebKit only reliably presents frames *during playback*, so a never-played video screenshots blank (this PR's first iteration diffed the navbar pond video as an unpainted region).

## Change

`preventMediaPlayback(page)` installs a capture-phase `play` listener via `addInitScript` (so it exists before autoplay first fires) that lets each play attempt present **exactly its first frame**: `requestVideoFrameCallback` fires on that first presentation (mediaTime 0 for a fresh start), and the video is paused right there with its clock snapped back to 0. The compositor holds a painted frame 0, and playback never drifts into mid-play territory — there is nothing to seek back, so the WebKit seeked-frame race can't occur. Audio and non-rVFC media pause immediately at the play event.

Applied to `section-fixtures.spec.ts` and `visual-regression.spec.ts`, which never assert real playback. The `autoplay` attribute is left untouched, so the VSC-controller tests that assert on it are unaffected. Playback-asserting specs (navbar pond video playback) don't get the listener.

## Testing

- New Playwright tests: audio pauses at time 0 on the immediate path; a canvas-capture-stream video pauses on its first presented frame (clock < 0.5 s). Both pass on Desktop Chrome locally.
- VSC-controller + playback-rate suite (6 tests) — passes with the listener installed.
- The snapshot comparisons themselves are CI's to make (baselines live in R2).

## Lessons learned

- When a visual snapshot keeps flaking on media content, check whether the pipeline is *reacting* to playback (pause + seek back + bounded waits) rather than bounding it at the source. WebKit's compositor only reliably paints video frames during playback: a paused seek may never present, and a never-played video may stay blank. The deterministic sweet spot is "pause on the first presented frame" via `requestVideoFrameCallback` — playback both forces the paint and is halted before drift.
- Media `play` events are dispatched from a queued task, not synchronously from `play()` — tests asserting on listener side effects must poll one task later.
- A canvas `captureStream()` video is a network-free way to exercise real frame-presentation paths in browser tests.