### PR TITLE
fix(favicon): keep left gap after serif 'r' and in faux-bold contexts

### DIFF
--- a/.github/actions/wait-for-server/action.yml
+++ b/.github/actions/wait-for-server/action.yml
@@ -31,7 +31,14 @@ runs:
         SERVE_PORT: ${{ inputs.port }}
         MAX_ATTEMPTS: ${{ inputs.max-attempts }}
       run: |
-        pnpm exec serve "$SERVE_PATH" -l "$SERVE_PORT" &
+        # Resolve the binary before the readiness window opens. `pnpm exec`
+        # reaches for the registry when the store lacks the package, and a
+        # slow registry would otherwise spend the attempt budget on a
+        # download that has nothing to do with server startup.
+        pnpm exec serve --version
+
+        SERVER_LOG="$(mktemp)"
+        pnpm exec serve "$SERVE_PATH" -l "$SERVE_PORT" > "$SERVER_LOG" 2>&1 &
         SERVER_PID=$!
         echo "pid=$SERVER_PID" >> "$GITHUB_OUTPUT"
 
@@ -40,9 +47,16 @@ runs:
             echo "Server ready on port $SERVE_PORT (attempt $i)"
             exit 0
           fi
+          # A dead server never becomes ready; report its output now.
+          if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "::error::Server on port $SERVE_PORT exited before becoming ready"
+            cat "$SERVER_LOG"
+            exit 1
+          fi
           sleep 1
         done
 
         echo "::error::Server on port $SERVE_PORT not ready after $MAX_ATTEMPTS attempts"
+        cat "$SERVER_LOG"
         kill "$SERVER_PID" 2>/dev/null || true
         exit 1

--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -1,4 +1,5 @@
 @use "../../styles/variables" as *;
+@use "../../styles/faux-bold" as *;
 
 #table-of-contents {
   @media all and (max-width: $max-mobile-width) {
@@ -92,8 +93,9 @@
         color: var(--midground);
 
         &.active {
+          @include faux-bold(var(--midground-strong));
+
           color: var(--midground-strong);
-          text-shadow: $faux-bold-offset $faux-bold-offset var(--midground-strong);
         }
       }
     }

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -229,28 +229,69 @@ test.describe("favicon ink gap", () => {
   })
 
   // Faux-bold contexts paint glyph ink $faux-bold-offset further right via
-  // text-shadow; the same rules set --favicon-bold-nudge so the favicon's
-  // visual gap stays constant. The margin delta must equal the shadow offset.
+  // text-shadow; the faux-bold mixin (_faux-bold.scss) sets
+  // --favicon-bold-nudge alongside the shadow so the favicon's visual gap
+  // stays constant. Every set-site must widen the margin by exactly the
+  // shadow offset, and the .right reset must return it to the plain value.
+  // The boosted expectation is derived in-page from a probe whose
+  // margin-left is the same calc the engine evaluates, so the assertion
+  // inherits the engine's own LayoutUnit quantization instead of comparing
+  // raw floats against the SCSS token.
   test("faux-bold contexts widen the favicon margin by the shadow offset", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const margins = await page.evaluate(() => {
-      const host = document.createElement("div")
-      const article = document.querySelector("article") ?? document.body
-      article.appendChild(host)
-      host.innerHTML =
-        '<p><span id="plain">r<svg class="favicon" aria-hidden="true"></svg></span>' +
-        '<strong id="bold">r<svg class="favicon" aria-hidden="true"></svg></strong></p>'
-      const marginOf = (selector: string): number => {
-        const favicon = host.querySelector(`${selector} svg.favicon`)
-        if (!favicon) throw new Error(`fixture failed for ${selector}`)
-        return parseFloat(getComputedStyle(favicon).marginLeft)
-      }
-      const result = { plain: marginOf("#plain"), bold: marginOf("#bold") }
-      host.remove()
-      return result
-    })
+    const contextWrappers = [
+      { name: "strong", open: "<strong>", close: "</strong>", bolded: true },
+      { name: "title-cell", open: '<div class="title-cell">', close: "</div>", bolded: true },
+      {
+        name: "admonition-title",
+        open: '<span class="admonition-title-inner">',
+        close: "</span>",
+        bolded: true,
+      },
+      {
+        name: "right-reset",
+        open: '<div class="right"><strong>',
+        close: "</strong></div>",
+        bolded: false,
+      },
+    ] as const
 
-    expect(margins.bold - margins.plain).toBeCloseTo(parseFloat(fauxBoldOffset), 2)
+    const margins = await page.evaluate(
+      ({ wrappers, offset }) => {
+        const host = document.createElement("div")
+        const article = document.querySelector("article") ?? document.body
+        article.appendChild(host)
+        const faviconHtml = '<svg class="favicon" aria-hidden="true"></svg>'
+        const measure = (html: string): number => {
+          host.innerHTML = html
+          const favicon = host.querySelector("svg.favicon")
+          if (!favicon) throw new Error(`fixture failed for ${html}`)
+          return parseFloat(getComputedStyle(favicon).marginLeft)
+        }
+        const plain = measure(`<span>r${faviconHtml}</span>`)
+        const boosted = measure(
+          `<span><svg class="favicon" aria-hidden="true" style="margin-left: calc(${plain}px + ${offset})"></svg></span>`,
+        )
+        const byContext = wrappers.map((wrapper) => ({
+          name: wrapper.name,
+          marginPx: measure(`${wrapper.open}r${faviconHtml}${wrapper.close}`),
+        }))
+        host.remove()
+        return { plain, boosted, byContext }
+      },
+      { wrappers: contextWrappers, offset: fauxBoldOffset },
+    )
+
+    // One LayoutUnit (1/64 px in Chromium/WebKit, 1/60 px in Firefox) of
+    // slack absorbs the double quantization of the derived expectation.
+    const quantumPx = 0.02
+    for (const [index, { name, marginPx }] of margins.byContext.entries()) {
+      const expected = contextWrappers[index].bolded ? margins.boosted : margins.plain
+      expect(
+        Math.abs(marginPx - expected),
+        `${name}: margin ${marginPx}px, expected ${expected}px`,
+      ).toBeLessThan(quantumPx)
+    }
   })
 })

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -101,6 +101,7 @@ interface Measurement {
   marginPx: number
   fontSizePx: number
   gapPx: number | null
+  fromFallbackFace: boolean
 }
 
 interface Probe {
@@ -204,9 +205,28 @@ async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Meas
       return null
     }
 
