### PR TITLE
fix: replace dead IASEAI link in leaving-google-deepmind

### DIFF
--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -159,7 +159,7 @@ When I arrived at the IASEAI venue, I expected some of the hundreds of AI profes
 ## I wanted to mobilize the AI luminaries at the conference
 
 Stuart Russell
-: Founder of IASEAI. Co-authored the standard AI textbook used in [over 1,500 universities](https://www.iaseai.org/conference/people/stuart-russell-2). Founder of UC Berkeley's Center for Human-Compatible AI, where I interned for several summers and completed a postdoc. For many years he was the only big-shot academic who took the existential risk from AI seriously. I had long appreciated that.
+: Founder of IASEAI. Co-authored the standard AI textbook used in [over 1,500 universities](https://aima.cs.berkeley.edu/adoptions.html). Founder of UC Berkeley's Center for Human-Compatible AI, where I interned for several summers and completed a postdoc. For many years he was the only big-shot academic who took the existential risk from AI seriously. I had long appreciated that.
 
 : Most importantly: [the leading figure in the global campaign to ban lethal autonomous weapons](https://awards.acm.org/award_winners/russell_3816360), with [his site highlighting over *two hundred prestigious talks on the subject*](https://people.eecs.berkeley.edu/~russell/research/LAWS.html). He presented the  *[Slaughterbots](https://www.youtube.com/watch?v=O-2tpwW0kmU)* [videos](https://www.youtube.com/watch?v=9rDo1QxI260) to the United Nations. If anyone on this green planet Earth had a reason to call out an "all lawful use" military AI deal, it was the man who organized the field against SLAUGHTERBOTS.
 


### PR DESCRIPTION
## Summary

- The "over 1,500 universities" link in `leaving-google-deepmind.md` pointed at `iaseai.org/conference/people/stuart-russell-2`, which no longer resolves to a speaker page.
- Repointed it at the AIMA adoptions list, which is the primary source for the figure — the page title is literally "1556 Schools Worldwide That Have Adopted AIMA."

## Changes

- `website_content/leaving-google-deepmind.md`: link target changed to `https://aima.cs.berkeley.edu/adoptions.html`.

## Testing

- `curl` confirms the new URL returns HTTP 200 with the adoptions listing; CI link-checking covers the rest.


---
_Generated by [Claude Code](https://claude.ai/code/session_0199AbEoYNaUbpkgM7Z2ecki)_