### PR TITLE
test: use SSOT tightScrollTolerance (10px) for scroll assertions

### DIFF
--- a/quartz/components/scripts/spa.inline.spec.ts
+++ b/quartz/components/scripts/spa.inline.spec.ts
@@ -406,15 +406,15 @@ test.describe("Instant Scroll Restoration", () => {
     // a late SPA navigation destroys the execution context between separate
     // waitForFunction + page.evaluate calls (seen on Firefox & Safari).
     const handle = await page.waitForFunction(
-      (target) => {
-        if (Math.abs(window.scrollY - target) < 50) return window.scrollY
+      ({ target, tolerance }) => {
+        if (Math.abs(window.scrollY - target) <= tolerance) return window.scrollY
         return false
       },
-      scrollPos,
+      { target: scrollPos, tolerance: tightScrollTolerance },
       { timeout: 15_000, polling: WAIT_POLL_INTERVAL_MS },
     )
     const finalScroll = await handle.jsonValue()
-    expect(finalScroll).toBeCloseTo(scrollPos, -1)
+    expect(Math.abs(Number(finalScroll) - scrollPos)).toBeLessThanOrEqual(tightScrollTolerance)
   })
 
   test("restores hash position immediately on reload", async ({ page }) => {
@@ -591,7 +591,7 @@ test.describe("Cross-Session Scroll Persistence (localStorage)", () => {
     const key = `${scrollPositionKeyPrefix}${new URL(page.url()).pathname}`
     const stored = await page.evaluate((k) => localStorage.getItem(k), key)
     expect(stored).not.toBeNull()
-    expect(Number(stored)).toBeCloseTo(scrollPos, -1)
+    expect(Math.abs(Number(stored) - scrollPos)).toBeLessThanOrEqual(tightScrollTolerance)
   })
 
   test("does not save scroll position below minimum threshold", async ({ page }) => {
@@ -629,7 +629,7 @@ test.describe("Cross-Session Scroll Persistence (localStorage)", () => {
       { timeout: 15_000, polling: WAIT_POLL_INTERVAL_MS },
     )
     const finalScroll = await handle.jsonValue()
-    expect(finalScroll).toBeCloseTo(scrollPos, -1)
+    expect(Math.abs(Number(finalScroll) - scrollPos)).toBeLessThanOrEqual(tightScrollTolerance)
 
     await newPage.close()
   })
@@ -839,9 +839,10 @@ test.describe("Same-page navigation", () => {
     await clickToc(page)
 
     await page.goBack()
+    await waitForScroll(page, scrollTarget)
 
     const finalScroll = await page.evaluate(() => window.scrollY)
-    expect(finalScroll).toBeCloseTo(scrollTarget, -1)
+    expect(Math.abs(finalScroll - scrollTarget)).toBeLessThanOrEqual(tightScrollTolerance)
   })
 })
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -763,7 +763,9 @@ test.describe("Right sidebar", () => {
 
     // Verify sidebar did scroll
     expect(finalSidebarScrollTop).toBeGreaterThan(initialSidebarScrollTop)
-    expect(finalSidebarScrollTop).toBeCloseTo(initialSidebarScrollTop + 100, 0) // Allow for slight rounding
+    expect(Math.abs(finalSidebarScrollTop - (initialSidebarScrollTop + 100))).toBeLessThanOrEqual(
+      tightScrollTolerance,
+    )
   })
 
   test("Right sidebar fades top/bottom based on scroll position", async ({ page }) => {


### PR DESCRIPTION
## What

Route every scroll-position assertion through the shared `tightScrollTolerance` constant (currently **10px** in `config/constants.json`), replacing hardcoded `toBeCloseTo(pos, -1)` assertions (an implicit **5px** tolerance).

## Why

The reported flake:

```
1) [Desktop Chrome] › spa.inline.spec.ts:372 › restores saved scroll position immediately on reload
   Expected: 500  Received: 494  (diff 6, tolerance 5)
```

The assertions used `toBeCloseTo(pos, -1)` — a **5px** tolerance — while the `waitForFunction` calls that gated them exited at `tightScrollTolerance` (**10px**). When scroll restoration landed 6–10px off the target (subpixel/`devicePixelRatio` rounding), the wait passed but the tighter assertion failed. No retry-free fix was possible because the two tolerances disagreed.

## Fix

- Every scroll assertion now compares `Math.abs(actual - expected) <= tightScrollTolerance` — a single source of truth.
- Each is gated by a wait using **that same** `tightScrollTolerance`, and the wait returns the exact `window.scrollY` value it validated. The value that satisfies the wait is therefore guaranteed to satisfy the assertion → deterministic, no retries.
- `spa.inline.spec.ts:372` — wait tolerance changed from a hardcoded `< 50` to `<= tightScrollTolerance`, matching the assertion.
- `spa.inline.spec.ts` "going back after anchor navigation" — added a missing `waitForScroll(page, scrollTarget)` after `goBack()` so the read isn't racing scroll restoration.
- `visual-regression.spec.ts:766` — same anti-pattern: wait gated on `tightScrollTolerance` (10) but assertion demanded `toBeCloseTo(..., 0)` (0.5px). Now uses `tightScrollTolerance`.

## Lessons learned

When a Playwright assertion checks a value that a preceding `waitForFunction` gates on, the assertion tolerance must be **≥** the wait tolerance, or the test flakes whenever the value settles in the gap between them. Prefer routing both through one shared tolerance constant and having the wait return the exact value it validated, so the passing-wait value is provably within the assertion bound. `toBeCloseTo(x, -1)` / `toBeCloseTo(x, 0)` bury a hidden 5px / 0.5px tolerance that's easy to set below the wait's — prefer an explicit `Math.abs(a - b) <= TOL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKTR61GDcwoLwdSXNWTVMT)_