### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
@@ -30,11 +30,9 @@ placeholders where hidden HTML was spliced out.
 
 ## Entry points
 
-Split into subpaths so the heavy HTML dependency stays opt-in. The **seam**
-column marks entry points that inject the agent-specific concern (a callback
-you supply) rather than baking it in; `—` means the function is a pure
-transform with no such hook, and `fs (direct)` means it does its own file I/O
-(Node's filesystem, not an agent harness) instead of taking a callback.
+Split into subpaths so the heavy HTML dependency stays opt-in. **Seam** names
+the callback you inject for the agent-specific concern; `—` is a pure transform,
+`fs (direct)` does its own file I/O instead of taking one.
 
 | #   | Import          | Purpose                                                                                                                                                    | Seam                        |
 | --- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
@@ -69,16 +67,12 @@ without notice.
 
 ### `FILTER_WARNING` codes (Layer 5)
 
-The Layer-5 `filterInjection` seam is deliberately thin: the injected filter may
-only ask for **verbatim span deletions** (`removeSpans`) and may only warn with a
-**closed enum code** (`warning`), never free text. Because the filter runs on
-attacker-influenced content and its `warning` would otherwise be concatenated
-straight into the model-facing context **without** re-passing Layer 1, a
-compromised or prompt-injected filter emitting arbitrary text would defeat the
-"a compromised filter can only remove bytes, never inject" contract. So the
-**library owns the message** for each code, and a filter returning any value
-outside this enum makes `sanitizeText` **throw** (fail loud). Branch on the code,
-like `found`:
+The Layer-5 `filterInjection` seam is deliberately thin: the filter may only
+request **verbatim span deletions** (`removeSpans`) and warn with a **closed
+enum code**, never free text. Its warning reaches the model-facing context
+without re-passing Layer 1, so a prompt-injected filter emitting arbitrary text
+would defeat the "can only remove bytes, never inject" contract. The library
+owns each message, and any value outside the enum makes `sanitizeText` **throw**:
 
 | `FILTER_WARNING` code | Meaning                                                                                 |
 | --------------------- | --------------------------------------------------------------------------------------- |
@@ -86,15 +80,81 @@ like `found`:
 | `filter-flagged`      | The filter flagged the output as a possible injection without deleting (content intact) |
 | `filter-error`        | The filter reported a non-fatal internal error while scanning (a fatal filter throws)   |
 
+## Using it with Claude Code
+
+Four hooks put Layers 1–4 on the tool stream: tool input, tool output, user
+prompts, and a session-start scan of the instruction files.
+
+```
+/plugin marketplace add AlexanderMattTurner/agent-sanitizer
+/plugin install agent-sanitizer@agent-sanitizer
+```
+
+The plugin needs no `node_modules` and no build step — just `python3` on PATH
+for Layer 4.
+
+To wire them yourself instead, one entry dispatches all four modes on `--hook=`:
+
+```jsonc
+// settings.json — one entry per event; PreToolUse/PostToolUse also take "matcher": "*"
+{
+  "type": "command",
+  "command": "node ./node_modules/agent-sanitizer/claude-hooks/plugin-hooks.mjs --hook=sanitize-output",
+}
+```
+
+| Event              | `--hook=`              |
+| ------------------ | ---------------------- |
+| `UserPromptSubmit` | `sanitize-user-prompt` |
+| `PreToolUse`       | `pretooluse-sanitize`  |
+| `PostToolUse`      | `sanitize-output`      |
+| `SessionStart`     | `scan-invisible-chars` |
+
+`require.resolve("agent-sanitizer/claude-hooks")` gives the path without
+hardcoding a layout. Importing the module rather than spawning it is a no-op.
+
+**To compose the hooks instead of spawning them**, each module is a subpath of
+its own, typed, with the pieces exported individually:
+
+```js
+import {
+  sanitizeText,
+  evaluateToolOutput,
+} from "agent-sanitizer/claude-hooks/sanitize-output";
+import {
+  lazyImport,
+  makeDeadline,
+} from "agent-sanitizer/claude-hooks/lib/hook-io";
+```
+
+`agent-sanitizer/claude-hooks/<module>` for the four hooks
+(`sanitize-output`, `pretooluse-sanitize`, `sanitize-user-prompt`,
+`scan-invisible-chars`) and `agent-sanitizer/claude-hooks/lib/<module>` for the
+shared libs. Importing one runs no CLI and reads no stdin. Same stability
+posture as the `_AGENT_SANITIZER_*` variables below: reachable and typed, but
+the supported surface is the `--hook=` CLI, so these move between minor
+versions.
+
+**Layer 4 needs the Python engine** — `pip install 'agent-sanitizer[secrets]'`,
+version-matched to the npm package. Without it `sanitize-output` fails closed:
+secret-shaped output is suppressed, not shown unvetted. Layers 1–3 still run.
+
+**Layer 5 (second-model injection filtering) is not included.** These hooks
+never supply the `/output` seam's `filterInjection` callback, so nothing here
+calls a model or leaves the machine.
+
+Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
+path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The
+leading underscore marks them unstable — the supported surface is the `--hook=`
+CLI above.
+
 ## How this compares
 
-The "sanitize untrusted LLM input" space mostly splits into two camps: ML
-classifiers that score a prompt's _intent_ (Lakera Guard, Meta's Prompt
-Guard, Rebuff, NeMo Guardrails' input rails), and PII-focused redactors
-(Microsoft Presidio). Neither targets the byte-level hiding channel this
-library covers, and that gap is exactly where invisible-Unicode and
-hidden-HTML payloads live—content a semantic classifier never "sees" as
-suspicious because it renders as blank space or doesn't render at all.
+The space splits into ML classifiers that score a prompt's _intent_ (Lakera
+Guard, Meta's Prompt Guard, Rebuff, NeMo Guardrails) and PII redactors
+(Presidio). Neither targets the byte-level hiding channel — content a semantic
+classifier never "sees" as suspicious because it renders as blank space or
+doesn't render at all.
 
 |                               | `agent-sanitizer`                                                                                                        | Semantic guard/classifier (Lakera, Prompt Guard, Rebuff, NeMo rails)                                       | PII redactor (Presidio)                                      |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -106,13 +166,10 @@ suspicious because it renders as blank space or doesn't render at all.
 | **Reversibility**             | `/rehydrate` re-anchors a model's edit from the sanitized view back onto real bytes, denying anything ambiguous          | N/A—classifiers only pass/block, they don't rewrite-and-reverse                                            | N/A                                                          |
 | **Non-JS support**            | Same verdicts via a bundled CLI/worker—Python client included, no reimplementation                                       | Usually a hosted API (language-agnostic) or Python-only SDK                                                | Python-first (spaCy-based)                                   |
 
-In practice these are complementary, not competing: run a semantic guard for
-intent, Presidio for PII you must not leak, and this library for the hidden
-channel both of those are blind to. If you already run a classifier and are
-still getting bitten by zero-width payloads or `display:none` instructions
-riding along in RAG context, that's the gap this library closes.
+These are complementary: a semantic guard for intent, Presidio for PII, and this
+for the hidden channel both are blind to.
 
-### Examples
+## Examples
 
 ```js
 import { stripInvisibleWithReport } from "agent-sanitizer/invisible";
@@ -162,6 +219,23 @@ await rehydrateRedacted("Edit", toolInput, {
 }); // { updatedInput, context } | { deny } | null — a deny never exposes a secret
 ```
 
+The credential-noun vocabulary — the words that make an identifier name a
+secret — is published as data so a consumer with its own matcher derives it
+rather than forking it. Each noun's `uses` marks where it is valid: `env-name`
+inspects a variable NAME only, `field-value` also redacts what follows
+`noun = ` (too broad for `key` and `pat`, which stay name-only).
+
+```js
+import { createRequire } from "node:module";
+createRequire(import.meta.url)("agent-sanitizer/credential-names").nouns;
+// [{ parts: ["api", "key"], uses: ["env-name", "field-value"] }, …]
+```
+
+```python
+from agent_sanitizer.secrets import credential_name_segments
+credential_name_segments()  # ("API_KEY", "APIKEY", "ACCESS_KEY", …)
+```
+
 ## Limits
 
 The CLI (and the worker that backs the Python client) rejects any single request
@@ -178,17 +252,14 @@ layer does and does not defend against.
 
 ## Non-JS pipelines (Python, etc.)
 
-The JS is the **single source of truth**—non-JS callers drive the same verdicts
-through the bundled CLI, so there’s
-no second implementation to drift. An `op` field selects the entry point
-(default `sanitize`); the self-contained ones—`sanitizeText`, `classifyPrompt`,
-`scanInstructionFiles`, `cleanFile`—are all bridged. Entry points with an
-injected JS callback have no wire form and stay JS-only. The bridged
-`sanitizeText` runs Layers 1–3 only (invisible/ANSI strip, HTML hidden-content
-splice, exfil detection): it never redacts secrets (Layer 4) or runs injection
-filtering (Layer 5), and the wire protocol's `sgrNote` (Python's
-`TextResult.sgr_note`) is always `false`, since the bridge never wires
-`sgrCarveOut`.
+The JS is the **single source of truth** — non-JS callers drive the same
+verdicts through the bundled CLI, so no second implementation can drift. An `op`
+field selects the entry point (default `sanitize`); the self-contained ones —
+`sanitizeText`, `classifyPrompt`, `scanInstructionFiles`, `cleanFile` — are
+bridged, while entry points taking a JS callback have no wire form. Bridged
+`sanitizeText` runs Layers 1–3 only: no secret redaction (Layer 4), no injection
+filtering (Layer 5), and `sgrNote` is always `false` since the bridge never
+wires `sgrCarveOut`.
 
 ```sh
 echo '{"text":"a​b"}' | npx sanitize-cli           # default op: sanitize
@@ -196,16 +267,13 @@ echo '{"op":"classifyPrompt","text":"…"}' | npx sanitize-cli
 sanitize-cli --worker                              # newline-delimited, one response/line
 ```
 
