### PR TITLE
ci: harden visual-baseline reliability at the drift/flake root causes

### DIFF
--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -46,6 +46,23 @@ const rafPollingSyntax = [
   },
 ]
 
+// A hast node built once at module scope is shared across every page's tree.
+// Later HTML plugins (InlineCodeSpacing, Favicons, ...) mutate the tree in
+// place, so each page's edits accumulate onto the one shared node — output
+// becomes a function of page count and processing order (e.g. the after-article
+// contact line grew one hair space per page, drifting the visual baselines).
+// Build injected nodes fresh inside a function so each page gets its own copy.
+const moduleScopeHastSyntax = {
+  selector: [
+    "Program > VariableDeclaration > VariableDeclarator > CallExpression[callee.name='h']",
+    "Program > VariableDeclaration > VariableDeclarator > TSAsExpression > CallExpression[callee.name='h']",
+    "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > CallExpression[callee.name='h']",
+    "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > TSAsExpression > CallExpression[callee.name='h']",
+  ].join(", "),
+  message:
+    "Do not build hast nodes (`h(...)`) at module scope: the single node is shared across every page and accumulates in-place mutations from later pipeline plugins. Build it fresh inside a function so each page gets its own copy.",
+}
+
 // Every built page embeds the looping navbar pond video, whose continuous
 // range requests can hold the `load` event open indefinitely in WebKit, so a
 // load-event gate is a latent shard-flaking timeout. Fixture documents
