### PR TITLE
fix(typography): apply shared work-title styling to in-prose titles

### DIFF
--- a/quartz/components/tests/visual_utils.spec.ts
+++ b/quartz/components/tests/visual_utils.spec.ts
@@ -244,14 +244,18 @@ test.describe("visual_utils functions", () => {
       })
       await waitPromise
 
-      // Verify element is stable by checking computed transform is at final position
+      // Sample both positions inside a single page evaluate: a handle round
+      // trip against this page can cost seconds, so one iteration of a
+      // multi-call predicate would not fit the poll budget.
       await expect
-        .poll(async () => {
-          const box1 = await element.boundingBox()
-          await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)))
-          const box2 = await element.boundingBox()
-          return box1?.x === box2?.x && box1?.y === box2?.y
-        })
+        .poll(() =>
+          element.evaluate(async (el) => {
+            const before = el.getBoundingClientRect()
+            await new Promise((resolve) => requestAnimationFrame(resolve))
+            const after = el.getBoundingClientRect()
+            return before.x === after.x && before.y === after.y
+          }),
+        )
         .toBe(true)
     })
 

--- a/quartz/plugins/transformers/bindLinkTitles.test.ts
+++ b/quartz/plugins/transformers/bindLinkTitles.test.ts
@@ -64,11 +64,11 @@ describe("bindTitlesInTree", () => {
     expect(textOf(root)).toContain(">The Live Title<")
   })
 