+    // True when the requested family has no outline for `char`, so the
+    // canvas drew whichever face the platform substitutes. Such a glyph
+    // measures differently per OS. Detected by advance width: a substituted
+    // glyph matches what a nonexistent family produces, since both resolve
+    // through the same fallback chain.
+    const isFallbackGlyph = (style: CSSStyleDeclaration, char: string): boolean => {
+      const glyph = style.fontVariantCaps === "small-caps" ? char.toUpperCase() : char
+      ctx2d.font = `${style.fontStyle} ${CANVAS_FONT_PX}px ${style.fontFamily}`
+      const requested = ctx2d.measureText(glyph).width
+      ctx2d.font = `${style.fontStyle} ${CANVAS_FONT_PX}px "__no_such_family__"`
+      const substituted = ctx2d.measureText(glyph).width
+      return Math.abs(requested - substituted) < 0.01
+    }
+
     await document.fonts.ready
-    const results: { key: string; marginPx: number; fontSizePx: number; gapPx: number | null }[] =
-      []
+    const results: {
+      key: string
+      marginPx: number
+      fontSizePx: number
+      gapPx: number | null
+      fromFallbackFace: boolean
+    }[] = []
     for (const probe of probeList) {
       host.innerHTML =
         `<p>${probe.wrapperHtml[0]}<span class="ink-probe">${probe.char}</span>` +
@@ -225,6 +245,7 @@ async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Meas
         marginPx,
         fontSizePx,
         gapPx: bearingEm === null ? null : marginPx + bearingEm * fontSizePx,
+        fromFallbackFace: isFallbackGlyph(probeStyle, probe.char),
       })
     }
     host.remove()
@@ -279,12 +300,12 @@ function collectBoldFailures(margins: BoldMargins, wrappers: readonly ContextWra
     .filter(Boolean)
 }
 
-// Glyphs that plausibly end link text, restricted to those the shipped
-// EBGaramond faces actually carry: ™ is absent from both, so a probe for it
-// would measure a platform fallback face and reach a different verdict per OS.
+// Glyphs that plausibly end link text. A face missing one of them renders it
+// from a platform substitute whose metrics vary per OS; measureProbes marks
+// those and the sweep reports them rather than judging them.
 const MEMBERSHIP_CHARS: readonly string[] = [
   ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-  ..."()[]{}\\/®©°%&*+=<>|!?;:’”†‡",
+  ..."()[]{}\\/®™©°%&*+=<>|!?;:’”†‡",
 ]
 
 // Thresholds in em of the probe's font, slackened from the bars that produced
@@ -337,11 +358,15 @@ function collectMembershipViolations(
   return violations
 }
 
