### PR TITLE
fix: check that srcset URLs resolve

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -42,6 +42,12 @@ Three stages: **Transform → Filter → Emit**.
   assets already on R2: `uv run scripts/generate_inverted_variants.py
 --asset-directory ~/Downloads/website-media-r2`, then re-run `r2_upload`
   to push the new `-inverted` files.
+- The `-inverted` variants reach the browser only through
+  `<picture><source srcset>`, which **linkchecker never fetches**: its HTML5
+  tag table maps `<source>` to `src` alone (`srcset` is listed for `<img>`
+  only), so a missing variant 404s in dark mode with every link check green.
+  `built_site_checks.check_srcset_urls` covers that hole—it collects every
+  `srcset` URL site-wide and HEADs each unique one exactly once.
 - **Video captions**: `scripts/transcribe_videos.py` (run by
   `handle_assets.sh` after `convert_assets.py`, before `r2_upload.py`)
   transcribes every `.mp4` with a real, non-silent audio stream via a

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -16,10 +16,11 @@ import unicodedata
 import urllib.parse
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Literal, NamedTuple
+from typing import Final, Literal, NamedTuple
 from urllib.parse import urlparse
 
 import requests
@@ -3285,6 +3286,98 @@ def _maybe_collect_citation_keys(
         citation_to_files[key].append(rel_path)
 
 
+_SRCSET_TAGS: Final[tuple[str, ...]] = ("img", "source")
+_SRCSET_CHECK_WORKERS: Final[int] = 20
+
+
+def parse_srcset(srcset: str) -> list[str]:
+    """
+    URLs of every candidate in a ``srcset`` attribute.
+
+    Follows the HTML parsing algorithm closely enough that a comma inside a URL
+    (legal, and a candidate separator only when it terminates the URL token)
+    does not split the candidate: the URL runs to the first whitespace, and any
+    trailing commas there end the candidate.
+    """
+    urls: list[str] = []
+    pos, length = 0, len(srcset)
+    while pos < length:
+        while pos < length and (srcset[pos].isspace() or srcset[pos] == ","):
+            pos += 1
+        start = pos
+        while pos < length and not srcset[pos].isspace():
+            pos += 1
+        url = srcset[start:pos]
+        if not url.endswith(","):
+            # Skip the width/density descriptor trailing this candidate.
+            while pos < length and srcset[pos] != ",":
+                pos += 1
+        url = url.rstrip(",")
+        if url:
+            urls.append(url)
+    return urls
+
+
+def collect_srcset_urls(
+    soup: BeautifulSoup,
+    file_path: Path,
+    public_dir: Path,
+    srcset_to_files: dict[str, list[str]],
+) -> None:
+    """
+    Record every ``srcset`` URL and the pages referencing it.
+
+    ``srcset`` is the only place the dark-mode ``-inverted`` variants appear in
+    the HTML, and nothing else fetches them: the per-page media checks read
+    ``src``, and linkchecker's HTML5 tag table maps ``<source>`` to ``src``
+    alone. Collecting site-wide lets one HEAD per unique URL cover every page.
+    """
+    if script_utils.is_redirect(soup):
+        return
+
+    rel_path = str(file_path.relative_to(public_dir))
+    for tag in _tags_only(soup.find_all(_SRCSET_TAGS)):
+        srcset = tag.get("srcset")
+        if not isinstance(srcset, str):
+            continue
+        for url in parse_srcset(srcset):
+            srcset_to_files[url].append(rel_path)
+
+
+def _srcset_url_issue(url: str, public_dir: Path) -> str | None:
+    """Describe why ``url`` fails to resolve, or ``None`` when it resolves."""
+    if url.startswith(("http://", "https://")):
+        try:
+            response = _head_with_retry(url)
+        except requests.RequestException as exc:
+            return f"{url} failed to load: {exc}"
+        if response.ok:
+            return None
+        return f"{url} returned status {response.status_code}"
+
+    resolved = resolve_media_path(_CACHE_VERSION_RE.sub("", url), public_dir)
+    if resolved.is_file():
+        return None
+    return f"{url} (resolved to {resolved}) does not exist"
+
+
+def check_srcset_urls(
+    srcset_to_files: Mapping[str, list[str]], public_dir: Path
+) -> list[str]:
+    """Check that every collected ``srcset`` URL resolves."""
+    urls = list(srcset_to_files)
+    with ThreadPoolExecutor(max_workers=_SRCSET_CHECK_WORKERS) as executor:
+        results = executor.map(
+            lambda url: _srcset_url_issue(url, public_dir), urls
+        )
+        return [
+            f"<srcset> {issue} (referenced by "
+            f"{', '.join(sorted(set(srcset_to_files[url])))})"
+            for url, issue in zip(urls, results)
+            if issue is not None
+        ]
+
+
 def check_root_files_location(base_dir: Path) -> list[str]:
     """Check that required files exist in the root directory."""
     issues = []
@@ -3691,6 +3784,7 @@ def _process_html_files(  # pylint: disable=too-many-locals
     permalink_to_md_path_map = script_utils.build_html_to_md_map(content_dir)
     files_to_skip: set[str] = script_utils.collect_aliases(content_dir)
     citation_to_files: dict[str, list[str]] = defaultdict(list)
+    srcset_to_files: dict[str, list[str]] = defaultdict(list)
     paragraph_map: dict[str, list[str]] = {}
 
     included_domains = _build_included_favicon_domains(public_dir.parent)
@@ -3728,6 +3822,7 @@ def _process_html_files(  # pylint: disable=too-many-locals
             _maybe_collect_citation_keys(
                 soup, file_path, public_dir, citation_to_files
             )
+            collect_srcset_urls(soup, file_path, public_dir, srcset_to_files)
             _collect_paragraphs_for_spellcheck(
                 soup, file, file_path, public_dir, paragraph_map
             )
@@ -3736,6 +3831,11 @@ def _process_html_files(  # pylint: disable=too-many-locals
     citation_issues = _find_duplicate_citations(citation_to_files)
     if citation_issues:
         _print_issues(public_dir, {"duplicate_citations": citation_issues})
+        issues_found_in_html = True
+
+    srcset_issues = check_srcset_urls(srcset_to_files, public_dir)
+    if srcset_issues:
+        _print_issues(public_dir, {"unresolvable_srcset_urls": srcset_issues})
         issues_found_in_html = True
 
     # Spellcheck flattened paragraph text across all pages

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -8172,3 +8172,191 @@ def test_process_html_files_duplicate_citations(tmp_path: Path):
             public_dir, content_dir, check_fonts=False
         )
     assert result is True
+
+
+@pytest.mark.parametrize(
+    "srcset,expected",
+    [
+        ("", []),
+        ("   ", []),
+        ("/a.avif", ["/a.avif"]),
+        ("/a.avif 2x", ["/a.avif"]),
+        ("/a.avif 1x, /b.avif 2x", ["/a.avif", "/b.avif"]),
+        ("/a.avif, /b.avif", ["/a.avif", "/b.avif"]),
+        ("  /a.avif 100w ,  /b.avif 200w  ", ["/a.avif", "/b.avif"]),
+        # Per spec the URL token runs to the first space, so an unspaced comma
+        # belongs to the URL rather than separating candidates.
+        ("/a.avif,/b.avif", ["/a.avif,/b.avif"]),
+        ("/a,b.avif 2x", ["/a,b.avif"]),
+        ("/a.avif,, /b.avif", ["/a.avif", "/b.avif"]),
+    ],
+)
+def test_parse_srcset(srcset: str, expected: list[str]):
+    assert built_site_checks.parse_srcset(srcset) == expected
+
+
+def test_collect_srcset_urls_skips_redirect(tmp_path: Path):
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    html = (
+        '<html><head><meta http-equiv="refresh" content="0;url=/new"></head>'
+        '<body><picture><source srcset="/a-inverted.avif"></picture></body>'
+        "</html>"
+    )
+    file_path = public_dir / "redirect.html"
+    file_path.write_text(html)
+
+    srcset_to_files: dict[str, list[str]] = defaultdict(list)
+    built_site_checks.collect_srcset_urls(
+        BeautifulSoup(html, "html.parser"),
+        file_path,
+        public_dir,
+        srcset_to_files,
+    )
+    assert not srcset_to_files
+
+
+def test_collect_srcset_urls_collects_and_skips_tags_without_srcset(
+    tmp_path: Path,
+):
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    html = (
+        "<html><body><picture>"
+        '<source srcset="/a-inverted.avif" media="(prefers-color-scheme: dark)">'
+        '<img src="/a.avif">'
+        "</picture>"
+        '<img srcset="/b.avif 2x" src="/b.avif">'
+        "</body></html>"
+    )
+    file_path = public_dir / "page.html"
+    file_path.write_text(html)
+
+    srcset_to_files: dict[str, list[str]] = defaultdict(list)
+    built_site_checks.collect_srcset_urls(
+        BeautifulSoup(html, "html.parser"),
+        file_path,
+        public_dir,
+        srcset_to_files,
+    )
+    assert srcset_to_files == {
+        "/a-inverted.avif": ["page.html"],
+        "/b.avif": ["page.html"],
+    }
+
+
+def test_srcset_url_issue_remote_ok():
+    with patch.object(
+        built_site_checks,
+        "_head_with_retry",
+        return_value=mock.Mock(ok=True, status_code=200),
+    ):
+        assert (
+            built_site_checks._srcset_url_issue(
+                "https://assets.turntrout.com/a-inverted.avif", Path("/public")
+            )
+            is None
+        )
+
+
+def test_srcset_url_issue_remote_404():
+    with patch.object(
+        built_site_checks,
+        "_head_with_retry",
+        return_value=mock.Mock(ok=False, status_code=404),
+    ):
+        issue = built_site_checks._srcset_url_issue(
+            "https://assets.turntrout.com/a-inverted.avif", Path("/public")
+        )
+    assert issue == (
+        "https://assets.turntrout.com/a-inverted.avif returned status 404"
+    )
+
+
+def test_srcset_url_issue_remote_request_exception():
+    with patch.object(
+        built_site_checks,
+        "_head_with_retry",
+        side_effect=requests.RequestException("boom"),
+    ):
+        issue = built_site_checks._srcset_url_issue(
+            "https://assets.turntrout.com/a-inverted.avif", Path("/public")
+        )
+    assert issue is not None
+    assert issue.endswith("failed to load: boom")
+
+
+def test_srcset_url_issue_local_present(tmp_path: Path):
+    (tmp_path / "a-inverted.avif").write_bytes(b"data")
+    assert (
+        built_site_checks._srcset_url_issue("/a-inverted.avif?v=3", tmp_path)
+        is None
+    )
+
+
+def test_srcset_url_issue_local_missing(tmp_path: Path):
+    issue = built_site_checks._srcset_url_issue("/a-inverted.avif", tmp_path)
+    assert issue is not None
+    assert issue.startswith("/a-inverted.avif (resolved to ")
+    assert issue.endswith("does not exist")
+
+
+def test_check_srcset_urls_reports_referencing_pages(tmp_path: Path):
+    (tmp_path / "present.avif").write_bytes(b"data")
+    srcset_to_files = {
+        "/present.avif": ["a.html"],
+        "/absent.avif": ["b.html", "a.html", "a.html"],
+    }
+    issues = built_site_checks.check_srcset_urls(srcset_to_files, tmp_path)
+    assert len(issues) == 1
+    assert issues[0].startswith("<srcset> /absent.avif (resolved to ")
+    assert issues[0].endswith("does not exist (referenced by a.html, b.html)")
+
+
+def test_process_html_files_reports_unresolvable_srcset(tmp_path: Path):
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    content_dir = tmp_path / "website_content"
+    content_dir.mkdir()
+    (public_dir / "page.html").write_text(
+        "<html><body><picture>"
+        '<source srcset="/missing-inverted.avif">'
+        '<img src="/missing.avif"></picture></body></html>',
+        encoding="utf-8",
+    )
+
+    with (
+        patch.object(
+            built_site_checks, "check_file_for_issues", return_value={}
+        ),
+        patch.object(built_site_checks, "_print_issues") as print_issues,
+        patch.object(script_utils, "build_html_to_md_map", return_value={}),
+        patch.object(script_utils, "collect_aliases", return_value=set()),
+        patch.object(script_utils, "should_have_md", return_value=False),
+        patch.object(
+            built_site_checks,
+            "_build_included_favicon_domains",
+            return_value=frozenset(),
+        ),
+        patch.object(
+            script_utils,
+            "parse_html_file",
+            side_effect=lambda p: BeautifulSoup(
+                Path(p).read_text(encoding="utf-8"), "html.parser"
+            ),
+        ),
+    ):
+        result = built_site_checks._process_html_files(
+            public_dir, content_dir, check_fonts=False
+        )
+
+    assert result is True
+    reported = [
+        call.args[1]
+        for call in print_issues.call_args_list
+        if "unresolvable_srcset_urls" in call.args[1]
+    ]
+    assert len(reported) == 1
+    assert (
+        "/missing-inverted.avif" in reported[0]["unresolvable_srcset_urls"][0]
+    )


### PR DESCRIPTION
## Summary

- Three dark-mode `-inverted` image variants were 404ing on the live site (e.g. `zVkGE6q-top-inverted.avif` on [world-state-is-the-wrong-abstraction-for-impact](https://turntrout.com/world-state-is-the-wrong-abstraction-for-impact)) while every link check stayed green.
- Root cause of the blind spot: those variants only ever appear in `<picture><source srcset>`. linkchecker's HTML5 tag table maps `<source>` to `src` alone — `srcset` is listed for `<img>` only — so it never fetched them. `built_site_checks` was blind for the same reason: `check_media_asset_sources` / `check_local_media_files` read `src` or `href`, and a `<source>` in a `<picture>` has neither.
- Added a site-wide `srcset` resolution check so a missing variant fails CI.

## Changes

- `scripts/built_site_checks.py`
  - `parse_srcset` — extracts candidate URLs per the HTML srcset algorithm (the URL token runs to the first whitespace, so a comma inside a URL doesn't split the candidate).
  - `collect_srcset_urls` — accumulates every `<img>`/`<source>` `srcset` URL across the walk, mapped to the pages referencing it (redirect pages skipped).
  - `check_srcset_urls` — resolves each *unique* URL once: HEAD for absolute URLs, filesystem lookup for site-relative ones. Failures name the referencing pages.
  - Wired into `_process_html_files` alongside the existing duplicate-citation aggregation, so ~600 unique CDN variants cost one HEAD each per build rather than one per page.
- `.claude/dev-notes.md` — documents why `srcset` is invisible to linkchecker and which check now covers it.

The three missing variants were regenerated with `scripts/generate_inverted_variants.py` and uploaded to R2 out-of-band; all three now return 200.

## Testing

- `uv run pytest scripts/tests/test_built_site_checks.py` — 1026 passed, including 22 new cases covering srcset parsing edge cases (descriptors, unspaced commas, commas inside URLs, empty input), redirect skipping, remote 200/404/`RequestException`, local present/missing with cache-busting query, aggregated reporting, and the `_process_html_files` wiring.
- `uv run pylint scripts/built_site_checks.py` — 10.00/10; `ruff check` and `ruff format` clean.
- Verified the new check against the real URLs: the (now uploaded) `zVkGE6q-top-inverted.avif` passes and a fabricated missing variant is reported as `returned status 404`.

## Lessons Learned

- **What**: When adding or trusting a checker that walks HTML, enumerate the *attributes* link-bearing tags can use, not just the tag names. A tag can be matched by name and still be entirely unchecked if the code only reads one attribute.
- **Where**: any HTML/link validation code; here `scripts/built_site_checks.py` and `scripts/linkchecker.fish`.
- **Why**: `<source srcset>` was reachable by both checkers' tag filters yet checked by neither, because both read `src`. Third-party checkers have the same gap — linkchecker 10.6.0 lists `srcset` for `<img>` only — so "we run a link checker" is not evidence that a URL class is covered. Verify by planting a known-bad URL and confirming the tool actually fails.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EW2CepEc3jAgpU6ZJGT9Lt)_