-  it("marks the resolved anchor no-smallcaps so title acronyms stay plain", () => {
+  it("marks the resolved anchor as a work title so it gets the shared title styling", () => {
     const root = tree(boundAnchor({ "data-slug": "other-page", href: "/other-page" }))
     bindTitlesInTree(root, idx, "source" as FullSlug, "source.md")
     const anchor = root.children[0] as Element
-    expect(anchor.properties.className).toContain("no-smallcaps")
+    expect(anchor.properties.className).toContain("work-title")
   })
 
   it("lowercases the title for the @title-lower sentinel", () => {

--- a/quartz/plugins/transformers/bindLinkTitles.ts
+++ b/quartz/plugins/transformers/bindLinkTitles.ts
@@ -7,7 +7,11 @@ import { visit } from "unist-util-visit"
 import type { TitleIndex } from "../../processors/buildTitleIndex"
 import type { QuartzTransformerPlugin } from "../types"
 
-import { LINK_TITLE_LOWER_SENTINEL, LINK_TITLE_SENTINEL } from "../../components/constants"
+import {
+  LINK_TITLE_LOWER_SENTINEL,
+  LINK_TITLE_SENTINEL,
+  WORK_TITLE_CLASS,
+} from "../../components/constants"
 import { titleIndexFile } from "../../components/constants.server"
 import { type FullSlug, splitAnchor } from "../../util/path"
 import { addClass } from "./utils"
@@ -133,9 +137,10 @@ export function bindTitlesInTree(
     const lead = match.groups.lead.trim()
     const trail = match.groups.trail.trim()
     node.children = [{ type: "text", value: `${lead}${bound}${trail}` }]
-    // A resolved title is the name of a work, not prose, so acronyms in it
-    // (AGI, GPT, …) should not render as small-caps.
-    addClass(node, "no-smallcaps")
+    // A resolved title is the name of a work, not prose, so it takes the same
+    // typographic treatment as every other title-rendering surface: plain-caps
+    // acronyms (AGI, GPT, …) and lining figures.
+    addClass(node, WORK_TITLE_CLASS)
   })
 }
 

--- a/quartz/plugins/transformers/tagSmallcaps.ts
+++ b/quartz/plugins/transformers/tagSmallcaps.ts
@@ -9,7 +9,7 @@ import { visitParents } from "unist-util-visit-parents"
 
 import type { QuartzTransformerPlugin } from "../types"
 
-import { HEADING_TAGS, NBSP } from "../../components/constants"
+import { HEADING_TAGS, NBSP, WORK_TITLE_CLASS } from "../../components/constants"
 import {
   addClass,
   gatherTextBeforeIndex,
@@ -227,6 +227,7 @@ const combinedRegex = new RegExp(
 // Predicate if we should skip smallcaps for a given node
 export const skipSmallcapsClasses: readonly string[] = [
   "no-smallcaps",
+  WORK_TITLE_CLASS,
   "no-formatting",
   "bad-handwriting",
   "katex",
@@ -447,10 +448,11 @@ const WORK_TITLE_TAGS: ReadonlySet<string> = new Set(["a", "em", "i", "cite"])
 
 /**
  * Tags links/emphasis/cite elements whose text reads as a title-cased work
- * title with `no-smallcaps`, so their acronyms render as plain caps. Title
- * case is the marker: authors opt in by writing a work title in title case
- * and opt out by sentence-casing. Heading text must keep its small-caps, so
- * the anchor wrappers inside headings are exempt.
+ * title with {@link WORK_TITLE_CLASS}, the site-wide marker for text naming a
+ * work: acronyms render as plain caps and figures are lining. Title case is
+ * the marker: authors opt in by writing a work title in title case and opt out
+ * by sentence-casing. Heading text must keep its small-caps, so the anchor
+ * wrappers inside headings are exempt.
  */
 export function markWorkTitles(tree: Node): void {
   visitParents(tree, "element", (node: Element, ancestors: Parent[]) => {
@@ -460,7 +462,7 @@ export function markWorkTitles(tree: Node): void {
     )
     if (inHeading) return
     if (looksLikeWorkTitle(toString(node))) {
-      addClass(node, "no-smallcaps")
+      addClass(node, WORK_TITLE_CLASS)
     }
   })
 }

--- a/quartz/plugins/transformers/tests/tagSmallcaps.test.ts
+++ b/quartz/plugins/transformers/tests/tagSmallcaps.test.ts
@@ -1411,12 +1411,12 @@ describe("markWorkTitles", () => {
     [
       "a title-cased link keeps its acronym as plain caps",
       '<p>See <a href="/x">AGI Ruin: A List of Lethalities</a> for more.</p>',
-      '<p>See <a href="/x" class="no-smallcaps">AGI Ruin: A List of Lethalities</a> for more.</p>',
+      '<p>See <a href="/x" class="work-title">AGI Ruin: A List of Lethalities</a> for more.</p>',
     ],
     [
       "a title-cased emphasized title keeps its acronym as plain caps",
       "<p>I read <em>Seeking Power Is Often Robustly Instrumental in MDPs</em> today.</p>",
-      '<p>I read <em class="no-smallcaps">Seeking Power Is Often Robustly Instrumental in MDPs</em> today.</p>',
+      '<p>I read <em class="work-title">Seeking Power Is Often Robustly Instrumental in MDPs</em> today.</p>',
     ],
     [
       "a sentence-cased link still gets small-caps",
@@ -1441,7 +1441,7 @@ describe("markWorkTitles", () => {
     [
       "a title-cased emphasis nested in a link is suppressed once",
       '<p><a href="/x"><em>Corrigibility Can Be VNM-Incoherent</em></a></p>',
-      '<p><a href="/x" class="no-smallcaps"><em class="no-smallcaps">Corrigibility Can Be VNM-Incoherent</em></a></p>',
+      '<p><a href="/x" class="work-title"><em class="work-title">Corrigibility Can Be VNM-Incoherent</em></a></p>',
     ],
   ])("%s", (_label, input, expected) => {
     expect(testTagSmallcapsHTML(input)).toBe(expected)

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -408,10 +408,12 @@ figure,
   }
 }
 
-// Every title-rendering surface (article title, backlinks, prev/next post,
-// sequence links, related posts, page listings, …) wraps its output in
-// `.work-title` (see `renderTitleNodes`/`renderInlineFormatting` in
-// `component_utils.tsx`), so one rule covers all of them.
+// Every title-rendering surface wraps its output in `.work-title`, so one rule
+// covers all of them: components (article title, backlinks, prev/next post,
+// sequence links, related posts, page listings, …) via `renderTitleNodes` /
+// `renderInlineFormatting` in `component_utils.tsx`, and in-prose titles
+// (`@title`-bound links, title-cased links/emphasis naming a work) via
+// `bindLinkTitles.ts` / `markWorkTitles` in `tagSmallcaps.ts`.
 .work-title {
   font-variant-numeric: lining-nums;
 }

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -45,6 +45,8 @@ Subtitle: MATS (starting with smallcaps).
 
 The `@title` sentinel ties a link's text to its target's current title at build time: [@title](/test-page) renders this page's title, and [@title](#header-4) renders the current text of the "Header 4" section.
 
+A resolved title gets the same typography as every other title surface, so its figures are lining rather than oldstyle: [@title](/reward-hacking-doesnt-show-reward-is-optimization-target).
+
 # `@title`s and quote smallcaps
 
 Acronyms in a resolved `@title` fill and in title-cased `[!quote]` titles render as plain caps instead of smallcaps.


### PR DESCRIPTION
## Summary

- A page title rendered inline by the `@title` sentinel showed oldstyle numerals ("2025-era …"), unlike every other title surface on the site.
- The markup pipeline marked in-prose titles with `no-smallcaps`, which only suppresses small-caps acronyms; the lining-figure rule lives on `.work-title`, applied only by the component pipeline.
- Both markers now emit `WORK_TITLE_CLASS`, so one class carries the whole title treatment.
- Also fixes a Playwright stability poll that timed out on the iPhone-12 Firefox shard.

## Changes

- `bindLinkTitles.ts`: resolved `@title` anchors get `WORK_TITLE_CLASS` instead of `no-smallcaps`.
- `tagSmallcaps.ts`: `markWorkTitles` tags title-cased links/emphasis/cite with `WORK_TITLE_CLASS`; that class joins `skipSmallcapsClasses`, so it still suppresses small-caps acronyms.
- `custom.scss`: the `.work-title` comment now names both pipelines that produce the class.
- `test-page.md`: an `@title` link resolving to a title that starts with digits, so the baseline captures lining figures.
- Updated the two tests that asserted the old class name.
- `visual_utils.spec.ts`: the "element stops changing after transition completes" poll sampled two `boundingBox()` calls plus a `requestAnimationFrame` evaluate — three protocol round trips per iteration. The trace from the failing shard shows one handle resolution taking 4.0 s against the test page, so the first iteration ate the entire 5 s poll budget. Both rects are now sampled inside a single `element.evaluate`; the assertion is unchanged and no budget was raised.

## Testing

- `pnpm test` (full Jest suite): 5141 passed.
- `tsc --noEmit`, eslint, and stylelint clean.
- Verified on the PR preview that the bound title renders with `class="… work-title"`.
- Visual baselines will shift for in-prose work titles containing digits — expected.

## Lessons learned

- **What**: When a styling rule is documented as a single source of truth for a concept, make the *marker class* the SSOT too — don't let a second pipeline invent a parallel class that carries only half the treatment.
- **Where**: `quartz/plugins/transformers/{bindLinkTitles,tagSmallcaps}.ts`, `quartz/styles/custom.scss`.
- **Why**: Two pipelines both marked "this text names a work," with different classes, so only one got lining figures. The divergence surfaced as a visible typography bug much later.

- **What**: When a Playwright poll times out, download the shard's trace artifact and diff the `before`/`after` timestamps per protocol call before touching the assertion — the culprit is often round-trip cost, not the condition under test.
- **Where**: any `expect.poll` whose predicate makes multiple `await`s against the page.
- **Why**: The log said only "Timeout 5000ms exceeded while waiting on the predicate," which reads as "the condition never became true." The trace showed the predicate never completed a single iteration. Keeping poll predicates to one round trip is the general fix; raising the timeout would have hidden it.