@@ -133,6 +150,17 @@ export default [
   {
     rules: {
       "no-restricted-syntax": ["error", noReexportSyntax],
+    },
+  },
+
+  // Pipeline plugins mutate the hast tree in place, so nodes they inject must be
+  // built per page — never shared from module scope. (Barrel index.ts files are
+  // re-enabled to "off" below; this block precedes them so that override wins.)
+  {
+    files: ["quartz/plugins/**/*.ts"],
+    ignores: ["**/*.test.ts", "**/*.spec.ts"],
+    rules: {
+      "no-restricted-syntax": ["error", noReexportSyntax, moduleScopeHastSyntax],
     },
   },
 

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -719,9 +719,13 @@ export async function pauseMediaElements(page: Page, scope?: Locator): Promise<v
  *
  * `pauseMediaElements` seeks videos to currentTime 0, but `paused`/`currentTime
  * === 0` are satisfied even when the engine (notably WebKit) has presented no
- * frame yet. Screenshotting that blank, never-painted state diffs against the
- * painted baseline — the source of the flake. requestVideoFrameCallback fires
- * only on a real paint, which is the signal we actually need.
+ * frame yet. A fresh sub-frame seek forces a presentation even when frame 0 was
+ * already on screen, and two independent signals report it: rVFC (a real paint,
+ * but never delivered by WebKit while paused) and "seeked" + double rAF.
+ *
+ * A video that never paints within budget throws instead of letting the
+ * screenshot proceed: a blank-video capture that gets approved poisons the
+ * shared R2 baselines for every later run.
  */
 async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
   for (const video of await scope.locator("video").all()) {
@@ -729,29 +733,47 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
     if (!handle) throw new Error("Could not get element handle for video")
     await handle.evaluate(
       (el, dataTimeoutMs) =>
-        new Promise<void>((resolve) => {
+        new Promise<void>((resolve, reject) => {
           const videoEl = el as HTMLVideoElement & {
             requestVideoFrameCallback?: (cb: () => void) => number
           }
-          const timers: ReturnType<typeof setTimeout>[] = []
           let settled = false
+          const timer = setTimeout(() => {
+            if (settled) return
+            settled = true
+            reject(
+              new Error(
+                `Video never painted within ${dataTimeoutMs}ms ` +
+                  `(readyState=${videoEl.readyState}): ${videoEl.currentSrc || "<no src>"}`,
+              ),
+            )
+          }, dataTimeoutMs)
           const finish = () => {
             if (settled) return
             settled = true
-            timers.forEach(clearTimeout)
+            clearTimeout(timer)
             resolve()
           }
           const waitForPaint = () => {
             videoEl.pause()
-            if (videoEl.currentTime !== 0) videoEl.currentTime = 0
-            if (typeof videoEl.requestVideoFrameCallback !== "function") {
-              finish()
-              return
+            // Race both presentation signals; `finish` is idempotent so the
+            // first to fire wins. WebKit never delivers video-frame callbacks
+            // while the video is paused, so it completes via "seeked" + double
+            // rAF; Chromium and Firefox fire rVFC on the paused seek itself.
+            if (typeof videoEl.requestVideoFrameCallback === "function") {
+              videoEl.requestVideoFrameCallback(finish)
             }
-            videoEl.requestVideoFrameCallback(finish)
-            // Fallback for the case where frame 0 is already on screen: no new
-            // frame is presented, so rVFC would never fire.
-            timers.push(setTimeout(finish, 1500))
+            videoEl.addEventListener(
+              "seeked",
+              () => requestAnimationFrame(() => requestAnimationFrame(finish)),
+              { once: true },
+            )
+            // Seek to a sub-frame offset (or back to 0 if already nudged): an
+            // actual position change runs the full seek algorithm in every
+            // engine, forcing the compositor to present frame 0 whether or not
+            // it was already on screen. That presentation fires the callback
+            // registered above.
+            videoEl.currentTime = videoEl.currentTime === 0 ? 1e-4 : 0
           }
           if (videoEl.readyState >= 2) {
             // HAVE_CURRENT_DATA or better: a frame is decodable now.
@@ -762,9 +784,6 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
             // data at all; for HAVE_METADATA the decode is already in flight.
             if (videoEl.readyState === 0) videoEl.load()
           }
-          // Never hang on a video whose data never arrives (e.g. a broken
-          // source); let the screenshot proceed and fail on its own terms.
-          timers.push(setTimeout(finish, dataTimeoutMs))
         }),
       VIDEO_PAINT_TIMEOUT_MS,
     )

--- a/scripts/r2_baselines.py
+++ b/scripts/r2_baselines.py
@@ -27,6 +27,13 @@ except ImportError:
 R2_PREFIX = "visual-baselines"
 LOCAL_DIR = Path("tests/visual-baselines")
 
+# Cloudflare R2 intermittently answers object transfers with
+# ``501 NotImplemented`` ("Failed to copy"). rclone's default three whole-run
+# retries usually absorb a lone blip, but a cluster of 501s across a
+# multi-file sync can exhaust them and fail an otherwise-good baseline
+# push/pull. Raise the ceiling so transient R2 errors can't sink the sync.
+_R2_RETRY_FLAGS = ["--retries=10", "--low-level-retries=20"]
+
 
 def _write_rclone_config(config_path: Path) -> None:
     """Thin alias for the shared rclone-config writer (see ``r2_sync``)."""
@@ -61,6 +68,7 @@ def download(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *_R2_RETRY_FLAGS,
             ],
             config,
         )
@@ -90,6 +98,7 @@ def upload(local_dir: Path) -> None:
                 "--checksum",
                 "--transfers=16",
                 "--checkers=16",
+                *_R2_RETRY_FLAGS,
             ],
             config,
         )


### PR DESCRIPTION
## Summary

Salvages the still-unique, still-relevant fixes from the stale branch behind #1648. The bulk of #1648 — a merge-race rewrite of `update-visual-baselines.yaml` — was **superseded on `main`** by five later commits that solve the same problem a different way, leaving #1648 conflicted and largely redundant. These three changes are the parts `main` does *not* already have, each targeting a distinct root cause of visual-baseline drift/flakiness. Extracted onto a clean branch off `main`; the redundant workflow rewrite is dropped.

## Changes

- **`config/javascript/eslint.config.js`** — new `no-restricted-syntax` rule forbidding module-scope `h(...)` hast nodes in `quartz/plugins/**`. A node built once at module scope is shared across every page's tree and accumulates in-place mutations from later HTML plugins, so output becomes a function of page count/order (e.g. the after-article contact line grew one hair space per page, drifting baselines). Verified zero existing violations on `main`.
- **`scripts/r2_baselines.py`** — add `--retries=10 --low-level-retries=20` to the baseline download/upload syncs. Cloudflare R2 intermittently returns `501 NotImplemented` on transfers; rclone's default retries can be exhausted by a cluster of 501s, failing an otherwise-good sync.
- **`quartz/components/tests/visual_utils.ts`** — rewrite `waitForVideosPainted` to force a real frame-0 presentation via a sub-frame seek (`currentTime = 1e-4`), report it through either `requestVideoFrameCallback` (Chromium/Firefox) or `"seeked"` + double-rAF (WebKit, which never fires rVFC while paused), and **throw** if the video never paints within budget instead of silently screenshotting a blank frame. A blank capture that gets approved poisons the shared R2 baselines for every later run. This function is unchanged on `main` since the branch point, so the rewrite applies cleanly without touching `main`'s separate `takeRegressionScreenshot`/media-playback refactor.

## Testing

- `tsc --noEmit`, `eslint` (incl. the new rule across all `quartz/plugins/**`), `prettier` — clean.
- `ruff` + `pylint` on `r2_baselines.py` — clean (10.00/10); `pytest scripts/tests/test_r2_baselines.py` — 12 passed.
- The `waitForVideosPainted` behavior is exercised by the visual-regression specs in CI.

## Lessons Learned

- **What**: When a branch conflicts with `main`, check whether `main` already landed a competing implementation of the same feature before resolving — salvage only the genuinely-unique, cleanly-applicable parts rather than reconciling a superseded rewrite.
- **Where**: PR-conflict triage workflow.
- **Why**: #1648's core workflow change was independently re-solved on `main` across five commits; a blind conflict resolution would have re-litigated settled logic in the live baseline-approval pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1Yd1r241f3Hh5q5J767mx)_