### PR TITLE
feat(signature): build a self-contained turntrout.com email signature

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -187,6 +187,37 @@ runs this daily and opens an auto-merged PR when content changed. When adding a
 new GitHub source, add it to `externalReadmes.ts`, run the script, and commit
 the new snapshot — a missing snapshot fails the build with instructions.
 
+## Email signature
+
+`scripts/email_signature/` builds the signature pasted into Proton Mail. Open
+`signature.html` in a browser and press **Copy signature**; it is a build
+artifact, so edit `template.html` (markup and colours) or `page.js` (clipboard
+handling) and regenerate:
+
+```bash
+uv run python scripts/build_email_signature.py
+```
+
+Two constraints shape the design:
+
+- **Fonts are inlined, not linked.** Mail clients do not fetch remote
+  `@font-face` sources, so the build subsets EBGaramond and FiraCode down to
+  the characters the signature actually renders (a few kB total) and embeds
+  them as base64 `data:` URLs. An element declares its face with
+  `data-tt-font="serif|mono"`; the build reads the glyph set from that
+  annotation and strips the attribute from the output. Adding text to the
+  signature therefore requires a rebuild, or the new glyphs fall back to
+  Garamond/Palatino/Times.
+- **The copy goes through a `copy` event.** `navigator.clipboard.write`
+  sanitizes `text/html` and deletes the `<style>` element the faces arrive in,
+  as does selecting the preview by hand. `document.execCommand("copy")` with an
+  overridden `clipboardData` is passed through verbatim.
+
+Colours are literal hex values mirroring the light palette, with a
+`prefers-color-scheme: dark` block for clients that honour it; `signature.html`
+previews both. `config/prettier/.prettierignore` skips this directory's HTML —
+prettier rewrites the `{{TOKEN}}` placeholders into nested CSS/JS blocks.
+
 ## Favicon kerning audit
 
 Favicon spacing (`quartz/styles/favicon.scss` `$domain-left-insets`,

--- a/config/prettier/.prettierignore
+++ b/config/prettier/.prettierignore
@@ -31,3 +31,6 @@ pnpm-lock.yaml
 .claude-tooling/
 .worktrees
 .pnpm-store
+# Email-signature page: prettier-html rewrites the `{{TOKEN}}` placeholders
+# into nested CSS/JS blocks, and `signature.html` is generated output.
+**/scripts/email_signature/*.html

--- a/scripts/build_email_signature.py
+++ b/scripts/build_email_signature.py
@@ -1,0 +1,183 @@
+"""
+Build the self-contained turntrout.com email signature page.
+
+Email clients cannot fetch `@font-face` sources reliably and strip most
+external references, so the signature carries its own faces: each font is
+subset down to the exact characters the signature renders and inlined as a
+base64 `data:` URL. Both subsets together weigh a few kilobytes.
+
+The characters to keep are read out of `template.html` — an element tagged
+`data-tt-font="<key>"` declares that its text is rendered in that face. The
+attribute is a build-time annotation and is stripped from the output.
+
+Usage:
+    uv run python scripts/build_email_signature.py
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Final, NamedTuple
+
+from bs4 import BeautifulSoup
+from fontTools.subset import Options, Subsetter
+from fontTools.ttLib import TTFont
+from fontTools.varLib import instancer
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+_FONT_DIR: Final[Path] = _REPO_ROOT / "quartz" / "static" / "styles" / "fonts"
+_SIGNATURE_DIR: Final[Path] = _REPO_ROOT / "scripts" / "email_signature"
+TEMPLATE_PATH: Final[Path] = _SIGNATURE_DIR / "template.html"
+SCRIPT_PATH: Final[Path] = _SIGNATURE_DIR / "page.js"
+OUTPUT_PATH: Final[Path] = _SIGNATURE_DIR / "signature.html"
+
+_BUILD_ATTRIBUTE: Final[str] = "data-tt-font"
+_BUILD_ATTRIBUTE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    rf'\s*{_BUILD_ATTRIBUTE}="[^"]*"'
+)
+
+
+class FontSpec(NamedTuple):
+    """A face to subset and inline, keyed by its `data-tt-font` value."""
+
+    key: str
+    family: str
+    source: Path
+    # Variable-font axis positions to pin before subsetting, or None for a
+    # static face. Emails have no use for the extra axis machinery.
+    pin: Mapping[str, float] | None
+
+
+FONT_SPECS: Final[tuple[FontSpec, ...]] = (
+    FontSpec(
+        key="serif",
+        family="EBGaramondSig",
+        source=_FONT_DIR / "EBGaramond" / "EBGaramond08-Regular.woff2",
+        pin=None,
+    ),
+    FontSpec(
+        key="mono",
+        family="FiraCodeSig",
+        source=_FONT_DIR / "firacode-vf.woff2",
+        # The site renders inline code at the normal weight; FiraCode's
+        # variable default is 300.
+        pin={"wght": 400},
+    ),
+)
+
+
+# Dark-background overrides, keyed by the class the template puts on each part.
+# The inline styles carry the light palette, so these need `!important` to win.
+# Clients without `prefers-color-scheme` fall back to the inline colors, which
+# their own dark-mode heuristics invert.
+DARK_RULES: Final[tuple[tuple[str, str], ...]] = (
+    ("tt-sig-name", "color: #eff2ff !important;"),
+    ("tt-sig-link", "color: #b4c7f5 !important;"),
+    ("tt-sig-rule", "border-left-color: #333540 !important;"),
+)
+
+
+def collect_font_text(template_html: str) -> dict[str, str]:
+    """Map each `data-tt-font` key to the concatenated text it renders."""
+    soup = BeautifulSoup(template_html, "html.parser")
+    per_key: dict[str, str] = {}
+    for element in soup.select(f"[{_BUILD_ATTRIBUTE}]"):
+        key = str(element[_BUILD_ATTRIBUTE])
+        per_key[key] = per_key.get(key, "") + element.get_text()
+    return per_key
+
+
+def subset_font(spec: FontSpec, text: str) -> bytes:
+    """Return a WOFF2 subset of `spec` covering exactly the glyphs in `text`."""
+    # `recalcTimestamp` would stamp `head.modified` with the build time, making
+    # the checked-in page churn on every rebuild.
+    font = TTFont(spec.source, recalcTimestamp=False)
+    if spec.pin is not None:
+        font = instancer.instantiateVariableFont(
+            font, dict(spec.pin), inplace=True
+        )
+
+    options = Options()
+    options.layout_features = ["kern", "liga", "calt", "locl", "ccmp"]
+    options.desubroutinize = True
+    options.name_IDs = []
+    options.name_legacy = False
+    options.notdef_outline = False
+    options.drop_tables += ["DSIG", "FFTM"]
+
+    subsetter = Subsetter(options=options)
+    subsetter.populate(text=text)
+    subsetter.subset(font)
+
+    font.flavor = "woff2"
+    buffer = io.BytesIO()
+    font.save(buffer)
+    return buffer.getvalue()
+
+
+def render_font_face(spec: FontSpec, payload: bytes) -> str:
+    """Render a single `@font-face` rule with the subset inlined."""
+    encoded = base64.b64encode(payload).decode("ascii")
+    return (
+        "@font-face {\n"
+        f"  font-family: {spec.family};\n"
+        "  font-style: normal;\n"
+        "  font-weight: 400;\n"
+        "  font-display: swap;\n"
+        f'  src: url("data:font/woff2;base64,{encoded}") format("woff2");\n'
+        "}"
+    )
+
+
+def build_font_faces(template_html: str) -> str:
+    """Render the `@font-face` block for every spec used by the template."""
+    per_key = collect_font_text(template_html)
+    missing = sorted({spec.key for spec in FONT_SPECS} - per_key.keys())
+    if missing:
+        raise ValueError(
+            f"template has no {_BUILD_ATTRIBUTE} element for: {', '.join(missing)}"
+        )
+    return "\n".join(
+        render_font_face(spec, subset_font(spec, per_key[spec.key]))
+        for spec in FONT_SPECS
+    )
+
+
+def render_dark_rules(prefix: str = "") -> str:
+    """Render the dark-background overrides, optionally scoped by `prefix`."""
+    return "\n".join(
+        f"{prefix}.{class_name} {{ {declarations} }}"
+        for class_name, declarations in DARK_RULES
+    )
+
+
+def build_page(template_html: str, page_script: str) -> str:
+    """Substitute the generated fonts, overrides, and script into the
+    template."""
+    page = template_html.replace(
+        "{{FONT_FACES}}", build_font_faces(template_html)
+    )
+    page = page.replace("{{DARK_RULES}}", render_dark_rules())
+    page = page.replace(
+        "{{DARK_PREVIEW_RULES}}", render_dark_rules(".card.dark ")
+    )
+    page = page.replace("{{COPY_SCRIPT}}", page_script)
+    return _BUILD_ATTRIBUTE_PATTERN.sub("", page)
+
+
+def main() -> None:
+    """Regenerate `signature.html` from the template, script, and fonts."""
+    template_html = TEMPLATE_PATH.read_text(encoding="utf-8")
+    page_script = SCRIPT_PATH.read_text(encoding="utf-8")
+    OUTPUT_PATH.write_text(
+        build_page(template_html, page_script), encoding="utf-8"
+    )
+    print(f"Wrote {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/email_signature/page.js
+++ b/scripts/email_signature/page.js
@@ -7,7 +7,7 @@
 
 const signature = document.getElementById("tt-signature")
 const fontStyle = document.getElementById("tt-signature-fonts")
-const status = document.getElementById("copy-status")
+const statusLine = document.getElementById("copy-status")
 
 const signatureHtml = fontStyle.outerHTML + signature.outerHTML
 const plainText = signature.innerText.trim().replace(/\n\s*\n/g, "\n")
@@ -19,10 +19,10 @@ document.getElementById("source").value = signatureHtml
 
 let statusTimer = 0
 function report(message) {
-  status.textContent = message
+  statusLine.textContent = message
   window.clearTimeout(statusTimer)
   statusTimer = window.setTimeout(() => {
-    status.textContent = ""
+    statusLine.textContent = ""
   }, 4000)
 }
 

--- a/scripts/email_signature/page.js
+++ b/scripts/email_signature/page.js
@@ -1,0 +1,74 @@
+// Drives the generated signature preview page: renders the dark-background
+// preview, exposes the HTML source, and copies the signature to the clipboard.
+//
+// A hand-made selection is serialized by the browser as inline styles only,
+// and the embedded font faces live in a <style> element, so the clipboard
+// payload has to be assembled explicitly.
+
+const signature = document.getElementById("tt-signature")
+const fontStyle = document.getElementById("tt-signature-fonts")
+const status = document.getElementById("copy-status")
+
+const signatureHtml = fontStyle.outerHTML + signature.outerHTML
+const plainText = signature.innerText.trim().replace(/\n\s*\n/g, "\n")
+
+const darkPreview = signature.cloneNode(true)
+darkPreview.removeAttribute("id")
+document.getElementById("dark-preview").append(darkPreview)
+document.getElementById("source").value = signatureHtml
+
+let statusTimer = 0
+function report(message) {
+  status.textContent = message
+  window.clearTimeout(statusTimer)
+  statusTimer = window.setTimeout(() => {
+    status.textContent = ""
+  }, 4000)
+}
+
+/**
+ * Put `flavors` (a MIME-type → payload map) on the clipboard.
+ *
+ * `navigator.clipboard.write` sanitizes `text/html`, which deletes the <style>
+ * element the embedded fonts arrive in. A `copy` event's payload is passed
+ * through verbatim, so the fonts survive the round trip into Proton Mail.
+ */
+function copyToClipboard(flavors) {
+  const onCopy = (event) => {
+    event.preventDefault()
+    for (const [type, payload] of Object.entries(flavors)) {
+      event.clipboardData.setData(type, payload)
+    }
+  }
+  document.addEventListener("copy", onCopy, { once: true })
+
+  // Firefox refuses `execCommand("copy")` without a live selection.
+  const selection = window.getSelection()
+  const range = document.createRange()
+  range.selectNode(signature)
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  const copied = document.execCommand("copy")
+
+  selection.removeAllRanges()
+  document.removeEventListener("copy", onCopy)
+  return copied
+}
+
+function bind(id, flavors, message) {
+  document.getElementById(id).addEventListener("click", () => {
+    report(
+      copyToClipboard(flavors)
+        ? message
+        : "Copy failed — open “HTML source” below and copy it by hand.",
+    )
+  })
+}
+
+bind(
+  "copy-rich",
+  { "text/html": signatureHtml, "text/plain": plainText },
+  "Copied — paste into Proton’s signature editor.",
+)
+bind("copy-source", { "text/plain": signatureHtml }, "Copied HTML source.")

--- a/scripts/email_signature/signature.html
+++ b/scripts/email_signature/signature.html
@@ -234,7 +234,7 @@
 
 const signature = document.getElementById("tt-signature")
 const fontStyle = document.getElementById("tt-signature-fonts")
-const status = document.getElementById("copy-status")
+const statusLine = document.getElementById("copy-status")
 
 const signatureHtml = fontStyle.outerHTML + signature.outerHTML
 const plainText = signature.innerText.trim().replace(/\n\s*\n/g, "\n")
@@ -246,10 +246,10 @@ document.getElementById("source").value = signatureHtml
 
 let statusTimer = 0
 function report(message) {
-  status.textContent = message
+  statusLine.textContent = message
   window.clearTimeout(statusTimer)
   statusTimer = window.setTimeout(() => {
-    status.textContent = ""
+    statusLine.textContent = ""
   }, 4000)
 }
 

--- a/scripts/email_signature/signature.html
+++ b/scripts/email_signature/signature.html
@@ -1,0 +1,305 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>turntrout.com email signature</title>
+    <style id="tt-signature-fonts">
+      @font-face {
+  font-family: EBGaramondSig;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("data:font/woff2;base64,d09GMgABAAAAAAagAA4AAAAACzgAAAZMAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGhYbIByBMgZgAHQRCAqPFIxYATYCJAMwCxoABCAFBgcgG+sIQB6HsWP6jzOxMlO7A9y0C8FGkFAgAapC3ZEZUnGhnRhsDvOnqjNTyot7+x8g/mz+yxT8//crfX9oOJqijAd0RP6fO1W9GZYt1McjGhcsWnhtwXAfw7lC/+YLaH01BgQA2IA+CiBgwLYXAGCBAzgBolCps4AJVEDaPFBKCBRQAtSstHJFR9PEqu2obuzQVK5vASfgSjVH1ClZLmD3NQN7GOU4BCiV5U164Da1VjaBkAZzawRQYAIBfiOUpZmAQCIgRU+PFW4mOpWHAgJ2BgcKZAMWTVi9DguoVB2yG2gANCPNHgAh91qhV6GCwkQo6KNR6OCgUufeeKu0GmUVJIMLLKc9++8ZAMOZEiLFRhNoioALSHwSpDgACOOBPSoVyv4iDihQwQVSIAuqoQlaoAO6YPk8APrvMP+RG44ZM6BfjzfsCQE0Ie2p7kWjeL8x5SwAmgNoou6pW2UA8tpfh2U6c7yWRMv1cfJ/DCzTHKDXF72IGA/ZyHPHRqU5gyy2SZzVfyTizAWQCEeqztb4Jdu+Pmw11DdGrhoaG9p7LLnvFWbuGRg4Iam3WrM7+gcwzDzkVjDo8I/hvIdpzjoO2Cy6VPXIhjCMLNpzOe9vOb6fZTqIGG2IcQ4xHsLMD6wYz/woru/QPsx8AAzjYLCCoZ9lyrnJYpuGgW6wLu6xthpes0xzc4jRhpmtYOBFLcJ+gJgVM9uI7WsMPRjHfAwxuh3Qmpo995zvdjcjzyLGS97npL0DwNRsHmFdZbBYph/EgvYZUANeyDPw54NhfyGd07+0AhYKYMDMslD0FFtTtxqEPUv3Vd8h8lB1PIE0wAnEoJsmVA0SvZPE4J7d5zWX0DYtiZV0D1HtmNmmIYeOjwAY1XCvufSrAvUSOb1LQJhladiq3L6hSb+cw736+/f3g+GAaOYCSNE8PKYb2uS5BXNeDzugSpTdg5lJRbjh1yrLSEB27jGe1EFi9qDxEt1qtm3y2icr22qNONNqCTaZUzIX2YMDrAYa9ovyB+wLT4HijdX7On/6enDOI4guk7yMBPPA9PMz2hJT40TrMU/NMUxETuLcj+XE6aAvXENjbyyX5Ig3a95/6LwyvwR3X8h9hb7iOORiHKd0PheVi1b88femUeXm6OM+gjcqNv2v37CprPwdlPXfD8P0cu4/QZsTy1SS757vD5H+7VT70eq1q15AXHKAw8kUNIump8n8mmhqGjX9FsfYv346UiaPkSa7/u3hgBcMxXLsAviiBYvc7dAUpiiBhwVmOIY8Cj2O6MvEGD+SS98idUDrmVKLnTCiUOKTwLlASGNkctVpuQiebw87U29qnl6ve9h95b/5y9u3Sbc98bjorrrbOy1uz/IyTUAZkUzSnV++zR7gc7l0sWxJdGDmqhogPHxV4u0YT2jGSE+Sb58vKfBWyw7bn4n/wQX37vCsFCv5TH63a4nMS12QJ4HUHz0XyLZ3C7RQ0yMTfJ20xGZCExhbUr1bU9zQ2o4s7PpOQzgJujzEzZZByq4jLk+ww4Hnf9TB6bcqKb/bLZxLZx6s0A019Bzs6Azw0hYsFoFPPGh0csF2vTrJgYLjCm59KWwmrVx1qDlMFr/LyzG1wYFbFkN4KmK80F3ecbpVmSTEBMuenIsgsF/Eftn+Sga9MjVC71mUox8q6cnQH3XBGRWiXOFIXhematWtqTnd+fKN6aXsL5z52oxTbbgWW8C87mGpK+8fBpNguUDsuCfeTwpeFDJOiLb3Is/jjkpRWsArsmuybiv88Ttrmsqtmqjy4+HnRckndF4B5xRWcch+XKK4HGw/f/b3BTGL39rrgO8n7U5oJBqJThQyXghMva8y7b9lhYbqzV+zufqJzIMuPmK8GHOSYzjZj4uVxG8tpcTy8fVni9epM4ePQPA/rfFHZAV80j7940yZPk4ukuD9JK8SwwUnshknrG7Uvq5k37l9fXs7lU6giC1+n+SlXyk8cv8ikX+HtNV6aOOVEZ2eBUWG48qu9A7XP/gAaETOmy5RB/9byov/jYkxAXnP6t6uhVt8vvavy0Cf/yRvWicAMIGip/yttNFC+Ohp/79fDdloJlQg+2Qe70u9DItQFwiiRIAzNQ98Ka/BF30IQnQCJGgB0I9U/1NCeqBUE9zGJQNy6YCCvPnbBQAAAA==") format("woff2");
+}
+@font-face {
+  font-family: FiraCodeSig;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("data:font/woff2;base64,d09GMgABAAAAAAQ0ABAAAAAAB3wAAAPZAAYAgwAAAAAAAAAAAAAAAAAAAAAAAAAAGhYbIByCQgZgP1NUQVREAFQRCAqFVIR/ATYCJAMaCxoABCAFRAcgDAcb9QUoBiKgs6qeTDYTHKgVfGDWuBwAv8CZ737qomlnN9wbpXtFWoYf4L0ZNa2tgKt0OqDhf7PNtjGajVYYJCJymfXtQAhgAwAUBMGEIICFznRFIqMTM9FQAXQdAFyCQBJxyvW1O2rKdlhYk18Ky8bWVfAmFFcUcR0OhzZilABiH1tWh5YKQM01Zzwfn3Hm8KqNcgIEDeFNmmTERkf640usCRS0dgDBgNb4oGANC5BRNBWWBwVwskQNSBpehZJNHdetYqEtPXHtZEEJwkEycSN01CkBb41oYScM7tmqekyWYQT1V3UFsEIIKQdxl+Buq2Y2goKao2WCRmRGhnMNZ+pN2n/7wKQpuYAAqF2MY4HuGL8EWqMQozNKY2FRnQCotEcBFFFkGcgokBuAwehSLgGgULg1hsB9VEIBGxoKKs7YqaSGel0HjVxOqvtMf1vfoq/WV+orENgvCPC7ZoBgA6A9YAEegbgA/YHWVIGgoEi9zhtDl95tm9vaG9u3bl658I2UrFevLAtef12mv/GGdeFrWZlbg2XBK6a99trEUfIaThbj9IFmXpNma9ZNQH7IFcobDlSXYgm+GqziyLRwY9a9Mq/tDVkrrWI1WaQJmvDKPHMneIhiZbTkWHMnPpojxWgRq+QoTTJt6nAFTBSVOSarZsl+5TTZ36197kZ2OVLmeaxNK4/0vx4xcvO7c2p/3b2l7u93l27JPxYYF5hWGe48xzl63tGHzxelHluUjs+vHh4jBgVMdjTf9Ju9XY6fywj/QeHumxWO27Bz2dhlltlxqCQ9JbDYt33a4dJE7ndZalseknote/jGRTtX/Ldvelm7WQmBqcFlXpmp53T67PJYfW9O3m97txf+cW/RqlX35xb8vntn6ftgwcp58xbce/Vs3v15/Lb3X7yYe4+X03d12jW9d9c/A6cfXrx0cKTNz3W1ltvLcfigx+Err09ffO6z5lOWt7MT+swrY32/+ANnjy+q+3nGzz/sbWUoazU9tyZ3xPCyAHun3bRr3eXroqzhw3M2jBsYYdrXZWmTxUEppzNHrl+zY+X/7FnvNiQ52dndI8VZQDe3IanQwz3ZeSpqP7R/QwETmt4clf1Pury6/q8xV/jTHRgD/32hf6W0k7i/3qoscew5dRoCODGz9q2Zw0c3C/xNM5i2ALz39O/vS+DVgElIUk0wdvd3KgAI/D2beszDIr8HAuvEXotUzpLPfVbykq3cl73/fYF8CwSw0RsFVwy4Sg0YGNg6VDMKTUGRErDRVDX/WDr5FFJPGWOpIYd8iimkiDoMAKBvwh0QuPSc6LOPqYsBAAA=") format("woff2");
+}
+      @media (prefers-color-scheme: dark) {
+        .tt-sig-name { color: #eff2ff !important; }
+.tt-sig-link { color: #b4c7f5 !important; }
+.tt-sig-rule { border-left-color: #333540 !important; }
+      }
+    </style>
+    <style>
+      body {
+        margin: 0;
+        padding: 2.5rem 1.5rem;
+        background: #fcfcff;
+        color: #383a4e;
+        font-family: system-ui, sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        max-width: 44rem;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 0 0 0.25rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: #737483;
+        font-size: 0.9rem;
+      }
+
+      .card {
+        border: 1px solid #dfdfe4;
+        border-radius: 0.5rem;
+        padding: 1.5rem;
+        margin-bottom: 0.75rem;
+        background: #ffffff;
+      }
+
+      .card.dark {
+        background: #12141e;
+        border-color: #2c2f3f;
+      }
+
+      /* Mirrors the copied `prefers-color-scheme: dark` block so the dark card
+         previews it regardless of the browser's own colour scheme. */
+      .card.dark .tt-sig-name { color: #eff2ff !important; }
+.card.dark .tt-sig-link { color: #b4c7f5 !important; }
+.card.dark .tt-sig-rule { border-left-color: #333540 !important; }
+
+      .swatch-label {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #9a9ba6;
+        margin-bottom: 0.75rem;
+      }
+
+      button {
+        font: inherit;
+        font-size: 0.85rem;
+        padding: 0.5rem 0.9rem;
+        margin-right: 0.5rem;
+        border: 1px solid #dfdfe4;
+        border-radius: 0.375rem;
+        background: #ffffff;
+        color: #383a4e;
+        cursor: pointer;
+      }
+
+      button:hover {
+        border-color: #9a9ba6;
+      }
+
+      #copy-status {
+        font-size: 0.85rem;
+        color: #737483;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 9rem;
+        margin-top: 1rem;
+        padding: 0.75rem;
+        border: 1px solid #dfdfe4;
+        border-radius: 0.375rem;
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 0.75rem;
+        color: #555769;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>turntrout.com email signature</h1>
+      <p>
+        Press <strong>Copy signature</strong>, then paste into Proton Mail → Settings → Identity and
+        addresses → Edit signature. The button writes real <code>text/html</code> to the clipboard,
+        so the embedded fonts survive the paste; selecting the preview by hand does not carry them.
+      </p>
+
+      <div class="card">
+        <div class="swatch-label">On light</div>
+        <!-- Single source of truth: everything below the comment is what gets copied. -->
+        <table
+          id="tt-signature"
+          role="presentation"
+          cellpadding="0"
+          cellspacing="0"
+          border="0"
+          style="
+            margin: 0;
+            border: 0;
+            border-collapse: collapse;
+            background-color: transparent;
+          "
+        >
+          <tbody>
+            <tr>
+              <td
+                width="52"
+                style="
+                  padding: 0 14px 0 0;
+                  border: 0;
+                  vertical-align: middle;
+                "
+              >
+                <img
+                  src="https://assets.turntrout.com/static/images/apple-icon.png"
+                  alt="A leaping trout"
+                  width="52"
+                  height="41"
+                  style="
+                    display: block;
+                    width: 52px;
+                    height: 41px;
+                    border: 0;
+                    outline: none;
+                    text-decoration: none;
+                  "
+                />
+              </td>
+              <td
+                class="tt-sig-rule"
+                style="
+                  padding: 2px 0 2px 14px;
+                  border: 0;
+                  border-left: 1px solid #dfdfe4;
+                  vertical-align: middle;
+                "
+              >
+                <div
+                  class="tt-sig-name"
+                  style="
+                    font-family: EBGaramondSig, 'EB Garamond', EBGaramond, Garamond,
+                      'Palatino Linotype', Palatino, 'Times New Roman', serif;
+                    font-size: 19px;
+                    line-height: 24px;
+                    color: #383a4e;
+                  "
+                >
+                  Alex Turner
+                </div>
+                <div style="line-height: 18px">
+                  <a
+                    class="tt-sig-link"
+                    href="https://turntrout.com"
+                    style="text-decoration: none; color: #3c5899"
+                    ><span
+                      class="tt-sig-link"
+                      style="
+                        font-family: FiraCodeSig, 'Fira Code', FiraCode, 'JetBrains Mono', 'SF Mono',
+                          Menlo, Consolas, 'Courier New', monospace;
+                        font-size: 13px;
+                        line-height: 18px;
+                        color: #3c5899;
+                      "
+                      >turntrout.com</span
+                    ></a
+                  >
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="card dark">
+        <div class="swatch-label">On dark</div>
+        <div id="dark-preview"></div>
+      </div>
+
+      <p>
+        <button type="button" id="copy-rich">Copy signature</button>
+        <button type="button" id="copy-source">Copy HTML source</button>
+        <span id="copy-status" role="status"></span>
+      </p>
+
+      <details>
+        <summary>HTML source</summary>
+        <textarea id="source" readonly spellcheck="false"></textarea>
+      </details>
+    </main>
+    <script>
+      // Drives the generated signature preview page: renders the dark-background
+// preview, exposes the HTML source, and copies the signature to the clipboard.
+//
+// A hand-made selection is serialized by the browser as inline styles only,
+// and the embedded font faces live in a <style> element, so the clipboard
+// payload has to be assembled explicitly.
+
+const signature = document.getElementById("tt-signature")
+const fontStyle = document.getElementById("tt-signature-fonts")
+const status = document.getElementById("copy-status")
+
+const signatureHtml = fontStyle.outerHTML + signature.outerHTML
+const plainText = signature.innerText.trim().replace(/\n\s*\n/g, "\n")
+
+const darkPreview = signature.cloneNode(true)
+darkPreview.removeAttribute("id")
+document.getElementById("dark-preview").append(darkPreview)
+document.getElementById("source").value = signatureHtml
+
+let statusTimer = 0
+function report(message) {
+  status.textContent = message
+  window.clearTimeout(statusTimer)
+  statusTimer = window.setTimeout(() => {
+    status.textContent = ""
+  }, 4000)
+}
+
+/**
+ * Put `flavors` (a MIME-type → payload map) on the clipboard.
+ *
+ * `navigator.clipboard.write` sanitizes `text/html`, which deletes the <style>
+ * element the embedded fonts arrive in. A `copy` event's payload is passed
+ * through verbatim, so the fonts survive the round trip into Proton Mail.
+ */
+function copyToClipboard(flavors) {
+  const onCopy = (event) => {
+    event.preventDefault()
+    for (const [type, payload] of Object.entries(flavors)) {
+      event.clipboardData.setData(type, payload)
+    }
+  }
+  document.addEventListener("copy", onCopy, { once: true })
+
+  // Firefox refuses `execCommand("copy")` without a live selection.
+  const selection = window.getSelection()
+  const range = document.createRange()
+  range.selectNode(signature)
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  const copied = document.execCommand("copy")
+
+  selection.removeAllRanges()
+  document.removeEventListener("copy", onCopy)
+  return copied
+}
+
+function bind(id, flavors, message) {
+  document.getElementById(id).addEventListener("click", () => {
+    report(
+      copyToClipboard(flavors)
+        ? message
+        : "Copy failed — open “HTML source” below and copy it by hand.",
+    )
+  })
+}
+
+bind(
+  "copy-rich",
+  { "text/html": signatureHtml, "text/plain": plainText },
+  "Copied — paste into Proton’s signature editor.",
+)
+bind("copy-source", { "text/plain": signatureHtml }, "Copied HTML source.")
+
+    </script>
+  </body>
+</html>

--- a/scripts/email_signature/template.html
+++ b/scripts/email_signature/template.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>turntrout.com email signature</title>
+    <style id="tt-signature-fonts">
+      {{FONT_FACES}}
+      @media (prefers-color-scheme: dark) {
+        {{DARK_RULES}}
+      }
+    </style>
+    <style>
+      body {
+        margin: 0;
+        padding: 2.5rem 1.5rem;
+        background: #fcfcff;
+        color: #383a4e;
+        font-family: system-ui, sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        max-width: 44rem;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 0 0 0.25rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: #737483;
+        font-size: 0.9rem;
+      }
+
+      .card {
+        border: 1px solid #dfdfe4;
+        border-radius: 0.5rem;
+        padding: 1.5rem;
+        margin-bottom: 0.75rem;
+        background: #ffffff;
+      }
+
+      .card.dark {
+        background: #12141e;
+        border-color: #2c2f3f;
+      }
+
+      /* Mirrors the copied `prefers-color-scheme: dark` block so the dark card
+         previews it regardless of the browser's own colour scheme. */
+      {{DARK_PREVIEW_RULES}}
+
+      .swatch-label {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #9a9ba6;
+        margin-bottom: 0.75rem;
+      }
+
+      button {
+        font: inherit;
+        font-size: 0.85rem;
+        padding: 0.5rem 0.9rem;
+        margin-right: 0.5rem;
+        border: 1px solid #dfdfe4;
+        border-radius: 0.375rem;
+        background: #ffffff;
+        color: #383a4e;
+        cursor: pointer;
+      }
+
+      button:hover {
+        border-color: #9a9ba6;
+      }
+
+      #copy-status {
+        font-size: 0.85rem;
+        color: #737483;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 9rem;
+        margin-top: 1rem;
+        padding: 0.75rem;
+        border: 1px solid #dfdfe4;
+        border-radius: 0.375rem;
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 0.75rem;
+        color: #555769;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>turntrout.com email signature</h1>
+      <p>
+        Press <strong>Copy signature</strong>, then paste into Proton Mail → Settings → Identity and
+        addresses → Edit signature. The button writes real <code>text/html</code> to the clipboard,
+        so the embedded fonts survive the paste; selecting the preview by hand does not carry them.
+      </p>
+
+      <div class="card">
+        <div class="swatch-label">On light</div>
+        <!-- Single source of truth: everything below the comment is what gets copied. -->
+        <table
+          id="tt-signature"
+          role="presentation"
+          cellpadding="0"
+          cellspacing="0"
+          border="0"
+          style="
+            margin: 0;
+            border: 0;
+            border-collapse: collapse;
+            background-color: transparent;
+          "
+        >
+          <tbody>
+            <tr>
+              <td
+                width="52"
+                style="
+                  padding: 0 14px 0 0;
+                  border: 0;
+                  vertical-align: middle;
+                "
+              >
+                <img
+                  src="https://assets.turntrout.com/static/images/apple-icon.png"
+                  alt="A leaping trout"
+                  width="52"
+                  height="41"
+                  style="
+                    display: block;
+                    width: 52px;
+                    height: 41px;
+                    border: 0;
+                    outline: none;
+                    text-decoration: none;
+                  "
+                />
+              </td>
+              <td
+                class="tt-sig-rule"
+                style="
+                  padding: 2px 0 2px 14px;
+                  border: 0;
+                  border-left: 1px solid #dfdfe4;
+                  vertical-align: middle;
+                "
+              >
+                <div
+                  class="tt-sig-name"
+                  data-tt-font="serif"
+                  style="
+                    font-family: EBGaramondSig, 'EB Garamond', EBGaramond, Garamond,
+                      'Palatino Linotype', Palatino, 'Times New Roman', serif;
+                    font-size: 19px;
+                    line-height: 24px;
+                    color: #383a4e;
+                  "
+                >
+                  Alex Turner
+                </div>
+                <div style="line-height: 18px">
+                  <a
+                    class="tt-sig-link"
+                    href="https://turntrout.com"
+                    style="text-decoration: none; color: #3c5899"
+                    ><span
+                      class="tt-sig-link"
+                      data-tt-font="mono"
+                      style="
+                        font-family: FiraCodeSig, 'Fira Code', FiraCode, 'JetBrains Mono', 'SF Mono',
+                          Menlo, Consolas, 'Courier New', monospace;
+                        font-size: 13px;
+                        line-height: 18px;
+                        color: #3c5899;
+                      "
+                      >turntrout.com</span
+                    ></a
+                  >
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="card dark">
+        <div class="swatch-label">On dark</div>
+        <div id="dark-preview"></div>
+      </div>
+
+      <p>
+        <button type="button" id="copy-rich">Copy signature</button>
+        <button type="button" id="copy-source">Copy HTML source</button>
+        <span id="copy-status" role="status"></span>
+      </p>
+
+      <details>
+        <summary>HTML source</summary>
+        <textarea id="source" readonly spellcheck="false"></textarea>
+      </details>
+    </main>
+    <script>
+      {{COPY_SCRIPT}}
+    </script>
+  </body>
+</html>

--- a/scripts/tests/test_build_email_signature.py
+++ b/scripts/tests/test_build_email_signature.py
@@ -1,0 +1,146 @@
+"""Tests for the email-signature page builder."""
+
+import base64
+import re
+from pathlib import Path
+
+import pytest
+from fontTools.ttLib import TTFont  # type: ignore[import-untyped]
+
+from .. import build_email_signature
+from ..build_email_signature import (
+    DARK_RULES,
+    FONT_SPECS,
+    OUTPUT_PATH,
+    SCRIPT_PATH,
+    TEMPLATE_PATH,
+    FontSpec,
+    build_font_faces,
+    build_page,
+    collect_font_text,
+    render_dark_rules,
+    render_font_face,
+    subset_font,
+)
+
+_SERIF_SPEC = FONT_SPECS[0]
+_MONO_SPEC = FONT_SPECS[1]
+
+
+def test_repo_files_exist() -> None:
+    for path in (TEMPLATE_PATH, SCRIPT_PATH, OUTPUT_PATH):
+        assert path.is_file()
+    for spec in FONT_SPECS:
+        assert spec.source.is_file()
+
+
+def test_collect_font_text_concatenates_per_key() -> None:
+    html = (
+        '<p data-tt-font="serif">Alex</p>'
+        '<p data-tt-font="serif"> Turner</p>'
+        '<span data-tt-font="mono">turntrout.com</span>'
+    )
+    assert collect_font_text(html) == {
+        "serif": "Alex Turner",
+        "mono": "turntrout.com",
+    }
+
+
+def test_collect_font_text_ignores_untagged_elements() -> None:
+    assert collect_font_text("<p>plain</p>") == {}
+
+
+@pytest.mark.parametrize(
+    ("spec", "text"),
+    [(_SERIF_SPEC, "Alex Turner"), (_MONO_SPEC, "turntrout.com")],
+)
+def test_subset_font_keeps_only_requested_characters(
+    spec: FontSpec, text: str, tmp_path: Path
+) -> None:
+    payload = subset_font(spec, text)
+    assert payload[:4] == b"wOF2"
+
+    font = _load_woff2(payload, tmp_path)
+    codepoints = set(font.getBestCmap())
+    assert {ord(character) for character in text} <= codepoints
+    assert ord("Z") not in codepoints
+    # Subsets this small must stay inlinable as a data URL.
+    assert len(payload) < 8192
+
+
+def test_subset_font_pins_variable_axes(tmp_path: Path) -> None:
+    """The mono face ships variable; the subset must be a static instance."""
+    assert "fvar" not in _load_woff2(
+        subset_font(_MONO_SPEC, "turntrout.com"), tmp_path
+    )
+
+
+def test_render_font_face_inlines_a_decodable_data_url() -> None:
+    payload = b"not-really-a-font"
+    rule = render_font_face(_SERIF_SPEC, payload)
+
+    assert f"font-family: {_SERIF_SPEC.family};" in rule
+    encoded = re.search(r'base64,([^"]+)"', rule)
+    assert encoded is not None
+    assert base64.b64decode(encoded.group(1)) == payload
+
+
+def test_build_font_faces_emits_one_rule_per_spec() -> None:
+    faces = build_font_faces(TEMPLATE_PATH.read_text(encoding="utf-8"))
+    assert faces.count("@font-face") == len(FONT_SPECS)
+    for spec in FONT_SPECS:
+        assert f"font-family: {spec.family};" in faces
+
+
+def test_build_font_faces_rejects_a_template_missing_a_face() -> None:
+    with pytest.raises(ValueError, match="mono"):
+        build_font_faces('<p data-tt-font="serif">Alex Turner</p>')
+
+
+def test_render_dark_rules_scopes_with_prefix() -> None:
+    unscoped = render_dark_rules()
+    scoped = render_dark_rules(".card.dark ")
+
+    assert len(unscoped.splitlines()) == len(DARK_RULES)
+    for class_name, declarations in DARK_RULES:
+        assert f".{class_name} {{ {declarations} }}" in unscoped
+        assert f".card.dark .{class_name} {{ {declarations} }}" in scoped
+
+
+def test_build_page_substitutes_every_placeholder() -> None:
+    page = build_page(
+        TEMPLATE_PATH.read_text(encoding="utf-8"), "const marker = 1"
+    )
+
+    assert "{{" not in page
+    assert "data-tt-font" not in page
+    assert "const marker = 1" in page
+    assert "@media (prefers-color-scheme: dark)" in page
+    assert page.count("@font-face") == len(FONT_SPECS)
+
+
+def test_checked_in_output_matches_a_fresh_build() -> None:
+    expected = build_page(
+        TEMPLATE_PATH.read_text(encoding="utf-8"),
+        SCRIPT_PATH.read_text(encoding="utf-8"),
+    )
+    assert OUTPUT_PATH.read_text(encoding="utf-8") == expected
+
+
+def test_main_writes_the_page(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "signature.html"
+    monkeypatch.setattr(build_email_signature, "OUTPUT_PATH", destination)
+
+    build_email_signature.main()
+
+    assert "@font-face" in destination.read_text(encoding="utf-8")
+
+
+def _load_woff2(payload: bytes, tmp_path: Path) -> TTFont:
+    """FontTools infers the WOFF2 flavor from the file extension, so round-
+    trip."""
+    path = tmp_path / "subset.woff2"
+    path.write_bytes(payload)
+    return TTFont(path)


### PR DESCRIPTION
## Summary

- Adds `scripts/email_signature/`: a preview page whose **Copy signature** button puts the signature on the clipboard with its typography intact, for pasting into Proton Mail's signature editor.
- Mail clients don't fetch remote `@font-face` sources, so the build subsets EBGaramond and FiraCode down to the characters the signature actually renders and inlines them as base64 `data:` URLs — under 4 kB of font for the whole thing, so the site's type survives into the recipient's inbox instead of degrading to Times.
- Fixes the two defects in the hand-written markup this replaces: `<svg src=…>` renders nothing (an SVG needs an `<img>` to load an external file), and `var(--midground)` resolves to nothing outside the site's stylesheet.

## Changes

- **`scripts/build_email_signature.py`** — subsets each face to the exact glyph set, inlines it, and renders `signature.html`. The glyph set is read from `data-tt-font="serif|mono"` annotations in the template, so the signature text stays single-sourced; the attribute is stripped from the output. `recalcTimestamp=False` keeps the build byte-reproducible, so the checked-in artifact doesn't churn on every rebuild.
- **`scripts/email_signature/template.html`** — the markup: table-based, inline styles, literal hex colours mirroring the light palette, plus a `prefers-color-scheme: dark` block for clients that honour it. Previews on both light and dark.
- **`scripts/email_signature/page.js`** — clipboard handling. `navigator.clipboard.write` sanitizes `text/html` and deletes the `<style>` element the faces arrive in, as does selecting the preview by hand, so the payload goes out through a `copy` event, whose data the browser passes through verbatim.
- **`scripts/email_signature/signature.html`** — the generated artifact, committed so it can be opened directly.
- **`config/prettier/.prettierignore`** — skips this directory's HTML; prettier-html rewrites the `{{TOKEN}}` placeholders into nested CSS/JS blocks.
- **`.claude/dev-notes.md`** — documents the rebuild command and the two constraints above.

## Testing

- `scripts/tests/test_build_email_signature.py` — 13 tests, 100% line coverage of the new module. Covers per-key glyph collection, subset contents (requested codepoints present, unrequested absent, variable axes pinned, payload small enough to inline), data-URL round-trip, the missing-face error path, dark-rule scoping, placeholder substitution, and that the checked-in `signature.html` matches a fresh build.
- Verified end-to-end in Chromium: clicked **Copy signature**, read the clipboard back, rendered *only* that payload on a bare page, and confirmed both `EBGaramondSig` and `FiraCodeSig` reach `status: loaded` and the trout image resolves.
- `pylint` 10.00/10, `pyright` clean, `ruff check`/`format` clean, `eslint` and `prettier` clean on the new files, `tsc --noEmit` passes.

## Lessons learned

- **What**: When verifying that copied rich text carries its styling, assert on the clipboard payload rather than on the page that produced it — and read it back with `navigator.clipboard.read({ unsanitized: ["text/html"] })`, since the default read is sanitized too.
- **Where**: any repo doing clipboard/rich-text work; the pattern here is in `scripts/email_signature/page.js`.
- **Why**: the first implementation looked correct and reported success, but Chromium silently stripped the `<style>` element out of the `ClipboardItem`, so the fonts were gone before the paste ever happened. Only reading the clipboard back and rendering it standalone surfaced this.


---
_Generated by [Claude Code](https://claude.ai/code/session_017raWAvQpejfkmobd7ysLiw)_