-The [`python/`](./python) client wraps every bridged op (`sanitize`,
-`sanitize_text`, `classify_prompt`, `scan_instruction_files`, `clean_file`). The
-wheel ships a self-contained, single-file build of the CLI (`src/` and its npm
-dependencies bundled into one `.mjs` at release time), so a `pip install` plus
-Node.js (>=22) on `PATH` works with no separate JavaScript checkout to clone.
-`AGENT_SANITIZER_CLI` is only an override escape hatch (e.g. to point at a
-custom/dev build)—a normal install never needs to set it. The first
-`html=True` call starts a shared worker, so the ~200 ms HTML module-load is
-paid **once per process**; Layer-1 calls stay one-shot. `persist=True/False`
-forces the mode and `shutdown_worker()` (also an `atexit` hook) stops it.
+The [`python/`](./python) client wraps every bridged op. The wheel ships a
+single-file build of the CLI, so `pip install` plus Node.js (>=22) on `PATH`
+needs no JavaScript checkout; `AGENT_SANITIZER_CLI` is an override escape hatch
+a normal install never sets. The first `html=True` call starts a shared worker,
+paying the ~200 ms HTML module-load **once per process**; Layer-1 calls stay
+one-shot. `persist=True/False` forces the mode; `shutdown_worker()` (also an
+`atexit` hook) stops it.
 
 ```python
 from agent_sanitizer import sanitize, Sanitizer

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__ci-truth-serum__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__ci-truth-serum__main__README.md
@@ -27,11 +27,12 @@ lints that catch two kinds of lie a green check can hide:
 
 ### Identity (Tier 1, default-on)
 
-| Hook                        | Failure it prevents                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Example                                                                |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `check-pinned-base-images`  | Catches a Docker base image pinned to a tag the registry can quietly re-point to different bytes. Example: `FROM node:22` today may not be the same image tomorrow. **Requires a `@sha256:` digest** so the image you reviewed is the image CI builds.                                                                                                                                                                                                                      | `FROM node:22` — the digest behind the tag changes under you           |
-| `check-pinned-downloads`    | Catches downloading a binary and running it with no checksum or signature check, so a tampered release or hacked mirror can swap it. Also flags one-line installers like `curl -fsSL … \| sudo sh`, which pipe unverified bytes straight into a shell.                                                                                                                                                                                                                      | `curl -sL get.example.com \| bash` — no checksum, no signature         |
-| `check-provenance-repo-url` | Catches a `package.json` (or `pyproject.toml`) whose repository URL still points at the repo it was forked from. Example: a fork’s first `npm publish --provenance` fails with `E422 … Failed to validate repository information` because the URL names the upstream, not this fork. Compares the declared repository URL against your `origin` remote (never `Homepage`). A mismatch has no opt-out — forks must fix their URL. Repos with no `origin` remote are skipped. | a fork's `repository.url` still names upstream — npm publish dies E422 |
+| Hook                        | Failure it prevents                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Example                                                                |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `check-pinned-base-images`  | Catches a Docker base image pinned to a tag the registry can quietly re-point to different bytes. Example: `FROM node:22` today may not be the same image tomorrow. **Requires a `@sha256:` digest** so the image you reviewed is the image CI builds.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `FROM node:22` — the digest behind the tag changes under you           |
+| `check-pinned-downloads`    | Catches downloading a binary and running it with no checksum or signature check, so a tampered release or hacked mirror can swap it. Also flags one-line installers like `curl -fsSL … \| sudo sh`, which pipe unverified bytes straight into a shell.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `curl -sL get.example.com \| bash` — no checksum, no signature         |
+| `check-versionless-install` | Catches an install command that names no version — `pip install ruff`, `apt-get install -y docker-sbx`, `pipx install pre-commit`, `npm install -g pnpm` — so the bytes CI installs today are whatever the index serves today. Worse than an unpinned image tag: the version that changed appears nowhere in the diff. Example: a runtime installed with `apt-get install docker-sbx` served v0.37.1 while the repo’s own version file pinned v0.35.0 — the pin existed and nothing at install time read it, which cost days of red end-to-end runs. Covers shell scripts and inline workflow `run:` blocks (hadolint's DL3008/DL3013/DL3018 already own Dockerfiles). A requirements/constraints file, a local path or archive, a URL/VCS spec, and a variable-built spec are all left alone; a **local** `npm install pkg` is too (its range belongs in `package.json`). Opt out with `# pin-exempt: <reason>` — the distro-package case (`apt-get install -y curl`) is the recurring one, since apt serves one version per release. | `pip install pre-commit` — tomorrow’s CI runs a different pre-commit   |
+| `check-provenance-repo-url` | Catches a `package.json` (or `pyproject.toml`) whose repository URL still points at the repo it was forked from. Example: a fork’s first `npm publish --provenance` fails with `E422 … Failed to validate repository information` because the URL names the upstream, not this fork. Compares the declared repository URL against your `origin` remote (never `Homepage`). A mismatch has no opt-out — forks must fix their URL. Repos with no `origin` remote are skipped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | a fork's `repository.url` still names upstream — npm publish dies E422 |
 
 ### Security (Tier 1, default-on)
 
