### PR TITLE
Denominate favicon geometry in em so the gap model holds at every size

### DIFF
--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -302,7 +302,7 @@ async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Meas
       host.innerHTML =
         `<p>${probe.wrapperHtml[0]}<span class="ink-probe">${probe.char}</span>` +
         `<svg class="favicon${probe.nudgeClass ? ` ${probe.nudgeClass}` : ""}" aria-hidden="true"></svg>` +
-        `<span class="baseline-probe" style="display:inline-block;width:0;height:0"></span>` +
+        '<span class="baseline-probe" style="display:inline-block;width:0;height:0"></span>' +
         `${probe.wrapperHtml[1]}</p>`
       const probeSpan = host.querySelector<HTMLElement>(".ink-probe")
       const favicon = host.querySelector<SVGElement>("svg.favicon")

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -483,6 +483,67 @@ function collectSweepViolations(
   return violations
 }
 
+// The size contexts to compare, and the glyphs to compare them with: a round
+// reference, the widest and tightest serif overhangers, and a bracket and a
+// digit, which sit differently in the band.
+const SIZE_CONTEXTS: readonly ContextSpec[] = [
+  { name: "serif", wrapperHtml: ["", ""], context: EMPTY_GLYPH_CONTEXT },
+  { name: "h1", wrapperHtml: ["<h1>", "</h1>"], context: EMPTY_GLYPH_CONTEXT },
+  {
+    name: "subtitle",
+    wrapperHtml: ['<div class="subtitle">', "</div>"],
+    context: EMPTY_GLYPH_CONTEXT,
+  },
+  {
+    name: "tableCell",
+    wrapperHtml: ["<table><tr><td>", "</td></tr></table>"],
+    context: EMPTY_GLYPH_CONTEXT,
+  },
+]
+const SIZE_CHARS: readonly string[] = [..."oRxTfY(4"]
+
+// Two contexts render the same glyph at different sizes, so em-denominated
+// geometry must put the icon on the same slice of it. A tolerance this tight
+// leaves no room for a size term to hide in.
+const SIZE_TOLERANCE_EM = 0.005
+
+/** Names every size context whose gap or band departs from the first one's. */
+function collectSizeFailures(measurements: readonly Measurement[]): string[] {
+  const gapEm = (m: Measurement) => (m.gapPx as number) / m.fontSizePx
+  const byChar = new Map<string, Measurement[]>()
+  for (const measured of measurements) {
+    const char = measured.key.split("|")[1]
+    byChar.set(char, [...(byChar.get(char) ?? []), measured])
+  }
+
+  return [...byChar].flatMap(([char, group]) => {
+    const reference = group[0]
+    return group.slice(1).flatMap((measured) => {
+      // A glyph whose ink leaves the band in one context but not another is
+      // itself a size-invariance failure, so a null gap is a mismatch.
+      const lostInk = measured.gapPx === null || reference.gapPx === null
+      if (lostInk) return [`${measured.key}: ink left the band (${reference.key} kept it)`]
+
+      const gapOff = Math.abs(gapEm(measured) - gapEm(reference)) > SIZE_TOLERANCE_EM
+      const bandOff = Math.abs(measured.bandTopEm - reference.bandTopEm) > SIZE_TOLERANCE_EM
+      return [
+        ...(gapOff
+          ? [
+              `${measured.key}: gap ${gapEm(measured).toFixed(3)}em != ` +
+                `${gapEm(reference).toFixed(3)}em at ${reference.key} (char "${char}")`,
+            ]
+          : []),
+        ...(bandOff
+          ? [
+              `${measured.key}: band top ${measured.bandTopEm.toFixed(3)}em != ` +
+                `${reference.bandTopEm.toFixed(3)}em at ${reference.key}`,
+            ]
+          : []),
+      ]
+    })
+  })
+}
+
 test.describe("favicon ink gap", () => {
   test("margins resolve exactly and ink gaps stay inside the band", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
@@ -585,56 +646,12 @@ test.describe("favicon ink gap", () => {
   test("the gap is the same fraction of the text at every size", async ({ page }) => {
     await gotoPage(page, "http://localhost:8080/test-page")
 
-    const sizeContexts: readonly ContextSpec[] = [
-      { name: "serif", wrapperHtml: ["", ""], context: EMPTY_GLYPH_CONTEXT },
-      { name: "h1", wrapperHtml: ["<h1>", "</h1>"], context: EMPTY_GLYPH_CONTEXT },
-      {
-        name: "subtitle",
-        wrapperHtml: ['<div class="subtitle">', "</div>"],
-        context: EMPTY_GLYPH_CONTEXT,
-      },
-      {
-        name: "tableCell",
-        wrapperHtml: ["<table><tr><td>", "</td></tr></table>"],
-        context: EMPTY_GLYPH_CONTEXT,
-      },
-    ]
-    const measurements = await measureProbes(page, buildProbes(sizeContexts, [..."oRxTfY(4"]))
-
-    const gapEm = (m: Measurement) => (m.gapPx as number) / m.fontSizePx
-    const byChar = new Map<string, Measurement[]>()
-    for (const measured of measurements) {
-      const char = measured.key.split("|")[1]
-      byChar.set(char, [...(byChar.get(char) ?? []), measured])
-    }
+    const measurements = await measureProbes(page, buildProbes(SIZE_CONTEXTS, SIZE_CHARS))
 
     const sizes = [...new Set(measurements.map((m) => m.fontSizePx))]
     expect(sizes.length, `contexts must span distinct sizes, saw ${sizes}`).toBeGreaterThan(2)
 
-    const failures: string[] = []
-    for (const [char, group] of byChar) {
-      const reference = group[0]
-      for (const measured of group.slice(1)) {
-        // A glyph whose ink leaves the band in one context but not another is
-        // itself a size-invariance failure, so a null gap is a mismatch.
-        if (measured.gapPx === null || reference.gapPx === null) {
-          failures.push(`${measured.key}: ink left the band (${reference.key} kept it)`)
-          continue
-        }
-        if (Math.abs(gapEm(measured) - gapEm(reference)) > 0.005) {
-          failures.push(
-            `${measured.key}: gap ${gapEm(measured).toFixed(3)}em != ` +
-              `${gapEm(reference).toFixed(3)}em at ${reference.key} (char "${char}")`,
-          )
-        }
-        if (Math.abs(measured.bandTopEm - reference.bandTopEm) > 0.005) {
-          failures.push(
-            `${measured.key}: band top ${measured.bandTopEm.toFixed(3)}em != ` +
-              `${reference.bandTopEm.toFixed(3)}em at ${reference.key}`,
-          )
-        }
-      }
-    }
+    const failures = collectSizeFailures(measurements)
     expect(failures, failures.join("\n")).toEqual([])
   })
 })

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -88,6 +88,8 @@ const CONTEXTS: readonly ContextSpec[] = [
 // wider than the proportional ones — see the reasoning in favicon.scss.
 const BASE_MARGIN_EM = 0.0625
 const CODE_FACE_NUDGE_EM = -0.0156
+/** `--font-size-code-scale`: inline code's size as a fraction of its prose. */
+const CODE_FACE_SCALE = 0.81
 const NUDGE_EM: Readonly<Record<string, number>> = {
   "close-text": 0.0625,
   "closer-text": 0.125,
@@ -148,8 +150,13 @@ interface Probe {
 
 /** The probe's expected margin-left, in em of the text it sits beside. */
 function expectedMarginEm(probe: Probe): number {
-  const faceNudge = probe.contextName === "code" ? CODE_FACE_NUDGE_EM : 0
-  return BASE_MARGIN_EM + (probe.nudgeClass ? NUDGE_EM[probe.nudgeClass] : faceNudge)
+  const inCode = probe.contextName === "code"
+  const faceNudge = inCode ? CODE_FACE_NUDGE_EM : 0
+  const em = BASE_MARGIN_EM + (probe.nudgeClass ? NUDGE_EM[probe.nudgeClass] : faceNudge)
+  // In code the icon takes its em from the surrounding prose rather than the
+  // code face, so every length on it — this margin included — buys the same
+  // pixels it would beside body text.
+  return inCode ? em / CODE_FACE_SCALE : em
 }
 
 function collectFailures(probes: readonly Probe[], measurements: readonly Measurement[]): string[] {

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -388,9 +388,16 @@ function collectBoldFailures(margins: BoldMargins, wrappers: readonly ContextWra
 // Glyphs that plausibly end link text. A face missing one of them renders it
 // from a platform substitute whose metrics vary per OS; measureProbes marks
 // those and the sweep reports them rather than judging them.
+//
+// `charsToMoveIntoLinkFromRight` pulls a trailing mark inside the link, so
+// every mark in that set ends link text constantly and belongs here — a period
+// and a comma most of all. Their ink sits below the icon's band in the
+// proportional faces, so they cannot crowd it and the sweep skips them; in the
+// monospace face they carry a wide bearing and are judged like any other glyph.
 const MEMBERSHIP_CHARS: readonly string[] = [
   ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
   ..."()[]{}\\/®™©°%&*+=<>|!?;:’”†‡",
+  ...".,'\"",
 ]
 
 // The gap the model is trying to hold constant, in em: the median across all

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -23,11 +23,11 @@ import { gotoPage } from "./visual_utils"
 //     measured inside the band the icon actually occupies — must hold one
 //     constant across every face and every plausible link-ending glyph.
 //
-// The band is derived per probe from the rendered icon rather than assumed.
-// `--favicon-size` is rem-denominated while glyphs scale in em, so the icon
-// covers a different slice of the glyph in each context: 0.125em–0.750em in
-// body text but 0.154em–0.926em inside `<code>`. A fixed band measures the
-// wrong ink in every context but one.
+// The band is derived per probe from the rendered icon rather than assumed, so
+// the sweep keeps measuring the ink the icon actually sits beside even if the
+// box model moves. Every favicon length is em, so that band is the same slice
+// of the glyph in every context — which is what the size-invariance test below
+// asserts directly.
 //
 // Set membership itself is pinned exactly by `nudgeClassFor` unit tests in
 // favicons.test.ts; this spec catches rendering-level regressions (wrong font
@@ -48,8 +48,14 @@ const CODE_PROBE_CHARS: readonly string[] = [
   ...new Set([...charsToSpaceCode, ...charsToSpaceMostCode, ..."oenas"]),
 ]
 
+// The four shipped faces, each with its own metrics, plus the size contexts
+// that render the serif face at a different font size. Faces get per-face
+// thresholds; sizes are judged only against each other.
+type FaceName = "serif" | "italic" | "smallCaps" | "code"
+type ContextName = FaceName | "h1" | "subtitle" | "tableCell"
+
 interface ContextSpec {
-  name: "serif" | "italic" | "smallCaps" | "code"
+  name: ContextName
   wrapperHtml: [string, string]
   context: typeof EMPTY_GLYPH_CONTEXT
 }
@@ -73,20 +79,21 @@ const CONTEXTS: readonly ContextSpec[] = [
   },
 ]
 
-// margin-left = 0.125·base + nudge − inset·size, with a domainless icon
-// (inset 0). $base-margin is rem-denominated, so the absolute pixel value
-// varies with the viewport's root font size; the invariant is the RATIO to
-// the classless serif margin (the "unit"): close-text doubles it,
-// closer-text triples it, and inside code a uniform −0.125·base nudge
-// cancels it to zero, which the code classes return by a half step and a
-// whole step.
-const MARGIN_UNIT_MULTIPLIER: Readonly<Record<string, number>> = {
-  "close-text": 2,
-  "closer-text": 3,
-  "code-close-text": 0.5,
-  "code-closer-text": 1,
+// margin-left = 0.0625em + nudge − inset·size, with a domainless icon
+// (inset 0). Every term is em, so the expectation is a plain em constant per
+// (context, nudge class) rather than a ratio: the classless base, two upward
+// steps in the proportional faces, and a face-level negative in code that the
+// two code classes return by a half step and a whole step.
+const BASE_MARGIN_EM = 0.0625
+const CODE_FACE_NUDGE_EM = -0.0469
+const NUDGE_EM: Readonly<Record<string, number>> = {
+  "close-text": 0.0625,
+  "closer-text": 0.125,
+  // The face nudge returned by half a step and a whole step, rounded to the
+  // four decimals stylelint allows a length.
+  "code-close-text": -0.0156,
+  "code-closer-text": 0.0156,
 }
-const UNIT_PROBE_KEY = "serif|o"
 
 // Crowding floors per class (deep overhangers accept tighter clearance, as in
 // the serif audit) and drift ceilings per context, in em of the probe's font
@@ -104,7 +111,7 @@ const FLOOR_EM: Readonly<Record<string, number>> = {
   "code-close-text": -0.0125,
   "code-closer-text": -0.0125,
 }
-const CEILING_EM: Readonly<Record<string, number>> = {
+const CEILING_EM: Readonly<Record<FaceName, number>> = {
   serif: 0.32,
   italic: 0.22,
   smallCaps: 0.4,
@@ -122,26 +129,28 @@ interface Measurement {
   bandBottomEm: number
 }
 
+/** A per-face threshold, refusing to silently pass a context that has none. */
+function thresholdFor(table: Readonly<Record<FaceName, number>>, context: ContextName): number {
+  const threshold = table[context as FaceName]
+  if (threshold === undefined) throw new Error(`no threshold for context ${context}`)
+  return threshold
+}
+
 interface Probe {
   key: string
-  contextName: ContextSpec["name"]
+  contextName: ContextName
   char: string
   wrapperHtml: [string, string]
   nudgeClass: ReturnType<typeof nudgeClassFor>
 }
 
-/** The probe's expected margin as a multiple of the classless serif margin. */
-function marginMultiplier(probe: Probe): number {
-  if (probe.nudgeClass) return MARGIN_UNIT_MULTIPLIER[probe.nudgeClass]
-  // The uniform monospace correction cancels the classless margin entirely.
-  return probe.contextName === "code" ? 0 : 1
+/** The probe's expected margin-left, in em of the text it sits beside. */
+function expectedMarginEm(probe: Probe): number {
+  const faceNudge = probe.contextName === "code" ? CODE_FACE_NUDGE_EM : 0
+  return BASE_MARGIN_EM + (probe.nudgeClass ? NUDGE_EM[probe.nudgeClass] : faceNudge)
 }
 
 function collectFailures(probes: readonly Probe[], measurements: readonly Measurement[]): string[] {
-  const unit = measurements.find((m) => m.key === UNIT_PROBE_KEY)
-  if (!unit || unit.marginPx <= 0) {
-    return [`margin unit probe ${UNIT_PROBE_KEY} missing or non-positive`]
-  }
   const failures: string[] = []
   for (const probe of probes) {
     const measured = measurements.find((m) => m.key === probe.key)
@@ -149,7 +158,7 @@ function collectFailures(probes: readonly Probe[], measurements: readonly Measur
       failures.push(`${probe.key}: no measurement`)
       continue
     }
-    const expectedMargin = marginMultiplier(probe) * unit.marginPx
+    const expectedMargin = expectedMarginEm(probe) * measured.fontSizePx
     if (Math.abs(measured.marginPx - expectedMargin) > 0.1) {
       failures.push(
         `${probe.key}: margin ${measured.marginPx.toFixed(2)}px != ${expectedMargin.toFixed(2)}px`,
@@ -166,7 +175,7 @@ function collectFailures(probes: readonly Probe[], measurements: readonly Measur
     ) {
       const gapEm = measured.gapPx / measured.fontSizePx
       const floor = FLOOR_EM[probe.nudgeClass ?? "null"]
-      const ceiling = CEILING_EM[probe.contextName]
+      const ceiling = thresholdFor(CEILING_EM, probe.contextName)
       if (gapEm < floor || gapEm > ceiling) {
         failures.push(
           `${probe.key} (${probe.nudgeClass ?? "no class"}): ` +
@@ -196,11 +205,10 @@ function buildProbes(contexts: readonly ContextSpec[], chars: readonly string[])
  * and measures the favicon's computed margin plus the glyph's right side
  * bearing inside the favicon's vertical band, using the site's real fonts.
  *
- * The band is read off the rendered icon rather than assumed: `--favicon-size`
- * is rem-denominated while glyphs scale in em, so the slice of a glyph the icon
- * actually sits beside differs per context (0.125em–0.750em in body text,
- * 0.060em–0.362em in an `h1`). A zero-sized inline-block marker in the same
- * line box supplies the baseline the band is measured from.
+ * The band is read off the rendered icon rather than assumed, so a change to
+ * the box model moves the measurement with it instead of quietly measuring the
+ * wrong ink. A zero-sized inline-block marker in the same line box supplies the
+ * baseline the band is measured from.
  */
 async function measureProbes(page: Page, probes: readonly Probe[]): Promise<Measurement[]> {
   return await page.evaluate(async (probeList) => {
@@ -402,7 +410,7 @@ const OVERLAP_FLOOR_EM = 0
 // any glyph tighter *or* looser than its face's others widens the spread and
 // fails. Phases 2–3 shrink these toward a single global window; they must only
 // ever be lowered.
-const MAX_SPREAD_EM: Readonly<Record<ContextSpec["name"], number>> = {
+const MAX_SPREAD_EM: Readonly<Record<FaceName, number>> = {
   serif: 0.21,
   italic: 0.18,
   smallCaps: 0.2,
@@ -417,15 +425,15 @@ interface GapSample {
 /** Measured visual gaps per context, dropping probes that can't be judged. */
 function gapsByContext(
   measurements: readonly Measurement[],
-): ReadonlyMap<ContextSpec["name"], GapSample[]> {
-  const byContext = new Map<ContextSpec["name"], GapSample[]>()
+): ReadonlyMap<ContextName, GapSample[]> {
+  const byContext = new Map<ContextName, GapSample[]>()
   for (const measured of measurements) {
     // No ink in band means the glyph cannot crowd; a substituted face and an
     // unsupported small-caps probe would both measure differently per OS.
     if (measured.gapPx === null || measured.fromFallbackFace || measured.fromUnsupportedSmallCaps) {
       continue
     }
-    const context = measured.key.split("|")[0] as ContextSpec["name"]
+    const context = measured.key.split("|")[0] as ContextName
     const samples = byContext.get(context) ?? []
     samples.push({ key: measured.key, gapEm: measured.gapPx / measured.fontSizePx })
     byContext.set(context, samples)
@@ -440,7 +448,7 @@ function gapsByContext(
  * than stopping at the first, so a change's full blast radius is visible.
  */
 function collectSweepViolations(
-  byContext: ReadonlyMap<ContextSpec["name"], readonly GapSample[]>,
+  byContext: ReadonlyMap<ContextName, readonly GapSample[]>,
 ): string[] {
   const violations: string[] = []
   for (const [context, samples] of byContext) {
@@ -456,9 +464,10 @@ function collectSweepViolations(
       violations.push(`${tightest.key}: gap ${tightest.gapEm.toFixed(3)}em reaches the icon`)
     }
     const spread = loosest.gapEm - tightest.gapEm
-    if (spread > MAX_SPREAD_EM[context]) {
+    const limit = thresholdFor(MAX_SPREAD_EM, context)
+    if (spread > limit) {
       violations.push(
-        `${context}: gaps spread ${spread.toFixed(3)}em > ${MAX_SPREAD_EM[context]}em ` +
+        `${context}: gaps spread ${spread.toFixed(3)}em > ${limit}em ` +
           `(tightest ${tightest.key}=${tightest.gapEm.toFixed(3)}, ` +
           `loosest ${loosest.key}=${loosest.gapEm.toFixed(3)}, target ${TARGET_GAP_EM})`,
       )
@@ -557,5 +566,68 @@ test.describe("favicon ink gap", () => {
 
     const violations = collectSweepViolations(byContext)
     expect(violations, violations.join("\n")).toEqual([])
+  })
+
+  // The payoff of em-denominating the box: one per-glyph nudge is correct at
+  // every size because the icon covers the same slice of the glyph everywhere.
+  // A heading, a subtitle and a table cell render the same face at different
+  // sizes, so their gaps must agree to the em — not approximately, exactly.
+  // This is the assertion a rem-denominated model cannot pass, and the reason
+  // the `.subtitle` size override and the heading `vertical-align` override
+  // could be deleted rather than merely retuned.
+  test("the gap is the same fraction of the text at every size", async ({ page }) => {
+    await gotoPage(page, "http://localhost:8080/test-page")
+
+    const sizeContexts: readonly ContextSpec[] = [
+      { name: "serif", wrapperHtml: ["", ""], context: EMPTY_GLYPH_CONTEXT },
+      { name: "h1", wrapperHtml: ["<h1>", "</h1>"], context: EMPTY_GLYPH_CONTEXT },
+      {
+        name: "subtitle",
+        wrapperHtml: ['<div class="subtitle">', "</div>"],
+        context: EMPTY_GLYPH_CONTEXT,
+      },
+      {
+        name: "tableCell",
+        wrapperHtml: ["<table><tr><td>", "</td></tr></table>"],
+        context: EMPTY_GLYPH_CONTEXT,
+      },
+    ]
+    const measurements = await measureProbes(page, buildProbes(sizeContexts, [..."oRxTfY(4"]))
+
+    const gapEm = (m: Measurement) => (m.gapPx as number) / m.fontSizePx
+    const byChar = new Map<string, Measurement[]>()
+    for (const measured of measurements) {
+      const char = measured.key.split("|")[1]
+      byChar.set(char, [...(byChar.get(char) ?? []), measured])
+    }
+
+    const sizes = [...new Set(measurements.map((m) => m.fontSizePx))]
+    expect(sizes.length, `contexts must span distinct sizes, saw ${sizes}`).toBeGreaterThan(2)
+
+    const failures: string[] = []
+    for (const [char, group] of byChar) {
+      const reference = group[0]
+      for (const measured of group.slice(1)) {
+        // A glyph whose ink leaves the band in one context but not another is
+        // itself a size-invariance failure, so a null gap is a mismatch.
+        if (measured.gapPx === null || reference.gapPx === null) {
+          failures.push(`${measured.key}: ink left the band (${reference.key} kept it)`)
+          continue
+        }
+        if (Math.abs(gapEm(measured) - gapEm(reference)) > 0.005) {
+          failures.push(
+            `${measured.key}: gap ${gapEm(measured).toFixed(3)}em != ` +
+              `${gapEm(reference).toFixed(3)}em at ${reference.key} (char "${char}")`,
+          )
+        }
+        if (Math.abs(measured.bandTopEm - reference.bandTopEm) > 0.005) {
+          failures.push(
+            `${measured.key}: band top ${measured.bandTopEm.toFixed(3)}em != ` +
+              `${reference.bandTopEm.toFixed(3)}em at ${reference.key}`,
+          )
+        }
+      }
+    }
+    expect(failures, failures.join("\n")).toEqual([])
   })
 })

--- a/quartz/components/tests/faviconInkGap.spec.ts
+++ b/quartz/components/tests/faviconInkGap.spec.ts
@@ -83,16 +83,18 @@ const CONTEXTS: readonly ContextSpec[] = [
 // (inset 0). Every term is em, so the expectation is a plain em constant per
 // (context, nudge class) rather than a ratio: the classless base, two upward
 // steps in the proportional faces, and a face-level negative in code that the
-// two code classes return by a half step and a whole step.
+// two code classes return by a half step and a whole step. Code's negative is
+// deliberately shallower than its bearing surplus, so the face lands a step
+// wider than the proportional ones — see the reasoning in favicon.scss.
 const BASE_MARGIN_EM = 0.0625
-const CODE_FACE_NUDGE_EM = -0.0469
+const CODE_FACE_NUDGE_EM = -0.0156
 const NUDGE_EM: Readonly<Record<string, number>> = {
   "close-text": 0.0625,
   "closer-text": 0.125,
   // The face nudge returned by half a step and a whole step, rounded to the
   // four decimals stylelint allows a length.
-  "code-close-text": -0.0156,
-  "code-closer-text": 0.0156,
+  "code-close-text": 0.0156,
+  "code-closer-text": 0.0469,
 }
 
 // Crowding floors per class (deep overhangers accept tighter clearance, as in
@@ -400,10 +402,11 @@ const MEMBERSHIP_CHARS: readonly string[] = [
   ...".,'\"",
 ]
 
-// The gap the model is trying to hold constant, in em: the median across all
-// four faces, which agree to within 0.02em (serif 0.102, italic 0.082,
-// smallCaps 0.100, code 0.095). Only the extremes disagree, which is the point
-// of the sweep.
+// The gap the model holds across the proportional faces, in em, which agree to
+// within 0.02em (serif 0.102, italic 0.082, smallCaps 0.100). Reported in
+// violation messages so a spread failure says what it is spreading around.
+// Code targets a step wider; it renders at 0.81em, so an equal em gap there is
+// a fifth fewer pixels beside a proportionally smaller icon.
 const TARGET_GAP_EM = 0.095
 
 // Ink must never reach the icon. `f` sets this in both proportional faces —

--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -788,9 +788,12 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
             waitForPaint()
           } else {
             videoEl.addEventListener("loadeddata", waitForPaint, { once: true })
-            // Mirror pauseMediaElements: only force a reload when there is no
-            // data at all; for HAVE_METADATA the decode is already in flight.
-            if (videoEl.readyState === 0) videoEl.load()
+            // WebKit parks a paused video at HAVE_METADATA and fetches no
+            // further media data until something asks for it, so waiting on
+            // "loadeddata" alone can never return. Kick the load at every
+            // readyState below HAVE_CURRENT_DATA; navbar.inline.ts kicks the
+            // same stall on the page itself.
+            videoEl.load()
           }
         }),
       VIDEO_PAINT_TIMEOUT_MS,

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -32,11 +32,19 @@
   }
 }
 
+// Every length here is em, so the icon is the same fraction of its text at
+// every size: a heading, a subtitle, a table cell and inline code all get the
+// same box, the same rise off the baseline, and therefore the same slice of the
+// neighboring glyph beside the icon. That last part is what makes one per-glyph
+// nudge correct everywhere — a rem-sized icon covers a different part of the
+// glyph in each context, so no single correction can suit more than one of
+// them. `$faux-bold-offset` stays px: it is a text-shadow displacement, not a
+// typographic length.
 .favicon {
-  --size-decrease: 0rem; // Decrease in width and height of favicon size -- set this to a positive value to decrease the size
-  --base-vertical-adjustment: calc(0.5 * #{$base-margin});
+  --size-decrease: 0em; // Decrease in width and height of favicon size -- set this to a positive value to decrease the size
+  --base-vertical-adjustment: 0.25em;
   --vertical-adjustment: calc(var(--base-vertical-adjustment) + 0.5 * var(--size-decrease));
-  --favicon-base-size: calc(#{$base-margin} * 1.25 - var(--size-decrease));
+  --favicon-base-size: calc(0.625em - var(--size-decrease));
   --favicon-size: var(--favicon-base-size);
 
   // Left-gap model: constant visual gap = base + glyph nudge + bold nudge −
@@ -53,63 +61,49 @@
   // column (measured by scripts/notebooks/favicon_kerning_audit, capped at
   // ~2px); subtracting it puts every icon's visual left edge the same
   // distance from the text.
-  --glyph-nudge: 0rem;
+  --glyph-nudge: 0em;
   --left-inset: 0;
-  --text-gap: calc(0.125 * #{$base-margin} + var(--glyph-nudge) + var(--favicon-bold-nudge, 0px));
+  --text-gap: calc(0.0625em + var(--glyph-nudge) + var(--favicon-bold-nudge, 0px));
 
   display: inline;
   width: var(--favicon-size);
   height: var(--favicon-size);
-  margin: 0 auto calc(-0.25 * #{$base-margin})
-    calc(var(--text-gap) - var(--left-inset) * var(--favicon-size));
+  margin: 0 auto -0.125em calc(var(--text-gap) - var(--left-inset) * var(--favicon-size));
   vertical-align: var(--vertical-adjustment);
 
   // Don't pollute copied text with favicon
   user-select: none;
 
-  .subtitle & {
-    --favicon-size: calc(var(--favicon-base-size) / #{$font-scale-factor});
-  }
-
-  // Make favicons align properly with headings
-  h1 &,
-  h2 &,
-  h3 &,
-  h4 &,
-  h5 &,
-  h6 & {
-    vertical-align: 65%;
-  }
-
   &.close-text {
-    --glyph-nudge: calc(0.125 * #{$base-margin});
+    --glyph-nudge: 0.0625em;
   }
 
   &.closer-text {
-    --glyph-nudge: calc(0.25 * #{$base-margin});
+    --glyph-nudge: 0.125em;
   }
 
   // A favicon appended after inline code sits inside the <code>; the right gap
   // keeps a trailing ")" / "]" from cramping. Monospace advances end in
-  // built-in right side bearing (FiraCode ≈0.08em vs ≈0.03em for a serif
-  // round letter), so the last code glyph already clears the icon: the
-  // negative nudge returns the bearing's surplus, keeping the visual gap at
-  // the standard width. FiraCode centers each glyph in one fixed advance, so
-  // that surplus varies far more than in the proportional serif: the two
-  // classes below return a half and a whole step to the glyphs whose bearing
-  // falls short of the uniform correction (assigned per charsToSpace(Most)Code
-  // in quartz/plugins/transformers/favicons.ts).
+  // built-in right side bearing, so the last code glyph already clears the
+  // icon: the negative nudge returns that surplus, keeping the visual gap at
+  // the standard width. The constant is the measured offset that lands the
+  // face's median rendered gap on the proportional faces' median (0.098em
+  // against 0.095em). FiraCode centers each glyph in one fixed advance, so the
+  // surplus varies far more than in the proportional serif: the two classes
+  // below return a half and a whole step to the glyphs whose bearing falls
+  // short of the uniform correction (assigned per charsToSpace(Most)Code in
+  // quartz/plugins/transformers/favicons.ts).
   code & {
-    margin-right: calc(0.125 * #{$base-margin});
+    margin-right: 0.0625em;
 
-    --glyph-nudge: calc(-0.125 * #{$base-margin});
+    --glyph-nudge: -0.0469em;
 
     &.code-close-text {
-      --glyph-nudge: calc(-0.0625 * #{$base-margin});
+      --glyph-nudge: -0.0156em;
     }
 
     &.code-closer-text {
-      --glyph-nudge: 0rem;
+      --glyph-nudge: 0.0156em;
     }
   }
 }
@@ -142,12 +136,12 @@ svg.favicon {
   }
 
   &[data-domain="proton_me"] {
-    --size-decrease: calc(0.25 * #{$base-margin});
+    --size-decrease: 0.125em;
   }
 
   &[data-domain="substack_com"],
   &[data-domain="rss"] {
-    --size-decrease: calc(0.25 * #{$base-margin});
+    --size-decrease: 0.125em;
   }
 
   &[data-domain="arbital_com"] {

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -90,11 +90,16 @@
   // proportional serif: the two classes below return a half and a whole step to
   // the glyphs whose bearing falls short of the uniform correction (assigned
   // per charsToSpace(Most)Code in quartz/plugins/transformers/favicons.ts).
-  // The face sits a step wider than the proportional faces rather than level
-  // with them. Code runs at 0.81em, so an identical em gap buys a fifth fewer
-  // pixels there, and both the icon and the gap shrink together — the pair
-  // reads as crowded well before the number says it is.
+  // The icon annotates a link inside a paragraph; inline code runs smaller than
+  // the prose it sits in, so an em basis taken from the code face would shrink
+  // the icon against the very line it shares. Dividing that basis back out
+  // denominates the box, the gap and the rise in the surrounding text, which is
+  // the size the reader compares them to.
+  // The face still sits a step wider than the proportional faces: FiraCode
+  // centers each glyph in a fixed advance, so the icon meets a glyph whose ink
+  // stops short of where the advance ends.
   code & {
+    font-size: calc(1em / var(--font-size-code-scale));
     margin-right: 0.0625em;
 
     --glyph-nudge: -0.0156em;

--- a/quartz/styles/favicon.scss
+++ b/quartz/styles/favicon.scss
@@ -85,25 +85,26 @@
   // A favicon appended after inline code sits inside the <code>; the right gap
   // keeps a trailing ")" / "]" from cramping. Monospace advances end in
   // built-in right side bearing, so the last code glyph already clears the
-  // icon: the negative nudge returns that surplus, keeping the visual gap at
-  // the standard width. The constant is the measured offset that lands the
-  // face's median rendered gap on the proportional faces' median (0.098em
-  // against 0.095em). FiraCode centers each glyph in one fixed advance, so the
-  // surplus varies far more than in the proportional serif: the two classes
-  // below return a half and a whole step to the glyphs whose bearing falls
-  // short of the uniform correction (assigned per charsToSpace(Most)Code in
-  // quartz/plugins/transformers/favicons.ts).
+  // icon: the negative nudge returns that surplus. FiraCode centers each glyph
+  // in one fixed advance, so the surplus varies far more than in the
+  // proportional serif: the two classes below return a half and a whole step to
+  // the glyphs whose bearing falls short of the uniform correction (assigned
+  // per charsToSpace(Most)Code in quartz/plugins/transformers/favicons.ts).
+  // The face sits a step wider than the proportional faces rather than level
+  // with them. Code runs at 0.81em, so an identical em gap buys a fifth fewer
+  // pixels there, and both the icon and the gap shrink together — the pair
+  // reads as crowded well before the number says it is.
   code & {
     margin-right: 0.0625em;
 
-    --glyph-nudge: -0.0469em;
+    --glyph-nudge: -0.0156em;
 
     &.code-close-text {
-      --glyph-nudge: -0.0156em;
+      --glyph-nudge: 0.0156em;
     }
 
     &.code-closer-text {
-      --glyph-nudge: 0.0156em;
+      --glyph-nudge: 0.0469em;
     }
   }
 }

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -14,7 +14,10 @@
     --font-size-plus-#{$i}: #{calculate-scale($i)};
   }
 
-  --font-size-code: 0.81em;
+  // Kept unitless so a descendant can divide the em basis back out and size
+  // itself against the surrounding prose instead of the code face.
+  --font-size-code-scale: 0.81;
+  --font-size-code: calc(var(--font-size-code-scale) * 1em);
   --base-line-height: 1.4;
   --min-font-size: 0.875rem; // 14px
   --max-font-size: 1.5rem; // 24px

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -656,14 +656,12 @@ A mark authored after a link is pulled inside it, so the icon lands after that m
 
 A footnote reference right after a favicon-ending [same-page link](#external-links-with-favicons)[^favicon-footnote] must not wrap onto its own line.
 
-### A heading link to [GitHub](https://github.com) sizes its icon to the heading
+The icon is the same fraction of its text everywhere, so it shrinks inside code and inside a table's smaller face without any per-context override. Compare [GitHub](https://github.com) in body text with the same link inside code ([`github.com`](https://github.com)) and in the cells below.
 
-The icon is the same fraction of its text everywhere, so it grows with a heading and shrinks inside code without any per-context override. Compare the heading above with the same link in body text ([GitHub](https://github.com)), in a table cell, and inside code ([`github.com`](https://github.com)).
-
-| Context      | Link                            |
-| ------------ | ------------------------------- |
-| Table cell   | [GitHub](https://github.com)    |
-| Smaller face | [arXiv](https://arxiv.org)      |
+| Context      | Link                         |
+| :----------- | :--------------------------- |
+| Table cell   | [GitHub](https://github.com) |
+| Smaller face | [arXiv](https://arxiv.org)   |
 
 Faux-bold text widens glyph ink rightward, so a favicon after a bold link ending in an overhanging glyph, like **[Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)**, keeps the same visual gap, including in a collapsed quote title:
 

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -656,6 +656,15 @@ A mark authored after a link is pulled inside it, so the icon lands after that m
 
 A footnote reference right after a favicon-ending [same-page link](#external-links-with-favicons)[^favicon-footnote] must not wrap onto its own line.
 
+### A heading link to [GitHub](https://github.com) sizes its icon to the heading
+
+The icon is the same fraction of its text everywhere, so it grows with a heading and shrinks inside code without any per-context override. Compare the heading above with the same link in body text ([GitHub](https://github.com)), in a table cell, and inside code ([`github.com`](https://github.com)).
+
+| Context      | Link                            |
+| ------------ | ------------------------------- |
+| Table cell   | [GitHub](https://github.com)    |
+| Smaller face | [arXiv](https://arxiv.org)      |
+
 Faux-bold text widens glyph ink rightward, so a favicon after a bold link ending in an overhanging glyph, like **[Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)**, keeps the same visual gap, including in a collapsed quote title:
 
 > [!quote]- [Google Sits Pretty as A.I. Rivals Compete for Pentagon Favor](https://www.nytimes.com/2026/03/18/technology/google-ai-pentagon.html)


### PR DESCRIPTION
Phase 2 of the favicon-gap rework. Phase 1 (#1687, the sweep this is gated by) has merged, so this now targets `main`.

## The bug

The favicon's box, its rise off the baseline, and every per-glyph nudge were denominated in `rem`. The glyphs they compensate scale in `em`. So the icon covered a *different slice of its neighbouring glyph* in every context, and no single per-glyph nudge could be correct in more than one of them. Measured against the shipped box model, before:

| context | text | icon | band above baseline |
| --- | --- | --- | --- |
| body | 24px | 15px | 0.125em – 0.750em |
| `h1` | 49.8px | 15px | 0.687em – 0.988em |
| `.subtitle` | 20px | 12.5px | 0.150em – 0.775em |
| `code` | 19.4px | 15px | 0.154em – 0.926em |

Four different slices of the glyph. That is the root cause behind the repeated hand-patching of membership sets (#1655, #1685, #1686): a nudge tuned in body text is simply the wrong number everywhere else.

After: **0.125em – 0.750em** in body, `h1`, `.subtitle` and table cells alike.

## What changed

- `--favicon-base-size`, `--base-vertical-adjustment`, `--size-decrease`, `--text-gap`, the bottom margin and both proportional nudge classes are now `em`.
- Deleted `.subtitle & { --favicon-size: … / $font-scale-factor }`. It reproduces exactly under em denomination — it existed only to undo the mismatch (12.5px before, 12.5px after).
- Deleted the heading `vertical-align: 65%`. It was floating the icon *above the cap line* as a detached badge; with an em-sized box the shared `--vertical-adjustment` seats it correctly.
- `$faux-bold-offset` stays px — it is a `text-shadow` displacement, not a typographic length.

### Inline code takes its em from the prose, not the code face

Em denomination is right wherever the whole line scales together — a heading, a subtitle, a table cell. Inline code is the exception: it runs at `0.81em` *inside* a paragraph of full-size prose, so denominating the icon in the code face shrank it against the very line it shares. The first cut of this PR did exactly that, and the icons after `` `npm i abW` `` and `` `alex@turntrout.com` `` came out visibly undersized next to the serif around them.

Fixed by dividing that basis back out on the icon inside code. Every length on `.favicon` is already em, so a single `font-size` restores the box, the gap and the rise to the surrounding text's scale together. `--font-size-code` is now derived from a unitless `--font-size-code-scale` so the divisor has a name.

This also widened the code face: tightest rendered gap **0.097em → 0.108em**, median **0.137em → 0.155em**, in em of the code glyph beside it.

### The monospace nudge stays

The plan predicted the `code &` constant was a size artifact that em denomination would dissolve. With it at zero, the code face's median rendered gap lands at **0.145em** against the proportional faces' **0.095em** — FiraCode's advances carry built-in right side bearing regardless of size, so this is a *face* property, not a size one. Kept, with the reasoning in the comment.

(Constants are rounded to four decimals because stylelint's `number-max-precision` caps lengths there.)

## Tests

- The margin test now asserts a **plain em constant per (context, nudge class)** instead of a ratio to the serif margin, dividing by the code scale in the code context. Every term is em now, so the ratio indirection bought nothing and hid what the numbers were.
- New test: **the gap is the same fraction of the text at every size**, comparing body / `h1` / `.subtitle` / table cell across eight glyphs, to 0.005em on both the gap and the band top. This is the assertion the rem model structurally cannot pass.
- The sweep now covers `.` `,` `'` `"`. `charsToMoveIntoLinkFromRight` pulls a trailing mark inside the link, so those glyphs end link text more often than any letter, and none of them were being measured.
- Also fixed a real cross-engine failure that #1687 surfaced on `playwright-tests-macos`: WebKit's canvas has no `font-variant-caps`, so a small-caps probe there draws the *lowercase* form — serif lowercase `f` overhangs and reported a −0.065em gap for a glyph no reader sees. The sweep already dropped those probes; the margin test did not.

### Negative control

Per the plan, the size-invariance assertion is worthless unless it fails on the old model. Re-measured with the rem model restored: `h1`'s band is 0.687–0.988em against body's 0.125–0.750em — a 0.562em difference against a 0.005em tolerance, and the gap comparison diverges with it. The assertion is live, not vacuous.

### Verification run

```
serif:     band 0.125–0.750em (24px);    n=91  tightest f=0.060  median ’=0.102  loosest R=0.263
italic:    band 0.125–0.750em (24px);    n=89  tightest f=0.005  median w=0.083  loosest :=0.177
smallCaps: band 0.125–0.750em (24px);    n=91  tightest n=0.065  median ?=0.100  loosest R=0.263
code:      band 0.154–0.926em (19.44px); n=94  tightest f=0.108  median w=0.155  loosest L=0.445
```

## Recorded for later phases

**The serif spread is the next thing a reader will notice, and it is not units.** A reviewer flagged `abB` / `abC` / `abD` on the test page as sitting too close to their icons. Measured, those three are mid-pack — `B`=0.088em, `C`=0.100em, `D`=0.107em — but `A` in the same row is 0.180em and the face runs from `f`=0.060em to `R`=0.263em. What reads as wrong is neighbouring glyphs differing by 2×, which three buckets (none / `close-text` / `closer-text`) cannot express. Phase 3's continuous `clamp(TARGET_GAP − bearing, …)` is the fix; nothing here changes it.

**Monospace closing punctuation is still the loosest thing in the face.** FiraCode centres a low, narrow mark inside a fixed advance, so a trailing period or comma inside `<code>` carries roughly 0.24em of built-in bearing where a round letter carries 0.08em. Same three-bucket limitation, same phase.

**Root cause 6 in the plan — the "displaced anchor" — is not a defect.** The plan expected that a mark pulled into a link by `rearrangeLinkPunctuation` would strand the icon outside its `<code>` wrapper with the context lost. The rendered HTML:

```html
<code>npm i abW</code>,
```

The mark is where the reader sees it, `inlineAtomGlue` has already glued the mark and the icon into one `nowrap-span` so the pair cannot split, and there is no break opportunity between `</code>` and that span. The icon's neighbouring glyph genuinely *is* the serif comma, so the serif treatment applied to it is correct — and serif `,` / `.` have no ink in the icon's band at all, so they cannot crowd it. Pinned by the characterization test in #1687; no behaviour change.

**Phase 4** replaces the 34-entry `$domain-left-insets` table with an inset computed at build time.

## Visual baselines

Icon sizes change in headings and subtitles, and every code-context gap opens by a step — snapshot diffs are expected. Those are yours to approve via the gallery; I have not dispatched `update-visual-baselines.yaml`.

## Lessons learned

- **A unit mismatch between a correction and the thing it corrects is invisible when the two happen to coincide at one size.** Here `rem == em` in body text, which is where every nudge was audited, so a long history of tuning silently encoded "correct at exactly one font size." The general check: for any hand-tuned spacing constant, ask what it compensates for and whether that thing scales the same way. If not, the constant is right in exactly one context.
- **"Relative to the local context" is not always the right relativity — ask which thing the reader compares against.** Sizing the icon in em is correct for a heading, where the whole line scales, and wrong for inline code, where a smaller face sits inside larger prose on the same line. The unit was right; the referent was not. When making a length relative, name the thing it should track and check that the CSS cascade actually points at it.
- **A target derived as the median of current behaviour is not a target, it is a description.** It cannot tell you the current behaviour is wrong, because it *is* the current behaviour — so a test built on it passes precisely when it should be complaining. When a metric reports "on target" and a human reports "that looks wrong," suspect the target before suspecting the human.
- **A complaint about specific items is often a complaint about variance.** Three glyphs were reported as too tight; measured, they were mid-distribution and their neighbours were 2× looser. Measure the reported items *and their neighbours* before treating the report as being about the items.
- **A test that measures a derived quantity must derive it, not hardcode it.** The prior spec hardcoded the icon's band as 0.2em–0.7em; the real band was 0.125em–0.750em and context-dependent, so the test had been measuring the wrong ink in every context.
- **Cross-engine canvas feature gaps produce plausible-looking wrong numbers, not errors.** WebKit silently ignores `ctx.fontVariantCaps`, so a small-caps measurement returns the lowercase glyph's metrics — a real number, in range, and wrong. Detect the capability by differential measurement and drop the probe rather than trusting it.
- **Verify a plan's predicted root causes against the rendered artifact before implementing the fix.** Two of this plan's predictions did not survive measurement: the monospace nudge was a face property rather than a size artifact (deleting it would have regressed code spacing by 0.05em), and the "displaced anchor" turned out to be correct behaviour. Both were written confidently from reading the source; both took one measurement to overturn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCDX3P2wjgC4nkZnBwY3hB