### PR TITLE
fix: exit the invert labeler once every asset is reviewed

### DIFF
--- a/scripts/label_invert.py
+++ b/scripts/label_invert.py
@@ -12,6 +12,9 @@ Two ways to populate ``.invert_labels.json``:
    luminance, caches it to ``.invert_luminance.json``, and auto-labels
    every unlabeled asset with ``reviewed=false`` (luminance >= 0.7
    gets ``invert=true``, otherwise ``invert=false``).
+   Under ``--check-and-launch`` (the pre-push entry point) the server
+   stops itself as soon as the last candidate has a reviewed verdict,
+   so the hook proceeds without the user hunting for the terminal.
 
 2. Non-interactive: ``uv run scripts/label_invert.py --apply-annotations``
    Walks ``website_content/*.md`` for asset references followed by
@@ -46,6 +49,7 @@ import numpy as np
 import requests
 from flask import Flask, Response, abort, jsonify, render_template, request
 from PIL import Image
+from werkzeug.serving import BaseWSGIServer, make_server
 
 # Support `uv run python scripts/label_invert.py`: when Python is given
 # a script path, sys.path[0] is `scripts/`, not the project root, so
@@ -185,6 +189,19 @@ def mark_reviewed(labels: dict[str, Label], url: str) -> bool:
         return False
     labels[url] = Label(invert=labels[url]["invert"], reviewed=True)
     return True
+
+
+def find_unreviewed(
+    candidates: Iterable[str], labels: Mapping[str, Label]
+) -> tuple[str, ...]:
+    """
+    Return candidates that are absent from ``labels`` or have ``reviewed:
+
+    False`` — i.e. anything still requiring a human verdict.
+    """
+    return tuple(
+        u for u in candidates if u not in labels or not labels[u]["reviewed"]
+    )
 
 
 # --- markdown scanner --------------------------------------------------------
@@ -377,6 +394,8 @@ def _index_handler(
     candidates: tuple[str, ...],
     labels_path: Path,
     lum_map: Mapping[str, float],
+    *,
+    exits_when_complete: bool = False,
 ) -> Callable[[], str]:
     def index() -> str:
         labels = load_labels(labels_path)
@@ -403,13 +422,16 @@ def _index_handler(
             initial_filter=(
                 UNREVIEWED_FILTER if unreviewed_count else ALL_FILTER
             ),
+            exits_when_complete=exits_when_complete,
         )
 
     return index
 
 
 def _label_handler(
-    candidate_set: frozenset[str], labels_path: Path
+    candidate_set: frozenset[str],
+    labels_path: Path,
+    remaining: Callable[[], int],
 ) -> Callable[[], Response]:
     def post_label() -> Response:
         payload = request.get_json(silent=True) or {}
@@ -429,12 +451,14 @@ def _label_handler(
         labels = load_labels(labels_path)
         set_user_label(labels, url, _DECISION_PARAM[state])
         save_labels(labels, labels_path)
-        return jsonify(ok=True)
+        return jsonify(ok=True, remaining=remaining())
 
     return post_label
 
 
-def _review_handler(labels_path: Path) -> Callable[[], Response]:
+def _review_handler(
+    labels_path: Path, remaining: Callable[[], int]
+) -> Callable[[], Response]:
     def post_review() -> Response:
         """Bulk-mark URLs as user-reviewed (verdict unchanged)."""
         payload = request.get_json(silent=True) or {}
@@ -447,9 +471,30 @@ def _review_handler(labels_path: Path) -> Callable[[], Response]:
         reviewed_count = sum(1 for u in urls if mark_reviewed(labels, u))
         if reviewed_count:
             save_labels(labels, labels_path)
-        return jsonify(ok=True, reviewed=reviewed_count)
+        return jsonify(ok=True, reviewed=reviewed_count, remaining=remaining())
 
     return post_review
+
+
+def _remaining_counter(
+    candidates: tuple[str, ...],
+    labels_path: Path,
+    on_all_reviewed: Callable[[], None] | None,
+) -> Callable[[], int]:
+    """
+    Count still-unreviewed candidates, firing ``on_all_reviewed`` at zero.
+
+    Every label mutation ends with this count, so the last verdict the user
+    gives is what releases the caller waiting on the server.
+    """
+
+    def remaining() -> int:
+        count = len(find_unreviewed(candidates, load_labels(labels_path)))
+        if count == 0 and on_all_reviewed is not None:
+            on_all_reviewed()
+        return count
+
+    return remaining
 
 
 def create_app(
@@ -457,16 +502,27 @@ def create_app(
     *,
     labels_path: Path = LABELS_JSON,
     luminances: Mapping[str, float] | None = None,
+    on_all_reviewed: Callable[[], None] | None = None,
 ) -> Flask:
     """Build the labeling Flask app."""
     app = Flask(__name__, template_folder="templates")
     candidate_set = frozenset(candidates)
     lum_map: Mapping[str, float] = luminances or {}
+    remaining = _remaining_counter(candidates, labels_path, on_all_reviewed)
 
-    app.get("/")(_index_handler(candidates, labels_path, lum_map))
+    app.get("/")(
+        _index_handler(
+            candidates,
+            labels_path,
+            lum_map,
+            exits_when_complete=on_all_reviewed is not None,
+        )
+    )
     app.get("/api/labels")(lambda: jsonify(load_labels(labels_path)))
-    app.post("/api/label")(_label_handler(candidate_set, labels_path))
-    app.post("/api/review")(_review_handler(labels_path))
+    app.post("/api/label")(
+        _label_handler(candidate_set, labels_path, remaining)
+    )
+    app.post("/api/review")(_review_handler(labels_path, remaining))
 
     return app
 
@@ -479,7 +535,32 @@ def open_browser_async(url: str) -> None:
     threading.Thread(target=webbrowser.open, args=(url,), daemon=True).start()
 
 
-def _run_server(args: argparse.Namespace) -> int:
+class DeferredShutdown:
+    """
+    Stops a running server from inside one of its own request handlers.
+
+    ``shutdown()`` blocks until the serving loop drains, so it runs on a
+    separate thread: the handler returns immediately and the browser still
+    receives the response that triggered the shutdown.
+    """
+
+    def __init__(self) -> None:
+        self._server: BaseWSGIServer | None = None
+
+    def bind(self, server: BaseWSGIServer) -> None:
+        """Attach the server this handle stops."""
+        self._server = server
+
+    def request_shutdown(self) -> None:
+        """Ask the bound server to stop serving."""
+        if self._server is None:
+            raise RuntimeError("DeferredShutdown.bind() was never called")
+        threading.Thread(target=self._server.shutdown, daemon=True).start()
+
+
+def _run_server(
+    args: argparse.Namespace, *, exit_when_complete: bool = False
+) -> int:
     dims = json.loads(args.dimensions.read_text(encoding="utf-8"))
     candidates = enumerate_candidates(dims)
     if not candidates:
@@ -510,26 +591,27 @@ def _run_server(args: argparse.Namespace) -> int:
                 len(new) - inverts,
             )
 
-    url = f"http://{args.host}:{args.port}/"
+    shutdown = DeferredShutdown()
+    app = create_app(
+        candidates,
+        labels_path=args.labels,
+        luminances=luminances,
+        on_all_reviewed=(
+            shutdown.request_shutdown if exit_when_complete else None
+        ),
+    )
+    server = make_server(args.host, args.port, app)
+    shutdown.bind(server)
+
+    url = f"http://{args.host}:{server.port}/"
     logger.info("Labeling %d candidates. Open %s", len(candidates), url)
     if not args.no_browser:
         open_browser_async(url)
-    app = create_app(candidates, labels_path=args.labels, luminances=luminances)
-    app.run(host=args.host, port=args.port, debug=False, use_reloader=False)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
     return 0
-
-
-def find_unreviewed(
-    candidates: Iterable[str], labels: Mapping[str, Label]
-) -> tuple[str, ...]:
-    """
-    Return candidates that are absent from ``labels`` or have ``reviewed:
-
-    False`` — i.e. anything still requiring a human verdict.
-    """
-    return tuple(
-        u for u in candidates if u not in labels or not labels[u]["reviewed"]
-    )
 
 
 def _run_check_and_launch(args: argparse.Namespace) -> int:
@@ -551,7 +633,7 @@ def _run_check_and_launch(args: argparse.Namespace) -> int:
     )
     for url in missing:
         logger.info("  needs review: %s", url)
-    return _run_server(args)
+    return _run_server(args, exit_when_complete=True)
 
 
 def _run_apply_annotations(args: argparse.Namespace) -> int:

--- a/scripts/templates/invert_labeler.html
+++ b/scripts/templates/invert_labeler.html
@@ -16,6 +16,9 @@
                       border: 1px solid #2563eb; background: #2563eb; color: #fff;
                       cursor: pointer; }
       header button:disabled { opacity: 0.5; cursor: not-allowed; }
+      #done-banner { position: sticky; top: 3.25rem; z-index: 9; margin: 0;
+                     padding: 0.75rem 1rem; background: #dcfce7; color: #14532d;
+                     border-bottom: 1px solid #86efac; font-weight: 600; }
       main { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
              gap: 1rem; padding: 1rem; }
       .card { background: #fff; border: 2px solid #ddd; border-radius: 6px;
@@ -60,6 +63,10 @@
       </select>
       <button id="confirm-visible" type="button">Confirm visible as reviewed</button>
     </header>
+    <div id="done-banner" hidden data-exits-when-complete="{{ 'true' if exits_when_complete else 'false' }}">
+      All candidates reviewed — the labeler has shut down and your push is
+      continuing. You can close this tab.
+    </div>
     <main>
       {%- for url in candidates -%}
         {%- set entry = labels.get(url) -%}
@@ -121,6 +128,14 @@
         const u = document.querySelectorAll('.card[data-reviewed="false"]').length;
         counter.textContent = `${n} / ${total} invert · ${u} unreviewed`;
       };
+      const doneBanner = document.getElementById("done-banner");
+      // The server stops itself once nothing is left to review, so the banner
+      // is the page's only remaining signal that the work is finished.
+      const announceIfDone = (data) => {
+        if (data.remaining === 0 && doneBanner.dataset.exitsWhenComplete === "true") {
+          doneBanner.hidden = false;
+        }
+      };
       const cardMatchesFilter = (card, mode) => {
         if (mode === "all") return true;
         if (mode === "unreviewed") return card.dataset.reviewed === "false";
@@ -157,7 +172,9 @@
             if (prevRadio) prevRadio.checked = true;
             recount();
             alert(`Save failed: ${r.status}`);
+            return;
           }
+          announceIfDone(await r.json());
         });
       });
       const filterSelect = document.getElementById("filter");
@@ -198,6 +215,7 @@
           if (!r.ok) throw new Error(`HTTP ${r.status}`);
           visible.forEach((c) => (c.dataset.reviewed = "true"));
           recount();
+          announceIfDone(await r.json());
         } catch (err) {
           alert(`Bulk review failed: ${err.message}`);
         } finally {

--- a/scripts/tests/test_label_invert.py
+++ b/scripts/tests/test_label_invert.py
@@ -500,7 +500,8 @@ def test_check_and_launch_server_stops_itself(
     assert rc == 0
 
     apps[0].config["TESTING"] = True
-    resp = apps[0].test_client().post(
+    test_client = apps[0].test_client()
+    resp = test_client.post(
         "/api/label", json={"url": EXPECTED[0], "state": "invert"}
     )
     assert resp.get_json() == {"ok": True, "remaining": 0}

--- a/scripts/tests/test_label_invert.py
+++ b/scripts/tests/test_label_invert.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import threading
 from collections.abc import Callable, Mapping
 from pathlib import Path
 
@@ -30,6 +31,37 @@ def _label(invert: bool, reviewed: bool = True) -> label_invert.Label:
     return {"invert": invert, "reviewed": reviewed}
 
 
+class _FakeServer:
+    """Stands in for the werkzeug server so tests never bind a socket."""
+
+    def __init__(self, port: int) -> None:
+        self.port = port
+        self.served = False
+        self.closed = False
+        self.shutdown_called = threading.Event()
+
+    def serve_forever(self) -> None:
+        self.served = True
+
+    def server_close(self) -> None:
+        self.closed = True
+
+    def shutdown(self) -> None:
+        self.shutdown_called.set()
+
+
+def _patch_make_server(monkeypatch: pytest.MonkeyPatch) -> list[_FakeServer]:
+    """Replace ``make_server`` with a socket-free fake; return the instances."""
+    servers: list[_FakeServer] = []
+
+    def fake_make_server(_host: str, port: int, _app: object) -> _FakeServer:
+        servers.append(_FakeServer(port))
+        return servers[-1]
+
+    monkeypatch.setattr(label_invert, "make_server", fake_make_server)
+    return servers
+
+
 DIMS = {
     "https://assets.turntrout.com/static/images/posts/a.avif": {},
     "https://assets.turntrout.com/static/images/posts/b.png": {},
@@ -41,6 +73,7 @@ DIMS = {
     "https://assets.turntrout.com/static/images/twemoji/y.png": {},
     "https://assets.turntrout.com/static/images/card_images/z.jpg": {},
     "../asset_staging/local.avif": {},  # not http(s)
+    "https://assets.turntrout.com/static/paper.pdf": {},  # not labelable
 }
 EXPECTED = (
     "https://assets.turntrout.com/static/images/posts/a.avif",
@@ -358,11 +391,120 @@ def test_post_review_marks_existing_unreviewed(
     assert resp.status_code == 200
     # Only EXPECTED[0] needed promotion; the others were either already
     # reviewed (EXPECTED[1]) or not labeled at all (EXPECTED[2]).
-    assert resp.get_json() == {"ok": True, "reviewed": 1}
+    # 4 of the 6 candidates are still unlabeled, hence still unreviewed.
+    assert resp.get_json() == {"ok": True, "reviewed": 1, "remaining": 4}
     assert json.loads(labels_path.read_text(encoding="utf-8")) == {
         EXPECTED[0]: {"invert": True, "reviewed": True},
         EXPECTED[1]: {"invert": False, "reviewed": True},
     }
+
+
+# --- completion + shutdown ---------------------------------------------------
+
+
+def _completion_app(
+    tmp_path: Path, candidates: tuple[str, ...]
+) -> tuple[FlaskClient, list[int]]:
+    """A client whose app records every ``on_all_reviewed`` firing."""
+    fired: list[int] = []
+    app = label_invert.create_app(
+        candidates,
+        labels_path=tmp_path / "labels.json",
+        on_all_reviewed=lambda: fired.append(1),
+    )
+    app.config["TESTING"] = True
+    return app.test_client(), fired
+
+
+def test_post_label_fires_on_all_reviewed_only_when_done(
+    tmp_path: Path,
+) -> None:
+    test_client, fired = _completion_app(tmp_path, EXPECTED[:2])
+    first = test_client.post(
+        "/api/label", json={"url": EXPECTED[0], "state": "invert"}
+    )
+    assert first.get_json() == {"ok": True, "remaining": 1}
+    assert fired == []
+    second = test_client.post(
+        "/api/label", json={"url": EXPECTED[1], "state": "no-invert"}
+    )
+    assert second.get_json() == {"ok": True, "remaining": 0}
+    assert fired == [1]
+
+
+def test_post_review_fires_on_all_reviewed(tmp_path: Path) -> None:
+    labels_path = tmp_path / "labels.json"
+    label_invert.save_labels(
+        {url: _label(True, False) for url in EXPECTED[:2]}, labels_path
+    )
+    test_client, fired = _completion_app(tmp_path, EXPECTED[:2])
+    resp = test_client.post("/api/review", json={"urls": list(EXPECTED[:2])})
+    assert resp.get_json() == {"ok": True, "reviewed": 2, "remaining": 0}
+    assert fired == [1]
+
+
+@pytest.mark.parametrize("exits_when_complete", [True, False])
+def test_index_exposes_shutdown_flag(
+    tmp_path: Path, exits_when_complete: bool
+) -> None:
+    app = label_invert.create_app(
+        EXPECTED[:1],
+        labels_path=tmp_path / "labels.json",
+        on_all_reviewed=(lambda: None) if exits_when_complete else None,
+    )
+    app.config["TESTING"] = True
+    body = app.test_client().get("/").get_data(as_text=True)
+    flag = "true" if exits_when_complete else "false"
+    assert f'data-exits-when-complete="{flag}"' in body
+
+
+def test_deferred_shutdown_stops_bound_server() -> None:
+    handle = label_invert.DeferredShutdown()
+    server = _FakeServer(port=0)
+    handle.bind(server)  # type: ignore[arg-type]
+    handle.request_shutdown()
+    assert server.shutdown_called.wait(timeout=5)
+
+
+def test_deferred_shutdown_requires_bind() -> None:
+    with pytest.raises(RuntimeError, match="bind"):
+        label_invert.DeferredShutdown().request_shutdown()
+
+
+def test_check_and_launch_server_stops_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-push entry point wires the shutdown into the last verdict."""
+    dims = _write_dims(tmp_path, {EXPECTED[0]: {}})
+    labels_path = tmp_path / "labels.json"
+    servers = _patch_make_server(monkeypatch)
+    apps: list[label_invert.Flask] = []
+    real_create_app = label_invert.create_app
+    monkeypatch.setattr(
+        label_invert,
+        "create_app",
+        lambda *a, **kw: apps.append(real_create_app(*a, **kw)) or apps[-1],
+    )
+
+    rc = label_invert.main(
+        [
+            "--check-and-launch",
+            "--dimensions",
+            str(dims),
+            "--labels",
+            str(labels_path),
+            "--no-browser",
+            "--skip-luminance",
+        ]
+    )
+    assert rc == 0
+
+    apps[0].config["TESTING"] = True
+    resp = apps[0].test_client().post(
+        "/api/label", json={"url": EXPECTED[0], "state": "invert"}
+    )
+    assert resp.get_json() == {"ok": True, "remaining": 0}
+    assert servers[0].shutdown_called.wait(timeout=5)
 
 
 @pytest.mark.parametrize(
@@ -430,14 +572,9 @@ def test_main_serves_app(
     no_browser: bool,
 ) -> None:
     dims = _write_dims(tmp_path, {EXPECTED[0]: {}})
-    captured: dict[str, object] = {"ran": False}
+    servers = _patch_make_server(monkeypatch)
     opened: list[str] = []
 
-    monkeypatch.setattr(
-        label_invert.Flask,
-        "run",
-        lambda _self, **kwargs: captured.update(ran=True, kwargs=kwargs),
-    )
     monkeypatch.setattr(
         label_invert,
         "open_browser_async",
@@ -455,7 +592,8 @@ def test_main_serves_app(
     if no_browser:
         argv.append("--no-browser")
     assert label_invert.main(argv) == 0
-    assert captured["ran"] is True
+    assert servers[0].served is True
+    assert servers[0].closed is True
     assert opened == ([] if no_browser else ["http://127.0.0.1:0/"])
 
 
@@ -527,12 +665,7 @@ def test_main_check_and_launch(
     labels_path = tmp_path / "labels.json"
     if labels:
         labels_path.write_text(json.dumps(labels), encoding="utf-8")
-    ran = {"flask": False}
-    monkeypatch.setattr(
-        label_invert.Flask,
-        "run",
-        lambda _self, **_kwargs: ran.update(flask=True),
-    )
+    servers = _patch_make_server(monkeypatch)
     monkeypatch.setattr(label_invert, "open_browser_async", lambda _u: None)
     monkeypatch.setattr(
         label_invert, "ensure_luminances", lambda *_a, **_kw: {}
@@ -552,7 +685,7 @@ def test_main_check_and_launch(
         ]
     )
     assert rc == 0
-    assert ran["flask"] is expect_server
+    assert bool(servers) is expect_server
 
 
 def test_check_and_launch_logs_each_unreviewed_url(
@@ -566,9 +699,7 @@ def test_check_and_launch_logs_each_unreviewed_url(
         json.dumps({u: _label(True, True) for u in EXPECTED[:-1]}),
         encoding="utf-8",
     )
-    monkeypatch.setattr(
-        label_invert.Flask, "run", lambda _self, **_kwargs: None
-    )
+    _patch_make_server(monkeypatch)
     monkeypatch.setattr(label_invert, "open_browser_async", lambda _u: None)
 
     with caplog.at_level(logging.INFO, logger=label_invert.__name__):
@@ -848,7 +979,7 @@ def test_main_runs_luminance_and_autolabel(
         return _solid_png((255, 255, 255) if "a.avif" in url else (10, 10, 10))
 
     monkeypatch.setattr(label_invert, "_default_fetch", fake_fetch)
-    monkeypatch.setattr(label_invert.Flask, "run", lambda *_a, **_k: None)
+    _patch_make_server(monkeypatch)
     monkeypatch.setattr(label_invert, "open_browser_async", lambda _u: None)
 
     rc = label_invert.main(
@@ -895,7 +1026,7 @@ def test_main_skip_luminance(
         "ensure_luminances",
         lambda *a, **kw: called.append("called") or {},
     )
-    monkeypatch.setattr(label_invert.Flask, "run", lambda *_a, **_k: None)
+    _patch_make_server(monkeypatch)
     monkeypatch.setattr(label_invert, "open_browser_async", lambda _u: None)
 
     rc = label_invert.main(


### PR DESCRIPTION
## Summary

- The pre-push "Labeling images for dark-mode inversion" step served the Flask grid forever. Giving the last verdict in the browser left the terminal spinning, so the push only continued after the user hunted down the terminal and hit Ctrl-C.
- The server now stops itself the moment no candidate needs review, and the page says so.

## Changes

- `scripts/label_invert.py`: serve through `werkzeug.serving.make_server` instead of `app.run`, so a request handler can stop the serving loop. `DeferredShutdown` does the stop on a worker thread, letting the triggering response flush first.
- `/api/label` and `/api/review` now report `remaining` (unreviewed candidate count) and fire an `on_all_reviewed` callback at zero. `--check-and-launch` wires that callback to the shutdown; plain `uv run scripts/label_invert.py` passes `None` and keeps serving, so manual browsing/relabeling sessions are unaffected.
- The logged URL uses the socket's actual port, so `--port 0` prints something usable.
- `scripts/templates/invert_labeler.html`: a green "all candidates reviewed — you can close this tab" banner, shown when a mutation returns `remaining: 0` and the server is in self-exiting mode.

## Testing

- `uv run pytest scripts/tests/test_label_invert.py` — 89 passing, 100% line coverage of `scripts/label_invert.py`. Tests replace `make_server` with a socket-free fake, and cover the completion callback firing only at zero remaining, both endpoints' `remaining` field, `DeferredShutdown` bind/stop plus its unbound `RuntimeError`, and the template flag in both modes.
- End-to-end smoke run: launched `--check-and-launch` against a two-asset dimensions file, POSTed both verdicts, and confirmed the second response returned `remaining: 0`, the socket closed, and the process exited 0.
- `pylint` 10.00/10, `pyright` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFtq7CbigQfRXs27o7fPoo)_