### PR TITLE
fix: hug subtitle to its title in open collapsible admonitions

### DIFF
--- a/.github/workflows/visual-testing.yaml
+++ b/.github/workflows/visual-testing.yaml
@@ -135,8 +135,14 @@ jobs:
       # (zstd preinstalled); without zstd here too, this container's restore
       # would hash to a different version and miss a cache that was saved
       # successfully moments earlier.
+      # The image bakes in the NodeSource apt repo, but Node already ships in
+      # the image and everything installed here comes from Ubuntu's own
+      # archives — drop the third-party source so its availability cannot
+      # fail `apt-get update`.
       - name: Install container prerequisites
-        run: apt-get update && apt-get install -y --no-install-recommends sudo unzip zstd
+        run: |
+          rm -f /etc/apt/sources.list.d/nodesource*
+          apt-get update && apt-get install -y --no-install-recommends sudo unzip zstd
 
       - name: Setup Frontend Environment
         uses: ./.github/actions/setup-visual-testing-env

--- a/quartz/components/tests/collapsible.spec.ts
+++ b/quartz/components/tests/collapsible.spec.ts
@@ -312,6 +312,30 @@ test.describe("Collapsible admonition state persistence", () => {
     expect(open.contentTop - open.titleBottom).toBeLessThan(EDGE_TOLERANCE_PX)
   })
 
+  test("an open collapsible's subtitle hugs its title as tightly as a non-collapsible one's", async ({
+    page,
+  }) => {
+    // A collapsible title carries its block spacing as padding, which the
+    // margin-bottom zeroing for a title followed by a subtitle cannot reach.
+    const gapToSubtitle = (admonition: import("@playwright/test").Locator) =>
+      admonition.evaluate((el) => {
+        const title = el.querySelector(".admonition-title-inner") as HTMLElement
+        const subtitle = el.querySelector(".subtitle") as HTMLElement
+        return subtitle.getBoundingClientRect().top - title.getBoundingClientRect().bottom
+      })
+
+    const collapsible = page
+      .locator(".admonition.is-collapsible")
+      .filter({ hasText: "collapsible admonition with a subtitle" })
+    await expect(collapsible).not.toHaveClass(/is-collapsed/)
+    const plain = page
+      .locator(".admonition:not(.is-collapsible)")
+      .filter({ hasText: "A multi-line admonition." })
+    await expect(plain).toBeAttached()
+
+    expect(await gapToSubtitle(collapsible)).toBeCloseTo(await gapToSubtitle(plain), 0)
+  })
+
   test("clicking content does not close open collapsible", async ({ page }) => {
     // Target the specific "[!info]+ This collapsible admonition starts off open" admonition
     const openCollapsible = page

--- a/quartz/styles/admonitions.scss
+++ b/quartz/styles/admonitions.scss
@@ -195,6 +195,13 @@ $admonition-title-margin-block: calc(1.5 * $base-margin);
       transition: max-height $transition-duration-medium ease;
       overflow: hidden;
     }
+
+    // A subtitle is part of its title, so only the subtitle's own margin-top
+    // separates the two. Here the title's block spacing is padding, which the
+    // margin-bottom zeroing in custom.scss cannot reach.
+    &:not(.is-collapsed) > .admonition-title:has(+ .admonition-content > .subtitle) {
+      padding-bottom: 0;
+    }
   }
 
   &.is-collapsed {

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -267,6 +267,11 @@ Hi! Am I being transcluded? Here is a within-page link to the [admonitions secti
 > [!info]+ This collapsible admonition starts off open
 > Displayed content. {#test-open}
 
+> [!info]+ An open collapsible admonition with a subtitle
+> Subtitle: The subtitle hugs its title, just as in a non-collapsible admonition.
+>
+> Displayed content. {#test-open-subtitle}
+
 > [!quote] Admonition with tags
 > <br/>
 > <em>Hi!</em>


### PR DESCRIPTION
## Summary

- An open collapsible admonition (`> [!quote]-`) showed a 21 px gap between its title and subtitle, versus 3 px for a non-collapsible one.
- `admonitions.scss` moves a collapsible title's block spacing from `margin` into `padding` so the whole bar is clickable, but the rule in `custom.scss` that tightens a title against a following subtitle only zeroes `margin-bottom`. The title's `padding-bottom: 0.75rem` survived and stacked on the subtitle's own `0.125rem` margin.

## Changes

- `quartz/styles/admonitions.scss`: inside `&.is-collapsible`, zero `padding-bottom` on a title followed by a subtitle when the admonition is open. The `:not(.is-collapsed)` guard leaves the collapsed state's full bottom padding intact.
- `quartz/components/tests/collapsible.spec.ts`: Playwright test asserting the title→subtitle gap matches between an open collapsible and a plain admonition.
- `website_content/test-page.md`: an open collapsible admonition with a subtitle, so visual regression covers the element.
- `.github/workflows/visual-testing.yaml`: drop the Playwright image's baked-in NodeSource apt source before `apt-get update` in the container prerequisites step. A 403 from `deb.nodesource.com` failed the update on all three Linux visual shards, skipping the Playwright run entirely; Node already ships in the image and everything installed there comes from Ubuntu's own archives.

## Testing

Measured in Chromium against the real compiled `custom.scss` (`sass --load-path=quartz/styles`), title-text bottom → subtitle top:

|                    | before | after |
| ------------------ | ------ | ----- |
| collapsible (open) | 21 px  | 3 px  |
| non-collapsible    | 3 px   | 3 px  |

Collapsed state keeps its 18 px title `padding-bottom` (checked computed style). `stylelint quartz/styles/admonitions.scss` and `tsc --noEmit` both clean. DeepSource: no findings for this PR.

## Lessons Learned

- **What**: In containerized CI jobs, strip unneeded third-party apt sources (e.g. `rm -f /etc/apt/sources.list.d/nodesource*`) before running `apt-get update` for packages that come from the distro's own archives.
- **Where**: any workflow step that runs `apt-get update` inside a vendor Docker image (here `.github/workflows/visual-testing.yaml`'s container prerequisites step).
- **Why**: Vendor images bake in third-party repos (NodeSource in the Playwright image); a transient 403/outage on that repo hard-fails `apt-get update` even though nothing being installed depends on it, taking down the whole job.
