### PR TITLE
feat(dropcap): set an opening quote with the letter it introduces

### DIFF
--- a/quartz/components/tests/dropcap.spec.ts
+++ b/quartz/components/tests/dropcap.spec.ts
@@ -14,6 +14,8 @@ import {
 const DROPCAP_URL = "http://localhost:8080/test-page"
 // A solemn post that opts out of the random color via `no_dropcap_color`.
 const OPTED_OUT_URL = "http://localhost:8080/bruce-wayne-and-the-cost-of-inaction"
+// A fixture whose first paragraph opens on a quotation.
+const QUOTE_DROPCAP_URL = "http://localhost:8080/quote-dropcap-fixture"
 
 /** Mock Math.random so sequential calls return the given values (then 0.5).
  *  Must accept values as a parameter (not closure) because addInitScript serializes the function. */
@@ -39,6 +41,74 @@ const midgroundFaintColor = (paragraph: Locator) =>
 
 const firstDropcapParagraph = (root: Locator) =>
   root.locator("> p:not(.subtitle):first-of-type").first()
+
+/** Size of the `::before` float that reserves room for the dropcap. */
+const floatSpacerMetrics = (paragraph: Locator) =>
+  paragraph.evaluate((el) => {
+    const style = getComputedStyle(el, "::before")
+    return { fontSize: parseFloat(style.fontSize), paddingLeft: parseFloat(style.paddingLeft) }
+  })
+
+test.describe("Combined quote-and-letter dropcap", () => {
+  test("the opening quote joins the letter it introduces", async ({ page }) => {
+    await gotoPage(page, QUOTE_DROPCAP_URL)
+
+    const paragraph = firstDropcapParagraph(
+      page.locator('article[data-use-dropcap="true"]').first(),
+    )
+    await expect(paragraph).toHaveAttribute("data-first-letter", "“W")
+  })
+
+  test("the dropcap pads left by the quote's advance", async ({ page }) => {
+    await gotoPage(page, QUOTE_DROPCAP_URL)
+    await page.evaluate(() => document.fonts.ready)
+
+    const paragraph = firstDropcapParagraph(
+      page.locator('article[data-use-dropcap="true"]').first(),
+    )
+    await paragraph.scrollIntoViewIfNeeded()
+
+    const { fontSize, paddingLeft } = await floatSpacerMetrics(paragraph)
+
+    // The quote's advance in EB Garamond Initials is 266/1000 em.
+    expect(paddingLeft).toBeCloseTo(fontSize * 0.266, 1)
+  })
+
+  test("a letter-initial paragraph takes no left pad", async ({ page }) => {
+    await gotoPage(page, DROPCAP_URL)
+    await page.evaluate(() => document.fonts.ready)
+
+    const paragraph = firstDropcapParagraph(
+      page.locator('article[data-use-dropcap="true"]').first(),
+    )
+    const { paddingLeft } = await floatSpacerMetrics(paragraph)
+
+    expect(paddingLeft).toBe(0)
+  })
+
+  test("the quote renders inside the text block", async ({ page }) => {
+    await gotoPage(page, QUOTE_DROPCAP_URL)
+    await page.evaluate(() => document.fonts.ready)
+
+    const paragraph = firstDropcapParagraph(
+      page.locator('article[data-use-dropcap="true"]').first(),
+    )
+    await paragraph.scrollIntoViewIfNeeded()
+
+    // `#center-content` clips horizontal overflow, so a mark set outside the
+    // paragraph's content edge would be invisible.
+    const { paragraphLeft, initialLeft } = await paragraph.evaluate((el) => {
+      const range = document.createRange()
+      range.setStart(el.firstChild as ChildNode, 0)
+      range.setEnd(el.firstChild as ChildNode, 2)
+      return {
+        paragraphLeft: el.getBoundingClientRect().left,
+        initialLeft: range.getBoundingClientRect().left,
+      }
+    })
+    expect(initialLeft).toBeGreaterThanOrEqual(paragraphLeft)
+  })
+})
 
 test.describe("Random dropcap color", () => {
   test(`no color applied when Math.random >= ${colorDropcapProbability}`, async ({ page }) => {

--- a/quartz/components/tests/fixtures.ts
+++ b/quartz/components/tests/fixtures.ts
@@ -195,6 +195,22 @@ export const test = base.extend<SiteTestOptions>({
     })
     // skipcq: JS-0820 -- `use` is Playwright's fixture-yield callback, not a React hook
     await use(page)
+    // Specs that opt out of the CDN stubs stream real media bytes, and WebKit's
+    // graceful context close waits for an in-flight stream to finish — long
+    // enough to exceed the test timeout. Detaching the source ends the stream
+    // before teardown starts.
+    if (!page.isClosed()) {
+      await page.evaluate(() => {
+        for (const media of document.querySelectorAll<HTMLMediaElement>("video, audio")) {
+          media.pause()
+          media.removeAttribute("src")
+          for (const source of media.querySelectorAll("source")) {
+            source.remove()
+          }
+          media.load()
+        }
+      })
+    }
   },
 })
 

--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -405,6 +405,22 @@ test.describe("Unique content around the site", () => {
       }
     })
   }
