### PR TITLE
fix: open the invert labeler on the assets that still need review

### DIFF
--- a/quartz/plugins/transformers/related_posts.json
+++ b/quartz/plugins/transformers/related_posts.json
@@ -1017,14 +1017,14 @@
       "title": "My open source contributions"
     },
     {
-      "excerpt": "I'm TurnTrout, but the United States government insists on calling me \"Alexander Matt Turner.\" I like writing and learning about lots of stuff.",
-      "permalink": "about",
-      "title": "About me"
-    },
-    {
       "excerpt": "Displaying the features of the website for use in visual regression testing.",
       "permalink": "test-page",
       "title": "Testing site features"
+    },
+    {
+      "excerpt": "I'm TurnTrout, but the United States government insists on calling me \"Alexander Matt Turner.\" I like writing and learning about lots of stuff.",
+      "permalink": "about",
+      "title": "About me"
     },
     {
       "excerpt": "My dating doc, sharing who I am and who I'm looking for. Is it you? 💘",
@@ -2676,9 +2676,9 @@
   ],
   "punctilio": [
     {
-      "excerpt": "Displaying the features of the website for use in visual regression testing.",
-      "permalink": "test-page",
-      "title": "Testing site features"
+      "excerpt": "Showing off and explaining this site's beauty.",
+      "permalink": "design",
+      "title": "The design of this website"
     }
   ],
   "quantitative-strength-of-instrumental-convergence": [
@@ -2879,9 +2879,9 @@
       "title": "Conclusion to 'Reframing Impact'"
     },
     {
-      "excerpt": "Exploring the ideas behind Attainable Utility Preservation: penalize the AI for gaining power to bound its impact.",
-      "permalink": "attainable-utility-preservation-concepts",
-      "title": "Attainable Utility Preservation: Concepts"
+      "excerpt": "Impact measure research deconfuses power-seeking incentives in AI, aiding alignment efforts.",
+      "permalink": "excitement-about-impact-measures",
+      "title": "Reasons for Excitement about Impact of Impact Measure Research"
     }
   ],
   "residual-stream-norms-grow-exponentially-over-the-forward-pass": [

--- a/scripts/label_invert.py
+++ b/scripts/label_invert.py
@@ -359,6 +359,12 @@ def autolabel_by_luminance(
 # --- Flask app ---------------------------------------------------------------
 
 
+# Filter modes for the card grid. The grid opens on the work that remains,
+# so a pre-push launch with two stale assets does not present hundreds of
+# already-reviewed cards.
+UNREVIEWED_FILTER: Final[str] = "unreviewed"
+ALL_FILTER: Final[str] = "all"
+
 _DECISION_PARAM: Final[Mapping[str, bool | None]] = {
     "invert": True,
     "no-invert": False,
@@ -373,6 +379,15 @@ def _index_handler(
 ) -> Callable[[], str]:
     def index() -> str:
         labels = load_labels(labels_path)
+        # An unlabeled card has no JSON entry to review, so it also
+        # counts as "needs review" alongside labeled-but-unreviewed
+        # cards. Mirrors the template's "needs review" badge logic
+        # and the JS recount that targets `data-reviewed="false"`.
+        unreviewed_count = sum(
+            1
+            for u in candidates
+            if u not in labels or not labels[u]["reviewed"]
+        )
         return render_template(
             "invert_labeler.html",
             candidates=candidates,
@@ -383,14 +398,9 @@ def _index_handler(
             invert_count=sum(
                 1 for u in candidates if u in labels and labels[u]["invert"]
             ),
-            # An unlabeled card has no JSON entry to review, so it also
-            # counts as "needs review" alongside labeled-but-unreviewed
-            # cards. Mirrors the template's "needs review" badge logic
-            # and the JS recount that targets `data-reviewed="false"`.
-            unreviewed_count=sum(
-                1
-                for u in candidates
-                if u not in labels or not labels[u]["reviewed"]
+            unreviewed_count=unreviewed_count,
+            initial_filter=(
+                UNREVIEWED_FILTER if unreviewed_count else ALL_FILTER
             ),
         )
 
@@ -538,6 +548,8 @@ def _run_check_and_launch(args: argparse.Namespace) -> int:
         len(missing),
         len(candidates),
     )
+    for url in missing:
+        logger.info("  needs review: %s", url)
     return _run_server(args)
 
 

--- a/scripts/label_invert.py
+++ b/scripts/label_invert.py
@@ -359,9 +359,10 @@ def autolabel_by_luminance(
 # --- Flask app ---------------------------------------------------------------
 
 
-# Filter modes for the card grid. The grid opens on the work that remains,
-# so a pre-push launch with two stale assets does not present hundreds of
-# already-reviewed cards.
+# Card-grid filter modes, matching the template's `<option value>`s. The
+# grid opens on whichever one shows the work that remains, so a pre-push
+# launch presents the handful of assets needing a verdict rather than every
+# candidate on the site.
 UNREVIEWED_FILTER: Final[str] = "unreviewed"
 ALL_FILTER: Final[str] = "all"
 

--- a/scripts/templates/invert_labeler.html
+++ b/scripts/templates/invert_labeler.html
@@ -51,7 +51,7 @@
         {{ invert_count }} / {{ candidates|length }} invert &middot; {{ unreviewed_count }} unreviewed
       </span>
       <span class="controls-spacer"></span>
-      <select id="filter" class="filter">
+      <select id="filter" class="filter" data-initial="{{ initial_filter }}">
         <option value="all">Show all</option>
         <option value="invert">Show only invert</option>
         <option value="no-invert">Show only don't-invert</option>
@@ -160,12 +160,17 @@
           }
         });
       });
