### PR TITLE
fix(favicons): give tight monospace glyphs their own favicon nudge

### DIFF
--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -2,8 +2,10 @@ import type { Page } from "@playwright/test"
 
 import {
   charsToSpace,
+  charsToSpaceCode,
   charsToSpaceItalic,
   charsToSpaceMost,
+  charsToSpaceMostCode,
   charsToSpaceMostItalic,
   EMPTY_GLYPH_CONTEXT,
   nudgeClassFor,
@@ -36,6 +38,11 @@ const PROBE_CHARS: readonly string[] = [
     ..."oenas",
   ]),
 ]
+// The monospace sets are their own membership, so the code context probes them
+// rather than the proportional faces' chars.
+const CODE_PROBE_CHARS: readonly string[] = [
+  ...new Set([...charsToSpaceCode, ...charsToSpaceMostCode, ..."oenas"]),
+]
 
 interface ContextSpec {
   name: "serif" | "italic" | "smallCaps" | "code"
@@ -67,11 +74,13 @@ const CONTEXTS: readonly ContextSpec[] = [
 // varies with the viewport's root font size; the invariant is the RATIO to
 // the classless serif margin (the "unit"): close-text doubles it,
 // closer-text triples it, and inside code a uniform −0.125·base nudge
-// cancels it to zero.
+// cancels it to zero, which the code classes return by a half step and a
+// whole step.
 const MARGIN_UNIT_MULTIPLIER: Readonly<Record<string, number>> = {
-  null: 1,
   "close-text": 2,
   "closer-text": 3,
+  "code-close-text": 0.5,
+  "code-closer-text": 1,
 }
 const UNIT_PROBE_KEY = "serif|o"
 
@@ -88,6 +97,8 @@ const FLOOR_EM: Readonly<Record<string, number>> = {
   null: -0.0125,
   "close-text": -0.0375,
   "closer-text": -0.075,
+  "code-close-text": -0.0125,
+  "code-closer-text": -0.0125,
 }
 const CEILING_EM: Readonly<Record<string, number>> = {
   serif: 0.32,
@@ -112,6 +123,13 @@ interface Probe {
   nudgeClass: ReturnType<typeof nudgeClassFor>
 }
 
+/** The probe's expected margin as a multiple of the classless serif margin. */
+function marginMultiplier(probe: Probe): number {
+  if (probe.nudgeClass) return MARGIN_UNIT_MULTIPLIER[probe.nudgeClass]
+  // The uniform monospace correction cancels the classless margin entirely.
+  return probe.contextName === "code" ? 0 : 1
+}
+
 function collectFailures(probes: readonly Probe[], measurements: readonly Measurement[]): string[] {
   const unit = measurements.find((m) => m.key === UNIT_PROBE_KEY)
   if (!unit || unit.marginPx <= 0) {
@@ -124,10 +142,7 @@ function collectFailures(probes: readonly Probe[], measurements: readonly Measur
       failures.push(`${probe.key}: no measurement`)
       continue
     }
-    const expectedMargin =
-      probe.contextName === "code"
-        ? 0
-        : MARGIN_UNIT_MULTIPLIER[probe.nudgeClass ?? "null"] * unit.marginPx
+    const expectedMargin = marginMultiplier(probe) * unit.marginPx
     if (Math.abs(measured.marginPx - expectedMargin) > 0.1) {
       failures.push(
         `${probe.key}: margin ${measured.marginPx.toFixed(2)}px != ${expectedMargin.toFixed(2)}px`,
@@ -319,6 +334,13 @@ const SERIF_CLOSE_SHORTFALL_EM = 0.05
 const SERIF_MOST_SHORTFALL_EM = 0.12
 const ITALIC_CLOSE_BEARING_EM = -0.04
 const ITALIC_MOST_BEARING_EM = -0.11
+// Monospace measures the bearing itself against what the uniform code
+// correction already covers, so its bars are absolute rather than relative to
+// a reference glyph. The larger class's bar clears "K", the closest
+// non-member, by 0.01em, which leaves the set's own borderline members ("V",
+// "Y") above it — the sweep is one-directional, so extra members pass.
+const CODE_CLOSE_BEARING_EM = 0.05
+const CODE_MOST_BEARING_EM = 0.03
 
 /**
  * Names every glyph whose measured ink qualifies it for a nudge class it
@@ -354,6 +376,15 @@ function collectMembershipViolations(
     } else if (italicBearing <= ITALIC_CLOSE_BEARING_EM && !hasItalicNudge) {
       flag("italic", char, italicBearing, "close-text")
     }
+
+    // A glyph with no ink in band scores as maximally clear, so it never flags.
+    const codeBearing = bearings.get(`code|${char}`) ?? Number.POSITIVE_INFINITY
+    const hasCodeNudge = charsToSpaceCode.includes(char) || charsToSpaceMostCode.includes(char)
+    if (codeBearing < CODE_MOST_BEARING_EM && !charsToSpaceMostCode.includes(char)) {
+      flag("code", char, codeBearing, "code-closer-text")
+    } else if (codeBearing < CODE_CLOSE_BEARING_EM && !hasCodeNudge) {
+      flag("code", char, codeBearing, "code-close-text")
+    }
   }
   return violations
 }
@@ -377,7 +408,16 @@ test.describe("favicon ink gap", () => {
   test("margins resolve exactly and ink gaps stay inside the band", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const probes = buildProbes(CONTEXTS, PROBE_CHARS)
+    const probes = [
+      ...buildProbes(
+        CONTEXTS.filter((ctx) => ctx.name !== "code"),
+        PROBE_CHARS,
+      ),
+      ...buildProbes(
+        CONTEXTS.filter((ctx) => ctx.name === "code"),
+        CODE_PROBE_CHARS,
+      ),
+    ]
     const measurements = await measureProbes(page, probes)
     const failures = collectFailures(probes, measurements)
     expect(failures, failures.join("\n")).toEqual([])
@@ -431,7 +471,7 @@ test.describe("favicon ink gap", () => {
   test("glyphs that measure as crowding carry a nudge class", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const contexts = CONTEXTS.filter((ctx) => ctx.name === "serif" || ctx.name === "italic")
+    const contexts = CONTEXTS.filter((ctx) => ctx.name !== "smallCaps")
     const measurements = await measureProbes(page, buildProbes(contexts, MEMBERSHIP_CHARS))
     const bearings = bearingsByKey(measurements)
 

--- a/quartz/plugins/transformers/favicons.test.ts
+++ b/quartz/plugins/transformers/favicons.test.ts
@@ -32,7 +32,7 @@ const faviconSpanNode = {
 
 const createExpectedFavicon = (
   imgPath: string,
-  nudgeClass?: "close-text" | "closer-text",
+  nudgeClass?: ReturnType<typeof favicons.nudgeClassFor>,
 ): Record<string, unknown> => {
   const faviconElement = favicons.createFaviconElement(imgPath)
   faviconElement.properties.class = `favicon${nudgeClass ? ` ${nudgeClass}` : ""}`
@@ -511,6 +511,7 @@ describe("insertFavicon", () => {
     it.each([
       ["serif sets", favicons.charsToSpace, favicons.charsToSpaceMost],
       ["italic sets", favicons.charsToSpaceItalic, favicons.charsToSpaceMostItalic],
+      ["code sets", favicons.charsToSpaceCode, favicons.charsToSpaceMostCode],
     ])("keeps the %s disjoint", (_label, close, most) => {
       const overlap = close.filter((char) => most.includes(char))
       expect(overlap).toEqual([])
@@ -538,9 +539,17 @@ describe("insertFavicon", () => {
         ["T", {}, "close-text"],
         ["f", {}, "closer-text"],
         ["o", {}, null],
-        // Monospace bearing is handled uniformly in CSS.
-        ["T", { code: true }, null],
+        // Monospace membership follows FiraCode's own bearings, not the serif
+        // sets: "m" and "T" fall short of the uniform correction, "f" and "o"
+        // clear it, and "W" needs the full step back.
+        ["T", { code: true }, "code-close-text"],
+        ["m", { code: true }, "code-close-text"],
+        ["W", { code: true }, "code-closer-text"],
         ["f", { code: true }, null],
+        ["o", { code: true }, null],
+        // A code context wins over the faces it nests inside.
+        ["f", { code: true, italic: true }, null],
+        ["y", { code: true, smallCaps: true }, null],
         // Italic membership is ink-derived; leaning glyphs join, others leave.
         ["t", { italic: true }, "close-text"],
         ["V", { italic: true }, "closer-text"],
@@ -611,10 +620,19 @@ describe("insertFavicon", () => {
         expect(classOf(node)).toBe("favicon")
       })
 
-      it("suppresses per-glyph nudges inside <code>", () => {
+      it("assigns the monospace membership inside <code>", () => {
+        // "-y" ends in "y": monospace non-member, italic member.
         const node = h("a", { href: "https://example.com" }, [h("code", {}, ["subfont -y"])])
         favicons.insertFavicon(imgPath, node)
         expect(classOf(node)).toBe("favicon")
+      })
+
+      it("nudges a code link ending in a tight monospace glyph", () => {
+        const node = h("a", { href: "mailto:alex@turntrout.com" }, [
+          h("code", {}, ["alex@turntrout.com"]),
+        ])
+        favicons.insertFavicon(imgPath, node)
+        expect(classOf(node)).toBe("favicon code-close-text")
       })
 
       it("applies an outer context supplied by the caller", () => {

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -324,6 +324,31 @@ export const charsToSpaceItalic: readonly string[] = [
   "®",
 ]
 export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W"]
+// FiraCode centers every glyph in one fixed advance, so its right side bearing
+// swings from ~0.01em ("W") to ~0.4em ("L") — the uniform monospace correction
+// in CSS (`code .favicon`) is calibrated to the middle of that range and leaves
+// the tight end crowded. Membership derives from each glyph's ink clearance
+// within the favicon's vertical band (0.2em–0.7em above the baseline), as for
+// the italic sets: below ~0.067em the uniform correction runs short by half a
+// `close-text` step, below ~0.042em by a full one. Glyphs whose bearing already
+// covers the gap ("m" is the tightest common one at 0.059em) take no class.
+export const charsToSpaceCode: readonly string[] = [
+  "K",
+  "M",
+  "T",
+  "P",
+  "C",
+  "~",
+  "Q",
+  "g",
+  "O",
+  "D",
+  "*",
+  "m",
+  "#",
+  "F",
+]
+export const charsToSpaceMostCode: readonly string[] = ["W", "@", "w", "%", "&", "V", "Y"]
 
 /** Widens `context` with whatever face `element` switches its text into. */
 export function broadenContext(element: Element, context: GlyphContext): GlyphContext {
@@ -348,8 +373,9 @@ export function contextFromAncestors(ancestors: readonly Parent[]): GlyphContext
 /**
  * The nudge class for a favicon that lands after `lastChar` rendered in
  * `context`:
- *   - monospace advances carry their own right side bearing, handled uniformly
- *     in CSS (`code .favicon`), so no per-glyph class applies;
+ *   - monospace glyphs sit inside a uniform correction in CSS (`code .favicon`),
+ *     so only the ones whose bearing falls below it take a class, and the
+ *     classes carry monospace-sized nudges of their own;
  *   - small-cap forms of lowercase letters keep their in-band ink clear of the
  *     icon (even ``q``'s tail is a descender, below the icon), so none applies;
  *   - italic uses the ink-derived sets, the serif body face its audited ones.
@@ -357,8 +383,11 @@ export function contextFromAncestors(ancestors: readonly Parent[]): GlyphContext
 export function nudgeClassFor(
   lastChar: string,
   context: GlyphContext,
-): "close-text" | "closer-text" | null {
-  if (context.code) return null
+): "close-text" | "closer-text" | "code-close-text" | "code-closer-text" | null {
+  if (context.code) {
+    if (charsToSpaceMostCode.includes(lastChar)) return "code-closer-text"
+    return charsToSpaceCode.includes(lastChar) ? "code-close-text" : null
+  }
   if (context.smallCaps && /[a-z]/.test(lastChar)) return null
   const [most, close] = context.italic
     ? [charsToSpaceMostItalic, charsToSpaceItalic]

--- a/quartz/plugins/transformers/favicons.ts
+++ b/quartz/plugins/transformers/favicons.ts
@@ -330,8 +330,10 @@ export const charsToSpaceMostItalic: readonly string[] = ["V", "f", "/", "W"]
 // the tight end crowded. Membership derives from each glyph's ink clearance
 // within the favicon's vertical band (0.2em–0.7em above the baseline), as for
 // the italic sets: below ~0.067em the uniform correction runs short by half a
-// `close-text` step, below ~0.042em by a full one. Glyphs whose bearing already
-// covers the gap ("m" is the tightest common one at 0.059em) take no class.
+// `close-text` step, below ~0.042em by a full one. The superscript marks sit
+// high and narrow, so they land in the tight tier alongside "W". Glyphs whose
+// bearing already covers the gap ("m" is the tightest common letter at
+// 0.059em) take no class.
 export const charsToSpaceCode: readonly string[] = [
   "K",
   "M",
@@ -347,8 +349,9 @@ export const charsToSpaceCode: readonly string[] = [
   "m",
   "#",
   "F",
+  "®",
 ]
-export const charsToSpaceMostCode: readonly string[] = ["W", "@", "w", "%", "&", "V", "Y"]
+export const charsToSpaceMostCode: readonly string[] = ["W", "@", "w", "%", "&", "V", "Y", "™", "©"]
 
 /** Widens `context` with whatever face `element` switches its text into. */
 export function broadenContext(element: Element, context: GlyphContext): GlyphContext {

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -41,7 +41,8 @@
 
   // Left-gap model: constant visual gap = base + glyph nudge + bold nudge −
   // icon ink inset. `--glyph-nudge` compensates glyphs whose ink overhangs
-  // their advance width (set via .close-text / .closer-text, assigned per
+  // their advance width (set via .close-text / .closer-text and their
+  // .code-close-text / .code-closer-text counterparts, assigned per
   // charsToSpace/-Most in quartz/plugins/transformers/favicons.ts).
   // `--favicon-bold-nudge` compensates faux-bold contexts, whose text-shadow
   // paints every glyph's ink $faux-bold-offset further right; the faux-bold
@@ -93,12 +94,23 @@
   // built-in right side bearing (FiraCode ≈0.08em vs ≈0.03em for a serif
   // round letter), so the last code glyph already clears the icon: the
   // negative nudge returns the bearing's surplus, keeping the visual gap at
-  // the standard width. Per-glyph nudge classes are never assigned inside
-  // code (see `nudgeClassFor` in quartz/plugins/transformers/favicons.ts).
+  // the standard width. FiraCode centers each glyph in one fixed advance, so
+  // that surplus varies far more than in the proportional serif: the two
+  // classes below return a half and a whole step to the glyphs whose bearing
+  // falls short of the uniform correction (assigned per charsToSpace(Most)Code
+  // in quartz/plugins/transformers/favicons.ts).
   code & {
     margin-right: calc(0.125 * #{$base-margin});
 
     --glyph-nudge: calc(-0.125 * #{$base-margin});
+
+    &.code-close-text {
+      --glyph-nudge: calc(-0.0625 * #{$base-margin});
+    }
+
+    &.code-closer-text {
+      --glyph-nudge: 0rem;
+    }
   }
 }
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -650,7 +650,7 @@ Here's a link to [another page](/shard-theory) with popover preview. [This same-
 
 Links ending [with code tags should still wrap OK: `code.`](#external-links-with-favicons) Link to [`x.com`](https://x.com).
 
-FiraCode's right side bearing swings widely, so a favicon after code ending in a tight glyph keeps the same visual gap as one after a roomy glyph: [`alex@turntrout.com`](mailto:alex@turntrout.com), [`npm i abW`](https://npmjs.com), [`npm i abT`](https://npmjs.com), [`npm i abo`](https://npmjs.com).
+The monospace face's right side bearing swings widely, so a favicon after code ending in a tight glyph keeps the same visual gap as one after a roomy glyph: [`alex@turntrout.com`](mailto:alex@turntrout.com), [`npm i abW`](https://npmjs.com), [`npm i abT`](https://npmjs.com), [`npm i abo`](https://npmjs.com).
 
 A footnote reference right after a favicon-ending [same-page link](#external-links-with-favicons)[^favicon-footnote] must not wrap onto its own line.
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -650,6 +650,8 @@ Here's a link to [another page](/shard-theory) with popover preview. [This same-
 
 Links ending [with code tags should still wrap OK: `code.`](#external-links-with-favicons) Link to [`x.com`](https://x.com).
 
+FiraCode's right side bearing swings widely, so a favicon after code ending in a tight glyph keeps the same visual gap as one after a roomy glyph: [`alex@turntrout.com`](mailto:alex@turntrout.com), [`npm i abW`](https://npmjs.com), [`npm i abT`](https://npmjs.com), [`npm i abo`](https://npmjs.com).
+
 A footnote reference right after a favicon-ending [same-page link](#external-links-with-favicons)[^favicon-footnote] must not wrap onto its own line.
 
 Faux-bold text widens glyph ink rightward, so a favicon after a bold link ending in an overhanging glyph, like **[Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)**, keeps the same visual gap, including in a collapsed quote title:


### PR DESCRIPTION
The envelope favicon sits flush against the "m" of the `alex@turntrout.com` mail link in the after-article block.

## Diagnosis

A favicon appended inside `<code>` takes a uniform `-0.125 * $base-margin` nudge, which cancels the classless left margin on the premise that a monospace glyph's built-in right side bearing (`≈0.08em`) already supplies the gap. That premise holds only on average: FiraCode centers every glyph in one fixed advance, so its in-band bearing swings from 0.009em ("W") to 0.4em ("L"). Glyphs at the tight end lose the margin without having a bearing to replace it — "m" measures 0.059em, the tightest of the common lowercase letters, and `alex@turntrout.com` ends in one.

Per-glyph nudge classes existed for the serif and italic faces but were explicitly suppressed inside code.

## Fix

Two monospace nudge classes, mirroring `close-text` / `closer-text`:

| class | glyph bearing | returns |
| --- | --- | --- |
| `code-close-text` | 0.042em–0.067em | half the cancelled margin (`-0.0625 * $base-margin`) |
| `code-closer-text` | < 0.042em | all of it (`--glyph-nudge: 0`) |

Membership (`charsToSpaceCode` / `charsToSpaceMostCode` in `quartz/plugins/transformers/favicons.ts`) derives from each glyph's ink clearance inside the favicon's vertical band (0.2em–0.7em above the baseline) — the same measured basis as the italic sets, since there is no perceptual kerning audit for the monospace face. Glyphs whose bearing already covers the gap keep the current behavior, so the worst-case residual falls from ~1.3px to ~0.3px.

## Tests

- `favicons.test.ts`: `nudgeClassFor` now pins the monospace memberships, including that a code context wins over the italic/small-caps faces it nests inside, plus an end-to-end case for the mail link.
- `faviconInkGap.spec.ts`: the exact-margin layer gains ratios for the two classes (0.5× and 1× the classless serif margin); the membership ratchet now sweeps the code face too, so a future FiraCode update that tightens a glyph fails the build instead of shipping a crowded icon.
- `test-page.md`: a row of code links ending in tight, mid, and roomy monospace glyphs, for the visual baseline.

## Lessons learned

When a CSS correction is calibrated to the "typical" value of a font metric, check the metric's spread before trusting the average. A monospace face redistributes all of its glyph-width variation into side bearings, so its bearing range is far wider than a proportional face's — an average-calibrated correction is not merely imprecise there, it is wrong at both tails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCDX3P2wjgC4nkZnBwY3hB)_