### PR TITLE
fix(vale): run the pinned vale version in the pre-push prose gate

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -44,14 +44,17 @@ uv_install_if_missing() {
   fi
 }
 
-# Install vale (prose linter) if missing, from a pinned GitHub release.
-# webi has no vale package, so pull the official tarball directly. The version
-# is the single source of truth in config/vale/version, shared with CI
+# Install vale (prose linter) from a pinned GitHub release. webi has no vale
+# package, so pull the official tarball directly. The version is the single
+# source of truth in config/vale/version, shared with CI
 # (lint-and-validate.yaml) so pre-push and CI never drift; required by the
 # pre-push spellcheck/prose gate.
 VALE_VERSION="$(cat "$PROJECT_DIR/config/vale/version")"
-vale_install_if_missing() {
-  command -v vale &>/dev/null && return 0
+vale_install_if_unpinned() {
+  # A vale of another version (e.g. Homebrew's) does not satisfy the gate:
+  # rule scoping differs across releases, so the pin must be installed
+  # alongside it. ~/.local/bin precedes the rest of PATH in .hooks/pre-push.
+  "$PROJECT_DIR/scripts/resolve_vale.sh" &>/dev/null && return 0
   local os arch
   case "$(uname -s)" in
   Linux) os=Linux ;;
@@ -146,9 +149,10 @@ fi
 webi_install_if_missing shfmt shfmt@3
 webi_install_if_missing gh gh@2
 webi_install_if_missing jq jq@1.7
-# vale is required by the pre-push spellcheck/prose gate (it errors when vale
-# is absent), so install it here rather than letting it silently skip.
-vale_install_if_missing
+# vale is required by the pre-push spellcheck/prose gate (it errors when the
+# pinned version is absent), so install it here rather than letting it
+# silently skip.
+vale_install_if_unpinned
 uv_install_if_missing alt-text-llm
 if is_root; then
   # Map: command-to-probe -> apt package name. ffmpeg/imagemagick are

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -12,8 +12,8 @@ PROJECT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 SETUP_WARNINGS=0
 warn() {
-	echo "WARNING: $1" >&2
-	SETUP_WARNINGS=$((SETUP_WARNINGS + 1))
+  echo "WARNING: $1" >&2
+  SETUP_WARNINGS=$((SETUP_WARNINGS + 1))
 }
 is_root() { [[ "$(id -u)" = "0" ]]; }
 
@@ -38,10 +38,10 @@ emit_path_prepend() {
 
 # Install a command via uv if missing
 uv_install_if_missing() {
-	local cmd="$1" pkg="${2:-$1}"
-	if ! command -v "$cmd" &>/dev/null; then
-		uv tool install --quiet "$pkg" || warn "Failed to install $pkg"
-	fi
+  local cmd="$1" pkg="${2:-$1}"
+  if ! command -v "$cmd" &>/dev/null; then
+    uv tool install --quiet "$pkg" || warn "Failed to install $pkg"
+  fi
 }
 
 # Install vale (prose linter) if missing, from a pinned GitHub release.
@@ -51,49 +51,49 @@ uv_install_if_missing() {
 # pre-push spellcheck/prose gate.
 VALE_VERSION="$(cat "$PROJECT_DIR/config/vale/version")"
 vale_install_if_missing() {
-	command -v vale &>/dev/null && return 0
-	local os arch
-	case "$(uname -s)" in
-	Linux) os=Linux ;;
-	Darwin) os=macOS ;;
-	*) warn "Unsupported OS for vale install: $(uname -s)" && return 0 ;;
-	esac
-	case "$(uname -m)" in
-	x86_64 | amd64) arch=64-bit ;;
-	aarch64 | arm64) arch=arm64 ;;
-	*) warn "Unsupported arch for vale install: $(uname -m)" && return 0 ;;
-	esac
-	local url tarball
-	url="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_${os}_${arch}.tar.gz"
-	tarball=$(mktemp "${TMPDIR:-/tmp}/vale-XXXXXX.tar.gz")
-	mkdir -p "$HOME/.local/bin"
-	if curl --proto '=https' -fsSL "$url" -o "$tarball" 2>/dev/null; then
-		tar -xzf "$tarball" -C "$HOME/.local/bin" vale 2>/dev/null || warn "Failed to extract vale"
-	else
-		warn "Failed to download vale from $url"
-	fi
-	rm -f "$tarball"
+  command -v vale &>/dev/null && return 0
+  local os arch
+  case "$(uname -s)" in
+  Linux) os=Linux ;;
+  Darwin) os=macOS ;;
+  *) warn "Unsupported OS for vale install: $(uname -s)" && return 0 ;;
+  esac
+  case "$(uname -m)" in
+  x86_64 | amd64) arch=64-bit ;;
+  aarch64 | arm64) arch=arm64 ;;
+  *) warn "Unsupported arch for vale install: $(uname -m)" && return 0 ;;
+  esac
+  local url tarball
+  url="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_${os}_${arch}.tar.gz"
+  tarball=$(mktemp "${TMPDIR:-/tmp}/vale-XXXXXX.tar.gz")
+  mkdir -p "$HOME/.local/bin"
+  if curl --proto '=https' -fsSL "$url" -o "$tarball" 2>/dev/null; then
+    tar -xzf "$tarball" -C "$HOME/.local/bin" vale 2>/dev/null || warn "Failed to extract vale"
+  else
+    warn "Failed to download vale from $url"
+  fi
+  rm -f "$tarball"
 }
 
 # Install a command via webi if missing
 # $1 = command name, $2 = optional webi package specifier (e.g. tool@version)
 # Hardened: HTTPS-only, shebang validation, version pinning via $2
 webi_install_if_missing() {
-	local cmd="$1" pkg="${2:-$1}"
-	if ! command -v "$cmd" &>/dev/null; then
-		local installer
-		installer=$(mktemp "${TMPDIR:-/tmp}/webi-${cmd}-XXXXXX.sh")
-		if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
-			if head -n 1 "$installer" | grep -q '^#!'; then
-				sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"
-			else
-				warn "Installer for $cmd is not a shell script (missing shebang) — skipping"
-			fi
-		else
-			warn "Failed to download installer for $cmd"
-		fi
-		rm -f "$installer"
-	fi
+  local cmd="$1" pkg="${2:-$1}"
+  if ! command -v "$cmd" &>/dev/null; then
+    local installer
+    installer=$(mktemp "${TMPDIR:-/tmp}/webi-${cmd}-XXXXXX.sh")
+    if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
+      if head -n 1 "$installer" | grep -q '^#!'; then
+        sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"
+      else
+        warn "Installer for $cmd is not a shell script (missing shebang) — skipping"
+      fi
+    else
+      warn "Failed to download installer for $cmd"
+    fi
+    rm -f "$installer"
+  fi
 }
 
 #######################################
@@ -135,7 +135,7 @@ _check_hook_syntax
 
 export PATH="$HOME/.local/bin:$PATH"
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-	echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+  echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
 fi
 
 #######################################
@@ -151,32 +151,32 @@ webi_install_if_missing jq jq@1.7
 vale_install_if_missing
 uv_install_if_missing alt-text-llm
 if is_root; then
