### PR TITLE
fix(spoilers): dissolve blur at the spoiler's edges instead of shearing it

### DIFF
--- a/config/javascript/eslint.config.js
+++ b/config/javascript/eslint.config.js
@@ -246,6 +246,8 @@ export default [
           allowConditional: true,
         },
       ],
+      // Custom assertion helpers that wrap `expect` internally.
+      "playwright/expect-expect": ["warn", { assertFunctionNames: ["expectEdgesDissolve"] }],
     },
   },
 

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -37,6 +37,36 @@ const INTERIOR_OFFSET = 48
 // measuring anything. Subpixel line-box rounding is the only slack allowed.
 const EDGE_REACH_TOLERANCE = 2
 
+// A mask clips its element's paint to the border box on every side, not only
+// the two the gradient fades. The box's top edge sits nearer the first line
+// than the halo reaches, so that clip shears the block into a hard horizontal
+// seam — the same defect as at the inline edges, one axis over. (The bottom
+// edge is safe: half-leading and descender space put it further from the last
+// line than the halo carries.)
+//
+// The invariant: ink survives in the rows just above a concealed spoiler's box.
+// A clipped edge leaves them pixel-identical to the background further out.
+
+// How far above the box the halo is looked for. It is spent within the blur
+// radius; a couple of pixels past that costs nothing and tolerates rounding.
+const HALO_PROBE_DEPTH = 3
+// Where the background is sampled, in pixels above the box. Past the halo, and
+// near enough that a neighbouring element's own paint rarely intrudes.
+const HALO_REFERENCE_OFFSET = 6
+// Fraction of the box width trimmed from each side before sampling. The inline
+// gradient fades those columns toward transparent, so they carry no halo.
+const HALO_SAMPLE_INSET = 0.2
+// Ink carried by the strongest columns above the box, on the same 0–255
+// luminance scale. A sheared edge measures at most 1 — the residue of a
+// neighbour's paint, never the spoiler's own; an intact halo measures 3 or
+// more.
+const MIN_HALO_INK = 2
+// Which column to read once the columns above the box are ranked by ink. A
+// halo tracks the glyphs that cast it, so it lives in the strongest columns
+// rather than the average one; the top decile keeps that signal while ignoring
+// the single hottest column's noise.
+const HALO_INK_PERCENTILE = 0.9
+
 interface EdgeDeltas {
   /** How far the spoiler's outermost pixel column sits from the page background. */
   readonly edge: number
@@ -185,6 +215,63 @@ async function measureEdge(
 }
 
 /**
+ * Ink the blur halo leaves in the rows immediately above a concealed spoiler.
+ *
+ * Each row is differenced against one {@link HALO_REFERENCE_OFFSET} px higher,
+ * column by column, and the columns are ranked; the result is the
+ * {@link HALO_INK_PERCENTILE} column of the strongest row. Differencing against
+ * a nearby row rather than an absolute level keeps whatever the page paints
+ * behind the spoiler out of the measurement.
+ * @param page - Page the spoiler lives in.
+ * @param spoiler - The `.spoiler-container` to measure.
+ */
+async function measureTopHaloInk(page: Page, spoiler: Locator): Promise<number> {
+  const box = await requireBoundingBox(spoiler.locator(".spoiler-content"))
+  const bandHeight = HALO_REFERENCE_OFFSET + 2
+  if (box.y < bandHeight) {
+    throw new Error(
+      `Spoiler sits ${box.y.toFixed(1)}px from the top of the viewport, too high to probe`,
+    )
+  }
+
+  const inset = box.width * HALO_SAMPLE_INSET
+  const buffer = await page.screenshot({
+    clip: {
+      x: box.x + inset,
+      y: box.y - bandHeight,
+      width: box.width - 2 * inset,
+      height: bandHeight,
+    },
+  })
+  const { data, info } = await sharp(buffer)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  const scale = info.height / bandHeight
+  // Pixel row holding the point `depth` CSS px above the box.
+  const rowAt = (depth: number): number =>
+    Math.min(info.height - 1, Math.max(0, Math.round((bandHeight - depth - 0.5) * scale)))
+  const luminance = (x: number, y: number): number => {
+    const i = (y * info.width + x) * 4
+    return 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]
+  }
+
+  const referenceRow = rowAt(HALO_REFERENCE_OFFSET)
+  let ink = 0
+  for (let depth = 1; depth <= HALO_PROBE_DEPTH; depth++) {
+    const row = rowAt(depth)
+    const deltas: number[] = []
+    for (let x = 0; x < info.width; x++) {
+      deltas.push(Math.abs(luminance(x, row) - luminance(x, referenceRow)))
+    }
+    deltas.sort((a, b) => a - b)
+    ink = Math.max(ink, deltas[Math.floor(HALO_INK_PERCENTILE * (deltas.length - 1))])
+  }
+  return ink
+}
+
+/**
  * Assert that a concealed spoiler dissolves into the page at the given edges.
  * @param page - Page the spoiler lives in.
  * @param spoiler - The `.spoiler-container` to check.
@@ -241,6 +328,9 @@ for (const theme of ["light", "dark"] as const) {
       const edges = await liveEdges(spoiler)
       await expectEdgesDissolve(page, spoiler, edges)
       checked.push(...edges)
+
+      const halo = await measureTopHaloInk(page, spoiler)
+      expect(halo, "blur is sheared off at the top of the spoiler").toBeGreaterThan(MIN_HALO_INK)
     }
     // The test page carries a one-line spoiler precisely so that some spoiler is
     // always as wide as its own text; without one, the right fade goes untested.

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -92,6 +92,26 @@ function lineBandNearest(
   }, edge)
 }
 
+/** X coordinate of one inline edge of a laid-out box. */
+function inlineEdgeX(box: { x: number; width: number }, edge: "left" | "right"): number {
+  return edge === "left" ? box.x : box.x + box.width
+}
+
+/**
+ * Whether the spoiler's text actually runs to the given inline edge.
+ *
+ * Only then is there a halo at that edge for a clip to shear. Which spoilers
+ * touch the right margin is not fixed: text is ragged-right, and engines size
+ * `fit-content` differently around the `<br>`s a multi-line spoiler carries.
+ * @param spoiler - The `.spoiler-container` to check.
+ * @param edge - Which inline edge to test.
+ */
+async function reachesMargin(spoiler: Locator, edge: "left" | "right"): Promise<boolean> {
+  const box = await requireBoundingBox(spoiler)
+  const band = await lineBandNearest(spoiler, edge)
+  return Math.abs(band.reach - inlineEdgeX(box, edge)) <= EDGE_REACH_TOLERANCE
+}
+
 /**
  * Measure how a spoiler meets the page at one of its inline edges.
  *
@@ -114,7 +134,7 @@ async function measureEdge(
   const viewport = page.viewportSize()
   if (!viewport) throw new Error("Expected an emulated viewport")
 
-  const edgeX = edge === "left" ? box.x : box.x + box.width
+  const edgeX = inlineEdgeX(box, edge)
   const outward = edge === "left" ? -1 : 1
   // A probe only means something if text actually reaches the edge it targets;
   // otherwise there is no halo there for a clip to shear, and the measurement
@@ -189,33 +209,45 @@ async function expectEdgesDissolve(
   }
 }
 
-// A spoiler sized by its own longest line ends exactly where that line ends, so
-// both margins carry ink. One long enough to wrap is stretched to the column
-// instead, and ragged-right wrapping leaves its right margin bare — the left is
-// all there is to check.
-const BOTH_EDGES = ["left", "right"] as const
 const LEFT_EDGE = ["left"] as const
+
+/**
+ * The inline edges of a spoiler that its text actually runs to.
+ *
+ * Every line starts at the left margin, so that edge is always live; reaching
+ * the right one depends on where the text happens to wrap.
+ * @param spoiler - The `.spoiler-container` to inspect.
+ */
+async function liveEdges(spoiler: Locator): Promise<readonly ("left" | "right")[]> {
+  const edges: ("left" | "right")[] = ["left"]
+  if (await reachesMargin(spoiler, "right")) edges.push("right")
+  return edges
+}
 
 test.beforeEach(async ({ page }) => {
   await gotoPage(page, "http://localhost:8080/test-page")
 })
 
 for (const theme of ["light", "dark"] as const) {
-  test(`Article spoilers dissolve at both inline edges in ${theme} mode`, async ({ page }) => {
+  test(`Article spoilers dissolve at their inline edges in ${theme} mode`, async ({ page }) => {
     await setTheme(page, theme)
     const spoilers = page.locator("article .spoiler-container")
-    // The test page carries a short spoiler and one long enough to wrap and
-    // fill the column; the wrapping one is what puts text against both edges.
-    await expect(spoilers).toHaveCount(2)
+    const count = await spoilers.count()
 
-    for (const [index, edges] of [
-      [0, BOTH_EDGES],
-      [1, LEFT_EDGE],
-    ] as const) {
+    const checked: string[] = []
+    for (let index = 0; index < count; index++) {
       const spoiler = spoilers.nth(index)
       await spoiler.scrollIntoViewIfNeeded()
+      const edges = await liveEdges(spoiler)
       await expectEdgesDissolve(page, spoiler, edges)
+      checked.push(...edges)
     }
+    // The test page carries a one-line spoiler precisely so that some spoiler is
+    // always as wide as its own text; without one, the right fade goes untested.
+    expect(
+      checked.filter((edge) => edge === "right"),
+      "no article spoiler reached the right margin",
+    ).not.toHaveLength(0)
   })
 }
 

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -38,34 +38,35 @@ const INTERIOR_OFFSET = 48
 const EDGE_REACH_TOLERANCE = 2
 
 // A mask clips its element's paint to the border box on every side, not only
-// the two the gradient fades. The box's top edge sits nearer the first line
-// than the halo reaches, so that clip shears the block into a hard horizontal
-// seam — the same defect as at the inline edges, one axis over. (The bottom
-// edge is safe: half-leading and descender space put it further from the last
-// line than the halo carries.)
+// the two the gradient fades, so the block axis is at risk from the very
+// declaration that fixes the inline one — the same defect, one axis over.
+// (Below the last line nothing is at risk: descender space and half-leading put
+// the box further from the text than the halo carries.)
 //
-// The invariant: ink survives in the rows just above a concealed spoiler's box.
-// A clipped edge leaves them pixel-identical to the background further out.
+// The invariant is stated about the text rather than the box: the blur has to
+// carry a few pixels above the first line before the page goes bare. Anchoring
+// on the box would only re-describe wherever the box happens to sit.
 
-// How far above the box the halo is looked for. It is spent within the blur
-// radius; a couple of pixels past that costs nothing and tolerates rounding.
-const HALO_PROBE_DEPTH = 3
-// Where the background is sampled, in pixels above the box. Past the halo, and
-// near enough that a neighbouring element's own paint rarely intrudes.
-const HALO_REFERENCE_OFFSET = 6
-// Fraction of the box width trimmed from each side before sampling. The inline
-// gradient fades those columns toward transparent, so they carry no halo.
+// Fraction of the line's width trimmed from each side before sampling. The
+// inline gradient fades those columns toward transparent, so they carry no halo.
 const HALO_SAMPLE_INSET = 0.2
-// Ink carried by the strongest columns above the box, on the same 0–255
-// luminance scale. A sheared edge measures at most 1 — the residue of a
-// neighbour's paint, never the spoiler's own; an intact halo measures 3 or
-// more.
-const MIN_HALO_INK = 2
-// Which column to read once the columns above the box are ranked by ink. A
+// Which column to read once the columns above the line are ranked by ink. A
 // halo tracks the glyphs that cast it, so it lives in the strongest columns
 // rather than the average one; the top decile keeps that signal while ignoring
 // the single hottest column's noise.
 const HALO_INK_PERCENTILE = 0.9
+// Ink, on the 0–255 luminance scale, that counts as the blur still marking the
+// page rather than rounding noise.
+const MIN_INK = 1
+// How far above the first line the blur must still mark the page. Clipped, it
+// stops at the half-leading — 4px at the very most, across both viewports and
+// themes; intact, it carries 6 to 11.
+const MIN_HALO_REACH = 5
+// Furthest above the line the halo is looked for. Beyond three standard
+// deviations of a 4px blur there is nothing left to find.
+const MAX_HALO_REACH = 14
+// Where the bare page is sampled, in pixels above the first line.
+const HALO_REFERENCE_OFFSET = 18
 
 interface EdgeDeltas {
   /** How far the spoiler's outermost pixel column sits from the page background. */
@@ -215,30 +216,34 @@ async function measureEdge(
 }
 
 /**
- * Ink the blur halo leaves in the rows immediately above a concealed spoiler.
+ * How far above its first line a concealed spoiler's blur still marks the page.
  *
- * Each row is differenced against one {@link HALO_REFERENCE_OFFSET} px higher,
- * column by column, and the columns are ranked; the result is the
- * {@link HALO_INK_PERCENTILE} column of the strongest row. Differencing against
- * a nearby row rather than an absolute level keeps whatever the page paints
- * behind the spoiler out of the measurement.
+ * Rows above the line are differenced against one {@link HALO_REFERENCE_OFFSET}
+ * px higher, column by column, and ranked; a row counts as marked when its
+ * {@link HALO_INK_PERCENTILE} column clears {@link MIN_INK}. Differencing
+ * against a nearby row rather than an absolute level keeps whatever the page
+ * paints behind the spoiler out of the measurement.
+ *
+ * Returns nothing when the page above the spoiler is not bare — a neighbour's
+ * own paint reaching into the probe would be read as this spoiler's halo.
  * @param page - Page the spoiler lives in.
  * @param spoiler - The `.spoiler-container` to measure.
  */
-async function measureTopHaloInk(page: Page, spoiler: Locator): Promise<number> {
-  const box = await requireBoundingBox(spoiler.locator(".spoiler-content"))
+async function haloReachAboveFirstLine(page: Page, spoiler: Locator): Promise<readonly number[]> {
+  const line = await lineBandNearest(spoiler, "left")
   const bandHeight = HALO_REFERENCE_OFFSET + 2
-  if (box.y < bandHeight) {
+  if (line.y < bandHeight) {
     throw new Error(
-      `Spoiler sits ${box.y.toFixed(1)}px from the top of the viewport, too high to probe`,
+      `Spoiler sits ${line.y.toFixed(1)}px from the top of the viewport, too high to probe`,
     )
   }
 
+  const box = await requireBoundingBox(spoiler.locator(".spoiler-content"))
   const inset = box.width * HALO_SAMPLE_INSET
   const buffer = await page.screenshot({
     clip: {
       x: box.x + inset,
-      y: box.y - bandHeight,
+      y: line.y - bandHeight,
       width: box.width - 2 * inset,
       height: bandHeight,
     },
@@ -249,7 +254,7 @@ async function measureTopHaloInk(page: Page, spoiler: Locator): Promise<number> 
     .toBuffer({ resolveWithObject: true })
 
   const scale = info.height / bandHeight
-  // Pixel row holding the point `depth` CSS px above the box.
+  // Pixel row holding the point `depth` CSS px above the first line.
   const rowAt = (depth: number): number =>
     Math.min(info.height - 1, Math.max(0, Math.round((bandHeight - depth - 0.5) * scale)))
   const luminance = (x: number, y: number): number => {
@@ -258,17 +263,27 @@ async function measureTopHaloInk(page: Page, spoiler: Locator): Promise<number> 
   }
 
   const referenceRow = rowAt(HALO_REFERENCE_OFFSET)
-  let ink = 0
-  for (let depth = 1; depth <= HALO_PROBE_DEPTH; depth++) {
+  const inkAt = (depth: number): number => {
     const row = rowAt(depth)
     const deltas: number[] = []
     for (let x = 0; x < info.width; x++) {
       deltas.push(Math.abs(luminance(x, row) - luminance(x, referenceRow)))
     }
     deltas.sort((a, b) => a - b)
-    ink = Math.max(ink, deltas[Math.floor(HALO_INK_PERCENTILE * (deltas.length - 1))])
+    return deltas[Math.floor(HALO_INK_PERCENTILE * (deltas.length - 1))]
   }
-  return ink
+
+  // Every row between where the halo can still reach and the reference must be
+  // bare, or something other than this spoiler is painting into the probe.
+  for (let depth = MAX_HALO_REACH + 1; depth < HALO_REFERENCE_OFFSET; depth++) {
+    if (inkAt(depth) > MIN_INK) return []
+  }
+
+  let reach = 0
+  for (let depth = 1; depth <= MAX_HALO_REACH; depth++) {
+    if (inkAt(depth) > MIN_INK) reach = depth
+  }
+  return [reach]
 }
 
 /**
@@ -322,15 +337,14 @@ for (const theme of ["light", "dark"] as const) {
     const count = await spoilers.count()
 
     const checked: string[] = []
+    const reaches: number[] = []
     for (let index = 0; index < count; index++) {
       const spoiler = spoilers.nth(index)
       await spoiler.scrollIntoViewIfNeeded()
       const edges = await liveEdges(spoiler)
       await expectEdgesDissolve(page, spoiler, edges)
       checked.push(...edges)
-
-      const halo = await measureTopHaloInk(page, spoiler)
-      expect(halo, "blur is sheared off at the top of the spoiler").toBeGreaterThan(MIN_HALO_INK)
+      reaches.push(...(await haloReachAboveFirstLine(page, spoiler)))
     }
     // The test page carries a one-line spoiler precisely so that some spoiler is
     // always as wide as its own text; without one, the right fade goes untested.
@@ -338,6 +352,13 @@ for (const theme of ["light", "dark"] as const) {
       checked.filter((edge) => edge === "right"),
       "no article spoiler reached the right margin",
     ).not.toHaveLength(0)
+
+    // Spoilers stacked directly on top of each other paint into one another's
+    // probes; at least one has to sit under bare page for the halo to be read.
+    expect(reaches, "no article spoiler had bare page above it").not.toHaveLength(0)
+    expect(Math.min(...reaches), "blur is sheared off above the first line").toBeGreaterThanOrEqual(
+      MIN_HALO_REACH,
+    )
   })
 }
 

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -1,0 +1,258 @@
+import type { Locator, Page } from "@playwright/test"
+
+import sharp from "sharp"
+
+import { expect, test } from "./fixtures"
+import { gotoPage, isDesktopViewport, requireBoundingBox, search, setTheme } from "./visual_utils"
+
+// A concealed spoiler is blurred text, and a Gaussian blur's halo spreads past
+// the glyphs that cast it. Every container a spoiler renders in — the article
+// column, a link popover, the search preview — clips along its inline axis, and
+// a spoiler runs edge to edge inside all three, so that halo has nowhere to
+// spill: the clip shears it into a hard vertical wall of half-blurred text.
+//
+// The invariant: at either inline edge of a concealed spoiler, the page's own
+// background is all that is left, so the block dissolves into the page instead
+// of ending on a seam. Only pixels can show this — the geometry is identical
+// whether the halo fades out or is sheared off.
+
+// Luminance runs 0–255, so these are absolute levels rather than fractions.
+// A sheared edge measures 8–12 at the seam; a dissolved one stays under 1.5
+// across every viewport, theme, and container, so the gap is wide enough that
+// the threshold is never a judgement call.
+const MAX_EDGE_DELTA = 3
+// The window inboard of the edge has to actually hold blurred text, or these
+// tests would pass just as happily on an empty box. Measured deltas run 14–22.
+const MIN_INTERIOR_DELTA = 8
+// Where the page background is sampled, measured outboard from the spoiler's
+// edge. Far enough out to clear the fade, near enough to stay inside the
+// narrowest gutter the site has (18px, on a phone).
+const BACKGROUND_OFFSET = 14
+// How far inboard of the edge the blurred text is looked for. Wide enough to
+// clear the fade (3× the 4px blur radius; see $spoiler-edge-fade) and then to
+// reach ink even when the sampled line stops a word short of the margin.
+const INTERIOR_OFFSET = 48
+// How near the edge the longest line must come for a probe of that edge to be
+// measuring anything. Subpixel line-box rounding is the only slack allowed.
+const EDGE_REACH_TOLERANCE = 2
+
+interface EdgeDeltas {
+  /** How far the spoiler's outermost pixel column sits from the page background. */
+  readonly edge: number
+  /** How far a column well inside the spoiler sits from the page background. */
+  readonly interior: number
+}
+
+/**
+ * Mean luminance of one vertical pixel column of a decoded screenshot.
+ * @param raw - RGBA pixels of the captured band.
+ * @param width - Band width, in device pixels.
+ * @param height - Band height, in device pixels.
+ * @param x - Column to sample, in device pixels.
+ */
+function columnLuminance(raw: Buffer, width: number, height: number, x: number): number {
+  let sum = 0
+  for (let y = 0; y < height; y++) {
+    const i = (y * width + x) * 4
+    sum += 0.299 * raw[i] + 0.587 * raw[i + 1] + 0.114 * raw[i + 2]
+  }
+  return sum / height
+}
+
+/**
+ * Vertical extent of the spoiler line that reaches furthest toward one edge.
+ *
+ * Sampling a single line — rather than the whole block — keeps every averaged
+ * row on text. Which line matters depends on the edge: every line starts at the
+ * left margin, but text is ragged-right, so only the longest one approaches the
+ * right margin.
+ * @param spoiler - The `.spoiler-container` to measure.
+ * @param edge - Which inline edge the band should favour.
+ */
+async function lineBandNearest(
+  spoiler: Locator,
+  edge: "left" | "right",
+): Promise<{ y: number; height: number; reach: number }> {
+  return spoiler.evaluate((el, which) => {
+    const paragraph = el.querySelector(".spoiler-content p")
+    if (!paragraph) throw new Error("Spoiler has no paragraph to measure")
+    const range = document.createRange()
+    range.selectNodeContents(paragraph)
+    const lines = Array.from(range.getClientRects()).filter((r) => r.width > 1 && r.height > 1)
+    if (lines.length === 0) throw new Error("Spoiler paragraph rendered no line boxes")
+    const best = lines.reduce((a, b) =>
+      which === "right" ? (b.right > a.right ? b : a) : b.left < a.left ? b : a,
+    )
+    return { y: best.top, height: best.height, reach: which === "right" ? best.right : best.left }
+  }, edge)
+}
+
+/**
+ * Measure how a spoiler meets the page at one of its inline edges.
+ *
+ * Captures a band straddling the edge and compares the spoiler's outermost
+ * column — and the strongest column within {@link INTERIOR_OFFSET} inboard of
+ * it — against the background {@link BACKGROUND_OFFSET} outboard. Columns are
+ * averaged down the line's height: a seam runs that whole height, so it
+ * registers, while per-glyph blur variation largely cancels.
+ * @param page - Page the spoiler lives in.
+ * @param spoiler - The `.spoiler-container` to measure.
+ * @param edge - Which inline edge to probe.
+ */
+async function measureEdge(
+  page: Page,
+  spoiler: Locator,
+  edge: "left" | "right",
+): Promise<EdgeDeltas> {
+  const box = await requireBoundingBox(spoiler)
+  const band = await lineBandNearest(spoiler, edge)
+  const viewport = page.viewportSize()
+  if (!viewport) throw new Error("Expected an emulated viewport")
+
+  const edgeX = edge === "left" ? box.x : box.x + box.width
+  const outward = edge === "left" ? -1 : 1
+  // A probe only means something if text actually reaches the edge it targets;
+  // otherwise there is no halo there for a clip to shear, and the measurement
+  // would pass on a blank margin. Fail rather than quietly measure nothing.
+  if (Math.abs(band.reach - edgeX) > EDGE_REACH_TOLERANCE) {
+    throw new Error(
+      `Spoiler text stops ${Math.abs(band.reach - edgeX).toFixed(1)}px short of its ${edge} edge`,
+    )
+  }
+  const bandStart = edgeX + outward * BACKGROUND_OFFSET
+  const bandEnd = edgeX - outward * INTERIOR_OFFSET
+  const [clipLeft, clipRight] = bandStart < bandEnd ? [bandStart, bandEnd] : [bandEnd, bandStart]
+  if (clipLeft < 0 || clipRight > viewport.width) {
+    throw new Error(
+      `Probe band [${clipLeft}, ${clipRight}] for the ${edge} edge falls outside the ${viewport.width}px viewport`,
+    )
+  }
+
+  const buffer = await page.screenshot({
+    clip: { x: clipLeft, y: band.y, width: clipRight - clipLeft, height: band.height },
+  })
+  const { data, info } = await sharp(buffer)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  // The clip was in CSS pixels; the capture is in device pixels. Sample points
+  // sit half a pixel inside the band, so clamping only ever absorbs rounding.
+  const scale = info.width / (clipRight - clipLeft)
+  const at = (cssX: number): number => {
+    const column = Math.round((cssX - clipLeft) * scale)
+    return columnLuminance(
+      data,
+      info.width,
+      info.height,
+      Math.min(info.width - 1, Math.max(0, column)),
+    )
+  }
+  // Half a pixel inboard of a boundary lands on that column itself rather than
+  // straddling it.
+  const background = at(bandStart - outward * 0.5)
+
+  let interior = 0
+  for (let step = 1; step <= INTERIOR_OFFSET; step++) {
+    interior = Math.max(interior, Math.abs(at(edgeX - outward * step) - background))
+  }
+  return { edge: Math.abs(at(edgeX - outward * 0.5) - background), interior }
+}
+
+/**
+ * Assert that a concealed spoiler dissolves into the page at the given edges.
+ * @param page - Page the spoiler lives in.
+ * @param spoiler - The `.spoiler-container` to check.
+ * @param edges - Inline edges whose text reaches the margin.
+ */
+async function expectEdgesDissolve(
+  page: Page,
+  spoiler: Locator,
+  edges: readonly ("left" | "right")[],
+): Promise<void> {
+  await expect(spoiler).toBeVisible()
+  await expect(spoiler).not.toHaveClass(/revealed/)
+
+  for (const edge of edges) {
+    const deltas = await measureEdge(page, spoiler, edge)
+    expect(deltas.interior, `${edge} edge: no blurred text inboard of the edge`).toBeGreaterThan(
+      MIN_INTERIOR_DELTA,
+    )
+    expect(deltas.edge, `${edge} edge: blur is sheared off instead of dissolving`).toBeLessThan(
+      MAX_EDGE_DELTA,
+    )
+  }
+}
+
+// A spoiler sized by its own longest line ends exactly where that line ends, so
+// both margins carry ink. One long enough to wrap is stretched to the column
+// instead, and ragged-right wrapping leaves its right margin bare — the left is
+// all there is to check.
+const BOTH_EDGES = ["left", "right"] as const
+const LEFT_EDGE = ["left"] as const
+
+test.beforeEach(async ({ page }) => {
+  await gotoPage(page, "http://localhost:8080/test-page")
+})
+
+for (const theme of ["light", "dark"] as const) {
+  test(`Article spoilers dissolve at both inline edges in ${theme} mode`, async ({ page }) => {
+    await setTheme(page, theme)
+    const spoilers = page.locator("article .spoiler-container")
+    // The test page carries a short spoiler and one long enough to wrap and
+    // fill the column; the wrapping one is what puts text against both edges.
+    await expect(spoilers).toHaveCount(2)
+
+    for (const [index, edges] of [
+      [0, BOTH_EDGES],
+      [1, LEFT_EDGE],
+    ] as const) {
+      const spoiler = spoilers.nth(index)
+      await spoiler.scrollIntoViewIfNeeded()
+      await expectEdgesDissolve(page, spoiler, edges)
+    }
+  })
+}
+
+test("Revealing a spoiler restores ink at its inline edges", async ({ page }) => {
+  const spoiler = page.locator("article .spoiler-container").first()
+  await spoiler.scrollIntoViewIfNeeded()
+  await spoiler.click()
+  await expect(spoiler).toHaveClass(/revealed/)
+
+  // Revealed text must be legible right up to the margin, so the fade that
+  // conceals the blur's seam has to lift along with the blur itself.
+  const { edge } = await measureEdge(page, spoiler, "left")
+  expect(edge, "revealed text is still faded at the margin").toBeGreaterThan(MIN_INTERIOR_DELTA)
+})
+
+test("Search-preview spoilers dissolve at the column edge", async ({ page }) => {
+  test.skip(
+    !isDesktopViewport(page),
+    "The search preview pane is hidden below the tablet breakpoint",
+  )
+
+  await search(page, "hidden until you click")
+
+  const spoiler = page.locator("#preview-container .spoiler-container").first()
+  await spoiler.scrollIntoViewIfNeeded()
+  await expectEdgesDissolve(page, spoiler, LEFT_EDGE)
+})
+
+test("Popover spoilers dissolve at the column edge", async ({ page }) => {
+  test.skip(!isDesktopViewport(page), "Popovers are desktop-only")
+
+  // The nav handler suppresses hover until the pointer has moved once.
+  await page.mouse.move(1, 1)
+  const link = page.locator("a#first-link-test-page")
+  await link.evaluate((el) => el.setAttribute("href", "./test-page#spoilers"))
+  await link.scrollIntoViewIfNeeded()
+  await link.hover()
+
+  const popover = page.locator(".popover")
+  await expect(popover).toHaveClass(/popover-visible/, { timeout: 10_000 })
+
+  const spoiler = popover.locator(".spoiler-container").first()
+  await spoiler.scrollIntoViewIfNeeded()
+  await expectEdgesDissolve(page, spoiler, LEFT_EDGE)
+})

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -70,7 +70,7 @@ function columnLuminance(raw: Buffer, width: number, height: number, x: number):
  * @param spoiler - The `.spoiler-container` to measure.
  * @param edge - Which inline edge the band should favour.
  */
-async function lineBandNearest(
+function lineBandNearest(
   spoiler: Locator,
   edge: "left" | "right",
 ): Promise<{ y: number; height: number; reach: number }> {

--- a/quartz/components/tests/spoilerBlurEdge.spec.ts
+++ b/quartz/components/tests/spoilerBlurEdge.spec.ts
@@ -21,9 +21,10 @@ import { gotoPage, isDesktopViewport, requireBoundingBox, search, setTheme } fro
 // across every viewport, theme, and container, so the gap is wide enough that
 // the threshold is never a judgement call.
 const MAX_EDGE_DELTA = 3
-// The window inboard of the edge has to actually hold blurred text, or these
-// tests would pass just as happily on an empty box. Measured deltas run 14–22.
-const MIN_INTERIOR_DELTA = 8
+// What counts as a column carrying ink rather than bare background. The window
+// inboard of an edge has to clear this, or these tests would pass just as
+// happily on an empty box. Measured deltas run 17–30.
+const MIN_INK_DELTA = 8
 // Where the page background is sampled, measured outboard from the spoiler's
 // edge. Far enough out to clear the fade, near enough to stay inside the
 // narrowest gutter the site has (18px, on a phone).
@@ -39,7 +40,7 @@ const EDGE_REACH_TOLERANCE = 2
 interface EdgeDeltas {
   /** How far the spoiler's outermost pixel column sits from the page background. */
   readonly edge: number
-  /** How far a column well inside the spoiler sits from the page background. */
+  /** How far the strongest column inboard of the edge sits from that background. */
   readonly interior: number
 }
 
@@ -74,12 +75,16 @@ async function lineBandNearest(
   edge: "left" | "right",
 ): Promise<{ y: number; height: number; reach: number }> {
   return spoiler.evaluate((el, which) => {
-    const paragraph = el.querySelector(".spoiler-content p")
-    if (!paragraph) throw new Error("Spoiler has no paragraph to measure")
+    // Ranging over each paragraph's *contents* yields one rect per line box.
+    // Ranging over the block instead would hand back the block's own border
+    // box, which spans every line and reaches the margin whatever the text does.
     const range = document.createRange()
-    range.selectNodeContents(paragraph)
-    const lines = Array.from(range.getClientRects()).filter((r) => r.width > 1 && r.height > 1)
-    if (lines.length === 0) throw new Error("Spoiler paragraph rendered no line boxes")
+    const lines: DOMRect[] = []
+    for (const paragraph of el.querySelectorAll(".spoiler-content p")) {
+      range.selectNodeContents(paragraph)
+      lines.push(...Array.from(range.getClientRects()).filter((r) => r.width > 1 && r.height > 1))
+    }
+    if (lines.length === 0) throw new Error("Spoiler rendered no line boxes")
     const best = lines.reduce((a, b) =>
       which === "right" ? (b.right > a.right ? b : a) : b.left < a.left ? b : a,
     )
@@ -176,7 +181,7 @@ async function expectEdgesDissolve(
   for (const edge of edges) {
     const deltas = await measureEdge(page, spoiler, edge)
     expect(deltas.interior, `${edge} edge: no blurred text inboard of the edge`).toBeGreaterThan(
-      MIN_INTERIOR_DELTA,
+      MIN_INK_DELTA,
     )
     expect(deltas.edge, `${edge} edge: blur is sheared off instead of dissolving`).toBeLessThan(
       MAX_EDGE_DELTA,
@@ -214,7 +219,7 @@ for (const theme of ["light", "dark"] as const) {
   })
 }
 
-test("Revealing a spoiler restores ink at its inline edges", async ({ page }) => {
+test("Revealing a spoiler restores ink at the margin", async ({ page }) => {
   const spoiler = page.locator("article .spoiler-container").first()
   await spoiler.scrollIntoViewIfNeeded()
   await spoiler.click()
@@ -223,7 +228,7 @@ test("Revealing a spoiler restores ink at its inline edges", async ({ page }) =>
   // Revealed text must be legible right up to the margin, so the fade that
   // conceals the blur's seam has to lift along with the blur itself.
   const { edge } = await measureEdge(page, spoiler, "left")
-  expect(edge, "revealed text is still faded at the margin").toBeGreaterThan(MIN_INTERIOR_DELTA)
+  expect(edge, "revealed text is still faded at the margin").toBeGreaterThan(MIN_INK_DELTA)
 })
 
 test("Search-preview spoilers dissolve at the column edge", async ({ page }) => {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -874,7 +874,15 @@ img.emoji {
     black calc(100% - min($spoiler-edge-fade, 25%)),
     transparent 100%
   );
-  mask-repeat: no-repeat;
+
+  // A mask clips its element's paint to the border box on every side, and the
+  // blur halo bleeds past that box above the first line and below the last, so
+  // the block axis needs both keywords: `no-clip` lifts the clip, and tiling the
+  // horizontal gradient down the block axis keeps the mask opaque out where the
+  // gradient's own box has ended — untiled, it would be transparent there and
+  // erase the halo the lifted clip just let through.
+  mask-clip: no-clip;
+  mask-repeat: repeat-y;
 
   // Safari needs this
   & > * {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -838,6 +838,11 @@ img.emoji {
   position: relative;
   cursor: pointer;
   width: fit-content;
+
+  // Contains the negative margin that pays for the content's standoff padding.
+  // Left to collapse out, that margin would escape to the block quote and drag
+  // the surrounding text with it instead of cancelling the padding.
+  display: flow-root;
 }
 
 .spoiler-overlay {
@@ -874,15 +879,27 @@ img.emoji {
     black calc(100% - min($spoiler-edge-fade, 25%)),
     transparent 100%
   );
+  mask-repeat: no-repeat;
 
-  // A mask clips its element's paint to the border box on every side, and the
-  // blur halo bleeds past that box above the first line and below the last, so
-  // the block axis needs both keywords: `no-clip` lifts the clip, and tiling the
-  // horizontal gradient down the block axis keeps the mask opaque out where the
-  // gradient's own box has ended — untiled, it would be transparent there and
-  // erase the halo the lifted clip just let through.
-  mask-clip: no-clip;
-  mask-repeat: repeat-y;
+  // That mask clips this element's paint to its border box on every side, not
+  // just the two the gradient fades, and the halo reaches past the box above
+  // the first line. Standing the box off from the text by the full fade puts
+  // that clip out where the halo has already died; the negative margin hands
+  // back the space the padding took, so the block occupies what it always did.
+  padding-block: $spoiler-edge-fade;
+  margin-block: calc(-1 * #{$spoiler-edge-fade});
+
+  // Padding stops the outermost paragraph margins collapsing out of the block,
+  // which would otherwise trap them and grow every spoiler. Outside a spoiler
+  // they escape to the block quote and merge with its own equal margin, so they
+  // are pure surplus here.
+  & > :first-child {
+    margin-top: 0;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
 
   // Safari needs this
   & > * {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -18,6 +18,13 @@ $page-end-bottom-margin: calc(3 * $base-margin);
 // one variable keeps the two from drifting apart.
 $footnote-blockquote-indent: 0.5 * $base-margin;
 
+// Blur applied to concealed spoiler text, and the distance over which the
+// blurred block dissolves at its inline edges. A Gaussian blur is spent by
+// three standard deviations, so fading over 3× the radius covers the whole
+// halo; deriving one from the other keeps them in step.
+$spoiler-blur-radius: 4px;
+$spoiler-edge-fade: 3 * $spoiler-blur-radius;
+
 body {
   min-height: 100vh;
 }
@@ -851,8 +858,23 @@ img.emoji {
 }
 
 .spoiler-content {
-  filter: blur(4px);
+  filter: blur($spoiler-blur-radius);
   opacity: 0.65;
+
+  // Every container a spoiler renders in — the article column, a popover, the
+  // search preview — clips along its inline axis, and a spoiler runs edge to
+  // edge inside all of them, so the blur halo has nowhere to spill. Dissolve
+  // the block into the page rather than let a clip shear the halo into a hard
+  // vertical seam. The percentage cap keeps a solid core in spoilers narrower
+  // than two fades.
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black min($spoiler-edge-fade, 25%),
+    black calc(100% - min($spoiler-edge-fade, 25%)),
+    transparent 100%
+  );
+  mask-repeat: no-repeat;
 
   // Safari needs this
   & > * {
@@ -870,6 +892,7 @@ img.emoji {
 .spoiler-container.revealed .spoiler-content {
   filter: blur(0);
   opacity: 1;
+  mask-image: none;
 }
 
 // Make sure the bullet points don't feel choked

--- a/quartz/styles/print.scss
+++ b/quartz/styles/print.scss
@@ -152,6 +152,10 @@
   .spoiler-content {
     filter: none !important;
     opacity: 1 !important;
+    mask-image: none !important;
+
+    /* stylelint-disable-next-line property-no-vendor-prefix -- needed for Safari print */
+    -webkit-mask-image: none !important;
   }
 
   // ── Elvish: show both Tengwar and translation ──────────────────

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -613,6 +613,8 @@ Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium dolor
 
 > ! A spoiler long enough to wrap runs the full width of the column, so its blur reaches both the left and the right margin and has to dissolve into the page at each of them.
 
+> ! Short spoiler, one line.
+
 # Arrows
 
 -> and --> should be EB Garamond, but ←, ↑, ↓, and ↗ should be Fira Code.

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -611,6 +611,8 @@ Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium dolor
 > ! Multiple lines can be hidden
 > ! Like this!
 
+> ! A spoiler long enough to wrap runs the full width of the column, so its blur reaches both the left and the right margin and has to dissolve into the page at each of them.
+
 # Arrows
 
 -> and --> should be EB Garamond, but ←, ↑, ↓, and ↗ should be Fira Code.


### PR DESCRIPTION
## Summary

- A concealed spoiler's blur halo was being sheared flush by whatever container it rendered in, leaving a hard vertical wall of half-blurred text at the margin. Most visible on a phone, where the column runs to the gutter.
- The halo now fades out at the spoiler's own inline edges, so the block dissolves into the page instead of ending on a seam.
- Fixing the inline edges with a mask introduced a *second*, horizontal seam along the top, because a mask clips paint on every side. That is fixed too, in a way that holds in every engine.

## Root cause: the inline seam

`filter: blur()` paints past the box that casts it, but every container a spoiler renders in clips along the inline axis, and a spoiler runs edge to edge inside all of them:

| container | clip |
| --- | --- |
| `#center-content` | `overflow-x: hidden` |
| `.popover-inner` | `overflow: auto` |
| `#preview-container` | `overflow: hidden` / `auto` |

In every case the clip edge sits exactly on the column edge the spoiler text runs to, so the halo has nowhere to spill and gets cut mid-gradient. Measured at the seam, the sheared edge sat 8–12 luminance levels (of 255) off the page background in all three containers — a visible line.

Widening a container's clip was the other option and was tried first; on a phone it pushed the document's scroll width past the viewport, so it is out. Keeping the effect inside the element also matches the existing precedent for this clip (`:focus-visible` uses `outline-offset: -2px` so outlines can't be clipped either).

## Root cause: the block seam the mask itself caused

`mask-clip` defaults to `border-box`, so masking the element to fade its inline edges *also* clipped its paint at the top. The content box's top edge sat ~3px above the first line, inside the 4px halo, so the blur was cut into a hard horizontal seam there — a new defect, one axis over from the one being fixed. (The bottom was never at risk: descender space and half-leading put that edge 4–5.6px below the last line, further than the halo carries.)

`mask-clip: no-clip` (plus `mask-repeat: repeat-y`, needed because outside the gradient's own box an untiled mask is transparent and erases exactly what `no-clip` exposes) fixes it in Chromium — and does nothing in WebKit, which parses the keyword and reports it computed but still clips to the border box. That shipped in an earlier commit here and Safari CI caught it.

The fix that holds everywhere needs no keyword an engine might decline: **stand the box off from the text.** `padding-block: $spoiler-edge-fade` puts the border-box clip out where the halo has already died, and a matching negative margin hands the space back. Two consequences handled:

- Padding stops the outermost paragraph margins collapsing out of the block, which would trap them and grow every spoiler by 36–48px. Those margins are dropped: outside a spoiler they escape to the block quote and merge with its own equal margin (`blockquote` has no block padding or border), so they contribute nothing.
- The negative margin would itself collapse out and drag the surrounding text rather than cancel the padding, so `.spoiler-container` gets `display: flow-root` to contain it.

Measured against a build with the standoff removed, every spoiler box, every heading position, the document height and the scroll width match exactly on both mobile and desktop.

Verified in both engines on a reduced case — halo above the text, and ink left at the inline edge:

| variant | chromium halo | webkit halo | chromium edge | webkit edge |
| --- | --- | --- | --- | --- |
| unmasked (target) | 2.72 | 2.99 | 17.63 | 15.38 |
| mask, no standoff | 0.00 | 0.00 | 0.95 | 0.75 |
| `mask-clip: no-clip` | 2.72 | **0.00** | 0.95 | 0.75 |
| `mask-clip: margin-box` | 0.00 | 0.00 | 0.95 | 0.75 |
| **standoff padding** | **2.72** | **3.44** | **0.95** | **0.75** |

Masking the child instead of the parent was also measured and rejected: blurring after masking softens the fade back in, leaving 4.45 / 4.90 of ink at the inline edge against 0.95 / 0.75.

## Changes

- `quartz/styles/custom.scss`: mask `.spoiler-content` with a horizontal gradient that fades over `3 * $spoiler-blur-radius` at each inline edge — three standard deviations, so the whole halo is covered. Blur radius and fade distance are derived from one variable so they can't drift. A `min(…, 25%)` cap keeps a solid core in spoilers narrower than two fades. Block-axis standoff padding plus its cancelling negative margin, the outermost paragraph margins dropped, and `display: flow-root` on the container to contain the negative margin.
- Revealing a spoiler drops the mask along with the blur, so revealed text is legible right up to the margin.
- `quartz/styles/print.scss`: printing lifts the mask too, alongside the existing blur/opacity reset.
- `quartz/components/tests/spoilerBlurEdge.spec.ts`: new pixel-level spec, covering both axes.
- `website_content/test-page.md`: two more spoilers — one long enough to wrap and fill the column, one short enough to be a single line. Between them the fixture covers a spoiler stretched to the column and one sized to its own text.
- `config/javascript/eslint.config.js`: register the new spec's assertion helper with `playwright/expect-expect`, mirroring how the jest config already registers `expectRevealed`.

## Testing

The spec screenshots bands around a spoiler's edges, decodes them with `sharp`, and measures pixels. Geometry alone can't see either bug — the boxes are identical whether a halo fades or is sheared.

**Inline edges.** Compare the spoiler's outermost pixel column against the page background just outboard of it. Coverage: article (both margins, light and dark), popover, and search preview, plus a reveal case asserting the fade lifts. Which spoilers touch the *right* margin isn't fixed — text is ragged-right, and engines size `fit-content` differently around the `<br>`s a multi-line spoiler carries — so the article sweep asks each spoiler which margins its text reaches, probes those, and then asserts at least one reached the right margin, so that coverage can't quietly disappear.

**Block edge.** Stated about the text rather than the box, since the fix deliberately moves the box: the blur must still mark the page at least 5px above the first line. Rows above the line are differenced against one 18px higher, column by column, and ranked; the top-decile column decides whether a row is marked. Differencing against a nearby row keeps whatever the page paints behind the spoiler out of the measurement, and ranking columns rather than averaging them separates a halo (which tracks the glyphs casting it, so it is horizontally textured) from smooth contamination like a background gradient or the overlay's own 16px `text-shadow`. Swept across mobile and desktop in both themes, a clipped edge stops at 2–4px and an intact one carries 6–11px. Spoilers stacked directly on one another paint into each other's probes, so a spoiler only counts when the page above it is bare, and the test asserts at least one was.

Verified every part of the spec catches its bug by running against un-fixed CSS:

- mask disabled → the article, popover, and search-preview tests fail with edge deltas of 9.8–11.9 against a threshold of 3; with the fix they measure 0.35–1.18.
- `mask-clip` reverted to `border-box` (before the approach changed) → all four article tests fail on both viewports and both themes.
- standoff removed → all four article tests fail, measuring reach 3–4 against a required 5.

## Lessons learned

- **What**: A `mask-image` clips its element's paint to the border box on *every* side, not just the axis the gradient runs along. Reach for masking to fade one axis and you silently clip the other.
- **Where**: any `mask-image` used to soften an edge, especially on an element carrying `filter: blur()` or `box-shadow`.
- **Why**: Masking the inline edges fixed the reported seam and created a new one along the top, where the box sat closer to the first line than the blur radius. Fixing it by enlarging the element's own box is portable; fixing it with `mask-clip: no-clip` is not.

- **What**: A CSS keyword that `CSS.supports()` accepts, and that `getComputedStyle` reads back verbatim, can still do nothing when the engine paints.
- **Where**: any feature-detected CSS, and any cross-engine CSS fix.
- **Why**: WebKit reports `mask-clip: no-clip` as supported and computed, and clips to the border box anyway. Both the `@supports` guard and the computed-style check would have said the fix was live. Only a pixel measurement in the target engine showed otherwise — so prefer a mechanism every engine must honour (box geometry) over a keyword one might merely parse.

- **What**: When a fix trades layout for paint — padding cancelled by a negative margin — verify layout neutrality by fingerprinting the whole page, not the element.
- **Where**: any padding/negative-margin pair, or anything touching margin collapsing.
- **Why**: The first attempt grew every spoiler by 60–72px because padding trapped child margins that had been collapsing out; the second leaked the negative margin out by collapsing and shifted every heading below by 24px. Comparing document height, scroll width, every spoiler box and every heading position against a build with the change reverted caught both immediately.

- **What**: A fix that closes one edge of an effect can open another. After shipping, re-measure the edges you did not touch.
- **Where**: any fix to a clipped/faded visual effect.
- **Why**: The inline fix shipped with a spec that probed only inline edges, so the top seam it introduced passed CI and was caught by the user instead. Coverage that follows the reported symptom rather than the property being changed leaves the adjacent case untested.

- **What**: Anchor a visual assertion to the thing the user sees, not to a box the fix is free to move.
- **Where**: any pixel test measuring an effect around an element.
- **Why**: The block-edge assertion was first written against `.spoiler-content`'s border box, and the very fix that made the halo whole moved that box, so a correct build measured zero. Re-anchoring on the first line of text — which does not move — made the same assertion survive a change of approach.

- **What**: When a CSS effect is clipped by an ancestor, contain the effect inside its own element rather than loosening the ancestor's clip.
- **Where**: `quartz/styles/custom.scss`, and any similar "the effect gets cut off" fix.
- **Why**: Widening `#center-content`'s clip box with a padding/negative-margin pair looked equivalent and rendered perfectly on desktop, but grew the document's scroll width past the viewport on a phone — caught only by diffing full-page screenshot dimensions before/after, not by looking at the element itself.

- **What**: Before trusting a new rendering test, run it once against the un-fixed code and confirm it fails.
- **Where**: any pixel-measurement spec.
- **Why**: Two drafts of this spec passed on a broken build — one because the probe band fell outside the captured image and silently clamped to a uniform background, another because ragged-right wrapping left the sampled line short of the margin, so the probe measured blank page. Both looked green. A test that samples the wrong pixels is indistinguishable from a passing one unless the negative case is checked.

- **What**: When a pixel probe depends on an assumption about layout, assert the assumption in the probe rather than encoding it in the test's structure.
- **Where**: `spoilerBlurEdge.spec.ts`'s reach and bare-page guards.
- **Why**: The spec assumed a spoiler sized by `fit-content` ends exactly where its longest line ends. That holds in Chromium but not WebKit, where a multi-line spoiler's box ran 102.8px past its text. Because the probe checked and threw, Safari CI named the wrong assumption outright instead of silently measuring an empty margin and passing.

- **What**: `Range.getClientRects()` over a block element returns that element's own border box alongside the line boxes; range each paragraph's *contents* when you want line boxes.
- **Where**: any test that measures rendered text lines.
- **Why**: The block's box spans every line and reaches the container's margin whatever the text does, so it won a "line nearest the right edge" search and the probe sampled a mostly-blank band.

- **What**: Pick a pixel metric by sweeping candidates against known-broken and known-fixed builds, not by intuition.
- **Where**: any visual assertion that needs a numeric threshold.
- **Why**: Three plausible metrics for the same seam gave separations of 1.2×, 2.1×, and 3.1×. Choosing the first one that "looked right" would have shipped a threshold with no margin, which flakes as soon as a font or viewport changes.