-      document.getElementById("filter").addEventListener("change", (ev) => {
-        const mode = ev.target.value;
+      const filterSelect = document.getElementById("filter");
+      const applyFilter = (mode) => {
         document.querySelectorAll(".card").forEach((c) => {
           c.style.display = cardMatchesFilter(c, mode) ? "" : "none";
         });
-      });
+      };
+      filterSelect.addEventListener("change", (ev) => applyFilter(ev.target.value));
+      // Cards that pass the filter at load stay visible as the user labels
+      // them, so a verdict never makes the card being worked on disappear.
+      filterSelect.value = filterSelect.dataset.initial;
+      applyFilter(filterSelect.value);
       document.getElementById("confirm-visible").addEventListener("click", async (ev) => {
         const button = ev.target;
         // Bulk-confirm only applies to cards that already have a verdict

--- a/scripts/templates/invert_labeler.html
+++ b/scripts/templates/invert_labeler.html
@@ -167,8 +167,8 @@
         });
       };
       filterSelect.addEventListener("change", (ev) => applyFilter(ev.target.value));
-      // Cards that pass the filter at load stay visible as the user labels
-      // them, so a verdict never makes the card being worked on disappear.
+      // Filtering happens at load and on change only: a card that passes the
+      // filter stays visible while the user labels it.
       filterSelect.value = filterSelect.dataset.initial;
       applyFilter(filterSelect.value);
       document.getElementById("confirm-visible").addEventListener("click", async (ev) => {

--- a/scripts/tests/test_label_invert.py
+++ b/scripts/tests/test_label_invert.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from collections.abc import Callable, Mapping
 from pathlib import Path
 
@@ -286,6 +287,28 @@ def test_index_marks_state_and_review(client: tuple[FlaskClient, Path]) -> None:
     assert f"{expected_needs_review} unreviewed" in body
 
 
+def test_index_opens_on_unreviewed_when_work_remains(
+    client: tuple[FlaskClient, Path],
+) -> None:
+    test_client, labels_path = client
+    label_invert.save_labels(
+        {u: _label(True, True) for u in EXPECTED[:-1]}, labels_path
+    )
+    body = test_client.get("/").get_data(as_text=True)
+    assert f'data-initial="{label_invert.UNREVIEWED_FILTER}"' in body
+
+
+def test_index_opens_on_all_when_everything_reviewed(
+    client: tuple[FlaskClient, Path],
+) -> None:
+    test_client, labels_path = client
+    label_invert.save_labels(
+        {u: _label(True, True) for u in EXPECTED}, labels_path
+    )
+    body = test_client.get("/").get_data(as_text=True)
+    assert f'data-initial="{label_invert.ALL_FILTER}"' in body
+
+
 def test_get_labels_returns_json(client: tuple[FlaskClient, Path]) -> None:
     test_client, labels_path = client
     label_invert.save_labels({EXPECTED[0]: _label(True, True)}, labels_path)
@@ -527,6 +550,39 @@ def test_main_check_and_launch(
     )
     assert rc == 0
     assert ran["flask"] is expect_server
+
+
+def test_check_and_launch_logs_each_unreviewed_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dims = _write_dims(tmp_path, {url: {} for url in EXPECTED})
+    labels_path = tmp_path / "labels.json"
+    labels_path.write_text(
+        json.dumps({u: _label(True, True) for u in EXPECTED[:-1]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        label_invert.Flask, "run", lambda _self, **_kwargs: None
+    )
+    monkeypatch.setattr(label_invert, "open_browser_async", lambda _u: None)
+
+    with caplog.at_level(logging.INFO, logger=label_invert.__name__):
+        rc = label_invert.main(
+            [
+                "--check-and-launch",
+                "--dimensions",
+                str(dims),
+                "--labels",
+                str(labels_path),
+                "--no-browser",
+                "--skip-luminance",
+            ]
+        )
+    assert rc == 0
+    assert f"needs review: {EXPECTED[-1]}" in caplog.text
+    assert EXPECTED[0] not in caplog.text
 
 
 def test_main_runs_apply_annotations(tmp_path: Path) -> None:

--- a/scripts/tests/test_label_invert.py
+++ b/scripts/tests/test_label_invert.py
@@ -296,6 +296,8 @@ def test_index_opens_on_unreviewed_when_work_remains(
     )
     body = test_client.get("/").get_data(as_text=True)
     assert f'data-initial="{label_invert.UNREVIEWED_FILTER}"' in body
+    # The select can only adopt an initial mode that it offers.
+    assert f'<option value="{label_invert.UNREVIEWED_FILTER}"' in body
 
 
 def test_index_opens_on_all_when_everything_reviewed(
@@ -307,6 +309,7 @@ def test_index_opens_on_all_when_everything_reviewed(
     )
     body = test_client.get("/").get_data(as_text=True)
     assert f'data-initial="{label_invert.ALL_FILTER}"' in body
+    assert f'<option value="{label_invert.ALL_FILTER}"' in body
 
 
 def test_get_labels_returns_json(client: tuple[FlaskClient, Path]) -> None:


### PR DESCRIPTION
## Summary

- The pre-push "Labeling images for dark-mode inversion" check launches the labeler as soon as a single candidate lacks a reviewed verdict, but the grid opened on **Show all**. With 834 candidates and 2 unreviewed, that reads as "label hundreds of images" even though everything is already labeled.
- The filter now opens on the work that remains, so the launched grid shows only the cards awaiting a verdict.

## Changes

- `scripts/label_invert.py`: `_index_handler` passes `initial_filter` — `unreviewed` when any candidate needs review, `all` once everything is reviewed (so a manual run with nothing outstanding still shows the full grid).
- `scripts/templates/invert_labeler.html`: the filter `<select>` carries `data-initial` and the page applies the filter on load instead of only on `change`. Cards visible at load stay visible as they are labeled, so the card being worked on never disappears mid-review.
- `scripts/label_invert.py`: `--check-and-launch` logs each URL awaiting a verdict, so the terminal names the outstanding assets before the browser opens.
- Tests for both filter defaults and for the per-URL log line.

## Testing

- `uv run pytest scripts/tests/test_label_invert.py` — 82 passed.
- Rendered the page against the real `.asset_dimensions.json`: `data-initial="unreviewed"`, header reads `675 / 834 invert · 2 unreviewed`, and the grid displays those 2 cards.
- `uv run pylint scripts/label_invert.py scripts/tests/test_label_invert.py` — 10.00/10; prettier clean.
- Note: `scripts/tests/test_compress.py` has 3 pre-existing AVIF-encoder failures in this container, unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFasZC7mFBLYVSgSSGAa8Z)_