### PR TITLE
feat: catch prose accidentally wrapped in inline math

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -431,6 +431,33 @@ def check_unrendered_title_sentinel(soup: BeautifulSoup) -> list[str]:
     return leaked
 
 
+_MARKDOWN_LINK_SYNTAX_PATTERN = re.compile(r"\]\(")
+
+
+def check_unrendered_markdown_link_syntax(soup: BeautifulSoup) -> list[str]:
+    """
+    Check for visible text still containing literal ``](`` link syntax.
+
+    A surviving ``](`` means a markdown link failed to parse—often because
+    unescaped ``$`` signs elsewhere in the paragraph opened an inline-math
+    span that swallowed the link's own ``[...]`` and ``(...)`` parts—so the
+    raw syntax leaked into the rendered page instead of becoming an anchor.
+    Legitimate mentions live inside ``<code>`` elements, which ``should_skip``
+    excludes.
+    """
+    leaked: list[str] = []
+    for element in soup.find_all(string=True):
+        if not isinstance(element, NavigableString):  # pragma: no cover
+            continue
+        if not element.strip() or should_skip(element):
+            continue
+        if _MARKDOWN_LINK_SYNTAX_PATTERN.search(str(element)):
+            _append_to_list(
+                leaked, str(element), prefix="Unrendered markdown link syntax: "
+            )
+    return leaked
+
+
 def check_invalid_anchors(soup: BeautifulSoup, base_dir: Path) -> list[str]:
     """Check for invalid internal anchor links in the HTML."""
     invalid_anchors: list[str] = []
