### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
@@ -18,6 +18,7 @@ npm install agent-sanitizer
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
+/agent-sanitizer:enable-auto-update
 ```
 
 [What installing entails](#what-installing-entails) covers the footprint of each
@@ -114,12 +115,17 @@ buy you:
    first web page, and the occasional over-redaction of credential-shaped text —
    `AGENT_SANITIZER_OUTPUT_DISABLED=1` opts out of the rewrites.
 
-Failure is loud by design: every layer fails closed, so you see suppressed tool
-output (`[output sanitizer unavailable — original output suppressed]`), blocked
-prompts, or permission asks whose reason names the cause. The exception is a
-plugin that never loaded at all — Claude Code reads a crashed hook as "no
-objection", so confirm with `/plugin` rather than reading a quiet session as a
-working one.
+Failure is loud by design. Installed as Claude Code hooks the layers fail
+**open**: a hook that could not run lets the action through rather than halting
+your session on its own breakage — but it says so, in a warning the model and
+the transcript both carry. Set `AGENT_SANITIZER_FAIL_OPEN=0` and the same
+failures block instead: suppressed tool output
+(`[output sanitizer unavailable — original output suppressed]`), blocked
+prompts, permission asks whose reason names the cause. Either way, a plugin that
+never loaded at all is invisible — Claude Code reads a crashed hook as "no
+objection" — so confirm with `/plugin` rather than reading a quiet session as a
+working one. Neither posture touches what a sanitizer that RAN decided (see
+`plugin/README.md`).
 
 ## Using it with Claude Code
 
@@ -131,7 +137,22 @@ needs only `python3` on PATH, for Layer 4 — the plugin ships the engine itself
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
+/agent-sanitizer:enable-auto-update
 ```
+
+Claude Code auto-updates Anthropic's own marketplaces by default and nobody
+else's, so that install pins you to the release you added and later detector
+fixes never arrive. Claude Code ships no slash command for the toggle, so the
+plugin ships one — `/agent-sanitizer:enable-auto-update` writes the same bit the
+`/plugin` picker's **Enable auto-update** does, and refuses loudly rather than
+guessing if the marketplace was never added. To pull a release by hand instead:
+
+```
+/plugin marketplace update agent-sanitizer
+/plugin update agent-sanitizer@agent-sanitizer
+```
+
+`plugin/README.md` has the managed-settings form for enabling it fleet-wide.
 
 To wire them yourself instead, one entry dispatches all four modes on `--hook=`:
 
@@ -182,8 +203,8 @@ surface is the `--hook=` CLI, so these move between minor versions.
 
 **`sanitize-output` takes a host-extension bag** — an optional last argument on
 `sanitizeText`, `sanitizeValue`, `evaluateToolOutput`, `judgeSanitizeOutput`, and
-`cliMain`, so a composer that wraps `cliMain` gets the hook's exact fail-closed
-CLI wiring plus its own policy:
+`cliMain`, so a composer that wraps `cliMain` gets the hook's exact CLI wiring
+plus its own policy:
 
 | Field        | Runs                                                     | Does                                                                                 |
 | ------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -194,11 +215,13 @@ CLI wiring plus its own policy:
 
 Omit the bag and every seam is inert — the verdicts are byte-identical to this
 module alone. A callback that throws is **not** caught: it lands in the CLI's
-fail-closed catch and the tool output is suppressed, so a broken extension can
-never degrade into showing unvetted output. `postText` deliberately does not run
-on object field NAMES: a callback sees only the string and the tool, so it cannot
+failure catch, so a broken extension gets the caller's failure posture — the
+warning-and-pass-through default, or suppression under
+`AGENT_SANITIZER_FAIL_OPEN=0`. Wire `emitFailClosed` yourself if a host must
+suppress regardless of the environment. `postText` deliberately does not run on
+object field NAMES: a callback sees only the string and the tool, so it cannot
 tell a schema key from content, and rewriting a key can collapse two fields into
-one name — which this hook turns into whole-output suppression.
+one name — which this hook answers with that same failure path.
 
 Beyond the credential-shaped names it infers, the env-bound redaction set unions
 `_AGENT_SANITIZER_EXTRA_SECRET_VARS` — a comma-separated list of `[A-Z0-9_]`