-/** Right side bearings in em, keyed by probe, for probes with ink in band. */
+/**
+ * Right side bearings in em, keyed by probe. Probes with no ink in the band
+ * and probes the face rendered from a platform substitute are omitted: the
+ * former cannot crowd, the latter would measure differently per OS.
+ */
 function bearingsByKey(measurements: readonly Measurement[]): ReadonlyMap<string, number> {
   const bearings = new Map<string, number>()
   for (const measured of measurements) {
-    if (measured.gapPx !== null) {
+    if (measured.gapPx !== null && !measured.fromFallbackFace) {
       bearings.set(measured.key, (measured.gapPx - measured.marginPx) / measured.fontSizePx)
     }
   }
@@ -409,6 +434,9 @@ test.describe("favicon ink gap", () => {
     const contexts = CONTEXTS.filter((ctx) => ctx.name === "serif" || ctx.name === "italic")
     const measurements = await measureProbes(page, buildProbes(contexts, MEMBERSHIP_CHARS))
     const bearings = bearingsByKey(measurements)
+
+    const substituted = measurements.filter((m) => m.fromFallbackFace).map((m) => m.key)
+    console.info(`Glyphs judged: ${bearings.size}; rendered by a substitute face: ${substituted}`)
 
     const serifRef = bearings.get("serif|o")
     expect(serifRef, "round-letter reference probe has no ink in band").toBeDefined()

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -1,3 +1,5 @@
+import type { Page } from "@playwright/test"
+
 import {
   charsToSpace,
   charsToSpaceItalic,
@@ -145,85 +147,97 @@ function collectFailures(probes: readonly Probe[], measurements: readonly Measur
   return failures
 }
 
+/** Builds one probe per (context, char) pair with its expected nudge class. */
+function buildProbes(contexts: readonly ContextSpec[], chars: readonly string[]): Probe[] {
+  return contexts.flatMap((ctx) =>
+    chars.map((char) => ({
+      key: `${ctx.name}|${char}`,
+      contextName: ctx.name,
+      char,
+      wrapperHtml: ctx.wrapperHtml,
+      nudgeClass: nudgeClassFor(char, ctx.context),
+    })),
+  )
+}
+
+/**
+ * Renders each probe (glyph + favicon inside its context wrapper) on the page
+ * and measures the favicon's computed margin plus the glyph's right side
+ * bearing inside the favicon's vertical band, using the site's real fonts.
+ */
+async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Measurement[]> {
+  return await page.evaluate(async (probeList) => {
+    const host = document.createElement("div")
+    const article = document.querySelector("article") ?? document.body
+    article.appendChild(host)
+
+    const canvas = document.createElement("canvas")
+    const CANVAS_FONT_PX = 400
+    canvas.width = 1600
+    canvas.height = 900
+    const ctx2d = canvas.getContext("2d")
+    if (!ctx2d) throw new Error("no canvas context")
+
+    // Right side bearing of `char` inside the favicon's vertical band,
+    // in em of the rendered font. Null when the glyph has no ink there.
+    // Small-cap forms reuse the capital outlines, and canvas-level
+    // font-variant support differs per engine, so a small-caps probe
+    // measures the capital glyph directly.
+    const bearingInBand = (style: CSSStyleDeclaration, char: string): number | null => {
+      const glyph = style.fontVariantCaps === "small-caps" ? char.toUpperCase() : char
+      const baseline = 700
+      ctx2d.clearRect(0, 0, canvas.width, canvas.height)
+      ctx2d.font = `${style.fontStyle} ${CANVAS_FONT_PX}px ${style.fontFamily}`
+      ctx2d.textBaseline = "alphabetic"
+      ctx2d.fillText(glyph, 400, baseline)
+      const advance = ctx2d.measureText(glyph).width
+      const top = Math.floor(baseline - 0.7 * CANVAS_FONT_PX)
+      const bottom = Math.ceil(baseline - 0.2 * CANVAS_FONT_PX)
+      const image = ctx2d.getImageData(0, 0, canvas.width, canvas.height)
+      for (let x = canvas.width - 1; x >= 0; x--) {
+        for (let y = top; y <= bottom; y++) {
+          if (image.data[(y * canvas.width + x) * 4 + 3] > 40) {
+            return (400 + advance - x) / CANVAS_FONT_PX
+          }
+        }
+      }
+      return null
+    }
+
+    await document.fonts.ready
+    const results: { key: string; marginPx: number; fontSizePx: number; gapPx: number | null }[] =
+      []
+    for (const probe of probeList) {
+      host.innerHTML =
+        `<p>${probe.wrapperHtml[0]}<span class="ink-probe">${probe.char}</span>` +
+        `<svg class="favicon${probe.nudgeClass ? ` ${probe.nudgeClass}` : ""}" aria-hidden="true"></svg>` +
+        `${probe.wrapperHtml[1]}</p>`
+      const probeSpan = host.querySelector<HTMLElement>(".ink-probe")
+      const favicon = host.querySelector<SVGElement>("svg.favicon")
+      if (!probeSpan || !favicon) throw new Error(`fixture failed for ${probe.key}`)
+      const faviconStyle = getComputedStyle(favicon)
+      const probeStyle = getComputedStyle(probeSpan)
+      const marginPx = parseFloat(faviconStyle.marginLeft)
+      const fontSizePx = parseFloat(probeStyle.fontSize)
+      const bearingEm = bearingInBand(probeStyle, probe.char)
+      results.push({
+        key: probe.key,
+        marginPx,
+        fontSizePx,
+        gapPx: bearingEm === null ? null : marginPx + bearingEm * fontSizePx,
+      })
+    }
+    host.remove()
+    return results
+  }, probes)
+}
+
 test.describe("favicon ink gap", () => {
   test("margins resolve exactly and ink gaps stay inside the band", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const probes: Probe[] = CONTEXTS.flatMap((ctx) =>
-      PROBE_CHARS.map((char) => ({
-        key: `${ctx.name}|${char}`,
-        contextName: ctx.name,
-        char,
-        wrapperHtml: ctx.wrapperHtml,
-        nudgeClass: nudgeClassFor(char, ctx.context),
-      })),
-    )
-
-    const measurements: Measurement[] = await page.evaluate(async (probeList) => {
-      const host = document.createElement("div")
-      const article = document.querySelector("article") ?? document.body
-      article.appendChild(host)
-
-      const canvas = document.createElement("canvas")
-      const CANVAS_FONT_PX = 400
-      canvas.width = 1600
-      canvas.height = 900
-      const ctx2d = canvas.getContext("2d")
-      if (!ctx2d) throw new Error("no canvas context")
-
-      // Right side bearing of `char` inside the favicon's vertical band,
-      // in em of the rendered font. Null when the glyph has no ink there.
-      // Small-cap forms reuse the capital outlines, and canvas-level
-      // font-variant support differs per engine, so a small-caps probe
-      // measures the capital glyph directly.
-      const bearingInBand = (style: CSSStyleDeclaration, char: string): number | null => {
-        const glyph = style.fontVariantCaps === "small-caps" ? char.toUpperCase() : char
-        const baseline = 700
-        ctx2d.clearRect(0, 0, canvas.width, canvas.height)
-        ctx2d.font = `${style.fontStyle} ${CANVAS_FONT_PX}px ${style.fontFamily}`
-        ctx2d.textBaseline = "alphabetic"
-        ctx2d.fillText(glyph, 400, baseline)
-        const advance = ctx2d.measureText(glyph).width
-        const top = Math.floor(baseline - 0.7 * CANVAS_FONT_PX)
-        const bottom = Math.ceil(baseline - 0.2 * CANVAS_FONT_PX)
-        const image = ctx2d.getImageData(0, 0, canvas.width, canvas.height)
-        for (let x = canvas.width - 1; x >= 0; x--) {
-          for (let y = top; y <= bottom; y++) {
-            if (image.data[(y * canvas.width + x) * 4 + 3] > 40) {
-              return (400 + advance - x) / CANVAS_FONT_PX
-            }
-          }
-        }
-        return null
-      }
-
-      await document.fonts.ready
-      const results: { key: string; marginPx: number; fontSizePx: number; gapPx: number | null }[] =
-        []
-      for (const probe of probeList) {
-        host.innerHTML =
-          `<p>${probe.wrapperHtml[0]}<span class="ink-probe">${probe.char}</span>` +
-          `<svg class="favicon${probe.nudgeClass ? ` ${probe.nudgeClass}` : ""}" aria-hidden="true"></svg>` +
-          `${probe.wrapperHtml[1]}</p>`
-        const probeSpan = host.querySelector<HTMLElement>(".ink-probe")
-        const favicon = host.querySelector<SVGElement>("svg.favicon")
-        if (!probeSpan || !favicon) throw new Error(`fixture failed for ${probe.key}`)
-        const faviconStyle = getComputedStyle(favicon)
-        const probeStyle = getComputedStyle(probeSpan)
-        const marginPx = parseFloat(faviconStyle.marginLeft)
-        const fontSizePx = parseFloat(probeStyle.fontSize)
-        const bearingEm = bearingInBand(probeStyle, probe.char)
-        results.push({
-          key: probe.key,
-          marginPx,
-          fontSizePx,
-          gapPx: bearingEm === null ? null : marginPx + bearingEm * fontSizePx,
-        })
-      }
-      host.remove()
-      return results
-    }, probes)
-
+    const probes = buildProbes(CONTEXTS, PROBE_CHARS)
+    const measurements = await measureProbes(page, probes)
     const failures = collectFailures(probes, measurements)
     expect(failures, failures.join("\n")).toEqual([])
   })
@@ -235,8 +249,7 @@ test.describe("favicon ink gap", () => {
   // shadow offset, and the .right reset must return it to the plain value.
   // The boosted expectation is derived in-page from a probe whose
   // margin-left is the same calc the engine evaluates, so the assertion
-  // inherits the engine's own LayoutUnit quantization instead of comparing
-  // raw floats against the SCSS token.
+  // inherits the engine's own LayoutUnit quantization.
   test("faux-bold contexts widen the favicon margin by the shadow offset", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
@@ -269,13 +282,13 @@ test.describe("favicon ink gap", () => {
           if (!favicon) throw new Error(`fixture failed for ${html}`)
           return parseFloat(getComputedStyle(favicon).marginLeft)
         }
-        const plain = measure(`<span>r${faviconHtml}</span>`)
+        const plain = measure(`<span>o${faviconHtml}</span>`)
         const boosted = measure(
           `<span><svg class="favicon" aria-hidden="true" style="margin-left: calc(${plain}px + ${offset})"></svg></span>`,
         )
         const byContext = wrappers.map((wrapper) => ({
           name: wrapper.name,
-          marginPx: measure(`${wrapper.open}r${faviconHtml}${wrapper.close}`),
+          marginPx: measure(`${wrapper.open}o${faviconHtml}${wrapper.close}`),
         }))
         host.remove()
         return { plain, boosted, byContext }
@@ -283,8 +296,8 @@ test.describe("favicon ink gap", () => {
       { wrappers: contextWrappers, offset: fauxBoldOffset },
     )
 
-    // One LayoutUnit (1/64 px in Chromium/WebKit, 1/60 px in Firefox) of
-    // slack absorbs the double quantization of the derived expectation.
+    // Slack just above one LayoutUnit (1/64 px in Chromium/WebKit, 1/60 px
+    // in Firefox) absorbs the double quantization of the derived expectation.
     const quantumPx = 0.02
     for (const [index, { name, marginPx }] of margins.byContext.entries()) {
       const expected = contextWrappers[index].bolded ? margins.boosted : margins.plain
@@ -293,5 +306,77 @@ test.describe("favicon ink gap", () => {
         `${name}: margin ${marginPx}px, expected ${expected}px`,
       ).toBeLessThan(quantumPx)
     }
+  })
+
+  // Membership ratchet: render every plausible link-ending glyph in the
+  // shipped faces and require a nudge class for any glyph whose measured
+  // in-band ink qualifies under the sets' criteria. One-directional on
+  // purpose — the sets may hold extra perceptual members (serif "R", "r")
+  // whose crowding lives outside the measured band. Italic "~" and "^"
+  // overhang further than the largest nudge corrects and never end link
+  // text, so they stay out of the sets and out of this sweep; "†"/"‡" are
+  // absent from the test page's font subset.
+  const MEMBERSHIP_CHARS: readonly string[] = [
+    ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+    ..."()[]{}\\/®™©°%&*+=<>|!?;:’”",
+  ]
+
+  // Thresholds in em of the probe's font. Serif mirrors the kerning audit's
+  // bar (clearance more than ~1px short of a round letter's at body size);
+  // italic uses the ink-derived bearing bars that produced its sets. The
+  // nearest non-qualifying glyph sits ≥0.009em from its bar, so engine
+  // rasterization differences cannot flip a verdict.
+  const SERIF_CLOSE_SHORTFALL_EM = 0.05
+  const SERIF_MOST_SHORTFALL_EM = 0.12
+  const ITALIC_CLOSE_BEARING_EM = -0.03
+  const ITALIC_MOST_BEARING_EM = -0.11
+
+  test("glyphs that measure as crowding carry a nudge class", async ({ page }) => {
+    await gotoPage(page, "http://localhost:8080/test-page")
+
+    const contexts = CONTEXTS.filter((ctx) => ctx.name === "serif" || ctx.name === "italic")
+    const probes = buildProbes(contexts, MEMBERSHIP_CHARS)
+    const measurements = await measureProbes(page, probes)
+
+    const bearingOf = (key: string): number | null => {
+      const measured = measurements.find((m) => m.key === key)
+      if (!measured || measured.gapPx === null) return null
+      return (measured.gapPx - measured.marginPx) / measured.fontSizePx
+    }
+
+    const serifRef = bearingOf("serif|o")
+    expect(serifRef, "round-letter reference probe has no ink in band").not.toBeNull()
+
+    const violations: string[] = []
+    for (const char of MEMBERSHIP_CHARS) {
+      const serifBearing = bearingOf(`serif|${char}`)
+      if (serifBearing !== null && serifRef !== null) {
+        const shortfall = serifRef - serifBearing
+        if (shortfall > SERIF_MOST_SHORTFALL_EM && !charsToSpaceMost.includes(char)) {
+          violations.push(`serif ${char}: shortfall ${shortfall.toFixed(3)}em needs closer-text`)
+        } else if (
+          shortfall > SERIF_CLOSE_SHORTFALL_EM &&
+          !charsToSpaceMost.includes(char) &&
+          !charsToSpace.includes(char)
+        ) {
+          violations.push(`serif ${char}: shortfall ${shortfall.toFixed(3)}em needs close-text`)
+        }
+      }
+
+      const italicBearing = bearingOf(`italic|${char}`)
+      if (italicBearing !== null) {
+        if (italicBearing <= ITALIC_MOST_BEARING_EM && !charsToSpaceMostItalic.includes(char)) {
+          violations.push(`italic ${char}: bearing ${italicBearing.toFixed(3)}em needs closer-text`)
+        } else if (
+          italicBearing <= ITALIC_CLOSE_BEARING_EM &&
+          !charsToSpaceMostItalic.includes(char) &&
+          !charsToSpaceItalic.includes(char)
+        ) {
+          violations.push(`italic ${char}: bearing ${italicBearing.toFixed(3)}em needs close-text`)
+        }
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([])
   })
 })

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -232,6 +232,122 @@ async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Meas
   }, probes)
 }
 
+interface ContextWrapper {
+  name: string
+  open: string
+  close: string
+  bolded: boolean
+}
+
+// Every rule that applies the faux-bold text-shadow, plus the .right reset
+// that removes it.
+const FAUX_BOLD_WRAPPERS: readonly ContextWrapper[] = [
+  { name: "strong", open: "<strong>", close: "</strong>", bolded: true },
+  { name: "title-cell", open: '<div class="title-cell">', close: "</div>", bolded: true },
+  {
+    name: "admonition-title",
+    open: '<span class="admonition-title-inner">',
+    close: "</span>",
+    bolded: true,
+  },
+  {
+    name: "right-reset",
+    open: '<div class="right"><strong>',
+    close: "</strong></div>",
+    bolded: false,
+  },
+]
+
+interface BoldMargins {
+  plain: number
+  boosted: number
+  byContext: { name: string; marginPx: number }[]
+}
+
+// Slack just above one LayoutUnit (1/64 px in Chromium/WebKit, 1/60 px in
+// Firefox) absorbs the double quantization of the derived expectation.
+const MARGIN_QUANTUM_PX = 0.02
+
+/** Names the contexts whose favicon margin misses its faux-bold expectation. */
+function collectBoldFailures(margins: BoldMargins, wrappers: readonly ContextWrapper[]): string[] {
+  return margins.byContext
+    .map((measured, index) => {
+      const expected = wrappers[index].bolded ? margins.boosted : margins.plain
+      const off = Math.abs(measured.marginPx - expected) >= MARGIN_QUANTUM_PX
+      return off ? `${measured.name}: margin ${measured.marginPx}px != ${expected}px` : ""
+    })
+    .filter(Boolean)
+}
+
+// Glyphs that plausibly end link text, restricted to those the shipped
+// EBGaramond faces actually carry: ™ is absent from both, so a probe for it
+// would measure a platform fallback face and reach a different verdict per OS.
+const MEMBERSHIP_CHARS: readonly string[] = [
+  ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+  ..."()[]{}\\/®©°%&*+=<>|!?;:’”†‡",
+]
+
+// Thresholds in em of the probe's font, slackened from the bars that produced
+// the sets so that no glyph sits near a bar: the closest non-qualifying glyph
+// clears its threshold by more than 0.01em, well beyond what antialiasing
+// differences between rasterizers can shift a detected ink edge. Serif
+// measures shortfall against a round letter's clearance (the kerning audit's
+// unit); italic measures the bearing itself, since its glyphs lean past their
+// advance edge.
+const SERIF_CLOSE_SHORTFALL_EM = 0.05
+const SERIF_MOST_SHORTFALL_EM = 0.12
+const ITALIC_CLOSE_BEARING_EM = -0.04
+const ITALIC_MOST_BEARING_EM = -0.11
+
+/**
+ * Names every glyph whose measured ink qualifies it for a nudge class it
+ * doesn't have. One-directional on purpose: the sets may hold extra
+ * perceptual members (serif "R", "r") whose crowding lives outside the
+ * measured band, and glyphs like italic "~" that overhang past what any nudge
+ * corrects. Glyphs with no ink in the band are skipped — they cannot crowd.
+ */
+function collectMembershipViolations(
+  bearings: ReadonlyMap<string, number>,
+  serifRef: number,
+): string[] {
+  const violations: string[] = []
+  const flag = (face: string, char: string, amount: number, needs: string) =>
+    violations.push(`${face} ${char}: ${amount.toFixed(3)}em needs ${needs}`)
+
+  for (const char of MEMBERSHIP_CHARS) {
+    // A glyph with no ink in band scores as maximally clear, so it never flags.
+    const serifBearing = bearings.get(`serif|${char}`) ?? serifRef
+    const shortfall = serifRef - serifBearing
+    const hasSerifNudge = charsToSpace.includes(char) || charsToSpaceMost.includes(char)
+    if (shortfall > SERIF_MOST_SHORTFALL_EM && !charsToSpaceMost.includes(char)) {
+      flag("serif", char, shortfall, "closer-text")
+    } else if (shortfall > SERIF_CLOSE_SHORTFALL_EM && !hasSerifNudge) {
+      flag("serif", char, shortfall, "close-text")
+    }
+
+    const italicBearing = bearings.get(`italic|${char}`) ?? 0
+    const hasItalicNudge =
+      charsToSpaceItalic.includes(char) || charsToSpaceMostItalic.includes(char)
+    if (italicBearing <= ITALIC_MOST_BEARING_EM && !charsToSpaceMostItalic.includes(char)) {
+      flag("italic", char, italicBearing, "closer-text")
+    } else if (italicBearing <= ITALIC_CLOSE_BEARING_EM && !hasItalicNudge) {
+      flag("italic", char, italicBearing, "close-text")
+    }
+  }
+  return violations
+}
+
+/** Right side bearings in em, keyed by probe, for probes with ink in band. */
+function bearingsByKey(measurements: readonly Measurement[]): ReadonlyMap<string, number> {
+  const bearings = new Map<string, number>()
+  for (const measured of measurements) {
+    if (measured.gapPx !== null) {
+      bearings.set(measured.key, (measured.gapPx - measured.marginPx) / measured.fontSizePx)
+    }
+  }
+  return bearings
+}
+
 test.describe("favicon ink gap", () => {
   test("margins resolve exactly and ink gaps stay inside the band", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
@@ -253,24 +369,7 @@ test.describe("favicon ink gap", () => {
   test("faux-bold contexts widen the favicon margin by the shadow offset", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const contextWrappers = [
-      { name: "strong", open: "<strong>", close: "</strong>", bolded: true },
-      { name: "title-cell", open: '<div class="title-cell">', close: "</div>", bolded: true },
-      {
-        name: "admonition-title",
-        open: '<span class="admonition-title-inner">',
-        close: "</span>",
-        bolded: true,
-      },
-      {
-        name: "right-reset",
-        open: '<div class="right"><strong>',
-        close: "</strong></div>",
-        bolded: false,
-      },
-    ] as const
-
-    const margins = await page.evaluate(
+    const margins: BoldMargins = await page.evaluate(
       ({ wrappers, offset }) => {
         const host = document.createElement("div")
         const article = document.querySelector("article") ?? document.body
@@ -293,90 +392,28 @@ test.describe("favicon ink gap", () => {
         host.remove()
         return { plain, boosted, byContext }
       },
-      { wrappers: contextWrappers, offset: fauxBoldOffset },
+      { wrappers: FAUX_BOLD_WRAPPERS, offset: fauxBoldOffset },
     )
 
-    // Slack just above one LayoutUnit (1/64 px in Chromium/WebKit, 1/60 px
-    // in Firefox) absorbs the double quantization of the derived expectation.
-    const quantumPx = 0.02
-    for (const [index, { name, marginPx }] of margins.byContext.entries()) {
-      const expected = contextWrappers[index].bolded ? margins.boosted : margins.plain
-      expect(
-        Math.abs(marginPx - expected),
-        `${name}: margin ${marginPx}px, expected ${expected}px`,
-      ).toBeLessThan(quantumPx)
-    }
+    const failures = collectBoldFailures(margins, FAUX_BOLD_WRAPPERS)
+    expect(failures, failures.join("\n")).toEqual([])
   })
 
-  // Membership ratchet: render every plausible link-ending glyph in the
-  // shipped faces and require a nudge class for any glyph whose measured
-  // in-band ink qualifies under the sets' criteria. One-directional on
-  // purpose — the sets may hold extra perceptual members (serif "R", "r")
-  // whose crowding lives outside the measured band. Italic "~" and "^"
-  // overhang further than the largest nudge corrects and never end link
-  // text, so they stay out of the sets and out of this sweep; "†"/"‡" are
-  // absent from the test page's font subset.
-  const MEMBERSHIP_CHARS: readonly string[] = [
-    ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-    ..."()[]{}\\/®™©°%&*+=<>|!?;:’”",
-  ]
-
-  // Thresholds in em of the probe's font. Serif mirrors the kerning audit's
-  // bar (clearance more than ~1px short of a round letter's at body size);
-  // italic uses the ink-derived bearing bars that produced its sets. The
-  // nearest non-qualifying glyph sits ≥0.009em from its bar, so engine
-  // rasterization differences cannot flip a verdict.
-  const SERIF_CLOSE_SHORTFALL_EM = 0.05
-  const SERIF_MOST_SHORTFALL_EM = 0.12
-  const ITALIC_CLOSE_BEARING_EM = -0.03
-  const ITALIC_MOST_BEARING_EM = -0.11
-
+  // Membership ratchet: measure every plausible link-ending glyph in the
+  // shipped faces and demand a nudge class wherever the ink qualifies for
+  // one. This keeps the sets honest against future font updates, which shift
+  // bearings without touching any code the other tests cover.
   test("glyphs that measure as crowding carry a nudge class", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
     const contexts = CONTEXTS.filter((ctx) => ctx.name === "serif" || ctx.name === "italic")
-    const probes = buildProbes(contexts, MEMBERSHIP_CHARS)
-    const measurements = await measureProbes(page, probes)
+    const measurements = await measureProbes(page, buildProbes(contexts, MEMBERSHIP_CHARS))
+    const bearings = bearingsByKey(measurements)
 
-    const bearingOf = (key: string): number | null => {
-      const measured = measurements.find((m) => m.key === key)
-      if (!measured || measured.gapPx === null) return null
-      return (measured.gapPx - measured.marginPx) / measured.fontSizePx
-    }
+    const serifRef = bearings.get("serif|o")
+    expect(serifRef, "round-letter reference probe has no ink in band").toBeDefined()
 
-    const serifRef = bearingOf("serif|o")
-    expect(serifRef, "round-letter reference probe has no ink in band").not.toBeNull()
-
-    const violations: string[] = []
-    for (const char of MEMBERSHIP_CHARS) {
-      const serifBearing = bearingOf(`serif|${char}`)
-      if (serifBearing !== null && serifRef !== null) {
-        const shortfall = serifRef - serifBearing
-        if (shortfall > SERIF_MOST_SHORTFALL_EM && !charsToSpaceMost.includes(char)) {
-          violations.push(`serif ${char}: shortfall ${shortfall.toFixed(3)}em needs closer-text`)
-        } else if (
-          shortfall > SERIF_CLOSE_SHORTFALL_EM &&
-          !charsToSpaceMost.includes(char) &&
-          !charsToSpace.includes(char)
-        ) {
-          violations.push(`serif ${char}: shortfall ${shortfall.toFixed(3)}em needs close-text`)
-        }
-      }
-
-      const italicBearing = bearingOf(`italic|${char}`)
-      if (italicBearing !== null) {
-        if (italicBearing <= ITALIC_MOST_BEARING_EM && !charsToSpaceMostItalic.includes(char)) {
-          violations.push(`italic ${char}: bearing ${italicBearing.toFixed(3)}em needs closer-text`)
-        } else if (
-          italicBearing <= ITALIC_CLOSE_BEARING_EM &&
-          !charsToSpaceMostItalic.includes(char) &&
-          !charsToSpaceItalic.includes(char)
-        ) {
-          violations.push(`italic ${char}: bearing ${italicBearing.toFixed(3)}em needs close-text`)
-        }
-      }
-    }
-
+    const violations = collectMembershipViolations(bearings, serifRef ?? 0)
     expect(violations, violations.join("\n")).toEqual([])
   })
 })

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_GLYPH_CONTEXT,
   nudgeClassFor,
 } from "../../plugins/transformers/favicons"
+import { fauxBoldOffset } from "../../styles/variables"
 import { expect, test } from "./fixtures"
 import { gotoPage } from "./visual_utils"
 
@@ -225,5 +226,31 @@ test.describe("favicon ink gap", () => {
 
     const failures = collectFailures(probes, measurements)
     expect(failures, failures.join("\n")).toEqual([])
+  })
+
+  // Faux-bold contexts paint glyph ink $faux-bold-offset further right via
+  // text-shadow; the same rules set --favicon-bold-nudge so the favicon's
+  // visual gap stays constant. The margin delta must equal the shadow offset.
+  test("faux-bold contexts widen the favicon margin by the shadow offset", async ({ page }) => {
+    await gotoPage(page, "http://localhost:8080/test-page")
+
+    const margins = await page.evaluate(() => {
+      const host = document.createElement("div")
+      const article = document.querySelector("article") ?? document.body
+      article.appendChild(host)
+      host.innerHTML =
+        '<p><span id="plain">r<svg class="favicon" aria-hidden="true"></svg></span>' +
+        '<strong id="bold">r<svg class="favicon" aria-hidden="true"></svg></strong></p>'
+      const marginOf = (selector: string): number => {
+        const favicon = host.querySelector(`${selector} svg.favicon`)
+        if (!favicon) throw new Error(`fixture failed for ${selector}`)
+        return parseFloat(getComputedStyle(favicon).marginLeft)
+      }
+      const result = { plain: marginOf("#plain"), bold: marginOf("#bold") }
+      host.remove()
+      return result
+    })
+
+    expect(margins.bold - margins.plain).toBeCloseTo(parseFloat(fauxBoldOffset), 2)
   })
 })

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -554,6 +554,13 @@ describe("insertFavicon", () => {
         ["(", { smallCaps: true }, "close-text"],
         ["y", { smallCaps: true, italic: true }, null],
         ["R", { italic: true }, null],
+        // Ink-derived italic additions diverge from the serif sets.
+        ["6", { italic: true }, "close-text"],
+        ["H", { italic: true }, "close-text"],
+        ["X", { italic: true }, "close-text"],
+        ["W", { italic: true }, "closer-text"],
+        ["W", {}, null],
+        ["6", {}, null],
       ] as const)("%s in %o gets %s", (char, overrides, expected) => {
         expect(favicons.nudgeClassFor(char, ctx(overrides))).toBe(expected)
       })

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -263,11 +263,12 @@ export function insertFavicon(
 // scripts/notebooks/favicon_kerning_audit, which renders every real
 // (glyph, favicon) pair on the built site and reports each glyph's ink
 // clearance; glyphs land here when their median clearance falls more than
-// ~1px short of a round letter's.
+// ~1px short of a round letter's. "r" joins perceptually: its arm terminal
+// sits at x-height, level with the icon's raised box.
 export const charsToSpace: readonly string[] = [
   "T",
   "R",
-  "r", // arm terminal at x-height reaches the advance edge, inside the icon's band
+  "r",
   "V",
   "Y",
   "q",
@@ -311,8 +312,13 @@ export const charsToSpaceItalic: readonly string[] = [
   "r",
   "l",
   "g",
+  "6",
+  "H",
+  "I",
+  "M",
+  "X",
 ]
-export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/"]
+export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W", "~", "^"]
 
 /** Widens `context` with whatever face `element` switches its text into. */
 export function broadenContext(element: Element, context: GlyphContext): GlyphContext {

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -318,7 +318,7 @@ export const charsToSpaceItalic: readonly string[] = [
   "M",
   "X",
 ]
-export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W", "~", "^"]
+export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W"]
 
 /** Widens `context` with whatever face `element` switches its text into. */
 export function broadenContext(element: Element, context: GlyphContext): GlyphContext {

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -319,6 +319,9 @@ export const charsToSpaceItalic: readonly string[] = [
   "I",
   "M",
   "X",
+  // The italic face has no ®, so it comes from the upright face with
+  // synthesized oblique, which leans its ink past the advance edge.
+  "®",
 ]
 export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W"]
 

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -267,6 +267,7 @@ export function insertFavicon(
 export const charsToSpace: readonly string[] = [
   "T",
   "R",
+  "r", // arm terminal at x-height reaches the advance edge, inside the icon's band
   "V",
   "Y",
   "q",

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -293,9 +293,11 @@ export const charsToSpaceMost: readonly string[] = ["f", "Q", "/"]
 // The serif sets above come from the perceptual audit and stay its property.
 // Italic glyphs lean rightward, so the overhang set differs; with no audit for
 // the italic face, membership derives from measured ink clearance within the
-// favicon's vertical band (0.2em-0.7em above the baseline): glyphs whose
-// in-band ink reaches their advance edge get a nudge, and glyphs whose ink
-// overhangs by more than 0.1em get the larger one.
+// favicon's vertical band (0.2em-0.7em above the baseline). Among glyphs that
+// plausibly end link text, those whose in-band ink reaches their advance edge
+// get a nudge, and those overhanging by more than 0.1em get the larger one.
+// Glyphs that overhang past what the larger nudge corrects (italic "~", "^")
+// stay out: no nudge restores their gap, and they never end link text.
 export const charsToSpaceItalic: readonly string[] = [
   "T",
   "Y",

--- a/quartz/styles/_faux-bold.scss
+++ b/quartz/styles/_faux-bold.scss
@@ -1,0 +1,23 @@
+@use "./variables.scss" as *;
+
+// Faux bold widens every glyph's ink $faux-bold-offset rightward, so the
+// shadow and the favicon compensation (--favicon-bold-nudge, consumed by the
+// left-gap model in favicon.scss) must always travel together: a context with
+// the shadow but not the nudge crowds every favicon it contains, and vice
+// versa. These mixins are the only sanctioned way to apply or remove faux
+// bold.
+@mixin faux-bold($color: null) {
+  --favicon-bold-nudge: #{$faux-bold-offset};
+
+  @if $color {
+    text-shadow: $faux-bold-offset $faux-bold-offset $color;
+  } @else {
+    text-shadow: $faux-bold-offset $faux-bold-offset;
+  }
+}
+
+@mixin faux-bold-off {
+  --favicon-bold-nudge: 0px;
+
+  text-shadow: 0 0;
+}

--- a/quartz/styles/_faux-bold.scss
+++ b/quartz/styles/_faux-bold.scss
@@ -9,11 +9,9 @@
 @mixin faux-bold($color: null) {
   --favicon-bold-nudge: #{$faux-bold-offset};
 
-  @if $color {
-    text-shadow: $faux-bold-offset $faux-bold-offset $color;
-  } @else {
-    text-shadow: $faux-bold-offset $faux-bold-offset;
-  }
+  // Sass drops a null from the value list, so one declaration serves both
+  // the plain and the colored shadow.
+  text-shadow: $faux-bold-offset $faux-bold-offset $color;
 }
 
 @mixin faux-bold-off {

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -39,21 +39,26 @@
   --favicon-base-size: calc(#{$base-margin} * 1.25 - var(--size-decrease));
   --favicon-size: var(--favicon-base-size);
 
-  // Left-gap model: constant visual gap = base + glyph nudge − icon ink inset.
-  // `--glyph-nudge` compensates glyphs whose ink overhangs their advance width
-  // (set via .close-text / .closer-text, assigned per charsToSpace/-Most in
-  // quartz/plugins/transformers/favicons.ts). `--left-inset` is the fraction of
-  // the icon box left of its first ink column (measured by
+  // Left-gap model: constant visual gap = base + glyph nudge + bold nudge −
+  // icon ink inset. `--glyph-nudge` compensates glyphs whose ink overhangs
+  // their advance width (set via .close-text / .closer-text, assigned per
+  // charsToSpace/-Most in quartz/plugins/transformers/favicons.ts).
+  // `--favicon-bold-nudge` compensates faux-bold contexts, whose text-shadow
+  // paints every glyph's ink $faux-bold-offset further right; it is set (and
+  // reset) by the same rules that apply the shadow (fonts.scss, table.scss),
+  // so the two can't drift apart. `--left-inset` is the fraction of the icon
+  // box left of its first ink column (measured by
   // scripts/notebooks/favicon_kerning_audit, capped at ~2px); subtracting it
   // puts every icon's visual left edge the same distance from the text.
   --glyph-nudge: 0rem;
   --left-inset: 0;
+  --text-gap: calc(0.125 * #{$base-margin} + var(--glyph-nudge) + var(--favicon-bold-nudge, 0px));
 
   display: inline;
   width: var(--favicon-size);
   height: var(--favicon-size);
   margin: 0 auto calc(-0.25 * #{$base-margin})
-    calc(0.125 * #{$base-margin} + var(--glyph-nudge) - var(--left-inset) * var(--favicon-size));
+    calc(var(--text-gap) - var(--left-inset) * var(--favicon-size));
   vertical-align: var(--vertical-adjustment);
 
   // Don't pollute copied text with favicon

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -44,12 +44,14 @@
   // their advance width (set via .close-text / .closer-text, assigned per
   // charsToSpace/-Most in quartz/plugins/transformers/favicons.ts).
   // `--favicon-bold-nudge` compensates faux-bold contexts, whose text-shadow
-  // paints every glyph's ink $faux-bold-offset further right; it is set (and
-  // reset) by the same rules that apply the shadow (fonts.scss, table.scss),
-  // so the two can't drift apart. `--left-inset` is the fraction of the icon
-  // box left of its first ink column (measured by
-  // scripts/notebooks/favicon_kerning_audit, capped at ~2px); subtracting it
-  // puts every icon's visual left edge the same distance from the text.
+  // paints every glyph's ink $faux-bold-offset further right; the faux-bold
+  // mixin (_faux-bold.scss) emits the shadow and the nudge together. It is
+  // consumed only through the var() fallback and must never be initialized on
+  // .favicon itself — the value has to inherit from the bold ancestor.
+  // `--left-inset` is the fraction of the icon box left of its first ink
+  // column (measured by scripts/notebooks/favicon_kerning_audit, capped at
+  // ~2px); subtracting it puts every icon's visual left edge the same
+  // distance from the text.
   --glyph-nudge: 0rem;
   --left-inset: 0;
   --text-gap: calc(0.125 * #{$base-margin} + var(--glyph-nudge) + var(--favicon-bold-nudge, 0px));

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -297,10 +297,16 @@ b,
 strong,
 .admonition-title-inner,
 dt {
+  // The shadow widens every glyph's ink rightward, so descendant favicons
+  // read back --favicon-bold-nudge to keep their visual left gap constant.
+  --favicon-bold-nudge: #{$faux-bold-offset};
+
   text-shadow: $faux-bold-offset $faux-bold-offset;
   font-weight: 400 !important; // Normal font weight -- otherwise would be eg 600
 
   .right & {
+    --favicon-bold-nudge: 0px;
+
     text-shadow: 0 0; // No bolding needed on right sidebar; spacing works
   }
 }

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -1,4 +1,5 @@
 @use "./variables.scss" as *;
+@use "./faux-bold" as *;
 
 @function calculate-scale($steps) {
   @return calc(1rem * pow($font-scale-factor, #{$steps}));
@@ -297,17 +298,13 @@ b,
 strong,
 .admonition-title-inner,
 dt {
-  // The shadow widens every glyph's ink rightward, so descendant favicons
-  // read back --favicon-bold-nudge to keep their visual left gap constant.
-  --favicon-bold-nudge: #{$faux-bold-offset};
+  @include faux-bold;
 
-  text-shadow: $faux-bold-offset $faux-bold-offset;
   font-weight: 400 !important; // Normal font weight -- otherwise would be eg 600
 
+  // No bolding needed on right sidebar; spacing works
   .right & {
-    --favicon-bold-nudge: 0px;
-
-    text-shadow: 0 0; // No bolding needed on right sidebar; spacing works
+    @include faux-bold-off;
   }
 }
 

--- a/quartz/styles/table.scss
+++ b/quartz/styles/table.scss
@@ -88,6 +88,10 @@ tr.group-boundary > td {
 }
 
 .title-cell {
+  // Faux bold: descendant favicons read back --favicon-bold-nudge to keep
+  // their visual left gap constant despite the rightward ink widening.
+  --favicon-bold-nudge: #{$faux-bold-offset};
+
   text-align: center;
   text-shadow: $faux-bold-offset $faux-bold-offset var(--foreground);
 }

--- a/quartz/styles/table.scss
+++ b/quartz/styles/table.scss
@@ -1,4 +1,5 @@
 @use "./variables.scss" as *;
+@use "./faux-bold" as *;
 
 table {
   table-layout: fixed;
@@ -88,12 +89,9 @@ tr.group-boundary > td {
 }
 
 .title-cell {
-  // Faux bold: descendant favicons read back --favicon-bold-nudge to keep
-  // their visual left gap constant despite the rightward ink widening.
-  --favicon-bold-nudge: #{$faux-bold-offset};
+  @include faux-bold(var(--foreground));
 
   text-align: center;
-  text-shadow: $faux-bold-offset $faux-bold-offset var(--foreground);
 }
 
 .percentage-cell {

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -652,6 +652,11 @@ Links ending [with code tags should still wrap OK: `code.`](#external-links-with
 
 A footnote reference right after a favicon-ending [same-page link](#external-links-with-favicons)[^favicon-footnote] must not wrap onto its own line.
 
+Faux-bold text widens glyph ink rightward, so a favicon after a bold link ending in an overhanging glyph, like **[Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)**, keeps the same visual gap, including in a collapsed quote title:
+
+> [!quote]- [Google Sits Pretty as A.I. Rivals Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)
+> The favicon in the faux-bold title above keeps its gap after the final "r".
+
 [^favicon-footnote]: The footnote number stays glued to the favicon so it can't wrap onto its own line.
 
 <div id="populate-favicon-container" class="no-favicon-span"></div>


### PR DESCRIPTION
## Summary

- The NYT favicon in the collapsed quote-admonition title on `/why-i-left-google-deepmind` sat nearly touching the final "r" of "Pentagon Favor", while body-text NYT favicons looked fine. Causes: serif "r" carried no nudge class even though its arm terminal sits at x-height inside the icon's band; faux-bold contexts (admonition titles, `b`/`strong`, `dt`, table title cells) paint ink `$faux-bold-offset` further right via `text-shadow`, uncompensated by the left-gap model; and `nytimes_com`'s maximal ink inset (0.133) already drives the net margin negative.
- Beyond the point fix, this PR generalizes: the faux-bold shadow and its favicon compensation are now emitted together by one mixin (a third shadow site in `toc.scss` had already drifted), the italic nudge sets gain glyphs measured from the shipped fonts, and a new measured "membership ratchet" test fails CI whenever any glyph qualifies for a nudge but lacks one — including after future font updates.

## Changes

- `quartz/plugins/transformers/favicons.ts`: add `"r"` to `charsToSpace`; add measured italic overhangers `6/H/I/M/X` to `charsToSpaceItalic` and `W` to `charsToSpaceMostItalic` (italic `~`/`^` overhang beyond what the largest nudge corrects and never end link text, so they stay out).
- `quartz/styles/_faux-bold.scss` (new): `faux-bold($color)` / `faux-bold-off` mixins emit the `text-shadow` and `--favicon-bold-nudge` together; adopted at all three shadow sites (`fonts.scss`, `table.scss`, `toc.scss`).
- `quartz/styles/favicon.scss`: fold `--favicon-bold-nudge` (default `0px`, consumed only via `var()` fallback so it inherits from the bold ancestor) into the left-gap calc via a `--text-gap` intermediate.
- `quartz/components/tests/faviconInkGap.spec.ts`: shared `buildProbes`/`measureProbes` helpers; a faux-bold margin test parametrized over every set-site plus the `.right` reset, with its expectation derived in-page so it inherits the engine's own LayoutUnit quantization; and the membership-ratchet test sweeping ~90 glyphs in both faces against the sets' documented thresholds (one-directional: perceptual members like serif `R`/`r` stay allowed).
- `quartz/plugins/transformers/favicons.test.ts`: explicit `nudgeClassFor` samples for the new italic members and their serif divergence.
- `website_content/test-page.md`: reproducing example (bold r-final NYT link + collapsed quote-admonition title) for visual-regression baselines.

## Testing

- `jest favicons.test.ts`: 295 tests pass; membership tests parametrize over the exported sets.
- `tsc --noEmit`, `stylelint`, `prettier`, and a full `sass` compile all clean; compiled CSS verified to pair every shadow with its nudge.
- DeepSource: zero findings.
- Glyph additions derived from a headless-Chromium canvas sweep of the shipped `EBGaramond08` faces (same measurement the new ratchet test now runs in CI); serif face showed no other glyph within ~0.7px of the audit's bar.

## Lessons learned

- **What**: When two CSS declarations must always co-occur (e.g. an ink-widening `text-shadow` and a spacing compensation), emit them from a single mixin/helper rather than duplicating the pair at each site — one site had already drifted.
- **Where**: `quartz/styles/_faux-bold.scss` pattern; applies to any repo pairing visual effects with layout compensations.
- **Why**: Hand-paired declarations drift silently; a comment claiming "these can't drift apart" is aspiration unless code enforces it.
- **What**: For data tables derived from measurements (kerning sets, inset tables), add a one-directional CI test that re-measures from the shipped assets and fails when the data under-covers reality; allow manual extras.
- **Where**: `quartz/components/tests/faviconInkGap.spec.ts` membership-ratchet pattern.
- **Why**: The original set was audited once and then drifted from the fonts; a ratchet catches omissions and future asset updates automatically.