### PR TITLE
fix(ci): repair Dependabot auto-merge so update PRs stop piling up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,6 @@ updates:
     allow:
       - dependency-name: "subfont"
       - dependency-name: "punctilio"
-    # ignore:
-    #   # punctilio 3.3+ changes collectTransformableElements to return the
-    #   # outermost transformable element, so <p><a>URL</a></p> collects <p>
-    #   # and our "don't mangle URLs" check (elt.tagName !== "a") no longer
-    #   # fires. Re-enable once we either make the skip href-aware locally or
-    #   # add a per-text-node skip hook in punctilio itself.
-    #   - dependency-name: "punctilio"
-    #     versions: [">=3.3.0"]
     groups:
       npm-tracked:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Track subfont for version updates only. Security updates for all packages
+  # Track punctilio for version updates only. Security updates for all packages
   # are handled separately by GitHub's Dependabot security alerts.
   - package-ecosystem: "npm"
     directory: "/"
@@ -8,11 +8,6 @@ updates:
       interval: "monthly"
     versioning-strategy: auto
     allow:
-      - dependency-name: "subfont"
       - dependency-name: "punctilio"
-    groups:
-      npm-tracked:
-        patterns:
-          - "*"
     cooldown:
       default-days: 7

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -6,8 +6,11 @@ on:
   # zizmor: ignore[dangerous-triggers] pull_request_target is required so
   # Dependabot PRs (fork-like context) get write permissions; safe because no
   # step checks out or executes PR code — only metadata + gh pr commands run.
+  # `reopened` and `synchronize` keep the job self-healing: a PR whose `opened`
+  # run did not enable auto-merge is picked up on Dependabot's next rebase
+  # rather than sitting open indefinitely.
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write
@@ -24,20 +27,29 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444e5b86506 # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Re-approving on every `synchronize` would post a fresh approval event
+      # per Dependabot rebase, so approve only when this bot has not already.
       - name: Approve PR (minor/patch only)
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
+        run: |
+          approved=$(gh pr view "$PR_URL" --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and .state == "APPROVED")] | length')
+          if [[ "$approved" -eq 0 ]]; then
+            gh pr review --approve "$PR_URL"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # MERGE, not squash: the repository disallows squash merging, and
+      # `gh pr merge --auto` rejects a method the repo does not permit.
       - name: Enable auto-merge (minor/patch only)
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Dependabot auto-merge has never worked. All 30 runs of `auto-merge-dependabot.yml` since May failed, so nothing was ever approved or merged and the PRs accumulated.
- The cause is a corrupt action pin: `dependabot/fetch-metadata@d7267f60...e5b86506`. Its first 30 hex chars match the real v2.3.0 SHA (`d7267f60...713e90b7`), but the last 10 do not resolve to any object, so every run died at step 1 with `Unable to resolve action`.
- A second bug sat behind it: the merge step used `--squash`, which this repository disallows, so `gh pr merge --auto --squash` would have failed even once metadata resolved.
- Separately, narrow version updates to `punctilio` alone.

## Changes

`.github/workflows/auto-merge-dependabot.yml`

- Pin `dependabot/fetch-metadata` to v3.1.0 by its real SHA (`25dd0e34f4fe68f24cc83900b1fe3fe149efef98`). The `update-type` output this workflow gates on is unchanged in v3.
- Switch `gh pr merge --auto --squash` to `--merge`, matching `auto-merge-deepsource.yml` and `refresh-readme-snapshots.yaml`.
- Trigger on `reopened` and `synchronize` in addition to `opened`. A PR whose `opened` run failed to enable auto-merge previously stayed open forever with no second chance; it now recovers on Dependabot's next rebase. This also clears the five PRs already stuck open (#1573, #1634, #1636, #1637, #1644) without needing them closed and reopened by hand.
- Approve only when this bot has not already approved, so the added triggers don't post a fresh approval event per rebase.

`.github/dependabot.yml`

- Track only `punctilio` for version updates; drop `subfont` from the allow list. Security alerts still cover `subfont`, as they do every other package.
- Remove the `npm-tracked` group. With one allowed dependency it can no longer group anything, and the update is a single PR either way.
- Drop the commented-out `punctilio` ignore block. It described a `>=3.3.0` bound; punctilio is on 5.3.0, so the block was dead config for a constraint that no longer applies.

## Testing

- `git ls-remote --tags https://github.com/dependabot/fetch-metadata` confirms the old pin matches no tag and that `25dd0e34...` is v3.1.0.
- `mcp__github__get_job_logs` on run 29884229662 confirms the failure mode: `Unable to resolve action dependabot/fetch-metadata@d7267f60...`, one failed job, no other steps reached.
- Workflow run history (`actions_list` filtered to `actor: dependabot[bot]`) shows 30/30 runs failing back to 2026-05-16.
- `zizmor --offline` on the changed workflow: no findings. Both YAML files parse, and `dependabot.yml` round-trips to the intended single-allow structure. The approval step's shell body is `shellcheck`-clean under `set -euo pipefail`.

Note on scope: the five open PRs are Dependabot **security** updates originating from the Security Alerts page, not from `dependabot.yml` version updates. The default branch currently has 97 open advisories, and Dependabot throttles how many PRs it keeps open at once, so narrowing the version-update config does not reduce that volume — making auto-merge actually work does.

## Lessons Learned

- **What**: When a CI workflow's job is to act on PRs rather than produce a required check, verify it has actually succeeded at least once — a broken pinned action fails silently from the PR's point of view, since a non-required workflow's failure never surfaces on the PR itself.
- **Where**: Any repo with `auto-merge-*.yml`-style automation.
- **Why**: This workflow failed 30 consecutive times over three months while looking, from the PR list, like Dependabot was simply noisy. The symptom ("too many dep PRs") pointed away from the cause ("the thing that closes them is dead").

- **What**: Treat a pinned action SHA that "looks right" as unverified until resolved against the upstream tag list; `git ls-remote --tags <action-repo-url>` does this without needing GitHub API auth.
- **Where**: Any `uses: org/action@<sha>` pin, especially ones introduced by template sync or written from memory.
- **Why**: The bad pin here shared its first 30 hex characters with the genuine v2.3.0 SHA, so it survived every visual review. Only resolution catches that class of error.