### PR TITLE
refactor(typography): source the glue set's ellipsis from the shared constant

### DIFF
--- a/config/spellcheck/.wordlist.txt
+++ b/config/spellcheck/.wordlist.txt
@@ -1106,7 +1106,6 @@ fanfiction
 Fantana
 Farquhar
 Fatebook
-fatebook
 Favicon
 favicon
 Favicons

--- a/quartz/plugins/transformers/inlineAtomGlue.ts
+++ b/quartz/plugins/transformers/inlineAtomGlue.ts
@@ -3,6 +3,7 @@ import type { Element, ElementContent, Root, Text } from "hast"
 import { SKIP, visit } from "unist-util-visit"
 
 import {
+  ELLIPSIS,
   EMOJI_CLASS,
   FAVICON_CLASS,
   INLINE_IMG_CLASS,
@@ -72,7 +73,7 @@ const trailingGlueChars: ReadonlySet<string> = new Set([
   ":",
   "!",
   "?",
-  "…",
+  ELLIPSIS,
   ")",
   "]",
   "}",

--- a/quartz/plugins/transformers/tests/inlineAtomGlue.test.ts
+++ b/quartz/plugins/transformers/tests/inlineAtomGlue.test.ts
@@ -3,6 +3,7 @@ import { type Element, type Root, type Text } from "hast"
 import { h } from "hastscript"
 
 import {
+  ELLIPSIS,
   LEFT_DOUBLE_QUOTE,
   LEFT_SINGLE_QUOTE,
   NBSP,
@@ -129,7 +130,7 @@ describe("glueNodeSequence", () => {
     [":", "Say “", ": loudly"],
     ["!", "Say “", "! loudly"],
     ["?", "Say “", "? loudly"],
-    ["…", "Say “", "… loudly"],
+    [ELLIPSIS, "Say “", `${ELLIPSIS} loudly`],
   ])("pulls a closing %s into the glue span", (_closer, before, after) => {
     expect(glueNodeSequence([text(before), emoji(), text(after)])).toEqual([
       text("Say "),


### PR DESCRIPTION
Follow-up to #1678.

`inlineAtomGlue`'s closing-punctuation set carried a literal `…` while `config/constants.json` already exports `ELLIPSIS` through `quartz/components/constants.ts`. That JSON is the cross-language home for the site's Unicode typography characters (TypeScript and `scripts/built_site_checks.py` both read it), so the glue set and its test now read the constant.

The rest of the set stays literal on purpose: `, . ; : ! ? ) ] }` and the straight quotes are ASCII with no constant to share, and the curly quotes/guillemet already come from the same JSON.

### On sourcing this from punctilio

punctilio does define exactly the terminal half of this set — `TERMINAL_PUNCTUATION` in `dist/constants.js`, covering `! ? . , ; : …` plus the CJK and Arabic forms. It is not reachable from any entry point in the package's `exports` map (`.`, `/rehype`, `/remark`, `/markdown`, `/html`), so importing it would mean a deep import past the export map that a patch release could break. The site's own JSON also has to stay authoritative for the characters Python reads. If punctilio later re-exports `TERMINAL_PUNCTUATION` from its root, folding it in would be a clean win.

Also drops the `fatebook` wordlist entry added in #1678: #1679's stripper now rewrites footnote labels to `[^00000000]` before retext-spell sees them, so the entry is dead weight. Verified by running `scripts/strip_for_spellcheck.py` and then `scripts/spellcheck.sh` over the stripped tree with the entry removed — clean.

## Testing

- 104 Jest suites / 5119 tests, 100% coverage
- `tsc`, eslint clean
- spellcheck over the stripped content tree passes without the removed entry


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lu4HLm1cNiUeL4xVLk9Ngk)_