@@ -117,6 +118,7 @@ repos:
       # ── Tier 1 · Identity (default-on) ──
       - id: check-pinned-base-images
       - id: check-pinned-downloads
+      - id: check-versionless-install # every install command must name a version
       - id: check-provenance-repo-url
       # ── Tier 1 · Security (default-on) ──
       - id: check-trusted-base
@@ -240,7 +242,7 @@ contexts, and rewrites the repo’s branch-protection ruleset so
 single source of truth, so the required-set stops drifting in the GitHub UI.
 
 ```bash
-pip install ci-truth-serum
+pip install "git+https://github.com/AlexanderMattTurner/ci-truth-serum@v1.0.0"
 
 # Report drift and exit non-zero WITHOUT mutating (PR-safe gate):
 sync-required-checks --repo owner/name --check
@@ -277,22 +279,23 @@ two captures must be equal. Repeat `--pair` for more pins.
 ### Apply: verify a release with release-canary
 
 `release-canary` asserts the places a release leaves its version agree: the
-npm registry (semver-max of `npm view <pkg> versions --json`—deliberately NOT
-`npm view <pkg> version`, which returns the `latest` dist-tag and silently
-misreports when a publish set the tag wrong), the semver-max `v*` git tag, and
-the changelog's top dated `## [x.y.z]` heading (`## Unreleased` is skipped). If
-the repo also ships to the AUR, a `PKGBUILD`'s `pkgver=` is folded in as an
-optional fourth marker — checked only when a PKGBUILD is present, so forgetting
-to bump it is caught while a repo without one is unaffected (a build-time
-`pkgver()` that can't be read offline is skipped, never a failure). On mismatch
-it prints all present labeled values and exits non-zero; the `npm view` call is
-its only network touch.
+semver-max `v*` git tag and the changelog's top dated `## [x.y.z]` heading
+(`## Unreleased` is skipped). If the repo also ships to the AUR, a `PKGBUILD`'s
+`pkgver=` is folded in as an optional third marker — checked only when a
+PKGBUILD is present, so forgetting to bump it is caught while a repo without one
+is unaffected (a build-time `pkgver()` that can't be read offline is skipped,
+never a failure). A marker that is absent entirely — a changelog rolled but
+never tagged — is reported as a missing marker, which is what a half-finished
+release looks like. On mismatch it prints all present labeled values and exits
+non-zero. **Every marker is read locally, so the tool makes no network request
+and needs no registry credentials** — it runs in the same restricted job that
+cut the release.
 
 ```bash
-pip install ci-truth-serum
+pip install "git+https://github.com/AlexanderMattTurner/ci-truth-serum@v1.0.0"
 
-release-canary                    # package name read from ./package.json
-release-canary --package my-pkg --changelog CHANGELOG.md --repo-dir .
+release-canary                           # tag + changelog in the current repo
+release-canary --changelog CHANGELOG.md --repo-dir .
 release-canary --pkgbuild aur/PKGBUILD   # non-default PKGBUILD location
 ```
 

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__punctilio__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__punctilio__main__README.md
@@ -233,7 +233,7 @@ A `.pre-commit-hooks.yaml` ships in the package, so [pre-commit](https://pre-com
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/AlexanderMattTurner/punctilio
-    rev: v5.3.0
+    rev: v5.4.0
     hooks:
       - id: punctilio          # rewrites *.md / *.html in place
       - id: punctilio-check    # or: fail without writing (CI-friendly)


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.