### PR TITLE
fix: stand spoilers off from their neighbors

### DIFF
--- a/quartz/components/tests/spoilerSpacing.spec.ts
+++ b/quartz/components/tests/spoilerSpacing.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "./fixtures"
+import { gotoPage } from "./visual_utils"
+
+// A spoiler is authored as a block quote and replaces it in the tree, so it has
+// to stand off from its neighbors by exactly what the block quote it replaced
+// would have. Without that standoff, the test page's consecutive spoilers butt
+// against each other with no seam between them.
+
+test.describe("spoiler spacing", () => {
+  test("stands consecutive spoilers off by a block quote's margin", async ({ page }) => {
+    await gotoPage(page, "http://localhost:8080/test-page")
+
+    const measured = await page.evaluate(() => {
+      const spoilers = [...document.querySelectorAll("article .spoiler-container")]
+      const blockquote = document.querySelector("article blockquote")
+      if (spoilers.length < 2 || !blockquote) {
+        throw new Error("test page must carry a block quote and consecutive spoilers")
+      }
+      const boxes = spoilers.map((el) => el.getBoundingClientRect())
+      return {
+        gaps: boxes.slice(1).map((box, i) => box.top - boxes[i].bottom),
+        blockquoteMargin: Number.parseFloat(getComputedStyle(blockquote).marginBottom),
+      }
+    })
+
+    // Adjacent block margins collapse, so the seam between two spoilers is one
+    // margin wide rather than two.
+    expect(measured.blockquoteMargin).toBeGreaterThan(0)
+    for (const gap of measured.gaps) {
+      expect(gap).toBeCloseTo(measured.blockquoteMargin, 0)
+    }
+  })
+})

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -841,6 +841,11 @@ img.emoji {
   cursor: pointer;
   width: fit-content;
 
+  // A spoiler is written as a block quote and replaces it in the tree, so it
+  // has to carry the block quote's standoff itself: without it, consecutive
+  // spoilers butt against each other and against their neighbors.
+  margin: calc(2 * $base-margin) 0;
+
   // Contains the negative margin that pays for the content's standoff padding.
   // Left to collapse out, that margin would escape to the block quote and drag
   // the surrounding text with it instead of cancelling the padding.


### PR DESCRIPTION
## Summary

- Consecutive spoilers on the test page sit flush against each other and against the text around them, with no seam.
- A spoiler is authored as a block quote and the transformer *replaces* that `<blockquote>` with a `<div class="spoiler-container">`, so it loses the block quote's `calc(2 * $base-margin)` block margin and a bare div contributes none of its own.

## Changes

- `quartz/styles/custom.scss`: `.spoiler-container` carries the same block margin a block quote does. The container is already `display: flow-root`, so the negative margin inside `.spoiler-content` (which pays for its standoff padding) stays contained and doesn't interact with the new margin.
- `quartz/components/tests/spoilerSpacing.spec.ts`: asserts the gap between consecutive spoilers on the test page equals a block quote's own bottom margin — one margin wide, since adjacent block margins collapse. Runs in every browser/viewport project.

## Testing

- Measured against a local build of the test page's Spoilers section in headless Chromium, desktop (1280) and mobile (390) viewports:
  - before: gaps of `0px`
  - after: gaps of `24px` / `18px`, matching `getComputedStyle(blockquote).marginBottom` at each viewport
- `tsc --noEmit`, eslint, stylelint, prettier clean; `base-margin-multipliers` passes (the multiplier is the integer 2).

## Notes

Test-page visual baselines will change: the Spoilers section grows by the new gaps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFtq7CbigQfRXs27o7fPoo)_