@@ -2306,6 +2333,9 @@ def check_file_for_issues(
         "localhost_links": check_localhost_links(soup),
         "invalid_internal_links": check_invalid_internal_links(soup),
         "unrendered_title_sentinel": check_unrendered_title_sentinel(soup),
+        "unrendered_markdown_link_syntax": check_unrendered_markdown_link_syntax(
+            soup
+        ),
         "invalid_anchors": check_invalid_anchors(soup, base_dir),
         "malformed_hrefs": check_malformed_hrefs(soup),
         "problematic_paragraphs": paragraphs_contain_canary_phrases(soup),

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -637,6 +637,60 @@ def check_stray_katex(text: str) -> list[str]:
     return errors
 
 
+# Matches a paired inline math span: `$...$`, not crossing a newline, with
+# neither delimiter escaped. Mirrors the span-matching half of `remove_math`.
+_INLINE_MATH_SPAN_RE = re.compile(r"(?<!\\)\$([^$\n]*?)(?<!\\)\$")
+# LaTeX text-mode macros wrap literal prose inside math on purpose
+# (e.g. `\text{layers}`); their contents don't count as "leaked" prose.
+_TEXT_MACRO_RE = re.compile(
+    r"\\(?:text|mathrm|textrm|textit|textbf|operatorname)\s*\{[^}]*\}"
+)
+_MAGNITUDE_WORD_RE = re.compile(
+    r"\b(?:million|billion|trillion|thousand|percent|per cent)\b", re.IGNORECASE
+)
+# A standalone, whitespace-delimited token that's purely alphabetic prose
+# (with optional trailing punctuation), e.g. "requesting" or "requesting,".
+# Requiring the whole token to be letters excludes LaTeX identifiers such as
+# subscripts and function calls, which contain letter runs but aren't words.
+_PLAIN_WORD_RE = re.compile(r"^[A-Za-z]{3,}[,.;:!?]?$")
+
+
+def check_prose_inside_math(text: str) -> list[str]:
+    """
+    Check for inline math spans (`$...$`) whose contents look like prose that
+    accidentally got wrapped in math delimiters, e.g. two independent dollar
+    amounts in one sentence.
+
+    KaTeX renders such spans without error, so they
+    pass silently; the only symptom is glued-together, italicized output
+    text. This is the inverse of `check_stray_katex`: LaTeX escaping out of
+    math vs. prose leaking into it.
+    """
+    no_code_text = remove_code(text)
+    no_display_math = re.sub(r"\$\$.*?\$\$", "", no_code_text, flags=re.DOTALL)
+    errors = []
+    for match in _INLINE_MATH_SPAN_RE.finditer(no_display_math):
+        span = match.group(1)
+        core = _TEXT_MACRO_RE.sub("", span)
+        plain_words = [
+            token
+            for token in re.split(r"[\s,]+", core)
+            if _PLAIN_WORD_RE.match(token)
+        ]
+        if _MAGNITUDE_WORD_RE.search(core):
+            reason = "contains a magnitude word (million/billion/percent/…)"
+        elif "\\" not in core and len(plain_words) >= 2:
+            reason = "contains multiple plain-English words"
+        else:
+            continue
+        errors.append(
+            f"Prose found inside inline math (${span}$): {reason}. "
+            "If this is currency or literal text, escape the dollar "
+            'sign(s) as "\\$" instead of using math delimiters.'
+        )
+    return errors
+
+
 # Indented block-level constructs that render correctly inside a `<dd>` and so
 # do NOT need a `: ` prefix: list items, image/wikilink embeds, raw HTML,
 # blockquotes, tables, and headings.
@@ -1306,6 +1360,7 @@ def check_file_data(
         "video_tags": validate_video_tags(text),
         "forbidden_patterns": check_no_forbidden_patterns(text),
         "stray_katex": check_stray_katex(text),
+        "prose_inside_math": check_prose_inside_math(text),
         "description_list_continuations": check_description_list_continuations(
             text
         ),

--- a/scripts/source_file_checks.py
+++ b/scripts/source_file_checks.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import re
 import shutil
+import string
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -648,11 +649,20 @@ _TEXT_MACRO_RE = re.compile(
 _MAGNITUDE_WORD_RE = re.compile(
     r"\b(?:million|billion|trillion|thousand|percent|per cent)\b", re.IGNORECASE
 )
-# A standalone, whitespace-delimited token that's purely alphabetic prose
-# (with optional trailing punctuation), e.g. "requesting" or "requesting,".
-# Requiring the whole token to be letters excludes LaTeX identifiers such as
-# subscripts and function calls, which contain letter runs but aren't words.
-_PLAIN_WORD_RE = re.compile(r"^[A-Za-z]{3,}[,.;:!?]?$")
+# Sentence-trailing punctuation a word may carry, drawn from the stdlib
+# punctuation set rather than a hand-picked literal so the character class
+# has a single source of truth.
+_SENTENCE_TRAILING_PUNCT = "".join(
+    c for c in string.punctuation if c in ",.;:!?"
+)
+# A standalone, whitespace-delimited token that's purely Latin-alphabetic
+# prose (with optional trailing punctuation), e.g. "requesting" or
+# "requesting,". Requiring the whole token to be letters excludes LaTeX
+# identifiers such as subscripts and function calls, which contain letter
+# runs but aren't words.
+_PLAIN_WORD_RE = re.compile(
+    rf"^[{string.ascii_letters}]{{3,}}[{re.escape(_SENTENCE_TRAILING_PUNCT)}]?$"
+)
 
 
 def check_prose_inside_math(text: str) -> list[str]:

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2418,6 +2418,31 @@ def test_check_unrendered_title_sentinel(html, expected_count):
 
 
 @pytest.mark.parametrize(
+    "html,expected_count",
+    [
+        # Normal prose and a properly rendered link.
+        ("<p>Normal prose with no issues.</p>", 0),
+        ('<p>See <a href="/x">the link</a> for more.</p>', 0),
+        # A failed markdown link leaks its raw syntax into text.
+        ("<p>Cost was $225 million, now requesting ]($54.6 billion.</p>", 1),
+        # Multiple leaks within one text node still count as one finding
+        # (mirrors check_unrendered_title_sentinel, which reports per node).
+        ("<p>First ](one) and second ](two) leaked.</p>", 1),
+        # Legitimate mentions in code must be ignored.
+        ("<p><code>[text](url)</code> is markdown link syntax.</p>", 0),
+        ("<pre>[text](url)</pre>", 0),
+        # A lone bracket or paren without the pair isn't a leak.
+        ("<p>A closing bracket] then an open paren( elsewhere.</p>", 0),
+    ],
+)
+def test_check_unrendered_markdown_link_syntax(html, expected_count):
+    """The check flags any non-code text still containing literal ']('."""
+    soup = BeautifulSoup(html, "html.parser")
+    result = built_site_checks.check_unrendered_markdown_link_syntax(soup)
+    assert len(result) == expected_count
+
+
+@pytest.mark.parametrize(
     "md_content,expected_counts",
     [
         # Basic Markdown Image

--- a/scripts/tests/test_source_file_checks.py
+++ b/scripts/tests/test_source_file_checks.py
@@ -2259,6 +2259,40 @@ def test_check_stray_katex(text: str, expected_errors: list[str]):
 
 
 @pytest.mark.parametrize(
+    "text, expected_error_count",
+    [
+        ("This is normal text without any math.", 0),
+        # Real math: numerals, single identifiers, LaTeX commands.
+        ("The formula is $10^{-4}$ approximately.", 0),
+        ("Let $x$ be a variable and $U_{ideal}(plan)$ its utility.", 0),
+        ("A tensor $2\\cdot n_\\text{layers} \\cdot d_\\text{model}$ here.", 0),
+        ("The bound is $100\\times(1-\\alpha)\\%$ confidence.", 0),
+        # A single bare `$` (no pair) is untouched, e.g. a lone price mention.
+        ("Cost: $250 one-time.", 0),
+        # Two independent dollar amounts in one paragraph, wrapped as math:
+        # the classic "prose glued into a math span" bug.
+        (
+            "The budget was $225 million, now requesting $54.6 billion.",
+            1,
+        ),
+        # Magnitude word alone is enough, even with only two prose words.
+        ("A jump of $40 percent more$ than last year.", 1),
+        # Two plain English words with no magnitude word or backslash.
+        ("This is $clearly not math$ at all.", 1),
+        # Should be ignored: inside code or display math.
+        ("`$225 million, now requesting $54.6 billion`", 0),
+        ("$$225 million, now requesting $54.6 billion$$", 0),
+        # A single plain word doesn't trigger (could be a real identifier).
+        ("The variable $foo$ is defined above.", 0),
+    ],
+)
+def test_check_prose_inside_math(text: str, expected_error_count: int):
+    """Test the check_prose_inside_math function."""
+    errors = source_file_checks.check_prose_inside_math(text)
+    assert len(errors) == expected_error_count
+
+
+@pytest.mark.parametrize(
     "text, expected_errors",
     [
         # No HTML or valid HTML


### PR DESCRIPTION
## Summary
- Follow-up to #1723 (the DAWG-budget dollar-sign escape fix, already merged into `main`).
- Adds two new validation checks so this class of bug can't silently ship again—it rendered without any KaTeX error, so the only symptom was glued-together, italicized output text:
  - `check_prose_inside_math` (`scripts/source_file_checks.py`): flags inline `$...$` spans whose contents contain a magnitude word (million/billion/percent/…) or multiple plain-English words. This is the inverse of the existing `check_stray_katex`, which catches LaTeX leaking out of math; this catches prose leaking into it.
  - `check_unrendered_markdown_link_syntax` (`scripts/built_site_checks.py`): flags literal `](` surviving into rendered page text, catching any cause of a broken markdown link (not just this one).
- Verified both checks produce zero false positives against the full `website_content/` corpus (3,985 inline math spans checked).
- Both checks' character classes for "Latin letters" and "trailing punctuation" are derived from `string.ascii_letters` / `string.punctuation` rather than hand-typed literal ranges.

## Lessons learned
- When a markdown/LaTeX pipeline treats a punctuation character as a syntactic delimiter (e.g. `$` for inline math), a bug where two independent uses of that character get paired up won't show up as a rendering *error*—it renders successfully, just with the wrong meaning. Error-only checks (`.katex-error`, etc.) can't catch this class of bug; a heuristic content-shape check (e.g. "does this math span contain magnitude words or multiple plain-English words?") is needed instead, and is worth writing symmetrically alongside any existing "leaked syntax the other direction" check.
- Before adding a heuristic detection regex to a codebase, measure its false-positive rate against the full real corpus, not just a few hand-picked examples—a naive version of this check (parity of unescaped `$`, or a bare letter-run inside `$...$`) had either zero detection power or false-fired on legitimate LaTeX identifiers like `U_{ideal}(plan)`.

## Test plan
- [x] `uv run pytest scripts/tests/test_built_site_checks.py scripts/tests/test_source_file_checks.py` — 1508 passed
- [x] `uv run pylint` and `ruff check`/`ruff format --check` on changed files — clean
- [x] Manually ran both new checks against the entire `website_content/` corpus and confirmed zero false positives, plus confirmed the checks correctly flag a reconstruction of the original bug
- [ ] CI (build/lint/tests)
