### PR TITLE
refactor: extract _report_issues helper

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -2448,6 +2448,14 @@ def _print_issues(  # pragma: no cover
         print()  # Add a blank line between files with issues
 
 
+def _report_issues(path: Path, label: str, issues: list[str]) -> bool:
+    """Print ``issues`` under ``label``; ``True`` when there were any."""
+    if not issues:
+        return False
+    _print_issues(path, {label: issues})
+    return True
+
+
 def _strip_path(path_str: str) -> str:
     """Strip the git root path from a path string."""
     beginning_stripped = re.sub(
@@ -3827,50 +3835,49 @@ def _process_html_files(  # pylint: disable=too-many-locals
                 soup, file, file_path, public_dir, paragraph_map
             )
 
-    # Check for duplicate citation keys across all files
-    citation_issues = _find_duplicate_citations(citation_to_files)
-    if citation_issues:
-        _print_issues(public_dir, {"duplicate_citations": citation_issues})
-        issues_found_in_html = True
-
-    srcset_issues = check_srcset_urls(srcset_to_files, public_dir)
-    if srcset_issues:
-        _print_issues(public_dir, {"unresolvable_srcset_urls": srcset_issues})
-        issues_found_in_html = True
-
-    # Spellcheck flattened paragraph text across all pages
-    spelling_issues = _spellcheck_flattened_paragraphs(paragraph_map)
-    if spelling_issues:
-        _print_issues(
+    site_wide_reports = [
+        _report_issues(
             public_dir,
-            {"rendered_text_spelling": spelling_issues},
-        )
-        issues_found_in_html = True
+            "duplicate_citations",
+            _find_duplicate_citations(citation_to_files),
+        ),
+        _report_issues(
+            public_dir,
+            "unresolvable_srcset_urls",
+            check_srcset_urls(srcset_to_files, public_dir),
+        ),
+        _report_issues(
+            public_dir,
+            "rendered_text_spelling",
+            _spellcheck_flattened_paragraphs(paragraph_map),
+        ),
+    ]
 
-    return issues_found_in_html
+    return issues_found_in_html or any(site_wide_reports)
 
 
 def main() -> None:
     """Check all HTML files in the public directory for issues."""
     args = parser.parse_args()
-    overall_issues_found: bool = False
     check_rss_file_for_issues(_GIT_ROOT)
 
     css_file_path: Path = _PUBLIC_DIR / "index.css"
-    css_issues = check_css_issues(css_file_path)
-    if css_issues:
-        _print_issues(css_file_path, {"CSS_issues": css_issues})
-        overall_issues_found = True
-
-    root_files_issues = check_root_files_location(_PUBLIC_DIR)
-    if root_files_issues:
-        _print_issues(_PUBLIC_DIR, {"root_files_issues": root_files_issues})
-        overall_issues_found = True
-
-    fixture_issues = check_fixture_pages_excluded(_PUBLIC_DIR)
-    if fixture_issues:
-        _print_issues(_PUBLIC_DIR, {"fixture_artifacts": fixture_issues})
-        overall_issues_found = True
+    reports = [
+        _report_issues(
+            css_file_path, "CSS_issues", check_css_issues(css_file_path)
+        ),
+        _report_issues(
+            _PUBLIC_DIR,
+            "root_files_issues",
+            check_root_files_location(_PUBLIC_DIR),
+        ),
+        _report_issues(
+            _PUBLIC_DIR,
+            "fixture_artifacts",
+            check_fixture_pages_excluded(_PUBLIC_DIR),
+        ),
+    ]
+    overall_issues_found: bool = any(reports)
 
     defined_css_vars: set[str] = _get_defined_css_variables(css_file_path)
     html_issues_found = _process_html_files(


### PR DESCRIPTION
## Summary

Follow-up to #1699. The six site-level checks in `built_site_checks.py` each repeated the same four lines — run the check, print it under a label when non-empty, flip a found flag:

```python
srcset_issues = check_srcset_urls(srcset_to_files, public_dir)
if srcset_issues:
    _print_issues(public_dir, {"unresolvable_srcset_urls": srcset_issues})
    issues_found_in_html = True
```

## Changes

- `_report_issues(path, label, issues) -> bool` — prints under `label` when non-empty and returns whether anything was found.
- `_process_html_files` and `main` collect the helper's return values into a list and fold with `any(...)`, dropping the running mutable flags. A list (not `or`-chaining) keeps every check running rather than short-circuiting after the first failure.
- Net: 18 fewer statements, and two WHAT-comments (`# Check for duplicate citation keys across all files`, `# Spellcheck flattened paragraph text across all pages`) that only restated the label are gone.

Call shapes into `_print_issues` are unchanged — one call per check, same path, same single-key dict — so output granularity is identical and no existing test expectations needed updating.

## Testing

- `uv run pytest scripts/tests/test_built_site_checks.py` — 1026 passed, zero test changes in this PR.
- `uv run pyright` / `ruff check` / `ruff format` clean; `pylint` 10.00/10.
- Coverage: both helper branches are exercised by the existing `test_main_*` cases; the module's uncovered-line count dropped from 12 to 10.

## Lessons Learned

- **What**: Before compressing a repeated call pattern, check whether tests assert on the *call shape* of the thing being compressed (e.g. `mock.assert_any_call(path, {"key": [...]})`). Pick the compression that preserves the shape rather than the one that merges calls.
- **Where**: any refactor touching a function that tests mock and assert against; here `_print_issues` in `scripts/built_site_checks.py`.
- **Why**: The first attempt merged all same-path checks into one dict and one call. It was shorter, but broke three `test_main_*` assertions — and rewriting those would have meant changing test expectations to accommodate a refactor, which `CLAUDE.md` forbids without asking. The helper-based version compresses the same six sites with zero test churn.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EW2CepEc3jAgpU6ZJGT9Lt)_