-	# Map: command-to-probe -> apt package name. ffmpeg/imagemagick are
-	# needed by scripts/tests/test_compress.py et al. (the Stop hook runs
-	# pytest, and ~75 tests + 60 errors fall over without them). rclone
-	# (R2 uploads/downloads in scripts/r2_*.py and the pre-push hook) is
-	# only added below when R2 creds are present — fresh sandboxes
-	# without creds skip the ~5s apt install.
-	declare -A apt_needed=(
-		[shellcheck]=shellcheck
-		[fish]=fish
-		[ffmpeg]=ffmpeg
-		[convert]=imagemagick
-		[exiftool]=libimage-exiftool-perl
-	)
-	if [ -n "${ACCESS_KEY_ID_TURNTROUT_MEDIA:-}" ] && \
-	   [ -n "${SECRET_ACCESS_TURNTROUT_MEDIA:-}" ] && \
-	   [ -n "${S3_ENDPOINT_ID_TURNTROUT_MEDIA:-}" ]; then
-		apt_needed[rclone]=rclone
-	fi
-	apt_pkgs=()
-	for cmd in "${!apt_needed[@]}"; do
-		command -v "$cmd" &>/dev/null || apt_pkgs+=("${apt_needed[$cmd]}")
-	done
-	if [ ${#apt_pkgs[@]} -gt 0 ]; then
-		{ apt-get update -qq && apt-get install -y -qq "${apt_pkgs[@]}"; } ||
-			warn "Failed to install ${apt_pkgs[*]}"
-	fi
+  # Map: command-to-probe -> apt package name. ffmpeg/imagemagick are
+  # needed by scripts/tests/test_compress.py et al. (the Stop hook runs
+  # pytest, and ~75 tests + 60 errors fall over without them). rclone
+  # (R2 uploads/downloads in scripts/r2_*.py and the pre-push hook) is
+  # only added below when R2 creds are present — fresh sandboxes
+  # without creds skip the ~5s apt install.
+  declare -A apt_needed=(
+    [shellcheck]=shellcheck
+    [fish]=fish
+    [ffmpeg]=ffmpeg
+    [convert]=imagemagick
+    [exiftool]=libimage-exiftool-perl
+  )
+  if [ -n "${ACCESS_KEY_ID_TURNTROUT_MEDIA:-}" ] &&
+    [ -n "${SECRET_ACCESS_TURNTROUT_MEDIA:-}" ] &&
+    [ -n "${S3_ENDPOINT_ID_TURNTROUT_MEDIA:-}" ]; then
+    apt_needed[rclone]=rclone
+  fi
+  apt_pkgs=()
+  for cmd in "${!apt_needed[@]}"; do
+    command -v "$cmd" &>/dev/null || apt_pkgs+=("${apt_needed[$cmd]}")
+  done
+  if [ ${#apt_pkgs[@]} -gt 0 ]; then
+    { apt-get update -qq && apt-get install -y -qq "${apt_pkgs[@]}"; } ||
+      warn "Failed to install ${apt_pkgs[*]}"
+  fi
 fi
 
 # scripts/compress.py and convert_markdown_yaml.py hard-code the IM7
@@ -184,31 +184,31 @@ fi
 # legacy IM6 `convert`, so first try the official IM7 portable AppImage,
 # then fall back to a thin wrapper over IM6 `convert`.
 if ! command -v magick &>/dev/null; then
-	IM_DIR="$HOME/.local/imagemagick"
-	mkdir -p "$IM_DIR"
-	MAGICK_INSTALLED=false
-	if curl -fsSL https://imagemagick.org/archive/binaries/magick \
-		-o "$IM_DIR/magick.AppImage" 2>/dev/null; then
-		chmod +x "$IM_DIR/magick.AppImage"
-		if (cd "$IM_DIR" && "$IM_DIR/magick.AppImage" --appimage-extract >/dev/null 2>&1); then
-			ln -sf "$IM_DIR/squashfs-root/AppRun" "$HOME/.local/bin/magick" &&
-				MAGICK_INSTALLED=true
-		fi
-	fi
-	# Fallback: create a wrapper that delegates to IM6 `convert`.
-	# The codebase calls `magick <input> <flags> <output>` which is
-	# equivalent to IM6's `convert <input> <flags> <output>`.
-	if [ "$MAGICK_INSTALLED" = false ] && command -v convert &>/dev/null; then
-		cat > "$HOME/.local/bin/magick" <<'WRAPPER'
+  IM_DIR="$HOME/.local/imagemagick"
+  mkdir -p "$IM_DIR"
+  MAGICK_INSTALLED=false
+  if curl -fsSL https://imagemagick.org/archive/binaries/magick \
+    -o "$IM_DIR/magick.AppImage" 2>/dev/null; then
+    chmod +x "$IM_DIR/magick.AppImage"
+    if (cd "$IM_DIR" && "$IM_DIR/magick.AppImage" --appimage-extract >/dev/null 2>&1); then
+      ln -sf "$IM_DIR/squashfs-root/AppRun" "$HOME/.local/bin/magick" &&
+        MAGICK_INSTALLED=true
+    fi
+  fi
+  # Fallback: create a wrapper that delegates to IM6 `convert`.
+  # The codebase calls `magick <input> <flags> <output>` which is
+  # equivalent to IM6's `convert <input> <flags> <output>`.
+  if [ "$MAGICK_INSTALLED" = false ] && command -v convert &>/dev/null; then
+    cat >"$HOME/.local/bin/magick" <<'WRAPPER'
 #!/bin/sh
 # Thin IM6 compatibility wrapper: `magick` → `convert`
 # IM7's `magick <args>` ≈ IM6's `convert <args>` for image operations
 exec convert "$@"
 WRAPPER
-		chmod +x "$HOME/.local/bin/magick"
-	elif [ "$MAGICK_INSTALLED" = false ]; then
-		warn "ImageMagick not available (neither IM7 AppImage nor IM6 convert)"
-	fi
+    chmod +x "$HOME/.local/bin/magick"
+  elif [ "$MAGICK_INSTALLED" = false ]; then
+    warn "ImageMagick not available (neither IM7 AppImage nor IM6 convert)"
+  fi
 fi
 
 #######################################
@@ -219,18 +219,18 @@ fi
 #######################################
 
 if ! command -v rclone &>/dev/null && ! is_root; then
-	curl -fsSL https://rclone.org/install.sh | sudo bash 2>/dev/null ||
-		warn "Failed to install rclone"
+  curl -fsSL https://rclone.org/install.sh | sudo bash 2>/dev/null ||
+    warn "Failed to install rclone"
 fi
 
 # Configure rclone R2 remote from environment variables
-if command -v rclone &>/dev/null && \
-   [ -n "${ACCESS_KEY_ID_TURNTROUT_MEDIA:-}" ] && \
-   [ -n "${SECRET_ACCESS_TURNTROUT_MEDIA:-}" ] && \
-   [ -n "${S3_ENDPOINT_ID_TURNTROUT_MEDIA:-}" ]; then
-	RCLONE_CONFIG_DIR="${HOME}/.config/rclone"
-	mkdir -p "$RCLONE_CONFIG_DIR"
-	cat > "$RCLONE_CONFIG_DIR/rclone.conf" <<RCLONE_EOF
+if command -v rclone &>/dev/null &&
+  [ -n "${ACCESS_KEY_ID_TURNTROUT_MEDIA:-}" ] &&
+  [ -n "${SECRET_ACCESS_TURNTROUT_MEDIA:-}" ] &&
+  [ -n "${S3_ENDPOINT_ID_TURNTROUT_MEDIA:-}" ]; then
+  RCLONE_CONFIG_DIR="${HOME}/.config/rclone"
+  mkdir -p "$RCLONE_CONFIG_DIR"
+  cat >"$RCLONE_CONFIG_DIR/rclone.conf" <<RCLONE_EOF
 [r2]
 type = s3
 provider = Cloudflare
@@ -239,7 +239,7 @@ secret_access_key = ${SECRET_ACCESS_TURNTROUT_MEDIA}
 endpoint = https://${S3_ENDPOINT_ID_TURNTROUT_MEDIA}.r2.cloudflarestorage.com
 no_check_bucket = true
 RCLONE_EOF
-	chmod 600 "$RCLONE_CONFIG_DIR/rclone.conf"
+  chmod 600 "$RCLONE_CONFIG_DIR/rclone.conf"
 fi
 
 # Python projects: the pre-commit and pre-push hooks shell out to ruff, which
@@ -263,8 +263,8 @@ git config core.hooksPath .hooks
 # Pre-fetch the base branch so diffs against $CLAUDE_CODE_BASE_REF work
 # immediately (e.g. when creating PRs). Failure is non-fatal.
 if [ -n "${CLAUDE_CODE_BASE_REF:-}" ]; then
-	git fetch origin "$CLAUDE_CODE_BASE_REF" --quiet 2>/dev/null ||
-		warn "Failed to fetch base branch $CLAUDE_CODE_BASE_REF"
+  git fetch origin "$CLAUDE_CODE_BASE_REF" --quiet 2>/dev/null ||
+    warn "Failed to fetch base branch $CLAUDE_CODE_BASE_REF"
 fi
 
 #######################################
@@ -272,9 +272,9 @@ fi
 #######################################
 
 if ! command -v gh &>/dev/null; then
-	warn "gh CLI not found"
+  warn "gh CLI not found"
 elif [ -z "${GH_TOKEN:-}" ]; then
-	warn "GH_TOKEN is not set — GitHub CLI requires authentication"
+  warn "GH_TOKEN is not set — GitHub CLI requires authentication"
 fi
 
 #######################################
@@ -287,21 +287,21 @@ fi
 # owner/repo and export GH_REPO to make all gh commands work.
 
 if [ -z "${GH_REPO:-}" ]; then
-	remote_url=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)
-	if [[ "$remote_url" =~ /git/([^/]+/[^/]+)$ ]]; then
-		GH_REPO="${BASH_REMATCH[1]}"
-		GH_REPO="${GH_REPO%.git}"
-		export GH_REPO
-		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-			echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
-		fi
+  remote_url=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)
+  if [[ "$remote_url" =~ /git/([^/]+/[^/]+)$ ]]; then
+    GH_REPO="${BASH_REMATCH[1]}"
+    GH_REPO="${GH_REPO%.git}"
+    export GH_REPO
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
+    fi
 
-		# Add a real GitHub remote so gh CLI can resolve the host
-		if ! git -C "$PROJECT_DIR" remote get-url github &>/dev/null; then
-			git -C "$PROJECT_DIR" remote add github "https://github.com/${GH_REPO}.git" ||
-				warn "Failed to add github remote"
-		fi
-	fi
+    # Add a real GitHub remote so gh CLI can resolve the host
+    if ! git -C "$PROJECT_DIR" remote get-url github &>/dev/null; then
+      git -C "$PROJECT_DIR" remote add github "https://github.com/${GH_REPO}.git" ||
+        warn "Failed to add github remote"
+    fi
+  fi
 fi
 
 # Set gh's default repo so commands like `gh pr create` work even when
@@ -310,7 +310,7 @@ fi
 # may exit 0 via the `github` remote but `gh pr create` still fails
 # trying to resolve `origin`.
 if [ -n "${GH_REPO:-}" ] && command -v gh &>/dev/null; then
-	printf 'base\n%s\n' "$GH_REPO" >"$PROJECT_DIR/.gh-resolved"
+  printf 'base\n%s\n' "$GH_REPO" >"$PROJECT_DIR/.gh-resolved"
 fi
 
 #######################################
@@ -320,8 +320,8 @@ fi
 
 if ! command -v deepsource &>/dev/null; then
   echo "Installing DeepSource CLI..."
-  curl -fsSL https://cli.deepsource.com/install | BINDIR="$HOME/.local/bin" sh 2>/dev/null \
-    || warn "Failed to install DeepSource CLI"
+  curl -fsSL https://cli.deepsource.com/install | BINDIR="$HOME/.local/bin" sh 2>/dev/null ||
+    warn "Failed to install DeepSource CLI"
 fi
 
 if [ -n "${DEEPSOURCE_PAT:-}" ] && command -v deepsource &>/dev/null; then
@@ -344,32 +344,32 @@ is_web_sandbox=false
 [[ "$project_remote" == *"local_proxy@"* ]] && is_web_sandbox=true
 
 if [ ! -d "$PROJECT_DIR/.timestamps/.git" ]; then
-	# Bake the session token into the clone only in a web sandbox; locally,
-	# clone clean and let the user's credential helper provide auth.
-	if [ "$is_web_sandbox" = true ] && [ -n "${GH_TOKEN:-}" ]; then
-		git clone --quiet "https://x-access-token:${GH_TOKEN}@github.com/alexander-turner/.timestamps.git" \
-			"$PROJECT_DIR/.timestamps" ||
-			warn "Failed to clone .timestamps repo"
-	else
-		git clone --quiet https://github.com/alexander-turner/.timestamps "$PROJECT_DIR/.timestamps" ||
-			warn "Failed to clone .timestamps repo"
-	fi
+  # Bake the session token into the clone only in a web sandbox; locally,
+  # clone clean and let the user's credential helper provide auth.
+  if [ "$is_web_sandbox" = true ] && [ -n "${GH_TOKEN:-}" ]; then
+    git clone --quiet "https://x-access-token:${GH_TOKEN}@github.com/alexander-turner/.timestamps.git" \
+      "$PROJECT_DIR/.timestamps" ||
+      warn "Failed to clone .timestamps repo"
+  else
+    git clone --quiet https://github.com/alexander-turner/.timestamps "$PROJECT_DIR/.timestamps" ||
+      warn "Failed to clone .timestamps repo"
+  fi
 fi
 
 # Reconcile the .timestamps remote with the session type: inject the session
 # token in a web sandbox, or repair host config a prior session leaked into.
 bash "$PROJECT_DIR/scripts/configure_timestamps_remote.sh" \
-	"$PROJECT_DIR/.timestamps" "$is_web_sandbox" ||
-	warn "Failed to configure .timestamps remote"
+  "$PROJECT_DIR/.timestamps" "$is_web_sandbox" ||
+  warn "Failed to configure .timestamps remote"
 
 # Pre-fetch .timestamps origin/master so the post-commit hook's
 # `git pull --rebase` works against an already-warm DNS/TLS connection
 # and an already-up-to-date ref (the rebase still fetches, but the
 # delta is empty/small).
 if [ -d "$PROJECT_DIR/.timestamps/.git" ]; then
-	pre_fetch_err=$(git -C "$PROJECT_DIR/.timestamps" \
-		fetch --quiet origin master 2>&1) ||
-		warn "Failed to pre-fetch .timestamps origin/master: $pre_fetch_err"
+  pre_fetch_err=$(git -C "$PROJECT_DIR/.timestamps" \
+    fetch --quiet origin master 2>&1) ||
+    warn "Failed to pre-fetch .timestamps origin/master: $pre_fetch_err"
 fi
 
 # Configure `.timestamps`'s local git identity from the authenticated
@@ -379,36 +379,36 @@ fi
 # noreply@anthropic.com). Falls back to the GitHub noreply email when
 # the public email is hidden. Only writes when the local config is
 # unset, so a deliberate user override survives subsequent sessions.
-if [ -d "$PROJECT_DIR/.timestamps/.git" ] && \
-   command -v gh >/dev/null 2>&1; then
-	if ! command -v jq >/dev/null 2>&1; then
-		warn "jq missing; skipping .timestamps identity setup"
-	else
-		gh_user_json=$(gh api user 2>/dev/null) || {
-			[ -n "${GH_TOKEN:-}" ] && warn \
-				"gh api user failed; .timestamps identity not configured"
-			gh_user_json=""
-		}
-		if [ -n "$gh_user_json" ]; then
-			ts_repo="$PROJECT_DIR/.timestamps"
-			gh_name=$(echo "$gh_user_json" | jq -r '.name // empty')
-			gh_email=$(echo "$gh_user_json" | jq -r '.email // empty')
-			gh_login=$(echo "$gh_user_json" | jq -r '.login // empty')
-			gh_id=$(echo "$gh_user_json" | jq -r '.id // empty')
-			if [ -n "$gh_name" ] && \
-			   ! git -C "$ts_repo" config --local --get user.name >/dev/null; then
-				git -C "$ts_repo" config user.name "$gh_name"
-			fi
-			if ! git -C "$ts_repo" config --local --get user.email >/dev/null; then
-				if [ -n "$gh_email" ]; then
-					git -C "$ts_repo" config user.email "$gh_email"
-				elif [ -n "$gh_id" ] && [ -n "$gh_login" ]; then
-					git -C "$ts_repo" config user.email \
-						"${gh_id}+${gh_login}@users.noreply.github.com"
-				fi
-			fi
-		fi
-	fi
+if [ -d "$PROJECT_DIR/.timestamps/.git" ] &&
+  command -v gh >/dev/null 2>&1; then
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq missing; skipping .timestamps identity setup"
+  else
+    gh_user_json=$(gh api user 2>/dev/null) || {
+      [ -n "${GH_TOKEN:-}" ] && warn \
+        "gh api user failed; .timestamps identity not configured"
+      gh_user_json=""
+    }
+    if [ -n "$gh_user_json" ]; then
+      ts_repo="$PROJECT_DIR/.timestamps"
+      gh_name=$(echo "$gh_user_json" | jq -r '.name // empty')
+      gh_email=$(echo "$gh_user_json" | jq -r '.email // empty')
+      gh_login=$(echo "$gh_user_json" | jq -r '.login // empty')
+      gh_id=$(echo "$gh_user_json" | jq -r '.id // empty')
+      if [ -n "$gh_name" ] &&
+        ! git -C "$ts_repo" config --local --get user.name >/dev/null; then
+        git -C "$ts_repo" config user.name "$gh_name"
+      fi
+      if ! git -C "$ts_repo" config --local --get user.email >/dev/null; then
+        if [ -n "$gh_email" ]; then
+          git -C "$ts_repo" config user.email "$gh_email"
+        elif [ -n "$gh_id" ] && [ -n "$gh_login" ]; then
+          git -C "$ts_repo" config user.email \
+            "${gh_id}+${gh_login}@users.noreply.github.com"
+        fi
+      fi
+    fi
+  fi
 fi
 
 # Install opentimestamps-client (needed by post-commit hook, not pre-installed in web sessions)
@@ -419,16 +419,16 @@ uv_install_if_missing ots opentimestamps-client
 # back the commit with a stale-looking error. Surface the prior warning
 # count so a slow install isn't drowned out by the exit-1 message.
 die_ots() {
-	[ "$SETUP_WARNINGS" -gt 0 ] && echo \
-		"(plus $SETUP_WARNINGS earlier warning(s) — see above)" >&2
-	exit 1
+  [ "$SETUP_WARNINGS" -gt 0 ] && echo \
+    "(plus $SETUP_WARNINGS earlier warning(s) — see above)" >&2
+  exit 1
 }
 if ! command -v ots >/dev/null 2>&1; then
-	echo "ERROR: ots not on PATH after install; post-commit hook will fail" >&2
-	die_ots
+  echo "ERROR: ots not on PATH after install; post-commit hook will fail" >&2
+  die_ots
 elif ! ots --version >/dev/null 2>&1; then
-	echo "ERROR: ots --version failed; post-commit hook may misbehave" >&2
-	die_ots
+  echo "ERROR: ots --version failed; post-commit hook may misbehave" >&2
+  die_ots
 fi
 
 #######################################
@@ -436,51 +436,51 @@ fi
 #######################################
 
 if [ -f "$PROJECT_DIR/package.json" ]; then
-	# Always run install (git hooks are configured in package.json postinstall)
-	# Skip Puppeteer's Chrome download — sandboxed environments can't reach
-	# storage.googleapis.com, and we use Playwright's browsers instead.
-	# Without this, subfont's nested `pnpm install` fails on puppeteer's
-	# postinstall, aborting the entire install and leaving node_modules incomplete.
-	export PUPPETEER_SKIP_DOWNLOAD=true
-	if command -v pnpm &>/dev/null; then
-		# Skip Puppeteer browser download — sandboxed environments can't reach
-		# storage.googleapis.com and Playwright browsers are used instead.
-		#
-		# --config.confirm-modules-purge=false: the container's pre-provisioned
-		# node_modules can be inconsistent with the lockfile, so pnpm wants to
-		# purge and reinstall it. Without this flag that prompt aborts under no
-		# TTY (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY), leaving node_modules
-		# stale — which then makes every later `pnpm exec` (e.g. the pre-push
-		# checks) fail the same way. Letting the purge proceed here leaves a
-		# consistent tree so subsequent `pnpm exec` runs skip the reinstall.
-		PUPPETEER_SKIP_DOWNLOAD=true pnpm install --silent \
-			--config.confirm-modules-purge=false ||
-			warn "Failed to install Node dependencies"
-	elif command -v npm &>/dev/null; then
-		npm install --silent || warn "Failed to install Node dependencies"
-	fi
-	# Add node_modules/.bin to PATH so binaries like `sass` (used by
-	# source_file_checks.py) and `vale`/`spellchecker` are reachable from
-	# the pre-push hook without invoking pnpm exec.
-	if [ -d "$PROJECT_DIR/node_modules/.bin" ]; then
-		export PATH="$PROJECT_DIR/node_modules/.bin:$PATH"
-		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-			echo "export PATH=\"$PROJECT_DIR/node_modules/.bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
-		fi
-	fi
+  # Always run install (git hooks are configured in package.json postinstall)
+  # Skip Puppeteer's Chrome download — sandboxed environments can't reach
+  # storage.googleapis.com, and we use Playwright's browsers instead.
+  # Without this, subfont's nested `pnpm install` fails on puppeteer's
+  # postinstall, aborting the entire install and leaving node_modules incomplete.
+  export PUPPETEER_SKIP_DOWNLOAD=true
+  if command -v pnpm &>/dev/null; then
+    # Skip Puppeteer browser download — sandboxed environments can't reach
+    # storage.googleapis.com and Playwright browsers are used instead.
+    #
+    # --config.confirm-modules-purge=false: the container's pre-provisioned
+    # node_modules can be inconsistent with the lockfile, so pnpm wants to
+    # purge and reinstall it. Without this flag that prompt aborts under no
+    # TTY (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY), leaving node_modules
+    # stale — which then makes every later `pnpm exec` (e.g. the pre-push
+    # checks) fail the same way. Letting the purge proceed here leaves a
+    # consistent tree so subsequent `pnpm exec` runs skip the reinstall.
+    PUPPETEER_SKIP_DOWNLOAD=true pnpm install --silent \
+      --config.confirm-modules-purge=false ||
+      warn "Failed to install Node dependencies"
+  elif command -v npm &>/dev/null; then
+    npm install --silent || warn "Failed to install Node dependencies"
+  fi
+  # Add node_modules/.bin to PATH so binaries like `sass` (used by
+  # source_file_checks.py) and `vale`/`spellchecker` are reachable from
+  # the pre-push hook without invoking pnpm exec.
+  if [ -d "$PROJECT_DIR/node_modules/.bin" ]; then
+    export PATH="$PROJECT_DIR/node_modules/.bin:$PATH"
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo "export PATH=\"$PROJECT_DIR/node_modules/.bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+    fi
+  fi
 fi
 
 if [ -f "$PROJECT_DIR/uv.lock" ] && command -v uv &>/dev/null; then
-	uv sync --quiet || warn "Failed to sync Python dependencies"
-	# Add .venv/bin to PATH so Python tools are available to hooks
-	if [ -d "$PROJECT_DIR/.venv/bin" ]; then
-		export PATH="$PROJECT_DIR/.venv/bin:$PATH"
-		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-			echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
-		fi
-	fi
+  uv sync --quiet || warn "Failed to sync Python dependencies"
+  # Add .venv/bin to PATH so Python tools are available to hooks
+  if [ -d "$PROJECT_DIR/.venv/bin" ]; then
+    export PATH="$PROJECT_DIR/.venv/bin:$PATH"
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+    fi
+  fi
 fi
 
 if [ "$SETUP_WARNINGS" -gt 0 ]; then
-	echo "Setup done with $SETUP_WARNINGS warning(s) — see above" >&2
+  echo "Setup done with $SETUP_WARNINGS warning(s) — see above" >&2
 fi

--- a/quartz/plugins/transformers/.invert_labels.json
+++ b/quartz/plugins/transformers/.invert_labels.json
@@ -955,6 +955,14 @@
     "invert": true,
     "reviewed": true
   },
+  "https://assets.turntrout.com/static/images/posts/Why I left Google DeepMind-06242026-1.mp4": {
+    "invert": false,
+    "reviewed": true
+  },
+  "https://assets.turntrout.com/static/images/posts/Why%20I%20left%20Google%20DeepMind-06242026-1.mp4": {
+    "invert": false,
+    "reviewed": true
+  },
   "https://assets.turntrout.com/static/images/posts/WjTqF2y.avif": {
     "invert": true,
     "reviewed": true
@@ -1191,12 +1199,12 @@
     "invert": true,
     "reviewed": true
   },
-  "https://assets.turntrout.com/static/images/posts/brufvgichbfhjzdfqzkf.avif": {
-    "invert": true,
-    "reviewed": true
-  },
   "https://assets.turntrout.com/static/images/posts/bruce-wayne-and-the-cost-of-inaction-05222026-1.avif": {
     "invert": false,
+    "reviewed": true
+  },
+  "https://assets.turntrout.com/static/images/posts/brufvgichbfhjzdfqzkf.avif": {
+    "invert": true,
     "reviewed": true
   },
   "https://assets.turntrout.com/static/images/posts/burning.mp4": {

--- a/quartz/plugins/transformers/related_posts.json
+++ b/quartz/plugins/transformers/related_posts.json
@@ -151,14 +151,14 @@
       "title": "Inner and outer alignment decompose one hard problem into two extremely hard problems"
     },
     {
-      "excerpt": "Values steer optimization, they are not optimized against. Values don't have to be robustly \"correct\", because they are not the thing being optimized.",
-      "permalink": "alignment-without-total-robustness",
-      "title": "Alignment allows 'non-robust' decision-influences and doesn't require robust grading"
-    },
-    {
       "excerpt": "Aligning an AI to evaluations of your goals won't give you what you want. Don't do it.",
       "permalink": "dont-align-agents-to-evaluations-of-plans",
       "title": "Don't align agents to evaluations of plans"
+    },
+    {
+      "excerpt": "Values steer optimization, they are not optimized against. Values don't have to be robustly \"correct\", because they are not the thing being optimized.",
+      "permalink": "alignment-without-total-robustness",
+      "title": "Alignment allows 'non-robust' decision-influences and doesn't require robust grading"
     }
   ],
   "about": [
@@ -393,14 +393,14 @@
       "title": "Environmental Structure Can Cause Instrumental Convergence"
     },
     {
-      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
-      "permalink": "satisficers-tend-to-seek-power",
-      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
-    },
-    {
       "excerpt": "Power, reframed: It's not just about optimal value, but about what you can actually accomplish.",
       "permalink": "power-as-easily-exploitable-opportunities",
       "title": "Power as Easily Exploitable Opportunities"
+    },
+    {
+      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
+      "permalink": "satisficers-tend-to-seek-power",
+      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
     }
   ],
   "attainable-utility-landscape": [
@@ -501,14 +501,14 @@
       "title": "Attainable Utility Preservation: Empirical Results"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "AI agents trained with Attainable Utility Preservation avoid most side effects in Conway's Game of Life without explicit instructions.",
       "permalink": "avoiding-side-effects-in-complex-environments",
       "title": "Avoiding Side Effects in Complex Environments"
+    },
+    {
+      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
+      "permalink": "towards-a-new-impact-measure",
+      "title": "Towards a New Impact Measure"
     }
   ],
   "attainable-utility-preservation-scaling-to-superhuman": [
@@ -765,14 +765,14 @@
       "title": "My research"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "A foundational examination of \"impact\" for AI alignment, exploring why some actions matter more and how to formalize these intuitions.",
       "permalink": "reframing-impact",
       "title": "Reframing Impact"
+    },
+    {
+      "excerpt": "A new AI safety paper formalizing \"attainable utility preservation\" to penalize negative AI impacts, with experimental results.",
+      "permalink": "attainable-utility-preservation-paper",
+      "title": "Penalizing Impact via Attainable Utility Preservation"
     }
   ],
   "conservative-agency-with-multiple-stakeholders": [
@@ -841,14 +841,14 @@
       "title": "Thoughts on 'Human-Compatible'"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "Formal analysis showing that, for agents optimizing a reward function, corrigibility is rare and perhaps even incoherent.",
       "permalink": "a-certain-formalization-of-corrigibility-is-vnm-incoherent",
       "title": "A Certain Formalization of Corrigibility Is VNM-Incoherent"
+    },
+    {
+      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
+      "permalink": "towards-a-new-impact-measure",
+      "title": "Towards a New Impact Measure"
     },
     {
       "excerpt": "The mistakes made, the lessons learned, and the drive to solve a hilariously neglected super-problem.",
@@ -939,9 +939,9 @@
       "title": "My open source contributions"
     },
     {
-      "excerpt": "Showing off and explaining this site's beauty.",
-      "permalink": "design",
-      "title": "The design of this website"
+      "excerpt": "A tour of the research areas I've loved over the years.",
+      "permalink": "research",
+      "title": "My research"
     }
   ],
   "deducing-impact": [
@@ -966,9 +966,9 @@
       "title": "World State is the Wrong Abstraction for Impact"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
+      "excerpt": "Impact reframed: a gears-level view of how and why some things seem important to us.",
+      "permalink": "the-gears-of-impact",
+      "title": "The Gears of Impact"
     }
   ],
   "deep-causal-transcoding": [
@@ -993,9 +993,9 @@
       "title": "Steering Llama-2 with contrastive activation additions"
     },
     {
-      "excerpt": "Activation additions: steering language models by adding a bias to the forward pass. Surprisingly broad control, small impact on off-target capabilities.",
-      "permalink": "gpt2-steering-paper-announcement",
-      "title": "ActAdd: Steering Language Models without Optimization"
+      "excerpt": "Open questions on controlling language models at runtime via activation engineering.",
+      "permalink": "open-problems-in-activation-engineering",
+      "title": "Open problems in activation engineering"
     }
   ],
   "deepmind-equity-discussion": [
@@ -1017,11 +1017,6 @@
       "title": "My open source contributions"
     },
     {
-      "excerpt": "Displaying the features of the website for use in visual regression testing.",
-      "permalink": "test-page",
-      "title": "Testing site features"
-    },
-    {
       "excerpt": "I'm TurnTrout, but the United States government insists on calling me \"Alexander Matt Turner.\" I like writing and learning about lots of stuff.",
       "permalink": "about",
       "title": "About me"
@@ -1030,6 +1025,11 @@
       "excerpt": "My dating doc, sharing who I am and who I'm looking for. Is it you? 💘",
       "permalink": "date-me",
       "title": "I'm that \"other fish in the sea\""
+    },
+    {
+      "excerpt": "Displaying the features of the website for use in visual regression testing.",
+      "permalink": "test-page",
+      "title": "Testing site features"
     }
   ],
   "digital-minimalism": [
@@ -1056,14 +1056,14 @@
       "title": "Don't align agents to evaluations of plans"
     },
     {
+      "excerpt": "Common alignment ideas involve gaming the grader, not achieving the goal. Counterproductive, like building a toaster which both warms and cools the bread.",
+      "permalink": "dont-design-agents-which-exploit-adversarial-inputs",
+      "title": "Don't design agents which exploit adversarial inputs"
+    },
+    {
       "excerpt": "Four distinct concepts related to \"loss function\" in AI are often conflated, leading to ambiguity in the field of AI alignment.",
       "permalink": "four-usages-of-loss-in-ai",
       "title": "Four usages of 'loss' in AI"
-    },
-    {
-      "excerpt": "\"Reward hacking\" is usually specification gaming, not reward signal optimization. My 2022 post stands.",
-      "permalink": "reward-hacking-doesnt-show-reward-is-optimization-target",
-      "title": "2025-era \"reward hacking\" does not show that reward is the optimization target"
     }
   ],
   "distillation-robustifies-unlearning": [
@@ -1266,14 +1266,14 @@
       "title": "Self-fulfilling misalignment data might be poisoning our AI models"
     },
     {
-      "excerpt": "Simple & effective: train the AI to behave as if the jailbreak were not present. Explores activation-level training of Gemini 2.5 Flash.",
-      "permalink": "consistency-training",
-      "title": "Consistency Training Helps Stop Sycophancy and Jailbreaks"
-    },
-    {
       "excerpt": "Aligning an AI to evaluations of your goals won't give you what you want. Don't do it.",
       "permalink": "dont-align-agents-to-evaluations-of-plans",
       "title": "Don't align agents to evaluations of plans"
+    },
+    {
+      "excerpt": "Simple & effective: train the AI to behave as if the jailbreak were not present. Explores activation-level training of Gemini 2.5 Flash.",
+      "permalink": "consistency-training",
+      "title": "Consistency Training Helps Stop Sycophancy and Jailbreaks"
     }
   ],
   "excitement-about-impact-measures": [
@@ -1428,14 +1428,14 @@
       "title": "Some of my disagreements with List of Lethalities"
     },
     {
-      "excerpt": "\"Reward hacking\" is usually specification gaming, not reward signal optimization. My 2022 post stands.",
-      "permalink": "reward-hacking-doesnt-show-reward-is-optimization-target",
-      "title": "2025-era \"reward hacking\" does not show that reward is the optimization target"
-    },
-    {
       "excerpt": "Aligning an AI to evaluations of your goals won't give you what you want. Don't do it.",
       "permalink": "dont-align-agents-to-evaluations-of-plans",
       "title": "Don't align agents to evaluations of plans"
+    },
+    {
+      "excerpt": "\"Reward hacking\" is usually specification gaming, not reward signal optimization. My 2022 post stands.",
+      "permalink": "reward-hacking-doesnt-show-reward-is-optimization-target",
+      "title": "2025-era \"reward hacking\" does not show that reward is the optimization target"
     }
   ],
   "functional-analysis-textbook-review": [
@@ -1541,9 +1541,9 @@
       "title": "The shard theory of human values"
     },
     {
-      "excerpt": "Conjecture: Alignment catastrophe is exclusively caused by AI seeking power.",
-      "permalink": "the-catastrophic-convergence-conjecture",
-      "title": "The Catastrophic Convergence Conjecture"
+      "excerpt": "A critical look at the idea of \"lethal\" AI failures, challenging common assumptions about reward functions, alignment, and the limits of human values.",
+      "permalink": "disagreements-with-list-of-lethalities",
+      "title": "Some of my disagreements with List of Lethalities"
     }
   ],
   "gpt2-steering-paper-announcement": [
@@ -1749,14 +1749,14 @@
       "title": "General alignment properties"
     },
     {
-      "excerpt": "A critical look at the idea of \"lethal\" AI failures, challenging common assumptions about reward functions, alignment, and the limits of human values.",
-      "permalink": "disagreements-with-list-of-lethalities",
-      "title": "Some of my disagreements with List of Lethalities"
-    },
-    {
       "excerpt": "Imperfect human values like familial love seem to contradict AI alignment arguments about Goodhart's Curse.",
       "permalink": "humane-values-despite-imperfections",
       "title": "People care about each other even though they have imperfect motivational pointers?"
+    },
+    {
+      "excerpt": "A critical look at the idea of \"lethal\" AI failures, challenging common assumptions about reward functions, alignment, and the limits of human values.",
+      "permalink": "disagreements-with-list-of-lethalities",
+      "title": "Some of my disagreements with List of Lethalities"
     },
     {
       "excerpt": "Stuart Russell's \"Human Compatible\" makes the case for aligning AI with human values and sketches a research agenda based on uncertainty.",
@@ -1820,14 +1820,14 @@
   ],
   "impact-measure-desiderata": [
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "A foundational examination of \"impact\" for AI alignment, exploring why some actions matter more and how to formalize these intuitions.",
       "permalink": "reframing-impact",
       "title": "Reframing Impact"
+    },
+    {
+      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
+      "permalink": "towards-a-new-impact-measure",
+      "title": "Towards a New Impact Measure"
     },
     {
       "excerpt": "Impact measures: Can they make AI safer, or are they a dangerous distraction from more promising approaches?",
@@ -1947,14 +1947,14 @@
       "title": "Reasons for Excitement about Impact of Impact Measure Research"
     },
     {
-      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
-      "permalink": "satisficers-tend-to-seek-power",
-      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
-    },
-    {
       "excerpt": "This post explores a hypothetical scenario where the AI alignment problem seems lower-stakes due to a unique universe structure.",
       "permalink": "lower-stakes-alignment-scenario",
       "title": "A world in which the alignment problem seems lower-stakes"
+    },
+    {
+      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
+      "permalink": "satisficers-tend-to-seek-power",
+      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
     }
   ],
   "instrumental-convergence-via-vnm-preferences": [
@@ -2190,14 +2190,14 @@
       "title": "Walkthrough of 'Formalizing Convergent Instrumental Goals'"
     },
     {
-      "excerpt": "Impact measure research deconfuses power-seeking incentives in AI, aiding alignment efforts.",
-      "permalink": "excitement-about-impact-measures",
-      "title": "Reasons for Excitement about Impact of Impact Measure Research"
-    },
-    {
       "excerpt": "The structure of environments, not just reward functions, contributes to power-seeking in AI agents.",
       "permalink": "environmental-structure-can-cause-instrumental-convergence",
       "title": "Environmental Structure Can Cause Instrumental Convergence"
+    },
+    {
+      "excerpt": "Impact measure research deconfuses power-seeking incentives in AI, aiding alignment efforts.",
+      "permalink": "excitement-about-impact-measures",
+      "title": "Reasons for Excitement about Impact of Impact Measure Research"
     }
   ],
   "managerial-decision-making-review": [
@@ -2415,9 +2415,9 @@
       "title": "Mechanistically Eliciting Latent Behaviors in Language Models"
     },
     {
-      "excerpt": "Adding a \"top-right vector\" makes a maze-solver go to the top-right. We show composition with other vectors, like the \"cheese vector.\"",
-      "permalink": "top-right-steering-vector",
-      "title": "Maze-solving agents: Add a top-right vector, make the agent go to the top-right"
+      "excerpt": "Principled derivation of unsupervised steering vector discovery methods. Unlocks password-locked models and breaks jailbreak defenses.",
+      "permalink": "deep-causal-transcoding",
+      "title": "Deep Causal Transcoding: A Framework for Mechanistically Eliciting Latent Behaviors in Language Models"
     }
   ],
   "open-source": [
@@ -2478,14 +2478,14 @@
       "title": "Recontextualization Mitigates Specification Gaming Without Modifying the Specification"
     },
     {
-      "excerpt": "\"Reward hacking\" is usually specification gaming, not reward signal optimization. My 2022 post stands.",
-      "permalink": "reward-hacking-doesnt-show-reward-is-optimization-target",
-      "title": "2025-era \"reward hacking\" does not show that reward is the optimization target"
-    },
-    {
       "excerpt": "Unsupervised perturbations to language models reveal hidden capabilities, including the potential to bypass safety measures and exhibit backdoor behaviors.",
       "permalink": "mechanistically-eliciting-latent-behaviors",
       "title": "Mechanistically Eliciting Latent Behaviors in Language Models"
+    },
+    {
+      "excerpt": "\"Reward hacking\" is usually specification gaming, not reward signal optimization. My 2022 post stands.",
+      "permalink": "reward-hacking-doesnt-show-reward-is-optimization-target",
+      "title": "2025-era \"reward hacking\" does not show that reward is the optimization target"
     },
     {
       "excerpt": "Principled derivation of unsupervised steering vector discovery methods. Unlocks password-locked models and breaks jailbreak defenses.",
@@ -2510,14 +2510,14 @@
       "title": "Impact Measure Desiderata"
     },
     {
-      "excerpt": "A foundational examination of \"impact\" for AI alignment, exploring why some actions matter more and how to formalize these intuitions.",
-      "permalink": "reframing-impact",
-      "title": "Reframing Impact"
-    },
-    {
       "excerpt": "An impact measure for AI safety that whitelists the object transformations which are allowed.",
       "permalink": "whitelisting-impact-measure",
       "title": "Worrying about the Vase: Whitelisting"
+    },
+    {
+      "excerpt": "A foundational examination of \"impact\" for AI alignment, exploring why some actions matter more and how to formalize these intuitions.",
+      "permalink": "reframing-impact",
+      "title": "Reframing Impact"
     },
     {
       "excerpt": "How to make AI agents avoid negative side effects, especially in multi-stakeholder environments.",
@@ -2566,24 +2566,24 @@
       "title": "Seeking Power is Often Convergently Instrumental in MDPs"
     },
     {
-      "excerpt": "Impact measure research deconfuses power-seeking incentives in AI, aiding alignment efforts.",
-      "permalink": "excitement-about-impact-measures",
-      "title": "Reasons for Excitement about Impact of Impact Measure Research"
-    },
-    {
       "excerpt": "Conjecture: Alignment catastrophe is exclusively caused by AI seeking power.",
       "permalink": "the-catastrophic-convergence-conjecture",
       "title": "The Catastrophic Convergence Conjecture"
     },
     {
-      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
-      "permalink": "satisficers-tend-to-seek-power",
-      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
+      "excerpt": "Impact measure research deconfuses power-seeking incentives in AI, aiding alignment efforts.",
+      "permalink": "excitement-about-impact-measures",
+      "title": "Reasons for Excitement about Impact of Impact Measure Research"
     },
     {
       "excerpt": "Revised post clarifies theory on power-seeking  and corrects terminology used in the original post.",
       "permalink": "announcing-rewrite-of-power-seeking-post",
       "title": "2019 Review Rewrite: Seeking Power is Often Robustly Instrumental in MDPs"
+    },
+    {
+      "excerpt": "Power-seeking isn't just for optimal agents; it's a feature of many decision-making processes, including satisficers. This is a problem for AI alignment.",
+      "permalink": "satisficers-tend-to-seek-power",
+      "title": "Satisficers Tend To Seek Power: Instrumental Convergence Via Retargetability"
     }
   ],
   "power-seeking-beyond-MDPs": [
@@ -2737,14 +2737,14 @@
   ],
   "questioning-why-simple-alignment-plan-fails": [
     {
-      "excerpt": "Arguments that AI will inevitably \"scheme\" are oversimplified and unconvincing. Deep learning defies naive predictions, and better arguments are needed.",
-      "permalink": "invalid-ai-risk-arguments",
-      "title": "Many arguments for AI x-risk are wrong"
-    },
-    {
       "excerpt": "RL doesn't train reward optimizers. Reward chisels cognition into agents. Worry less about safe objectives, more about good cognition.",
       "permalink": "reward-is-not-the-optimization-target",
       "title": "Reward is not the optimization target"
+    },
+    {
+      "excerpt": "Arguments that AI will inevitably \"scheme\" are oversimplified and unconvincing. Deep learning defies naive predictions, and better arguments are needed.",
+      "permalink": "invalid-ai-risk-arguments",
+      "title": "Many arguments for AI x-risk are wrong"
     },
     {
       "excerpt": "Aligning an AI to evaluations of your goals won't give you what you want. Don't do it.",
@@ -2847,14 +2847,14 @@
       "title": "Reasons for Excitement about Impact of Impact Measure Research"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "Impact measures: Can they make AI safer, or are they a dangerous distraction from more promising approaches?",
       "permalink": "best-reasons-for-pessimism-about-impact-measures",
       "title": "Best reasons for pessimism about impact of impact measures?"
+    },
+    {
+      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
+      "permalink": "towards-a-new-impact-measure",
+      "title": "Towards a New Impact Measure"
     }
   ],
   "research": [
@@ -2977,14 +2977,14 @@
       "title": "Many arguments for AI x-risk are wrong"
     },
     {
-      "excerpt": "A list of some of my major conceptual mistakes.",
-      "permalink": "mistakes",
-      "title": "Mistaken claims I've made"
-    },
-    {
       "excerpt": "Resist specification gaming by generating data with anti-misbehavior prompts, then training on pro-misbehavior prompts.",
       "permalink": "recontextualization-mitigates-specification-gaming",
       "title": "Recontextualization Mitigates Specification Gaming Without Modifying the Specification"
+    },
+    {
+      "excerpt": "Four distinct concepts related to \"loss function\" in AI are often conflated, leading to ambiguity in the field of AI alignment.",
+      "permalink": "four-usages-of-loss-in-ai",
+      "title": "Four usages of 'loss' in AI"
     }
   ],
   "reward-is-not-the-optimization-target": [
@@ -3279,9 +3279,9 @@
       "title": "Maze-solving agents: Add a top-right vector, make the agent go to the top-right"
     },
     {
-      "excerpt": "A deep dive into reinforcement learning, covering algorithms, exploration vs. exploitation, and the importance of safe AI development.",
-      "permalink": "RL-textbook-review",
-      "title": "Making a Difference Tempore: Insights from 'Reinforcement Learning: An Introduction'"
+      "excerpt": "A mathematical exploration of why goal-directed AI, regardless of its programmed goal, might be driven to seek power.",
+      "permalink": "seeking-power-is-often-convergently-instrumental-in-mdps",
+      "title": "Seeking Power is Often Convergently Instrumental in MDPs"
     }
   ],
   "swimming-upstream": [
@@ -3328,14 +3328,14 @@
       "title": "I'm that \"other fish in the sea\""
     },
     {
-      "excerpt": "A tour of the research areas I've loved over the years.",
-      "permalink": "research",
-      "title": "My research"
-    },
-    {
       "excerpt": "A technical deep dive exploring how to align an AI with the goal of creating diamonds, rather than more nebulous human values.",
       "permalink": "a-shot-at-the-diamond-alignment-problem",
       "title": "A shot at the diamond-alignment problem"
+    },
+    {
+      "excerpt": "A tour of the research areas I've loved over the years.",
+      "permalink": "research",
+      "title": "My research"
     }
   ],
   "test-page": [
@@ -3404,9 +3404,9 @@
       "title": "Conclusion to 'Reframing Impact'"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
+      "excerpt": "Impact is objectively important to agents, no matter their goals. Even robots hoarding pebbles care about a meteor strike.",
+      "permalink": "value-impact",
+      "title": "Value Impact"
     }
   ],
   "thoughts-on-human-compatible": [
@@ -3639,14 +3639,14 @@
       "title": "Reframing Impact"
     },
     {
-      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
-      "permalink": "towards-a-new-impact-measure",
-      "title": "Towards a New Impact Measure"
-    },
-    {
       "excerpt": "A tour of the research areas I've loved over the years.",
       "permalink": "research",
       "title": "My research"
+    },
+    {
+      "excerpt": "Impact is reframed as a change in attainable utility for both humans and AI agents.",
+      "permalink": "towards-a-new-impact-measure",
+      "title": "Towards a New Impact Measure"
     }
   ],
   "why-i-left-google-deepmind": [

--- a/scripts/resolve_vale.sh
+++ b/scripts/resolve_vale.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Print the path to a vale binary whose version matches config/vale/version,
+# or exit 1 when no such binary is installed.
+#
+# Vale's rule scoping is version-dependent: a `^`-anchored raw regex in
+# .vale-styles matches at different boundaries across releases, so a binary
+# other than the pinned one reports alerts that CI (which installs the pin)
+# never sees. Pre-push and CI must run the same version for the gate to mean
+# anything, hence an explicit resolve rather than whatever `vale` PATH offers.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+PINNED_VERSION=$(cat "$SCRIPT_DIR/../config/vale/version")
+
+# `vale --version` prints "vale version X.Y.Z".
+vale_version_of() {
+  "$1" --version 2>/dev/null | awk 'NR == 1 {print $NF}'
+}
+
+# session-setup.sh installs the pin into ~/.local/bin; check it before PATH so
+# a newer system-wide vale (e.g. Homebrew's) doesn't shadow the pinned copy.
+for candidate in "$HOME/.local/bin/vale" "$(command -v vale 2>/dev/null)"; do
+  [ -n "$candidate" ] && [ -x "$candidate" ] || continue
+  if [ "$(vale_version_of "$candidate")" = "$PINNED_VERSION" ]; then
+    printf '%s\n' "$candidate"
+    exit 0
+  fi
+done
+
+exit 1

--- a/scripts/resolve_vale.sh
+++ b/scripts/resolve_vale.sh
@@ -12,6 +12,12 @@ set -uo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 PINNED_VERSION=$(cat "$SCRIPT_DIR/../config/vale/version")
+if [ -z "$PINNED_VERSION" ]; then
+  # An empty pin would match the empty version string of any non-vale
+  # candidate below, silently approving an arbitrary binary.
+  echo "config/vale/version is missing or empty" >&2
+  exit 1
+fi
 
 # `vale --version` prints "vale version X.Y.Z".
 vale_version_of() {

--- a/scripts/run_spellcheck_and_vale.sh
+++ b/scripts/run_spellcheck_and_vale.sh
@@ -9,13 +9,15 @@ set -uo pipefail
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT" || exit 1
 
-# Fail loudly when vale is missing: this gate must never silently skip prose
-# checks. session-setup.sh installs vale; if it's absent, install it before
-# pushing.
-if ! command -v vale >/dev/null 2>&1; then
-	echo "vale is not installed; the spellcheck/prose gate cannot run." >&2
-	echo "Install it via 'webi vale@3' or rerun .claude/hooks/session-setup.sh." >&2
-	exit 1
+# Fail loudly when the pinned vale is unavailable: this gate must never
+# silently skip prose checks, and running an off-pin version reports alerts
+# that CI's pinned binary doesn't (see scripts/resolve_vale.sh).
+PINNED_VALE_VERSION=$(cat config/vale/version)
+if ! VALE_BIN=$(scripts/resolve_vale.sh); then
+  echo "vale ${PINNED_VALE_VERSION} (config/vale/version) is not installed;" \
+    "the spellcheck/prose gate cannot run." >&2
+  echo "Install it by rerunning .claude/hooks/session-setup.sh." >&2
+  exit 1
 fi
 
 # `mktemp -t TEMPLATE` is non-portable: macOS treats the arg as a literal
@@ -26,13 +28,13 @@ STRIPPED=$(mktemp -d "${TMPDIR:-/tmp}/turntrout-stripped-XXXXXX")
 trap 'rm -rf "$STRIPPED"' EXIT
 
 uv run python scripts/strip_for_spellcheck.py \
-	--source-dir website_content \
-	--output-dir "$STRIPPED" || exit 1
+  --source-dir website_content \
+  --output-dir "$STRIPPED" || exit 1
 
 STRIP_QUOTES_CONTENT_DIR="$STRIPPED" scripts/spellcheck.sh &
 SPELL_PID=$!
 
-vale --config config/vale/.vale.ini "$STRIPPED" &
+"$VALE_BIN" --config config/vale/.vale.ini "$STRIPPED" &
 VALE_PID=$!
 
 SPELL_RC=0
@@ -41,7 +43,7 @@ wait "$SPELL_PID" || SPELL_RC=$?
 wait "$VALE_PID" || VALE_RC=$?
 
 if [ "$SPELL_RC" -ne 0 ] || [ "$VALE_RC" -ne 0 ]; then
-	[ "$SPELL_RC" -ne 0 ] && echo "spellchecker failed (exit $SPELL_RC)" >&2
-	[ "$VALE_RC" -ne 0 ] && echo "vale failed (exit $VALE_RC)" >&2
-	exit 1
+  [ "$SPELL_RC" -ne 0 ] && echo "spellchecker failed (exit $SPELL_RC)" >&2
+  [ "$VALE_RC" -ne 0 ] && echo "vale failed (exit $VALE_RC)" >&2
+  exit 1
 fi

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -39,7 +39,7 @@ In January, Department of Homeland Security (DHS) officers killed [at least](htt
 </div>
 </figure>
 
-I learned that [Google sells its Cloud services to the relevant agencies within DHS](#google-supports-the-immigration-enforcement-supply-chain). I thought that was wrong. Federal agents should not be able to kill citizens in the street. I set out to find the most effective way to push my company to stop serving these agencies. My divestment campaign quickly broadened into an attempt to prevent Google from signing an unethical military AI deal, as the Pentagon started pressuring AI providers into military AI deals with no restrictions against use for killer robots or mass surveillance.[^surveil]
+I learned that [Google sells its Cloud services to the relevant agencies within DHS](#google-supports-the-immigration-enforcement-supply-chain). I thought that was wrong. Federal agents should not be able to kill innocent citizens in the street. I set out to find the most effective way to push my company to stop serving these agencies. My divestment campaign quickly broadened into an attempt to prevent Google from signing an unethical military AI deal, as the Pentagon started pressuring AI providers into military AI deals with no restrictions against use for killer robots or mass surveillance.[^surveil]
 
 [^surveil]: Technically, I'm worried about mass *profiling* from AI. Surveillance concerns data collection. Profiling takes data and draws conclusions, like "does this person dislike the government?".
 


### PR DESCRIPTION
## Summary

- The pre-push prose gate ran whatever `vale` PATH resolved to, while CI installs the version pinned in `config/vale/version` (3.9.0). A system-wide vale 3.17.0 shadows the pin locally, so pre-push and CI silently diverged — the exact drift `config/vale/version` exists to prevent.
- Vale's rule scoping changed between those releases: the `^`-anchored raw regexes in `.vale-styles/Openly/{UnclearAntecedent,ThereIs}.yml` now match at every **sentence** start instead of only at **block** starts. That surfaced 31 errors and 23 warnings across 20 posts nobody had touched, blocking pushes on content CI reports as clean.
- Many of those alerts were unfixable by design: verbatim GPT-2 completions in result tables and quoted paper abstracts in `steering-gpt-2-xl-by-adding-an-activation-vector.md` can't be reworded without misreporting the data.

## Changes

- **`scripts/resolve_vale.sh`** (new): prints the path of a vale binary matching `config/vale/version`, or exits 1. Checks `~/.local/bin` before PATH so a newer system-wide vale can coexist with the pin, and rejects an empty pin so a non-vale binary can't match by producing an empty version string.
- **`scripts/run_spellcheck_and_vale.sh`**: runs the resolved binary instead of bare `vale`, failing loudly with install instructions when no pinned vale is present — preserving the existing "never silently skip the prose gate" invariant.
- **`.claude/hooks/session-setup.sh`**: `vale_install_if_missing` → `vale_install_if_unpinned`. It previously returned early whenever *any* vale was on PATH, which is how the off-pin binary went unnoticed.
- A separate formatting-only commit normalizes `session-setup.sh` indentation, which had drifted into a tab/space mix that pre-commit's `shfmt -i 2` would otherwise rewrite inside the functional commit.

Also carried on this branch: a one-word wording change in `leaving-google-deepmind.md` (the commit whose push surfaced this), plus the `related_posts.json` / `.invert_labels.json` regeneration the pre-push hook commits automatically.

## Testing

- Installed the pin (3.9.0) locally and ran `scripts/run_spellcheck_and_vale.sh` against unmodified content: **0 errors, 0 warnings, 0 suggestions in 180 files** — versus 31 errors / 23 warnings from 3.17.0 on identical bytes.
- Cross-checked CI history: the last green `Run Vale` step on `main` was run `30781760356` on commit `d1a594e12` — the same commit that last touched every flagged file. Same content, pinned binary, zero alerts.
- Verified the failure paths: with no pinned vale reachable, `resolve_vale.sh` exits 1 and the gate aborts with install instructions rather than skipping; with an empty pin it exits 1 rather than accepting an arbitrary binary.
- `shellcheck` and `shfmt -i 2` clean on all three scripts; full pre-push suite green.

## Lessons Learned

- **What**: When a repo pins a lint/format tool version for CI, the local gate must *resolve and verify* that version rather than invoking the bare binary — a system package manager's newer copy will shadow the pin and produce alerts CI never sees. An `install_if_missing` check on a pinned tool should always be an `install_if_version_mismatched` check.
- **Where**: `scripts/resolve_vale.sh`, `scripts/run_spellcheck_and_vale.sh`, `.claude/hooks/session-setup.sh`
- **Why**: `vale_install_if_missing` treated "some vale exists" as "the pin is satisfied," so a Homebrew vale 3.17.0 blocked pushes with 31 errors on prose CI considers clean.

- **What**: Before rewriting content to satisfy a linter that suddenly went red on untouched files, confirm the tool version matches CI's and check whether the same bytes passed in an earlier CI run.
- **Where**: `CLAUDE.md` (CI monitoring / testing sections)
- **Why**: The failure looked like 31 real prose defects. It was one version mismatch, and "fixing" it would have meant editing verbatim model outputs and quoted paper abstracts — silently corrupting reported experimental results.