### PR TITLE
fix: stop the mobile navbar from ghosting over the article as it hides

### DIFF
--- a/quartz/components/styles/navbar.scss
+++ b/quartz/components/styles/navbar.scss
@@ -187,10 +187,9 @@
 
 @media all and (max-width: $max-mobile-width) {
   #page-columns #navbar {
-    opacity: 1;
-    transition:
-      transform $transition-duration-slow ease,
-      opacity $transition-duration-slow ease;
+    // Slide out of view without fading. Fading while the bar still overlaps
+    // the article turns it translucent over the text it is passing.
+    transition: transform $transition-duration-slow ease;
     z-index: $z-navbar;
     padding-top: calc(0.5 * $base-margin);
     pointer-events: auto;
@@ -202,7 +201,6 @@
 
     &.hide-above-screen {
       transform: translateY(-100%);
-      opacity: 0;
       pointer-events: none;
     }
   }

--- a/quartz/components/tests/navbar.spec.ts
+++ b/quartz/components/tests/navbar.spec.ts
@@ -303,7 +303,7 @@ test("Menu disappears when scrolling down and reappears when scrolling up", asyn
   })
 
   await expect(navbar).toHaveClass(/hide-above-screen/)
-  await expect(navbar).toHaveCSS("opacity", "0")
+  await expect(navbar).toHaveCSS("opacity", "1")
 
   await page.evaluate(() => {
     window.scrollTo({
@@ -344,11 +344,15 @@ test("Content behind hidden navbar is clickable on mobile", async ({ page }) => 
   await expect(page).not.toHaveURL(initialUrl)
 })
 
-test("Menu disappears gradually when scrolling down", async ({ page }) => {
+test("Menu slides out of view without fading when scrolling down", async ({ page }) => {
   test.skip(isDesktopViewport(page), "Mobile-only test")
 
   const navbar = page.locator("#navbar")
+  const sidebar = page.locator("#left-sidebar")
   await expect(navbar).toHaveCSS("opacity", "1")
+
+  const height = (await navbar.boundingBox())?.height
+  expect(height).toBeGreaterThan(0)
 
   // Scroll down past the 50px threshold. scrollTo dispatches a scroll event
   // which the scroll handler picks up via requestAnimationFrame. Using
@@ -356,10 +360,16 @@ test("Menu disappears gradually when scrolling down", async ({ page }) => {
   // Note: mouse.wheel() is not supported in mobile WebKit.
   await page.evaluate(() => window.scrollTo({ top: 200, behavior: "instant" }))
 
-  // The hide-above-screen class triggers a CSS opacity transition.
-  // Wait for the class to be applied and the transition to complete.
+  // The bar travels a full height upward while staying opaque, so it is never
+  // translucent over the article it passes. The sidebar behind it must not
+  // paint a backdrop that would linger once the bar has gone.
   await expect(navbar).toHaveClass(/hide-above-screen/)
-  await expect(navbar).toHaveCSS("opacity", "0")
+  await expect(async () => {
+    const box = await navbar.boundingBox()
+    expect(box?.y ?? 0).toBeLessThanOrEqual(-(height as number) + 1)
+  }).toPass()
+  await expect(navbar).toHaveCSS("opacity", "1")
+  await expect(sidebar).toHaveCSS("background-color", "rgba(0, 0, 0, 0)")
 })
 
 test("Navbar shows shadow when scrolling down (screenshot)", async ({ page }, testInfo) => {

--- a/quartz/components/tests/scrollbar.spec.ts
+++ b/quartz/components/tests/scrollbar.spec.ts
@@ -92,7 +92,10 @@ test.describe("Page scrollbar", () => {
 
     const { color, width } = await getBodyScrollbarStyle(page)
     expect(color).toBe("auto")
-    expect(width).toBe("auto")
+    // Engines pick their own un-styled width for an overlay scrollbar —
+    // Firefox resolves "none" under touch emulation where Chromium says
+    // "auto" — so accept either, as long as our "thin" rule stayed out.
+    expect(["auto", "none"]).toContain(width)
   })
 })
 

--- a/quartz/components/tests/scrollbar.spec.ts
+++ b/quartz/components/tests/scrollbar.spec.ts
@@ -52,34 +52,53 @@ function isRevealedPair(value: string): boolean {
   return Boolean(thumb && track) && thumb !== track
 }
 
-test.beforeEach(async ({ page }) => {
-  await gotoPage(page, testPageUrl, "domcontentloaded")
-  await moveMouseToSafePosition(page)
-})
+/** Register the shared setup for groups that assert on the fixture page. */
+function useTestPage(): void {
+  test.beforeEach(async ({ page }) => {
+    await gotoPage(page, testPageUrl, "domcontentloaded")
+    await moveMouseToSafePosition(page)
+  })
+}
+
+/** Read the resolved `scrollbar-color`/`scrollbar-width` of `document.body`. */
+function getBodyScrollbarStyle(page: Page): Promise<{ color: string; width: string }> {
+  return page.evaluate(() => {
+    const style = getComputedStyle(document.body)
+    return { color: style.scrollbarColor, width: style.scrollbarWidth }
+  })
+}
 
 test.describe("Page scrollbar", () => {
-  test("is restyled only where the engine keeps it on screen", async ({ page }) => {
+  useTestPage()
+
+  test("classic-scrollbar devices get the restyled thin scrollbar", async ({ page }) => {
     test.skip(
       !(await supportsScrollbarColor(page)),
       "Browser does not resolve scrollbar-color in computed style",
     )
+    test.skip(!(await usesClassicScrollbars(page)), "Only relevant for hover+fine-pointer devices")
 
-    const { color, width } = await page.evaluate(() => {
-      const style = getComputedStyle(document.body)
-      return { color: style.scrollbarColor, width: style.scrollbarWidth }
-    })
+    const { color, width } = await getBodyScrollbarStyle(page)
+    expect(isRevealedPair(color)).toBe(true)
+    expect(width).toBe("thin")
+  })
 
-    if (await usesClassicScrollbars(page)) {
-      expect(isRevealedPair(color)).toBe(true)
-      expect(width).toBe("thin")
-    } else {
-      expect(color).toBe("auto")
-      expect(width).toBe("auto")
-    }
+  test("touch devices keep the native scrollbar", async ({ page }) => {
+    test.skip(
+      !(await supportsScrollbarColor(page)),
+      "Browser does not resolve scrollbar-color in computed style",
+    )
+    test.skip(await usesClassicScrollbars(page), "Only relevant for coarse-pointer devices")
+
+    const { color, width } = await getBodyScrollbarStyle(page)
+    expect(color).toBe("auto")
+    expect(width).toBe("auto")
   })
 })
 
 test.describe("Sidebar scrollbar appears only on hover (desktop)", () => {
+  useTestPage()
+
   // The hover-reveal rule targets `.sidebar`, so both sidebars get the behavior.
   for (const selector of ["#left-sidebar", "#right-sidebar"] as const) {
     test(`${selector} thumb is hidden until the sidebar is hovered`, async ({ page }) => {
@@ -108,6 +127,8 @@ test.describe("Sidebar scrollbar appears only on hover (desktop)", () => {
 })
 
 test.describe("Sidebar scrollbar (mobile)", () => {
+  useTestPage()
+
   test("hover does not reveal a scrollbar", async ({ page }) => {
     test.skip(isDesktopViewport(page), "Mobile-only assertion")
     test.skip(

--- a/quartz/components/tests/scrollbar.spec.ts
+++ b/quartz/components/tests/scrollbar.spec.ts
@@ -60,27 +60,27 @@ function useTestPage(): void {
   })
 }
 
-/** Read the resolved `scrollbar-color`/`scrollbar-width` of `document.body`. */
-function getBodyScrollbarStyle(page: Page): Promise<{ color: string; width: string }> {
-  return page.evaluate(() => {
-    const style = getComputedStyle(document.body)
-    return { color: style.scrollbarColor, width: style.scrollbarWidth }
-  })
+/** Read the resolved `scrollbar-color` of `document.body`.
+ *
+ *  Only the colour is observable across engines: Playwright's Firefox build
+ *  resolves `scrollbar-width` to "none" on every device regardless of what the
+ *  stylesheet declares, so asserting the width would test the harness. The
+ *  colour is also the property that causes the ghosting being guarded here. */
+function getBodyScrollbarColor(page: Page): Promise<string> {
+  return page.evaluate(() => getComputedStyle(document.body).scrollbarColor)
 }
 
 test.describe("Page scrollbar", () => {
   useTestPage()
 
-  test("classic-scrollbar devices get the restyled thin scrollbar", async ({ page }) => {
+  test("classic-scrollbar devices get the restyled scrollbar", async ({ page }) => {
     test.skip(
       !(await supportsScrollbarColor(page)),
       "Browser does not resolve scrollbar-color in computed style",
     )
     test.skip(!(await usesClassicScrollbars(page)), "Only relevant for hover+fine-pointer devices")
 
-    const { color, width } = await getBodyScrollbarStyle(page)
-    expect(isRevealedPair(color)).toBe(true)
-    expect(width).toBe("thin")
+    expect(isRevealedPair(await getBodyScrollbarColor(page))).toBe(true)
   })
 
   test("touch devices keep the native scrollbar", async ({ page }) => {
@@ -90,12 +90,7 @@ test.describe("Page scrollbar", () => {
     )
     test.skip(await usesClassicScrollbars(page), "Only relevant for coarse-pointer devices")
 
-    const { color, width } = await getBodyScrollbarStyle(page)
-    expect(color).toBe("auto")
-    // Engines pick their own un-styled width for an overlay scrollbar —
-    // Firefox resolves "none" under touch emulation where Chromium says
-    // "auto" — so accept either, as long as our "thin" rule stayed out.
-    expect(["auto", "none"]).toContain(width)
+    expect(await getBodyScrollbarColor(page)).toBe("auto")
   })
 })
 

--- a/quartz/components/tests/scrollbar.spec.ts
+++ b/quartz/components/tests/scrollbar.spec.ts
@@ -1,11 +1,21 @@
 import type { Locator, Page } from "@playwright/test"
 
-import { expect, test } from "./fixtures"
+import { minDesktopWidth } from "../../styles/variables"
+import { expect, routeCdnAssetStubs, test } from "./fixtures"
 import { gotoPage, isDesktopViewport, moveMouseToSafePosition } from "./visual_utils"
+
+const testPageUrl = "http://localhost:8080/test-page"
 
 /** Read the resolved `scrollbar-color` of an element. */
 function getScrollbarColor(locator: Locator): Promise<string> {
   return locator.evaluate((el) => getComputedStyle(el).scrollbarColor)
+}
+
+/** Custom scrollbar colours are reserved for scrollbars the engine keeps on
+ *  screen. A touch device's overlay scrollbar fades out after a scroll and
+ *  leaves its custom colours painted behind, so those devices keep `auto`. */
+function usesClassicScrollbars(page: Page): Promise<boolean> {
+  return page.evaluate(() => matchMedia("(hover: hover) and (pointer: fine)").matches)
 }
 
 /** Whether the browser resolves `scrollbar-color` in computed style. Older
@@ -43,8 +53,30 @@ function isRevealedPair(value: string): boolean {
 }
 
 test.beforeEach(async ({ page }) => {
-  await gotoPage(page, "http://localhost:8080/test-page", "domcontentloaded")
+  await gotoPage(page, testPageUrl, "domcontentloaded")
   await moveMouseToSafePosition(page)
+})
+
+test.describe("Page scrollbar", () => {
+  test("is restyled only where the engine keeps it on screen", async ({ page }) => {
+    test.skip(
+      !(await supportsScrollbarColor(page)),
+      "Browser does not resolve scrollbar-color in computed style",
+    )
+
+    const { color, width } = await page.evaluate(() => {
+      const style = getComputedStyle(document.body)
+      return { color: style.scrollbarColor, width: style.scrollbarWidth }
+    })
+
+    if (await usesClassicScrollbars(page)) {
+      expect(isRevealedPair(color)).toBe(true)
+      expect(width).toBe("thin")
+    } else {
+      expect(color).toBe("auto")
+      expect(width).toBe("auto")
+    }
+  })
 })
 
 test.describe("Sidebar scrollbar appears only on hover (desktop)", () => {
@@ -88,5 +120,39 @@ test.describe("Sidebar scrollbar (mobile)", () => {
     // The hover-reveal rule lives inside a desktop media query, so on mobile the
     // sidebar never adopts the hidden-thumb resting state.
     expect(isHiddenOpaquePair(await getScrollbarColor(sidebar))).toBe(false)
+  })
+})
+
+test.describe("Sidebar scrollbar (touch device at desktop width)", () => {
+  // A large tablet is wide enough for the desktop layout while still painting
+  // fading overlay scrollbars, so its sidebars keep the native scrollbar.
+  test("sidebars keep the native scrollbar", async ({ browser, browserName }, testInfo) => {
+    test.skip(browserName !== "chromium", "Only Chromium emulates a coarse pointer")
+    test.skip(
+      !testInfo.project.name.startsWith("Desktop"),
+      "Emulation is set up in-test, so one project is enough",
+    )
+
+    const context = await browser.newContext({
+      viewport: { width: minDesktopWidth, height: 900 },
+      isMobile: true,
+      hasTouch: true,
+      deviceScaleFactor: 1,
+    })
+    try {
+      await routeCdnAssetStubs(context)
+      const page = await context.newPage()
+      await gotoPage(page, testPageUrl, "domcontentloaded")
+      expect(await usesClassicScrollbars(page)).toBe(false)
+
+      for (const selector of ["#left-sidebar", "#right-sidebar"] as const) {
+        const sidebar = page.locator(selector)
+        await expect(sidebar).toBeVisible()
+        expect(await getScrollbarColor(sidebar)).toBe("auto")
+        expect(await sidebar.evaluate((el) => getComputedStyle(el).scrollbarWidth)).toBe("auto")
+      }
+    } finally {
+      await context.close()
+    }
   })
 })

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -55,11 +55,17 @@ section {
 
 /* Scrollbar styling using the standard property (avoids Chromium repaint
    bug where ::-webkit-scrollbar pseudo-elements render as white rectangles
-   after a tab switch). scrollbar-color is supported in all modern browsers. */
-body,
-.right {
-  scrollbar-color: var(--midground-fainter) var(--background);
-  scrollbar-width: thin;
+   after a tab switch). scrollbar-color is supported in all modern browsers.
+
+   Only pointer devices with an always-present scrollbar may restyle it.
+   Touch devices use overlay scrollbars that fade out after a scroll, and a
+   non-`auto` scrollbar-color leaves the faded thumb painted on screen. */
+@media (hover: hover) and (pointer: fine) {
+  body,
+  .right {
+    scrollbar-color: var(--midground-fainter) var(--background);
+    scrollbar-width: thin;
+  }
 }
 
 .text-highlight {
@@ -227,12 +233,17 @@ a {
         // thumb until the sidebar is hovered. The resting thumb matches the
         // track color instead of being transparent, and the reveal is an
         // instant swap: Chromium paints transparent or animating
-        // scrollbar-color values as the default (black) scrollbar.
-        scrollbar-width: thin;
-        scrollbar-color: var(--background) var(--background);
+        // scrollbar-color values as the default (black) scrollbar. The reveal
+        // needs a hovering pointer, and a touch device's overlay scrollbar
+        // keeps its custom colors painted after it fades out, so touch
+        // devices stay on the native scrollbar.
+        @media (hover: hover) and (pointer: fine) {
+          scrollbar-width: thin;
+          scrollbar-color: var(--background) var(--background);
 
-        &:hover {
-          scrollbar-color: var(--midground-fainter) var(--background);
+          &:hover {
+            scrollbar-color: var(--midground-fainter) var(--background);
+          }
         }
       }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -708,13 +708,9 @@ img {
   z-index: $z-raised;
   background-color: var(--background);
 
-  // Sync with the navbar's translateY/opacity transition so the mobile
-  // backdrop fades alongside the bar instead of snapping in.
+  // The navbar carries its own opaque background and covers this box, so a
+  // second backdrop here would only linger as a band once the bar slides off.
   @media all and (max-width: $max-mobile-width) {
-    transition: background-color $transition-duration-slow ease;
-  }
-
-  &:has(#navbar.hide-above-screen) {
     background-color: transparent;
   }
 }

--- a/quartz/styles/generate-critical.ts
+++ b/quartz/styles/generate-critical.ts
@@ -156,8 +156,6 @@ em {
     top: $top-spacing;
     overflow-y: auto;
     max-height: calc(100vh - #{$top-spacing});
-    scrollbar-width: thin;
-    scrollbar-color: var(--background) var(--background);
   }
 
   #left-sidebar {
@@ -182,6 +180,13 @@ em {
     overflow-x: hidden;
     width: 100%;
     order: 2;
+  }
+}
+
+@media all and (min-width: $min-desktop-width) and (hover: hover) and (pointer: fine) {
+  .sidebar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--background) var(--background);
   }
 }
 

--- a/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
+++ b/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
@@ -135,8 +135,6 @@ em {
     top: $top-spacing;
     overflow-y: auto;
     max-height: calc(100vh - #{$top-spacing});
-    scrollbar-width: thin;
-    scrollbar-color: var(--background) var(--background);
   }
 
   #left-sidebar {
@@ -161,6 +159,13 @@ em {
     overflow-x: hidden;
     width: 100%;
     order: 2;
+  }
+}
+
+@media all and (min-width: $min-desktop-width) and (hover: hover) and (pointer: fine) {
+  .sidebar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--background) var(--background);
   }
 }
 


### PR DESCRIPTION
## Summary

The reported afterimage on tablet and mobile came from the navbar's hide animation, not from scrollbar styling. The bar hid with a simultaneous `translateY` **and** `opacity` fade, so it turned translucent *while still overlapping the article*, and `#left-sidebar` painted a second backdrop that faded on the same curve. Measured on iPhone 12 (bar is 40.5px tall):

| time | bar slid up | bar opacity | backdrop alpha |
|---|---|---|---|
| 180ms | 23.3px (58%) | 0.42 | 0.42 |
| 330ms | 36.7px (91%) | 0.09 | 0.09 |

That is the "plain background fades quickly even as the separate-looking navbar draws up" — a see-through bar sliding over the text, with a band left behind it.

The fix: transition `transform` only and keep the bar fully opaque for the whole slide, and drop the mobile backdrop. The navbar already paints its own opaque background across that box, so the backdrop only ever lingered once the bar left. Verified `opacity` stays `1` across the entire transition on both iPhone 12 and iPad Pro, and the bar returns correctly on scroll up.

The PR also carries a smaller, independent scrollbar change (below), which was my first read of the report before you clarified.

## Changes

**Navbar hide (the actual fix)**
- `quartz/components/styles/navbar.scss`: mobile `#navbar` transitions `transform` only; `.hide-above-screen` drops `opacity: 0` and keeps `pointer-events: none`.
- `quartz/styles/custom.scss`: `#left-sidebar` is transparent on mobile; removes the `background-color` transition and the `:has(#navbar.hide-above-screen)` rule.

**Scrollbar colors on touch devices**
- `quartz/styles/base.scss`: gates the `body, .right` scrollbar rule — which previously applied at every width — and the `.sidebar` hover-reveal on `(hover: hover) and (pointer: fine)`. Touch devices paint fading overlay scrollbars, and a non-`auto` `scrollbar-color` leaves the faded thumb painted; the hover-reveal also can't resolve `:hover` on a touch tablet wide enough for the desktop layout, which would have hidden that scrollbar permanently.
- `quartz/styles/generate-critical.ts`: the critical-CSS mirror moves into a matching combined media query so the inlined CSS can't re-apply what the stylesheet now excludes. Snapshot regenerated.

**Tests**
- `sidebarScrollbar.spec.ts` → `scrollbar.spec.ts`, plus page-scrollbar and touch-at-desktop-width coverage.
- Two navbar assertions that pinned the old fade (`opacity: 0` when hidden) now pin the new invariant: a full-height travel at `opacity: 1` over a transparent sidebar. Confirmed with you before changing them.

## Testing

- `navbar.spec.ts` (Chromium, Desktop + iPad Pro + iPhone 12): **25 passed, 0 failed**.
- `scrollbar.spec.ts` (same matrix): **8 passed**, rest viewport-gated.
- `tsc --noEmit`, `stylelint quartz/**/*.scss`, prettier, and `jest quartz/styles quartz/cli` (52 tests, 100% coverage) all clean.
- Transition state sampled directly at 60/180/330/730ms on both devices to confirm the bar never goes translucent and the backdrop never appears.

## Notes for review

- **`scrollbar-width` is not asserted.** Playwright's Firefox build resolves it to `none` on every device regardless of the stylesheet (it failed CI on Desktop Firefox expecting `thin`, and on touch expecting `auto`). Asserting it tests the harness, not the site — `scrollbar-color`, which is what actually causes ghosting, is asserted on every engine.
- **Visual snapshot diffs are expected** from the CSS change and are yours to approve via the gallery; the individual `visual-testing-*` shards are green.

## Lessons learned

- **What**: When a user reports a visual glitch, reproduce and *measure* the animation (sample computed styles at intervals mid-transition) before theorizing about engine bugs.
- **Where**: `CLAUDE.md`, debugging guidance.
- **Why**: I first attributed this to a Chromium/WebKit overlay-scrollbar repaint bug and shipped a plausible-but-wrong fix. A 20-line probe sampling `opacity`/`getBoundingClientRect` mid-transition identified the real cause immediately and turned a guess into a table of numbers.

- **What**: Don't assert computed values that the test harness controls rather than the code under test; assert the property that encodes the actual invariant.
- **Where**: `CLAUDE.md`, testing rules.
- **Why**: `scrollbar-width` cost two CI rounds because Playwright's Firefox reports `none` regardless of the stylesheet. The property that mattered (`scrollbar-color`) was portable across all engines.