+
+  test("Combined quote-and-letter dropcap (screenshot)", async ({ page }, testInfo) => {
+    await gotoPage(page, "http://localhost:8080/quote-dropcap-fixture")
+    // The dropcap composites two font faces; wait so its metrics are settled.
+    await page.evaluate(() => document.fonts.ready)
+
+    // Shoot the whole article: the quote hangs outside the paragraph's box, so
+    // an element shot of the paragraph alone would clip the thing under test.
+    const article = page.locator('article[data-use-dropcap="true"]').first()
+    await article.scrollIntoViewIfNeeded()
+    await expect(article).toBeVisible()
+
+    await takeRegressionScreenshot(page, testInfo, "quote-letter-dropcap", {
+      elementToScreenshot: article,
+    })
+  })
 })
 
 test.describe("Table of contents", () => {

--- a/quartz/plugins/transformers/formatting_improvement_html.ts
+++ b/quartz/plugins/transformers/formatting_improvement_html.ts
@@ -1076,11 +1076,37 @@ const checkedTextPasses: readonly ProsePass[] = [
 ]
 
 /**
+ * Opening quotes that a dropcap sets together with the letter they introduce.
+ * `RIGHT_SINGLE_QUOTE` is here for elision ("’Twas"), which reads as an opening
+ * mark even though it is typographically a closing one.
+ */
+const DROPCAP_LEADING_QUOTES: ReadonlySet<string> = new Set([
+  LEFT_DOUBLE_QUOTE,
+  LEFT_SINGLE_QUOTE,
+  RIGHT_SINGLE_QUOTE,
+])
+
+/**
+ * The characters a dropcap renders for `text`: a quoted opening yields the
+ * quote plus the letter it introduces, so the attribute matches the pair that
+ * `::first-letter` selects (CSS folds leading punctuation into the pseudo).
+ *
+ * @param text - The dropcap paragraph's text content
+ */
+export function dropcapInitial(text: string): string {
+  const [first, second] = text
+  if (first && second && DROPCAP_LEADING_QUOTES.has(first) && /\p{L}/u.test(second)) {
+    return first + second
+  }
+  return first ?? ""
+}
+
+/**
  * Sets a data-first-letter attribute on the first non-empty paragraph element in the tree.
  *
  * The function:
  * 1. Finds the first non-empty <p> element that is a direct child of the root
- * 2. Sets the data-first-letter attribute to the first character of the paragraph's text content
+ * 2. Sets the data-first-letter attribute to the paragraph's dropcap initial
  * 3. If the second character is an apostrophe, adds a space before it in the text node
  *
  * @param tree - The HAST root node to process
@@ -1090,8 +1116,8 @@ const checkedTextPasses: readonly ProsePass[] = [
  * Output: <p data-first-letter="F">First paragraph</p>
  *
  * @example
- * Input:  <p></p><p>'Twas the night</p>
- * Output: <p></p><p data-first-letter="'">' Twas the night</p>
+ * Input:  <p></p><p>“Twas the night</p>
+ * Output: <p></p><p data-first-letter="“T">“Twas the night</p>
  *
  * Note: Only processes non-empty paragraphs that are direct children of the root.
  * Empty paragraphs or nested paragraphs are ignored.
@@ -1111,7 +1137,7 @@ export function setFirstLetterAttribute(tree: Root): void {
   const firstLetter = paragraphText.charAt(0)
 
   firstParagraph.properties = firstParagraph.properties || /* istanbul ignore next */ {}
-  firstParagraph.properties["data-first-letter"] = firstLetter
+  firstParagraph.properties["data-first-letter"] = dropcapInitial(paragraphText)
 
   const firstTextNode = firstParagraph.children.find(
     (child): child is Text => child.type === "text",

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -1514,13 +1514,13 @@ describe("setFirstLetterAttribute", () => {
     ],
     [
       "opening double quote joins the letter it introduces",
-      `<p>"Whoever wishes to foresee the future must consult the past."</p>`,
-      `<p data-first-letter="“W">“Whoever wishes to foresee the future must consult the past.”</p>`,
+      '<p>"Whoever wishes to foresee the future must consult the past."</p>',
+      '<p data-first-letter="“W">“Whoever wishes to foresee the future must consult the past.”</p>',
     ],
     [
       "opening quote before a non-letter stands alone",
-      `<p>"1984 was a year."</p>`,
-      `<p data-first-letter="“">“1984 was a year.”</p>`,
+      '<p>"1984 was a year."</p>',
+      '<p data-first-letter="“">“1984 was a year.”</p>',
     ],
   ])("%s", (_description, input, expected) => {
     const processedHtml = testHtmlFormattingImprovement(input, false)

--- a/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_html.test.ts
@@ -27,6 +27,7 @@ import {
 import {
   applyTextTransforms,
   arrowsToWrap,
+  dropcapInitial,
   glueHyphens,
   HTMLFormattingImprovement,
   identifyLinkNode,
@@ -1381,6 +1382,21 @@ describe("flattenTextNodes and getTextContent", () => {
   })
 })
 
+describe("dropcapInitial", () => {
+  it.each([
+    ["Alpha", "A"],
+    [`${LEFT_DOUBLE_QUOTE}Whoever wishes`, `${LEFT_DOUBLE_QUOTE}W`],
+    [`${LEFT_SINGLE_QUOTE}Tis the season`, `${LEFT_SINGLE_QUOTE}T`],
+    [`${RIGHT_SINGLE_QUOTE}Twas the night`, `${RIGHT_SINGLE_QUOTE}T`],
+    [`${RIGHT_DOUBLE_QUOTE}Whoever wishes`, RIGHT_DOUBLE_QUOTE],
+    [`${LEFT_DOUBLE_QUOTE}1984 was a year`, LEFT_DOUBLE_QUOTE],
+    [LEFT_DOUBLE_QUOTE, LEFT_DOUBLE_QUOTE],
+    ["", ""],
+  ])("maps %p to %p", (text, expected) => {
+    expect(dropcapInitial(text)).toBe(expected)
+  })
+})
+
 describe("setFirstLetterAttribute", () => {
   it.each([
     [
@@ -1482,19 +1498,29 @@ describe("setFirstLetterAttribute", () => {
     `,
       `
       
-      <p data-first-letter="’">’Twas the night before Christmas.</p>
+      <p data-first-letter="’T">’Twas the night before Christmas.</p>
     
     `,
     ],
     [
       "second character is a quote and we have a direct text node to patch",
       '<p><strong></strong>"Twas the night</p>',
-      '<p data-first-letter="“"><strong></strong>“Twas the night</p>',
+      '<p data-first-letter="“T"><strong></strong>“Twas the night</p>',
     ],
     [
       "second character is an apostrophe and a direct text node exists",
       "<p><span></span>X's story</p>",
       '<p data-first-letter="X"><span></span>X ’s story</p>',
+    ],
+    [
+      "opening double quote joins the letter it introduces",
+      `<p>"Whoever wishes to foresee the future must consult the past."</p>`,
+      `<p data-first-letter="“W">“Whoever wishes to foresee the future must consult the past.”</p>`,
+    ],
+    [
+      "opening quote before a non-letter stands alone",
+      `<p>"1984 was a year."</p>`,
+      `<p data-first-letter="“">“1984 was a year.”</p>`,
     ],
   ])("%s", (_description, input, expected) => {
     const processedHtml = testHtmlFormattingImprovement(input, false)

--- a/quartz/styles/fonts.scss
+++ b/quartz/styles/fonts.scss
@@ -129,14 +129,18 @@ $fonts-dir: "/static/styles/fonts";
   font-family: "EBGaramondInitialsF1";
   src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF1.woff2") format("woff2");
   font-display: block;
-  -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Used in ::before, so subfont doesn't find automatically
+
+  // Used in ::before, so subfont doesn't find these automatically. The quotes
+  // are blank in this face, which keeps the embellishment registered with the
+  // letter of a quoted opening.
+  -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ“‘’";
 }
 
 @font-face {
   font-family: "EBGaramondInitialsF2";
   src: url("#{$fonts-dir}/EBGaramond/EBGaramond-InitialsF2.woff2") format("woff2");
   font-display: block;
-  -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  -subfont-text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ“‘’";
 }
 
 $italic-fonts: (
@@ -436,13 +440,34 @@ code {
   white-space: nowrap;
 }
 
+// A dropcap may open on a quotation ("“W"). The Initials faces kern the mark
+// to zero advance so it hangs to the left of the cap it introduces, and they
+// draw it blank on the embellishment layer — so the two layers stay registered
+// and only the left edge needs room. These are the marks' own advances:
+// 266/1000 em for the double mark, 169/1000 for the single ones.
+@mixin quoted-dropcap-inset {
+  --dropcap-quote-width: 0em;
+
+  &[data-first-letter^="“"] {
+    --dropcap-quote-width: 0.266em;
+  }
+
+  &[data-first-letter^="‘"],
+  &[data-first-letter^="’"] {
+    --dropcap-quote-width: 0.169em;
+  }
+}
+
 // For usage in the middle of a paragraph
 .dropcap {
+  @include quoted-dropcap-inset;
+
   display: inline-block;
   font-family: var(--font-dropcap-foreground);
   color: var(--foreground);
   position: relative;
   text-transform: uppercase;
+  padding-left: var(--dropcap-quote-width);
   margin-right: 0.05rem;
   cursor: text;
 
@@ -464,6 +489,8 @@ code {
 }
 
 article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
+  @include quoted-dropcap-inset;
+
   --dropcap-vertical-offset: #{$dropcap-vertical-offset};
   --dropcap-font-size: #{$dropcap-font-size};
   --before-color: var(--random-dropcap-color, var(--midground-faint));
@@ -476,14 +503,22 @@ article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
   cursor: text;
 
   // Float spacer: controls text wrapping with fixed width, preventing CLS
-  // when dropcap fonts load (::first-letter doesn't support width)
+  // when dropcap fonts load (::first-letter doesn't support width). The left
+  // pad holds the hanging quote of a quoted opening inside the text block:
+  // `#center-content` clips horizontal overflow, so a mark set outside the
+  // paragraph's content edge would be invisible.
   &::before {
     content: attr(data-first-letter);
     text-transform: uppercase;
     float: left;
+
+    // Two glyphs in a box sized for one, and a break after an opening quote is
+    // a legal break.
+    white-space: nowrap;
     width: var(--dropcap-font-size);
     font-size: var(--dropcap-font-size);
     line-height: 1;
+    padding-left: var(--dropcap-quote-width);
     padding-right: $dropcap-padding-right;
     padding-top: var(--dropcap-vertical-offset);
     font-family: var(--font-dropcap-background);
@@ -493,7 +528,9 @@ article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
 
   &::first-letter {
     // Pull back to overlap ::before; text wrapping is controlled by ::before's fixed width
-    margin-left: calc(-1 * var(--dropcap-font-size) - #{$dropcap-padding-right});
+    margin-left: calc(
+      -1 * var(--dropcap-font-size) - var(--dropcap-quote-width) - #{$dropcap-padding-right}
+    );
     padding-top: var(--dropcap-vertical-offset);
     text-transform: uppercase;
     font-style: normal !important;
@@ -503,6 +540,7 @@ article[data-use-dropcap="true"] > p:not(.subtitle):first-of-type {
     color: var(--foreground);
     font-size: var(--dropcap-font-size);
     line-height: 1;
+    padding-left: var(--dropcap-quote-width);
     padding-right: $dropcap-padding-right;
     font-family: var(--font-dropcap-foreground);
     font-weight: 500 !important;

--- a/quartz/styles/generate-critical.ts
+++ b/quartz/styles/generate-critical.ts
@@ -71,15 +71,28 @@ article[data-use-dropcap="true"][data-no-dropcap-color="true"] {
 article[data-use-dropcap="true"] > p:first-of-type {
   position: relative;
   min-height: #{$dropcap-min-height};
+
+  --dropcap-quote-width: 0em;
+}
+
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="“"] {
+  --dropcap-quote-width: 0.266em;
+}
+
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="‘"],
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="’"] {
+  --dropcap-quote-width: 0.169em;
 }
 
 article[data-use-dropcap="true"] > p:first-of-type::before {
   content: attr(data-first-letter);
   text-transform: uppercase;
   float: left;
+  white-space: nowrap;
   width: var(--dropcap-font-size);
   font-size: var(--dropcap-font-size);
   line-height: 1;
+  padding-left: var(--dropcap-quote-width);
   padding-right: #{$dropcap-padding-right};
   padding-top: var(--dropcap-vertical-offset);
   font-family: var(--font-dropcap-background);
@@ -87,7 +100,9 @@ article[data-use-dropcap="true"] > p:first-of-type::before {
 }
 
 article[data-use-dropcap="true"] > p:first-of-type::first-letter {
-  margin-left: calc(-1 * var(--dropcap-font-size) - #{$dropcap-padding-right});
+  margin-left: calc(
+    -1 * var(--dropcap-font-size) - var(--dropcap-quote-width) - #{$dropcap-padding-right}
+  );
   padding-top: var(--dropcap-vertical-offset);
   text-transform: uppercase;
   font-style: normal !important;
@@ -95,6 +110,7 @@ article[data-use-dropcap="true"] > p:first-of-type::first-letter {
   color: var(--foreground);
   font-size: var(--dropcap-font-size);
   line-height: 1;
+  padding-left: var(--dropcap-quote-width);
   padding-right: #{$dropcap-padding-right};
   font-family: var(--font-dropcap-foreground);
   font-weight: 500 !important;

--- a/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
+++ b/quartz/styles/tests/__snapshots__/generate-critical.test.ts.snap
@@ -50,15 +50,28 @@ article[data-use-dropcap="true"][data-no-dropcap-color="true"] {
 article[data-use-dropcap="true"] > p:first-of-type {
   position: relative;
   min-height: #{$dropcap-min-height};
+
+  --dropcap-quote-width: 0em;
+}
+
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="“"] {
+  --dropcap-quote-width: 0.266em;
+}
+
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="‘"],
+article[data-use-dropcap="true"] > p:first-of-type[data-first-letter^="’"] {
+  --dropcap-quote-width: 0.169em;
 }
 
 article[data-use-dropcap="true"] > p:first-of-type::before {
   content: attr(data-first-letter);
   text-transform: uppercase;
   float: left;
+  white-space: nowrap;
   width: var(--dropcap-font-size);
   font-size: var(--dropcap-font-size);
   line-height: 1;
+  padding-left: var(--dropcap-quote-width);
   padding-right: #{$dropcap-padding-right};
   padding-top: var(--dropcap-vertical-offset);
   font-family: var(--font-dropcap-background);
@@ -66,7 +79,9 @@ article[data-use-dropcap="true"] > p:first-of-type::before {
 }
 
 article[data-use-dropcap="true"] > p:first-of-type::first-letter {
-  margin-left: calc(-1 * var(--dropcap-font-size) - #{$dropcap-padding-right});
+  margin-left: calc(
+    -1 * var(--dropcap-font-size) - var(--dropcap-quote-width) - #{$dropcap-padding-right}
+  );
   padding-top: var(--dropcap-vertical-offset);
   text-transform: uppercase;
   font-style: normal !important;
@@ -74,6 +89,7 @@ article[data-use-dropcap="true"] > p:first-of-type::first-letter {
   color: var(--foreground);
   font-size: var(--dropcap-font-size);
   line-height: 1;
+  padding-left: var(--dropcap-quote-width);
   padding-right: #{$dropcap-padding-right};
   font-family: var(--font-dropcap-foreground);
   font-weight: 500 !important;

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -156,9 +156,16 @@ def check_favicons_missing(soup: BeautifulSoup) -> bool:
     return not soup.select("article p img.favicon, article p svg.favicon")
 
 
+#: Opening quotes a dropcap may set together with the letter they introduce.
+#: `RIGHT_SINGLE_QUOTE` covers elision ("’Twas").
+DROPCAP_LEADING_QUOTES: frozenset[str] = frozenset(
+    (LEFT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE)
+)
+
+
 def check_article_dropcap_first_letter(soup: BeautifulSoup) -> list[str]:
-    """Unless `data-use-dropcap="false"`, require `data-first-letter` to contain
-    an alphanumeric character."""
+    """Unless `data-use-dropcap="false"`, require `data-first-letter` to end in
+    an alphanumeric character, optionally preceded by an opening quote."""
     issues: list[str] = []
     for article in soup.find_all("article"):
         if article.get("data-use-dropcap") == "false":
@@ -169,13 +176,18 @@ def check_article_dropcap_first_letter(soup: BeautifulSoup) -> list[str]:
             continue
 
         first = p.get("data-first-letter", "")
-        if not isinstance(first, str) or len(first) != 1:
+        if not isinstance(first, str) or len(first) not in (1, 2):
             issues.append(
-                f"invalid data-first-letter length (expected 1): {first!r}"
+                f"invalid data-first-letter length (expected 1 or 2): {first!r}"
             )
             continue
-        if not first[0].isalnum():
+        if not first[-1].isalnum():
             issues.append(f"non-alphanumeric data-first-letter: {first!r}")
+            continue
+        if len(first) == 2 and first[0] not in DROPCAP_LEADING_QUOTES:
+            issues.append(
+                f"data-first-letter must lead with an opening quote: {first!r}"
+            )
 
     return issues
 

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -6755,6 +6755,22 @@ def test_check_html_tags_in_text_real_world_katex():
             f'<article><p data-first-letter="{built_site_checks.RIGHT_SINGLE_QUOTE}">{built_site_checks.RIGHT_SINGLE_QUOTE}Twas</p></article>',
             False,
         ),
+        (
+            f'<article><p data-first-letter="{built_site_checks.RIGHT_SINGLE_QUOTE}T">{built_site_checks.RIGHT_SINGLE_QUOTE}Twas</p></article>',
+            True,
+        ),
+        (
+            f'<article><p data-first-letter="{built_site_checks.LEFT_DOUBLE_QUOTE}W">{built_site_checks.LEFT_DOUBLE_QUOTE}Whoever</p></article>',
+            True,
+        ),
+        (
+            f'<article><p data-first-letter="{built_site_checks.LEFT_SINGLE_QUOTE}T">{built_site_checks.LEFT_SINGLE_QUOTE}Tis</p></article>',
+            True,
+        ),
+        (
+            f'<article><p data-first-letter="{built_site_checks.RIGHT_DOUBLE_QUOTE}W">{built_site_checks.RIGHT_DOUBLE_QUOTE}Whoever</p></article>',
+            False,
+        ),
     ],
 )
 def test_check_article_dropcap_first_letter(html: str, ok: bool):
@@ -6780,7 +6796,7 @@ def test_check_article_dropcap_first_letter(html: str, ok: bool):
         # Invalid: missing/empty attribute
         (
             "<article><p>Missing attribute</p></article>",
-            ["invalid data-first-letter length (expected 1): ''"],
+            ["invalid data-first-letter length (expected 1 or 2): ''"],
         ),
         # Invalid: non-alphanumeric
         (
@@ -6789,10 +6805,20 @@ def test_check_article_dropcap_first_letter(html: str, ok: bool):
                 f"non-alphanumeric data-first-letter: '{built_site_checks.RIGHT_SINGLE_QUOTE}'"
             ],
         ),
-        # Invalid: wrong length
+        # Invalid: two characters not led by an opening quote
         (
             '<article><p data-first-letter="AB">Alpha</p></article>',
-            ["invalid data-first-letter length (expected 1): 'AB'"],
+            ["data-first-letter must lead with an opening quote: 'AB'"],
+        ),
+        # Invalid: wrong length
+        (
+            '<article><p data-first-letter="ABC">Alpha</p></article>',
+            ["invalid data-first-letter length (expected 1 or 2): 'ABC'"],
+        ),
+        # Valid: an opening quote joined to the letter it introduces
+        (
+            f'<article><p data-first-letter="{built_site_checks.LEFT_DOUBLE_QUOTE}W">{built_site_checks.LEFT_DOUBLE_QUOTE}Whoever</p></article>',
+            [],
         ),
         # Direct child paragraph only (nested ignored)
         (

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -486,7 +486,7 @@ However, text [blocks](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
 ### Opening on a quotation
 
 <figure class="float-right" style="margin-top: 2rem;">
-<div class="dropcap" data-first-letter="“W" style="font-size: 4rem;">“W</div>
+<div class="dropcap" data-first-letter="“W" style="font-size: var(--dropcap-font-size);">“W</div>
 <figcaption>The mark hangs off the left of the capital.</figcaption>
 </figure>
 

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -483,6 +483,17 @@ However, text [blocks](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
 > }
 > ```
 
+### Opening on a quotation
+
+<figure class="float-right" style="margin-top: 2rem;">
+<div class="dropcap" data-first-letter="“W" style="font-size: 4rem;">“W</div>
+<figcaption>The mark hangs off the left of the capital.</figcaption>
+</figure>
+
+Some posts begin inside someone else's words. A quotation mark left at body size next to a four-line capital looks like a stray speck, so I set the mark at dropcap size alongside the letter it introduces. EB Garamond makes this easy: the initials kern an opening quote to zero width, and the embellishment face draws the mark blank, so the ornament stays behind the letter alone.
+
+<span class="dropcap" data-first-letter="“W">“W</span>hoever wishes to foresee the future must consult the past.”
+
 ### Rare dropcap coloring
 
 Every time you navigate to a new page, there's a <span id="populate-dropcap-probability"></span> chance to get a random dropcap color. :)

--- a/website_content/fixtures/quote-dropcap-fixture.md
+++ b/website_content/fixtures/quote-dropcap-fixture.md
@@ -1,0 +1,15 @@
+---
+title: Quote dropcap fixture
+permalink: quote-dropcap-fixture
+no_dropcap_color: "true"
+tags:
+  - website
+description: Stable fixture whose first paragraph opens on a quotation, used by dropcap.spec.ts to check the combined quote-and-letter dropcap.
+hideSubscriptionLinks: true
+date_published: 2026-08-03
+date_updated: 2026-08-03
+---
+
+"Whoever wishes to foresee the future must consult the past," wrote Machiavelli, and this page exists so the combined quote-and-letter dropcap has a deterministic home. The opening quotation mark is set at dropcap size beside the W, and the embellishment behind the pair stays under the letter alone. The paragraph runs long enough to wrap several times at every tested viewport width.
+
+The second paragraph takes no dropcap; it is here so the screenshot captures the rhythm of ordinary body text directly under the illuminated opening.

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -781,7 +781,9 @@ We held a 1-on-1 with GPT-4 about the 9-to-5 grind, X-ray goggles, and the mid-1
 
 <span id="single-letter-dropcap" class="dropcap" data-first-letter="T">T</span>his paragraph demonstrates a dropcap.
 
-<span id="quote-letter-dropcap" class="dropcap" data-first-letter="“W">“W</span>hoever wishes to foresee the future must consult the past,” wrote Machiavelli — and this paragraph demonstrates an opening quote set together with the letter it introduces.
+<figure class="float-right">
+<div id="quote-letter-dropcap" class="dropcap" data-first-letter="“W" style="font-size: var(--dropcap-font-size);">“W</div>
+</figure>
 
 <div style="font-size:4rem;line-height:1.4 !important;" class="centered ignore-pa11y">
 <span class="dropcap ignore-pa11y" style="font-family: var(--font-dropcap-background); color: var(--midground-faint);" aria-hidden="true">A</span>

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -781,14 +781,11 @@ We held a 1-on-1 with GPT-4 about the 9-to-5 grind, X-ray goggles, and the mid-1
 
 <span id="single-letter-dropcap" class="dropcap" data-first-letter="T">T</span>his paragraph demonstrates a dropcap.
 
-<figure class="float-right">
-<div id="quote-letter-dropcap" class="dropcap" data-first-letter="“W" style="font-size: var(--dropcap-font-size);">“W</div>
-</figure>
-
 <div style="font-size:4rem;line-height:1.4 !important;" class="centered ignore-pa11y">
 <span class="dropcap ignore-pa11y" style="font-family: var(--font-dropcap-background); color: var(--midground-faint);" aria-hidden="true">A</span>
 <span class="dropcap" data-first-letter="" style="color: var(--foreground);">A</span>
 <div class="dropcap" data-first-letter="A" style="color: var(--foreground);--before-color:var(--foreground);">A</div>
+<div id="quote-letter-dropcap" class="dropcap" data-first-letter="“A">“A</div>
 </div>
 
 <div id="the-pond-dropcaps" style="font-size:min(4rem, 15vw);line-height:1;" class="centered">

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -781,6 +781,8 @@ We held a 1-on-1 with GPT-4 about the 9-to-5 grind, X-ray goggles, and the mid-1
 
 <span id="single-letter-dropcap" class="dropcap" data-first-letter="T">T</span>his paragraph demonstrates a dropcap.
 
+<span id="quote-letter-dropcap" class="dropcap" data-first-letter="“W">“W</span>hoever wishes to foresee the future must consult the past,” wrote Machiavelli — and this paragraph demonstrates an opening quote set together with the letter it introduces.
+
 <div style="font-size:4rem;line-height:1.4 !important;" class="centered ignore-pa11y">
 <span class="dropcap ignore-pa11y" style="font-family: var(--font-dropcap-background); color: var(--midground-faint);" aria-hidden="true">A</span>
 <span class="dropcap" data-first-letter="" style="color: var(--foreground);">A</span>


### PR DESCRIPTION
## Summary

- A post that opens on a quotation could not get a proper dropcap: `data-first-letter` held only the quotation mark, so the embellishment layer drew a mark while `::first-letter` drew mark + capital. This makes the pair render as one illuminated initial.
- The EB Garamond Initials faces already do the typographically right thing — they kern an opening quote to *zero* advance so it hangs off the left of the capital, and they draw the mark blank on the embellishment face, so the two layers stay registered on their own. The only thing CSS has to supply is room on the left.
- `#center-content` clips horizontal overflow, so a mark left hanging outside the paragraph's content edge is invisible. The dropcap therefore pads left by the mark's own advance and the mark hangs just inside the text block.

## Changes

- `formatting_improvement_html.ts`: new `dropcapInitial()` — when the first paragraph opens on `“`, `‘`, or `’` followed by a letter, `data-first-letter` becomes the pair (`“W`). Otherwise unchanged.
- `fonts.scss` / `generate-critical.ts`: shared `quoted-dropcap-inset` mixin maps the leading mark to its advance (0.266em double, 0.169em single) and pads the dropcap left by it. Applied to both the first-paragraph dropcap and the inline `.dropcap` span. `white-space: nowrap` on the `::before` spacer — two glyphs in a box sized for one, and a break after an opening quote is a legal break.
- `fonts.scss`: added `“‘’` to `-subfont-text` for both Initials faces so the subsets keep the marks.
- `built_site_checks.py`: `check_article_dropcap_first_letter` now accepts an alphanumeric optionally preceded by an opening quote, instead of requiring exactly one alphanumeric character.
- New `website_content/fixtures/quote-dropcap-fixture.md`, a visual-regression shot, and geometry specs in `dropcap.spec.ts`.
- `test-page.md`: inline combined-dropcap example. `design.md`: a `### Opening on a quotation` section with a float-right figure and a demo sentence.

## Testing

- `pnpm test` (5150 tests, 104 suites) and `pnpm check` pass; `uv run pytest scripts/tests/test_built_site_checks.py` passes (1032 tests).
- Rendering verified against a local offline build in Chromium and Firefox: the mark renders at dropcap size, hangs left of the capital, and the embellishment stays registered behind the letter alone. WebKit is not installable in this sandbox, so macOS CI is the first WebKit signal.

### Test expectations changed

Three existing expectations encoded the old single-character behavior and had to move with the feature:

- `’Twas…` → `data-first-letter="’T"` (was `"’"`)
- `“Twas…` → `data-first-letter="“T"` (was `"“"`)
- Python: `"AB"` now reports "must lead with an opening quote" rather than a length error

## Lessons learned

- **What**: When a CSS change depends on how a glyph is laid out, measure the font before designing around it — `canvas.measureText(pair) - measureText(letter)` reveals kern pairs that make an intuition-based layout wrong.
- **Where**: any repo doing typographic CSS.
- **Why**: Two rounds of CSS here were built on the assumption that an opening quote advances normally. It does not in these faces (the kern is exactly `-advance`), which inverted the correct fix from "widen the box" to "pad the box". A one-line canvas measurement would have settled it before the first build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QaqdAdzCxcofDG39s878Fi)_