### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -114,32 +114,31 @@ On top of that isolation, `glovebox` adds its own oversight — sanitizing every
   'edgeLabelBackground':'#ffffff'
 }, 'themeCSS': '.node .label, .node .label foreignObject, .node .nodeLabel { overflow: visible; }'}}%%
 flowchart TB
-    IN["Fetched pages &amp; tool output"]
-
-    subgraph VM["🔒 Sandbox VM"]
-        direction TB
-        AGENT["Claude Code agent"]
-        AUTO{"Auto mode<br/>permission gate"}
-        RUN(["Tool call runs"])
-    end
-
     subgraph HOST["🖥️ Your machine — outside the VM"]
         direction TB
+        IN["Fetched pages &amp; tool output"]
         MON["Monitor — a second model<br/>reviews the flagged calls"]
         AUDIT[("Tamper-evident<br/>audit log")]
         PHONE(("Your<br/>phone"))
+
+        subgraph VM["🔒 Sandbox VM"]
+            direction TB
+            AGENT["Claude Code agent"]
+            AUTO{"Auto mode<br/>permission gate"}
+            RUN(["Tool call runs"])
+        end
     end
 
     BRANCH(["Reviewable glovebox/* branch<br/>you merge yourself"])
 
-    IN -->|"&nbsp;strip hidden Unicode / HTML&nbsp;"| VM
+    IN -->|"&nbsp;strip hidden Unicode / HTML&nbsp;"| AGENT
     AGENT -->|"&nbsp;every tool call&nbsp;"| AUTO
     AUTO -->|"&nbsp;safe&nbsp;"| RUN
     AUTO <-->|"&nbsp;destructive /<br/>external ⇄<br/>cleared or halted&nbsp;"| MON
     MON -->|"&nbsp;misalignment:<br/>halt + push alert&nbsp;"| PHONE
     AUTO -.->|"&nbsp;every call&nbsp;"| AUDIT
     MON -.-> AUDIT
-    RUN -->|"&nbsp;edits return as&nbsp;"| BRANCH
+    RUN --> BRANCH
 
     classDef filter fill:#e2e8fb,stroke:#5f76c4,stroke-width:1.5px,stroke-dasharray:6 4,color:#1f2733
     classDef safe fill:#dff2e6,stroke:#3f9d6b,stroke-width:1.5px,color:#12331f
@@ -241,6 +240,16 @@ Charts re-render on every merge to `main` and update in place.
 <sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published on every merge to `main`, updating in place. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` -> Tests; `.github/` -> CI/CD; `*.md`/`docs/`/`changelog.d/` -> Docs; manifests/lockfiles/dotfiles -> Config; everything else -> Source.</sub>
 
 <!-- codebase-breakdown:end -->
+
+<!-- ci-health:start -->
+
+### CI health
+
+![CI failure-rate-by-check chart](https://assets.turntrout.com/static/charts/glovebox/ci-health.svg)
+
+<sub>Failure rate of each check over a rolling window of recent `main` runs, worst offenders first — rendered by `.github/scripts/ci-failure-rates.py` and republished weekly (and on demand) to a fixed, revalidate-always object that updates in place. `cancelled` (supersession noise) and `skipped` (decide-gate no-ops) are excluded, so a bar means the check ran to a verdict and failed that often — a tall bar is where CI re-run cost concentrates.</sub>
+
+<!-- ci-health:end -->
 
 ### Sandbox latencies
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.