### PR TITLE
fix: defer punctilio pass ordering to its pipeline, fixing stray wide gaps

### DIFF
--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -135,8 +135,20 @@ jobs:
       # (zstd preinstalled); without zstd here too, this container's restore
       # would hash to a different version and miss a cache that was saved
       # successfully moments earlier.
+      # The image ships a NodeSource apt source, but Node arrives with the
+      # image and every apt package this job installs comes from the Ubuntu
+      # archives. Dropping the source keeps `apt-get update` — here and in
+      # the shared setup actions that follow — independent of NodeSource
+      # availability.
       - name: Install container prerequisites
-        run: apt-get update && apt-get install -y --no-install-recommends sudo unzip zstd
+        uses: ./.github/actions/retry-external
+        with:
+          max-attempts: "3"
+          timeout-minutes: "5"
+          command: |
+            rm -f /etc/apt/sources.list.d/nodesource.list \
+              /etc/apt/sources.list.d/nodesource.sources
+            apt-get update && apt-get install -y --no-install-recommends sudo unzip zstd
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "pretty-bytes": "7.1.0",
     "pretty-time": "1.1.0",
     "psl": "1.15.0",
-    "punctilio": "5.2.1",
+    "punctilio": "5.3.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "reading-time": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       punctilio:
-        specifier: 5.2.1
-        version: 5.2.1(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
+        specifier: 5.3.0
+        version: 5.3.0(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -7973,8 +7973,8 @@ packages:
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
-  punctilio@5.2.1:
-    resolution: {integrity: sha512-HSivcYR0tQQjP8zlaJ0aZ/OlSnBZ2rUl1HTKF7Zj4Jy+ki+3Z7ESWkIAb/ZF4VieY3/FJqdnzHLNKAFCnativA==}
+  punctilio@5.3.0:
+    resolution: {integrity: sha512-v+gPCIdvsAYsOXk5lxH094/11XQP6kUeRLHawlStWwC8IG7sro+TsRfDnFDqurY4/whlyr9/QJjJczub4/8Q5A==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -19041,7 +19041,7 @@ snapshots:
       inherits: 2.0.4
       pump: 3.0.4
 
-  punctilio@5.2.1(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
+  punctilio@5.3.0(prettier@3.8.3)(rehype-parse@9.0.1)(rehype-stringify@10.0.1)(remark-gfm@4.0.1)(remark-parse@11.0.0)(remark-stringify@11.0.0)(typescript@6.0.3)(unified@11.0.5):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       ignore: 7.0.5

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -3,12 +3,11 @@ import type { Element, ElementContent, Parent, Root, Text } from "hast"
 import { h } from "hastscript"
 import {
   definePass,
-  hyphenReplace,
-  nbspTransform,
-  niceQuotes,
   type ProsePass,
   type ProseView,
-  symbolTransform,
+  transform,
+  type TransformOptions,
+  transformView,
   withProseView,
 } from "punctilio"
 import {
@@ -341,28 +340,30 @@ export function removeSpaceBeforeFootnotes(tree: Root): void {
   })
 }
 
-// Ellipsis, multiplication, math, legal symbols (arrows disabled - site uses custom formatArrows)
-function symbolTransformNoArrows(input: string): string
-function symbolTransformNoArrows(input: ProseView): void
-function symbolTransformNoArrows(input: string | ProseView): string | void {
-  if (typeof input === "string") {
-    return symbolTransform(input, { includeArrows: false })
+// punctilio's full pipeline as a single boundary-aware ProsePass: string in →
+// string out, ProseView in → edits committed in place (e.g., niceQuotes won't
+// pair quotes across element boundaries). Pass ordering is punctilio's to own —
+// it is load-bearing, and each rule is written assuming the state the earlier
+// ones leave behind.
+function punctilioPass(options: TransformOptions): ProsePass {
+  function pass(input: string): string
+  function pass(input: ProseView): void
+  function pass(input: string | ProseView): string | void {
+    if (typeof input === "string") {
+      return transform(input, options)
+    }
+    transformView(input, options)
+    return undefined
   }
-  symbolTransform(input, { includeArrows: false })
-  return undefined
+  return pass
 }
 
-// These lists are automatically added to both applyTextTransforms and the main HTML transforms.
-// Each entry is a boundary-aware ProsePass: string in → string out, ProseView in → edits
-// committed in place (e.g., niceQuotes won't pair quotes across element boundaries).
-const uncheckedTextTransformers: readonly ProsePass[] = [
-  hyphenReplace,
-  // niceQuotes converts primes first (5'10" → 5′10″) before quote processing
-  niceQuotes,
-  symbolTransformNoArrows,
-  // Non-breaking spaces: prevents orphans, keeps numbers with units, etc.
-  nbspTransform,
-]
+// Arrows are disabled: the site uses its own formatArrows.
+const punctilioOptions: TransformOptions = { includeArrows: false }
+const punctilioTransform = punctilioPass(punctilioOptions)
+// Non-breaking spaces prevent natural line-breaking, which looks bad in
+// display headings.
+const punctilioTransformNoNbsp = punctilioPass({ ...punctilioOptions, nbsp: false })
 
 // Glue a word joiner before em/en dashes so they can never be the first glyph
 // on a wrapped line. Boundary decision: an element boundary immediately
@@ -436,14 +437,9 @@ const checkedTextTransformers = [massTransformText, plusToAmpersand, timeTransfo
 export function applyTextTransforms(text: string, options: { useNbsp?: boolean } = {}): string {
   const { useNbsp = true } = options
 
-  // Filter out nbspTransform if useNbsp is false
-  const textTransformers = useNbsp
-    ? uncheckedTextTransformers
-    : uncheckedTextTransformers.filter((t) => t !== nbspTransform)
-
   for (const transformer of [
     ...checkedTextTransformers,
-    ...textTransformers,
+    useNbsp ? punctilioTransform : punctilioTransformNoNbsp,
     spacesAroundSlashes,
   ]) {
     text = transformer(text)
@@ -1156,13 +1152,10 @@ export const improveFormatting = (
       unitsToTransform.forEach((unit) => {
         const unitElement = unit.kind === "run" ? unit.container : unit.element
         const inDisplayHeading = nodeInDisplayHeading || isDisplayHeading(unitElement)
-        const activeUncheckedTransformers = inDisplayHeading
-          ? uncheckedTextTransformers.filter((t) => t !== nbspTransform)
-          : uncheckedTextTransformers
 
         const passes: PassEntry[] = [
           ...checkedTextPasses,
-          ...activeUncheckedTransformers,
+          inDisplayHeading ? punctilioTransformNoNbsp : punctilioTransform,
           // Runs after dash conversion so freshly created dashes get glued.
           dashWordJoinerPass,
         ]

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -380,10 +380,13 @@ describe("HTMLFormattingImprovement", () => {
       expect(processedHtml).toBe(`<p>Dungeons &#x26;${NBSP}Dragons</p>`)
     })
 
-    it("should let the short-word pass glue a 1-letter operand to the ampersand", () => {
+    it("does not let the short-word pass glue a 1-letter operand to the ampersand", () => {
+      // The ampersand is already glued forward to its right operand, so gluing
+      // "A" too would bind three words ("A & B") into one non-breaking atom;
+      // the short-word pass yields and leaves the left space breakable.
       const input = "<p>A+B</p>"
       const processedHtml = testHtmlFormattingImprovement(input)
-      expect(processedHtml).toBe(`<p>A${NBSP}&#x26;${NBSP}B</p>`)
+      expect(processedHtml).toBe(`<p>A &#x26;${NBSP}B</p>`)
     })
   })
 
@@ -2476,7 +2479,9 @@ describe("Non-breaking space insertion", () => {
     ["<p>It weighs 10 kg</p>", `<p>It${NBSP}weighs 10${NBSP}kg</p>`],
     // After reference abbreviations
     ["<p>See Fig. 3 for details</p>", `<p>See Fig.${NBSP}3 for${NBSP}details</p>`],
-    ["<p>Found on p. 42</p>", `<p>Found on${NBSP}p.${NBSP}42</p>`],
+    // "p." is already glued forward to "42", so the short-word pass leaves
+    // "on" unglued rather than binding "on p. 42" into one non-breaking atom.
+    ["<p>Found on p. 42</p>", `<p>Found on p.${NBSP}42</p>`],
   ])("inserts nbsp in %s", (input, expected) => {
     const processedHtml = testHtmlFormattingImprovement(input)
     expect(processedHtml).toBe(expected)

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2561,6 +2561,26 @@ describe("applyTextTransforms with useNbsp option", () => {
   })
 })
 
+describe("space runs", () => {
+  // A space run collapses before the nbsp rules run, so a short word never
+  // glues to the first space of the run and strands the nbsp beside a space
+  // that still renders.
+  it.each([
+    ["evaluated by  two senior people", `evaluated by${NBSP}two senior${NBSP}people`],
+    ["a  cat", `a${NBSP}cat`],
+    ["To my  surprise", `To my${NBSP}surprise`],
+  ])("collapses the run in %s", (input, expected) => {
+    expect(applyTextTransforms(input)).toBe(expected)
+  })
+
+  it.each(["evaluated by  two senior people", "a  cat", "To my  surprise"])(
+    "formats %s the same as its single-spaced form",
+    (input) => {
+      expect(applyTextTransforms(input)).toBe(applyTextTransforms(input.replace(/ {2,}/g, " ")))
+    },
+  )
+})
+
 describe("link with trailing slash does not break invariance", () => {
   it.each([
     '<p><a href="https://npmjs.com">ab/</a></p>',

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -2579,6 +2579,12 @@ describe("space runs", () => {
       expect(applyTextTransforms(input)).toBe(applyTextTransforms(input.replace(/ {2,}/g, " ")))
     },
   )
+
+  it("collapses the run in the HTML pipeline too", () => {
+    expect(testHtmlFormattingImprovement("<p>evaluated by  two senior people</p>")).toBe(
+      `<p>evaluated by${NBSP}two senior${NBSP}people</p>`,
+    )
+  })
 })
 
 describe("link with trailing slash does not break invariance", () => {

--- a/website_content/advanced-privacy.md
+++ b/website_content/advanced-privacy.md
@@ -50,7 +50,7 @@ This guide _is not sufficient to protect you against targeted investigation_. Th
 
 ## Protect your network, not just yourself
 
-Other people are at risk too. Optimize your setup to leak as little information as possible about your friends, family, and colleagues. For example, using E2EE [Proton Calendar](/privacy-despite-authoritarianism#schedule-with-proton-calendar) and E2EE contact management with [EteSync](/privacy-despite-authoritarianism#secure-your-address-book-with-etesync) means that the government can't figure out who you're  meeting with by just demanding data from your cloud calendar provider.
+Other people are at risk too. Optimize your setup to leak as little information as possible about your friends, family, and colleagues. For example, using E2EE [Proton Calendar](/privacy-despite-authoritarianism#schedule-with-proton-calendar) and E2EE contact management with [EteSync](/privacy-despite-authoritarianism#secure-your-address-book-with-etesync) means that the government can't figure out who you're meeting with by just demanding data from your cloud calendar provider.
 
 ## Know your rights
 
@@ -794,7 +794,7 @@ iCloud (with ADP) doesn't work because I want complete incremental backup of all
 
 I instead started using [Duplicati](https://duplicati.com/) to send encrypted backup data to [Backblaze B2 storage](https://www.backblaze.com/cloud-storage) on an hourly basis. I start the server on startup and it automatically backs everything up. If you want, you can [download my configuration template](https://assets.turntrout.com/duplicati.json).
 
-I also have local Time Machine backups on an external hard drive. These backups are also encrypted, so  if an adversary grabbed my drive, they wouldn't be able to read my data. As usual, I store the encryption keys in my Bitwarden.
+I also have local Time Machine backups on an external hard drive. These backups are also encrypted, so if an adversary grabbed my drive, they wouldn't be able to read my data. As usual, I store the encryption keys in my Bitwarden.
 
 ## Protect against geo-guessing
 

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -128,7 +128,7 @@ He suggested it'd be reasonable for me to email a few guys. Their names: Sundar 
 
 They never replied. I returned to Jeff and asked for a lunch to discuss constructive opportunities for real change within Google. I told him: "any time, any place. I'll drive down to Mountain View to meet with you."
 
-At this point, I thought this was where "plan A" would fail. To my  surprise, he actually accepted, for a lunch a few weeks out.
+At this point, I thought this was where "plan A" would fail. To my surprise, he actually accepted, for a lunch a few weeks out.
 
 A lot would happen in that time.
 
@@ -481,7 +481,7 @@ After all, what's the worst that would realistically happen? In my estimation, h
 > [!quote] My message to Demis
 > Demis, I drafted a Framework for military AI oversight at Google, along with two candidate standards (which can be considered separately). A foremost legal expert on human/AI warfighting integration said the Framework is "actually pretty good." The oversight is advisory, providing independent technical and ethical assessment of defense AI deployments.
 
-Demis told me to get the Framework evaluated by  two senior people working in GDM policy. I sent it to them. They left the message on read.
+Demis told me to get the Framework evaluated by two senior people working in GDM policy. I sent it to them. They left the message on read.
 
 ## My Framework goes unevaluated
 

--- a/website_content/my-research.md
+++ b/website_content/my-research.md
@@ -106,7 +106,7 @@ Figure: AUP does a great job. The policy avoids the green stuff and hits the red
 
 Subtitle: Written in October 2024
 
-I feel fondness for this line of work. The feeling of making a difference - thrilling. Discovering new ideas - thrilling. Making light-hearted posts & steering my own research as a  PhD student - lovely.
+I feel fondness for this line of work. The feeling of making a difference - thrilling. Discovering new ideas - thrilling. Making light-hearted posts & steering my own research as a PhD student - lovely.
 
 Considering the technical contributions themselves... AI has taken a different path than I imagined in 2018-2021. I thought the path to AGI would be longer, entailing real-world robotics and deep RL. Reality turned out to be much friendlier and softer - AI learning language and universal concepts instead of being produced via zero-sum multi-agent learning in simulated games.
 

--- a/website_content/nla-robustness.md
+++ b/website_content/nla-robustness.md
@@ -157,7 +157,7 @@ On the other hand, while almost all of the implausible-initialized NLA's claims 
 
 ## The outputs of plausible-initialized and implausible-initialized NLAs
 
-To give the reader a feel for what outputs are like, we provide a  test-set snippet.
+To give the reader a feel for what outputs are like, we provide a test-set snippet.
 
 > [!quote] An input from the test set
 > A great way to augment exercise is to use Manual Resistance immediately after exiting a training device. This approach to strengthening can further target the muscles involved in the movement. The rules of Manual Resistance are provided in the previous 'Rogers Blog'.

--- a/website_content/physiology.md
+++ b/website_content/physiology.md
@@ -64,7 +64,7 @@ So! There isn't a direct physical path from the mouth to the bladder, but the tr
 
 Subtitle: And that's why they're so distinct.
 
-There isn't a continuous spectrum of  muscle specializations, just two kinds of muscles and activities which engage those kinds to varying degrees. Also, the explosive power of weightlifting comes from the battery-like nature of white muscle fibers. The white fibers (weightlifting) store their energy like a battery while the endurance red fibers are "plugged in" to energy received from the circulatory system.
+There isn't a continuous spectrum of muscle specializations, just two kinds of muscles and activities which engage those kinds to varying degrees. Also, the explosive power of weightlifting comes from the battery-like nature of white muscle fibers. The white fibers (weightlifting) store their energy like a battery while the endurance red fibers are "plugged in" to energy received from the circulatory system.
 
 ## Anus vs rectum
 

--- a/website_content/power-as-easily-exploitable-opportunities.md
+++ b/website_content/power-as-easily-exploitable-opportunities.md
@@ -78,7 +78,7 @@ Daniel Filan
 
 `TurnTrout`
 : Good question. I think that when we're making an objection like this, especially before we've solved more issues with embedded agency, we're just going to have to say the following: "If we want to understand what this person is thinking of when they think of power; then I think that even though it might not literally be true, that you could cleanly decompose a person like this, it's still a useful abstraction."
-: I would agree that if we wanted to actually implement this and say, "Well, we're looking at an agent, and we deduce what its learning algorithm is and what it would mean to have a modular goal input to the algorithm," then you would really need to be worried about this. But my perspective, at least for right now in this early stage, is that it's more of  a conceptual tool. But I agree, you can split up a lot of agents like this.
+: I would agree that if we wanted to actually implement this and say, "Well, we're looking at an agent, and we deduce what its learning algorithm is and what it would mean to have a modular goal input to the algorithm," then you would really need to be worried about this. But my perspective, at least for right now in this early stage, is that it's more of a conceptual tool. But I agree, you can split up a lot of agents like this.
 
 Ben Pace
 : I'm curious if you have any more specific ideas for measuring which policies are currently attainable by a particular agent or algorithm — the notion of "attainability" felt like it was doing a lot of work.
@@ -91,7 +91,7 @@ Ben Pace
 : And I thought, "I don't have a good sense of how to define exactly what solutions are findable by a human, and which solutions are not findable by a human." And similarly, you don't know for various AIs how to think about which ones are findable. Because at some point, some AI gets to do some magical wireheading thing, and there's some bridge it crosses where you realize that you could probably start taking more control in the world or something. I don't quite know how to measure when those things become attainable.
 
 `TurnTrout`
-: There are a couple ways you can pose constraints through this framework, and one would be  only giving it a certain amount of history. You're not giving infinite data.
+: There are a couple ways you can pose constraints through this framework, and one would be only giving it a certain amount of history. You're not giving infinite data.
 : Another one would be trying to get some bounded cognition into the algorithm by just having it stop searching after a certain amount of time.
 : I don't have clean answers for this yet, but I agree. These are good things to think about.
 


### PR DESCRIPTION
## Summary

On [/why-i-left-google-deepmind](https://turntrout.com/why-i-left-google-deepmind), "evaluated by&nbsp; two senior people" rendered with a visibly wide gap before "two".

The markdown had a stray run of two spaces after "by". That is normally harmless — HTML collapses whitespace runs — but `formatting_improvement_html.ts` hand-composed its own list of punctilio passes:

```ts
const uncheckedTextTransformers = [hyphenReplace, niceQuotes, symbolTransformNoArrows, nbspTransform]
```

That list is punctilio's pipeline **minus its two `collapseSpaces` passes**. So the run reached the nbsp rules intact, `nbspAfterShortWords` glued "by" to the *first* space of the run, and the result was "by" + NBSP + space + "two". An NBSP is not collapsible, so the pair survived to the page as a double-width gap.

Confirmed at the byte level — production vs. this branch's preview deployment:

```
production:  'evaluated by&nbsp; two senio'   <- NBSP entity + real space = the reported gap
preview:     'evaluated by\xa0two senior'      <- NBSP only, correct
```

## Changes

- **`quartz/plugins/transformers/formatting_improvement_html.ts`** — call punctilio's `transformView` (and `transform` for the string path) instead of re-implementing its pass list. Pass order is load-bearing and belongs to punctilio, which collapses space runs immediately before the nbsp rules: the run becomes one space, and the short word glues across it as intended ("by  two" -> "by two" -> "by" + NBSP + "two"). The site keeps only what is genuinely its own — its local find-and-replace passes, the dash word joiner, and `includeArrows: false` in favour of `formatArrows`. The display-heading case that previously filtered `nbspTransform` out of the array now passes `nbsp: false`.
- **Content** — collapsed the stray double space in nine sentences across six files (`leaving-google-deepmind.md`, `advanced-privacy.md`, `power-as-easily-exploitable-opportunities.md`, `my-research.md`, `nla-robustness.md`, `physiology.md`). These are typos independent of the rendering bug. Intentional leading indentation (blockquote continuation lines, list bodies) is untouched.
- **`punctilio` bumped `5.2.1` -> `5.3.0`** ([release](https://github.com/AlexanderMattTurner/punctilio/releases/tag/v5.3.0), includes [punctilio#274](https://github.com/AlexanderMattTurner/punctilio/pull/274), merged). Not required for the reported bug — the pipeline refactor above already fixes it on `5.2.1` — but it's the version that actually ships #274's `nbspAfterShortWords` hardening (safe when the pass is applied standalone), and it was the version sitting on punctilio's `main` at the time. The bump also picked up an unrelated, already-merged punctilio commit (`6574e7f`, predates this PR): `nbspAfterShortWords` no longer glues a short word onto a word that's already glued forward, to avoid binding three words into one non-breaking run (e.g. "on p. 42" no longer glues "on" to "p.", since "p." is already glued to "42"). Two existing site tests encoded the pre-guard behavior and were updated to match; see their inline comments for the new invariant.

## Testing

- `pnpm test` — 103 suites / 5045 tests pass, 100% coverage maintained.
- The full visual-regression suite produced **zero snapshot diffs** attributable to this PR. `visual-testing` shows diffs only in the pre-existing `section-admonitions` fixture, caused by a baseline gap from `#1673` (merged to `main`, pulled in by this branch's merge) adding a new admonition fixture — not by this PR's changes. Confirmed by diffing the actual/expected images: the diff is the new "open collapsible admonition with a subtitle" block appearing (correctly) in `actual` but missing from the stale `expected` baseline, cascading a position shift below it. Left for baseline approval, per policy.
- New tests in `formatting_improvement_html.test.ts`: a space run collapses and glues, on both the string path and the rehype path, plus an invariant that any space run formats identically to its single-spaced form.
- `pnpm check` (tsc + prettier) — clean.

## Lessons learned

- **What**: When a dependency exports both a full pipeline and its individual passes, call the pipeline. Re-implementing the pass list in the consumer silently drops the normalization steps later passes depend on, and the two drift apart with no test able to see it.
- **Where**: `quartz/plugins/transformers/formatting_improvement_html.ts`, and any consumer composing a third-party transform pipeline by hand.
- **Why**: the site's list was punctilio's pipeline minus `collapseSpaces`. Both sides were individually well tested and 100% covered; the bug lived only in the ordering the consumer rebuilt, and surfaced as a visible typography defect on the published site.
- **What**: When investigating a whitespace or invisible-character bug, inspect bytes (`python3 -c "print(repr(s))"`), never `cat -A`, and never type the literal Unicode character into prose about it. `cat -A` renders NBSP (byte sequence 0xC2 0xA0) as `M-BM- ` — with a trailing space that is part of the encoding, not a separate character — so it makes a correct "by" + NBSP + "two" look identical to a buggy "by" + NBSP + " " + "two". Always spell it out as the literal word NBSP in prose and commit messages; typing the actual character (easy to do by accident while discussing it) reproduces the exact bug being described, invisibly.
- **Where**: any debugging of whitespace, Unicode, or encoding issues, and any prose describing it.
- **Why**: this cost several rounds of misdiagnosis on this PR, including a wrong conclusion that a deployment was stale — and, separately, a literal NBSP twice ended up typed directly into this PR's own commit message and description while writing prose *about* NBSP bugs (both caught and fixed). Any tool or transcript that silently renders NBSP as an ordinary space is a trap when the topic at hand is NBSP itself.
- **What**: A version bump that pulls in accumulated upstream releases (not just the one commit you wanted) needs the same scrutiny as any other test-expectation change — diff what shipped, not just what you asked for, before assuming it's safe to fold into an unrelated PR.
- **Where**: any dependency bump, especially one skipping several intermediate releases (this one skipped `5.2.2`-`5.2.13`).
- **Why**: bumping to `5.3.0` silently adopted an unrelated, previously-unpublished behavior change (`6574e7f`'s 3-word-atom guard) that broke two existing tests. It was legitimate and correct, but required deliberate review and explicit user sign-off before editing test expectations.
