### PR TITLE
fix: stop spellchecking footnote labels

### DIFF
--- a/scripts/strip_for_spellcheck.py
+++ b/scripts/strip_for_spellcheck.py
@@ -5,6 +5,7 @@ Removes regions that produce false-positive lint hits:
 
 - `[!quote]` callout blocks (external authors, foreign quotes)
 - LaTeX math (`$...$` inline and `$$...$$` display)
+- footnote labels (`[^label]`), which name a footnote rather than render as prose
 
 Replaces stripped regions with blank lines / spaces to preserve line and
 column numbers, so reported error positions still match the original source.
@@ -49,6 +50,16 @@ _MATH_RE = re.compile(
 # full word — `<span class="dropcap">d</span>ropcap` becomes `dropcap`.
 # Narrow to `class="...dropcap..."` so we don't strip unrelated HTML
 # (which could expose code-block contents to spellcheck false positives).
+# Footnote reference/definition labels (`[^label]`, `[^label]:`). Labels are
+# identifiers, not prose, so descriptive ones like `[^fatebook]` are unknown
+# words to the spellchecker.
+_FOOTNOTE_LABEL_RE = re.compile(r"\[\^(?P<label>[^\]\s]+)\]")
+
+# Digits stand in for footnote label characters: the markdown parser keeps
+# treating the construct as a footnote label (so surrounding structure parses
+# identically), while retext has no word to spell-check.
+_FOOTNOTE_LABEL_FILLER = "0"
+
 _DROPCAP_TAG_RE = re.compile(
     r'<(?P<tag>span|div)\b[^>]*\bclass="[^"]*\bdropcap\b[^"]*"[^>]*>'
     r"(?P<inner>[^<]*)</(?P=tag)>"
@@ -171,9 +182,28 @@ def strip_callout_markers(text: str) -> str:
     return _CALLOUT_MARKER_RE.sub(_replace, text)
 
 
+def strip_footnote_labels(text: str) -> str:
+    """
+    Replace the label inside footnote references and definitions with digits.
+
+    A label such as `[^fatebook]` names a footnote; it never renders as prose,
+    but the markdown parser used by the spellchecker treats it as text, so any
+    label that isn't a dictionary word is reported as an unknown word. Each
+    label character becomes a digit, preserving line and column counts (so
+    reported coordinates still match the original source) as well as the
+    surrounding markdown structure.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        return f"[^{_FOOTNOTE_LABEL_FILLER * len(match.group('label'))}]"
+
+    return _FOOTNOTE_LABEL_RE.sub(_replace, text)
+
+
 _LINT_STRIPPERS: tuple[Callable[[str], str], ...] = (
     strip_quote_blocks,
     strip_callout_markers,
+    strip_footnote_labels,
     strip_math,
     strip_dropcap_tags,
 )

--- a/scripts/strip_for_spellcheck.py
+++ b/scripts/strip_for_spellcheck.py
@@ -44,22 +44,15 @@ _MATH_RE = re.compile(
     re.DOTALL,
 )
 
+# Footnote reference/definition label: `[^label]`, optionally followed by `:`.
+_FOOTNOTE_LABEL_RE = re.compile(r"\[\^(?P<label>[^\]\s]+)\]")
+
 # Dropcap span/div pattern: `<span class="dropcap" ...>L</span>` followed
 # by the rest of the word. Replacing the whole tag with just the inner
 # letter fuses it with the following text so the spellchecker sees the
 # full word — `<span class="dropcap">d</span>ropcap` becomes `dropcap`.
 # Narrow to `class="...dropcap..."` so we don't strip unrelated HTML
 # (which could expose code-block contents to spellcheck false positives).
-# Footnote reference/definition labels (`[^label]`, `[^label]:`). Labels are
-# identifiers, not prose, so descriptive ones like `[^fatebook]` are unknown
-# words to the spellchecker.
-_FOOTNOTE_LABEL_RE = re.compile(r"\[\^(?P<label>[^\]\s]+)\]")
-
-# Digits stand in for footnote label characters: the markdown parser keeps
-# treating the construct as a footnote label (so surrounding structure parses
-# identically), while retext has no word to spell-check.
-_FOOTNOTE_LABEL_FILLER = "0"
-
 _DROPCAP_TAG_RE = re.compile(
     r'<(?P<tag>span|div)\b[^>]*\bclass="[^"]*\bdropcap\b[^"]*"[^>]*>'
     r"(?P<inner>[^<]*)</(?P=tag)>"
@@ -186,16 +179,15 @@ def strip_footnote_labels(text: str) -> str:
     """
     Replace the label inside footnote references and definitions with digits.
 
-    A label such as `[^fatebook]` names a footnote; it never renders as prose,
-    but the markdown parser used by the spellchecker treats it as text, so any
-    label that isn't a dictionary word is reported as an unknown word. Each
-    label character becomes a digit, preserving line and column counts (so
-    reported coordinates still match the original source) as well as the
-    surrounding markdown structure.
+    A label such as `[^fatebook]` names a footnote and never renders as prose,
+    but the spellchecker's markdown parser reads it as text and reports any
+    label that isn't a dictionary word. Digits keep the construct shaped like a
+    label — so the surrounding markdown parses the same way — while giving
+    retext no word to check, and preserve line and column counts.
     """
 
     def _replace(match: re.Match[str]) -> str:
-        return f"[^{_FOOTNOTE_LABEL_FILLER * len(match.group('label'))}]"
+        return f"[^{'0' * len(match.group('label'))}]"
 
     return _FOOTNOTE_LABEL_RE.sub(_replace, text)
 

--- a/scripts/tests/test_strip_for_spellcheck.py
+++ b/scripts/tests/test_strip_for_spellcheck.py
@@ -324,6 +324,55 @@ def test_strip_callout_markers(text: str, expected: str):
     )
 
 
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        pytest.param("", "", id="empty"),
+        pytest.param("plain text", "plain text", id="no-footnote"),
+        pytest.param("[^1]: Body", "[^0]: Body", id="numeric-definition"),
+        pytest.param(
+            "[^fatebook]: Body", "[^00000000]: Body", id="named-definition"
+        ),
+        pytest.param(
+            "the door.[^fatebook] I left",
+            "the door.[^00000000] I left",
+            id="inline-reference",
+        ),
+        pytest.param(
+            "[^bignote-algs]: Body",
+            "[^000000000000]: Body",
+            id="hyphenated-label",
+        ),
+        pytest.param(
+            "a[^one] b[^two]", "a[^000] b[^000]", id="multiple-references"
+        ),
+        # A bracketed caret without a label, or with whitespace inside it, is
+        # not a footnote label.
+        pytest.param("[^]: Body", "[^]: Body", id="empty-label"),
+        pytest.param("[^two words]", "[^two words]", id="label-with-space"),
+        # `[!type]` callouts and ordinary links are left alone.
+        pytest.param("> [!note] Title", "> [!note] Title", id="callout"),
+        pytest.param("[link](url)", "[link](url)", id="link"),
+    ],
+)
+def test_strip_footnote_labels(text: str, expected: str):
+    result = strip_for_spellcheck.strip_footnote_labels(text)
+    assert result == expected
+    assert len(result) == len(text), "Length must be preserved"
+    assert result.count("\n") == text.count("\n"), (
+        "Line count must be preserved"
+    )
+
+
+def test_strip_for_lint_replaces_footnote_label():
+    text = "Signed the deal.[^fatebook]\n\n[^fatebook]: Tracked on Fatebook."
+    result = strip_for_spellcheck.strip_for_lint(text)
+    assert "fatebook]" not in result
+    assert "Signed the deal." in result
+    assert "Tracked on Fatebook." in result
+    assert len(result) == len(text)
+
+
 def test_strip_for_lint_blanks_non_quote_callout_marker():
     # The integration pipeline (quote-strip → callout-marker-strip → …) should
     # neutralize `[!type]` on non-quote callouts so a trailing period two

--- a/scripts/tests/test_strip_for_spellcheck.py
+++ b/scripts/tests/test_strip_for_spellcheck.py
@@ -346,11 +346,8 @@ def test_strip_callout_markers(text: str, expected: str):
         pytest.param(
             "a[^one] b[^two]", "a[^000] b[^000]", id="multiple-references"
         ),
-        # A bracketed caret without a label, or with whitespace inside it, is
-        # not a footnote label.
         pytest.param("[^]: Body", "[^]: Body", id="empty-label"),
         pytest.param("[^two words]", "[^two words]", id="label-with-space"),
-        # `[!type]` callouts and ordinary links are left alone.
         pytest.param("> [!note] Title", "> [!note] Title", id="callout"),
         pytest.param("[link](url)", "[link](url)", id="link"),
     ],

--- a/scripts/tests/test_strip_for_spellcheck_properties.py
+++ b/scripts/tests/test_strip_for_spellcheck_properties.py
@@ -22,6 +22,7 @@ from scripts.strip_for_spellcheck import (  # noqa: E402
     is_quote_callout_start,
     strip_callout_markers,
     strip_dropcap_tags,
+    strip_footnote_labels,
     strip_for_lint,
     strip_math,
     strip_quote_blocks,
@@ -72,6 +73,12 @@ class TestPositionPreservation:
         assert len(stripped) == len(text)
         assert stripped.count("\n") == text.count("\n")
 
+    @given(markdown_text)
+    def test_strip_footnote_labels_preserves_length(self, text: str):
+        stripped = strip_footnote_labels(text)
+        assert len(stripped) == len(text)
+        assert stripped.count("\n") == text.count("\n")
+
     @given(markdown_lines)
     def test_strip_quote_blocks_preserves_line_count(self, text: str):
         assert strip_quote_blocks(text).count("\n") == text.count("\n")
@@ -93,6 +100,11 @@ class TestIdempotence:
     def test_strip_callout_markers_idempotent(self, text: str):
         once = strip_callout_markers(text)
         assert strip_callout_markers(once) == once
+
+    @given(markdown_text)
+    def test_strip_footnote_labels_idempotent(self, text: str):
+        once = strip_footnote_labels(text)
+        assert strip_footnote_labels(once) == once
 
     @given(markdown_lines)
     def test_strip_quote_blocks_idempotent(self, text: str):
@@ -171,6 +183,10 @@ class TestMutationKillers:
             strip_callout_markers(nested)
             == f"> > {' ' * (len(marker) + 1)} body"
         )
+
+    def test_strip_footnote_labels_exact_filler(self):
+        assert strip_footnote_labels("[^ab]: x") == "[^00]: x"
+        assert strip_footnote_labels("a[^b]c[^de]") == "a[^0]c[^00]"
 
     def test_create_stripped_directory_handles_nested_dirs(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

- A footnote label names a footnote; it never renders as prose, so it shouldn't be spellchecked. `[^fatebook]` failed the pre-push gate with `Unexpected unknown word 'fatebook'`.
- The spellchecker's markdown parser doesn't understand GFM footnotes, so it reads the label of a footnote definition as text. Descriptive labels that happen not to be dictionary words (or hyphenated slugs shorter than the 10-char slug-ignore regex) get flagged.
- `strip_for_spellcheck.py` now neutralizes labels before linting, so no wordlist entry is needed per footnote name.

## Changes

- `scripts/strip_for_spellcheck.py`: new `strip_footnote_labels` stripper, registered in `_LINT_STRIPPERS`. Each character of a `[^label]` becomes a digit — retext has no word to check, while line/column coordinates and the surrounding markdown structure are preserved.
  - Digits rather than spaces: blanking the label entirely makes `[^label]:` parse differently, which changes how the definition's body is parsed and shifts which prose vale sees. Keeping the label shaped like a label keeps every other lint result identical.

## Testing

- `uv run pytest scripts/tests/test_strip_for_spellcheck.py scripts/tests/test_strip_for_spellcheck_properties.py` — 111 passed, 100% coverage of `strip_for_spellcheck.py`. Added a parametrized unit table (numeric/named/hyphenated labels, inline references, non-labels like `[^]`, `[^two words]`, `[!note]`, plain links), a `strip_for_lint` integration case, and Hypothesis properties for length preservation and idempotence.
- Reproduced the failure on a fixture with `[^fatebook]`, confirmed it's gone while a real typo in the footnote body is still reported at the correct coordinates.
- Ran the full `scripts/run_spellcheck_and_vale.sh` over `website_content` before and after: clean both times, so the change surfaces no new findings and hides none.


---
_Generated by [Claude Code](https://claude.ai/code/session_012DthYC2wre1TNnZadn2AeB)_