@@ -208,8 +231,9 @@ choosing. A malformed entry throws rather than being dropped.
 **Layer 4 needs the Python engine.** The plugin ships it and provisions it at
 SessionStart; a hand-wired npm install does not, so install it yourself —
 `pip install 'agent-sanitizer[secrets]'`, version-matched to the npm package.
-Without it `sanitize-output` fails closed: secret-shaped output is suppressed,
-not shown unvetted. Layers 1–3 still run.
+Without it `sanitize-output` fails: secret-shaped output reaches the model
+unredacted with a warning attached, or is suppressed under
+`AGENT_SANITIZER_FAIL_OPEN=0`. Layers 1–3 still run.
 
 **Layer 5 (second-model injection filtering) is not included.** These hooks
 never supply the `/output` seam's `filterInjection` callback, so nothing here
@@ -244,8 +268,8 @@ hook module, and every consumer waits on that path instead. `lib/control-plane`
 resolves the marker at module scope, so a call that lands after that import
 warns on stderr — it cannot steer the wait that already started.
 
-**A host's own remedy can replace the packaged one in every fail-closed
-reason.** Deep call sites (`lib/control-plane`'s missing-package throw) take no
+**A host's own remedy can replace the packaged one in every failure reason**
+(the fail-closed verdicts and the fail-open warning alike). Deep call sites (`lib/control-plane`'s missing-package throw) take no
 remedy argument, so by default they can only say `pnpm install`. A host whose
 install has one entry point calls `configureMissingPackageRemedy(text)` (from
 `lib/hook-io`) — typically at its bundle entry — and every remedy-less
@@ -262,7 +286,7 @@ credentials (and their length floor) in a registry of its own feeds the packaged
 helpers from it instead of forking the module. Unset fields keep the package
 derivation; `null` restores it entirely. A malformed source — a non-object, a
 key the seam does not read, a bad field — throws on first use, inside the
-consuming hook's fail-closed catch, never at configure time.
+consuming hook's failure catch, never at configure time.
 
 Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
 path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -253,9 +253,9 @@ See [`docs/configuration.md`](docs/configuration.md) for the full reference: wra
 
 ### 📊 Codebase composition
 
-![Codebase composition chart](https://assets.turntrout.com/static/charts/glovebox/codebase-composition.svg)
+![Codebase composition chart](https://assets.turntrout.com/static/charts/glovebox/codebase-composition.svg?v=71f5f1e48b0f)
 
-<sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published on every merge to `main`, updating in place. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` → Tests; `evals/` → Evals; `.github/` → CI/CD; `*.md`/`docs/`/`changelog.d/` → Docs; manifests/lockfiles/dotfiles → Config; everything else → Source.</sub>
+<sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published daily by the repo-health chart run, from the same read of the tree as the tracked-lines trend, so the two totals always agree. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` → Tests; `evals/` → Evals; `.github/` → CI/CD; `*.md`/`docs/`/`changelog.d/` → Docs; manifests/lockfiles/dotfiles → Config; everything else → Source. `.gitattributes` linguist-generated/vendored is set aside and left out of the total.</sub>
 
 <!-- codebase-breakdown:end -->
 
@@ -267,11 +267,11 @@ The agent runs on a model that will actually attempt the break-in (a safety-tune
 
 ### Other charts
 
-![Setup time chart](https://assets.turntrout.com/static/charts/glovebox/setup-time.svg?v=1)
+![Setup time chart](https://assets.turntrout.com/static/charts/glovebox/setup-time.svg?v=71f5f1e48b0f)
 
-![sbx launch timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-launch-timing.svg?v=1)
+![sbx launch timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-launch-timing.svg?v=71f5f1e48b0f)
 
-![sbx teardown timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-teardown-timing.svg?v=1)
+![sbx teardown timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-teardown-timing.svg?v=71f5f1e48b0f)
 
 More metrics re-render on every merge to `main` in [METRICS.md](METRICS.md).
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.