### PR TITLE
fix(tests): remove two Playwright flakes blocking main deploys

### DIFF
--- a/quartz/components/tests/search.spec.ts
+++ b/quartz/components/tests/search.spec.ts
@@ -85,9 +85,12 @@ async function clickPreviewToNavigate(page: Page): Promise<void> {
   }
 }
 
-test.afterEach(async ({ page }) => {
+test.afterEach(async ({ page, browserName }) => {
   // Navigate away to flush pending network/script activity, preventing
-  // WebKit from hanging during browserContext.close() teardown.
+  // WebKit from hanging during browserContext.close() teardown. Only WebKit
+  // needs the flush, and Firefox aborts the navigation (NS_BINDING_ABORTED)
+  // when it cancels those same in-flight loads, so scope it to WebKit.
+  if (browserName !== "webkit") return
   await page.goto("about:blank")
 })
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -1102,10 +1102,15 @@ test.describe("Right sidebar", () => {
       ol.innerHTML = Array.from({ length: 40 }, () => "<li><a>Test heading</a></li>").join("")
     })
 
-    // Scroll halfway through the (now-overflowing) sidebar so both fades show.
-    await rightSidebar.evaluate((el) => {
-      el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2)
-    })
+    // Scroll by a fixed offset: the capture must be identical run to run, and
+    // sidebar content keeps settling (late-loading images, font swaps) after
+    // any geometry measurement, so a target derived from `scrollHeight` lands
+    // a few pixels apart between runs. 40 synthetic entries overflow well past
+    // this offset, so both fades stay active — asserted below.
+    const scrollOffsetPx = 200
+    await rightSidebar.evaluate((el, offset) => {
+      el.scrollTop = offset
+    }, scrollOffsetPx)
     await expect(rightSidebar).toHaveClass(/can-scroll-up/)
     await expect(rightSidebar).toHaveClass(/can-scroll-down/)
 


### PR DESCRIPTION
## Summary

- The last two pushes to `main` each went red on a **single test that failed once and passed on retry**, and `visual-testing` gates `deploy.yaml`'s `verify-test-results` — so the Cloudflare deploy was skipped both times. Neither red was a stale baseline.
- Both flakes are in our own test code, so this fixes the tests rather than loosening the gate.

## Changes

**Right sidebar fade at mid-scroll (screenshot)** — the test derived its scroll target from live geometry (`Math.floor((scrollHeight - clientHeight) / 2)`), which is measured *before* `takeRegressionScreenshot` waits on fonts and images. Sidebar content that settles after that measurement moves the target. Comparing the run-30741060930 artifacts, the captured PNG is a pure **4-pixel vertical shift** of the approved baseline (mean abs residual 0.03 at +4px vs. 6.10 at 0), with no other difference. Replaced the derived target with a fixed 200px offset; the existing `can-scroll-up` / `can-scroll-down` assertions still prove both fades are active.

**`search.spec.ts` teardown** — `test.afterEach` navigates to `about:blank` to stop WebKit hanging during `browserContext.close()`, but it ran on every project. Firefox aborts that navigation with `NS_BINDING_ABORTED` when it cancels the same in-flight loads, which is what killed `playwright-tests-linux (8/8)` on `[iPhone 12 Firefox]`. Scoped the flush to WebKit.

## Testing

- `tsc --noEmit`, eslint, and prettier pass on both files.
- Full Playwright + visual suites run on this PR.
- The sidebar screenshot's scroll offset changes, so that one baseline will show a diff for review.

## Lessons Learned

- **What**: When a visual-regression test needs a scrolled or otherwise positioned element, set an explicit constant rather than computing the position from live geometry.
- **Where**: `quartz/components/tests/visual-regression.spec.ts`, and the testing-rules section of `CLAUDE.md`.
- **Why**: Geometry read before the harness waits on fonts/images is pre-settlement, so the same test lands a few pixels apart between runs. That reads as a snapshot diff, and because `classify_visual_failures.py` counts a retry-passed snapshot mismatch as a diff, one flaky pixel offset turns `visual-testing` red and blocks the production deploy.

- **What**: Scope browser-specific test workarounds with `browserName` instead of applying them to every project.
- **Where**: `quartz/components/tests/search.spec.ts`.
- **Why**: A teardown navigation added for one engine became a flake source in another; the fix for one browser is often a hazard in the next.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nbv6N62qVGVPVDAaN9ziz)_