### PR TITLE
fix(ci): restore missing security-scan scripts and narrow triage to static-site risk

### DIFF
--- a/.github/prompts/security-vulnerability-scan.md
+++ b/.github/prompts/security-vulnerability-scan.md
@@ -40,6 +40,11 @@ narrow what actually matters:
      injection or auth-bypass CVE in a build-only tool is not exploitable
      at all and should be closed as inapplicable; a “critical” RCE or
      malware alert in a build-only tool is exploitable and must be fixed.
+   - **Unclassified** (GitHub didn’t report a `dependency.scope`): don’t
+     assume build-only. Check the manifest path yourself (`dependencies` vs
+     `devDependencies` in `package.json`, or the equivalent for other
+     ecosystems) and apply the Runtime or Development rule above once
+     you’ve confirmed which one it is.
 3. **Actionability**: Is there a fix available (patched version, workaround)?
 4. **Duplicates**: Group related alerts (e.g., multiple CVEs in the same
    package that would all be fixed by one upgrade).

--- a/.github/prompts/security-vulnerability-scan.md
+++ b/.github/prompts/security-vulnerability-scan.md
@@ -12,12 +12,37 @@ You are a security analyst triaging vulnerability alerts from GitHub’s securit
 
 ## Triage Criteria
 
-For each alert, assess:
+turntrout.com is a **statically generated site with no server runtime**: the
+build produces plain HTML/CSS/JS that Cloudflare serves as static files.
+There is no database, no server-side request handling, no auth/session
+layer, and no user-submitted data processed at request time. Use that to
+narrow what actually matters:
 
-1. **Exploitability**: Is this dependency/code reachable in production? A vulnerability in a dev-only tool is lower priority than one in a runtime dependency.
-2. **Severity context**: Does the CVSS score match the actual risk for this project? A “critical” SQL injection in a library used only for static-site builds may be effectively low risk.
+1. **Attack surface reachability**: A vulnerability class that requires a
+   live server to exploit—SQL injection, server-side request forgery,
+   auth/session bypass, path traversal against a request handler, etc.—has
+   **no exploitable surface here**, regardless of CVSS score, unless the
+   vulnerable code also runs during the build or in a browser. Don’t spend
+   fix effort on these; note in the PR why they’re inapplicable.
+2. **Where the vulnerable code actually executes** (the report’s Dependabot
+   Alerts section is pre-split into “Runtime” and “Development” using
+   GitHub’s own `dependency.scope` classification):
+   - **Runtime-scope** (ships in the built output, executes in visitors’
+     browsers): client-exploitable classes—XSS, prototype pollution,
+     ReDoS on user-facing input, insecure deserialization of fetched
+     data—are real and should be fixed.
+   - **Development-scope** (build tooling, test runners, lint/format
+     plugins): only matters if the vulnerability lets an attacker execute
+     arbitrary code, exfiltrate secrets, or tamper with output during
+     `pnpm install`/build/CI—e.g. malicious packages, install-script RCE,
+     supply-chain compromise. These still have real reach: CI holds push
+     credentials and produces the deployed artifact. A “critical” SQL
+     injection or auth-bypass CVE in a build-only tool is not exploitable
+     at all and should be closed as inapplicable; a “critical” RCE or
+     malware alert in a build-only tool is exploitable and must be fixed.
 3. **Actionability**: Is there a fix available (patched version, workaround)?
-4. **Duplicates**: Group related alerts (e.g., multiple CVEs in the same package that would all be fixed by one upgrade).
+4. **Duplicates**: Group related alerts (e.g., multiple CVEs in the same
+   package that would all be fixed by one upgrade).
 
 ## Applying Fixes
 
@@ -31,6 +56,9 @@ For each actionable finding (critical/high with available fixes, or medium with 
 
 **Do NOT fix:**
 
+- Findings in a vulnerability class with no exploitable surface on a static
+  site (SQLi, server-side auth bypass, SSRF, etc.), regardless of severity
+  or scope—note these as inapplicable in the PR description instead
 - Low-severity findings that are dev-only and not exploitable
 - Issues where no fix is available upstream—note these in the PR description instead
 

--- a/.github/scripts/check-existing-security-pr.sh
+++ b/.github/scripts/check-existing-security-pr.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Locate the open security rollup PR (if any) by label, check out its branch,
+# and merge the default branch into it. Writes outputs consumed by the
+# security-vulnerability-scan workflow.
+#
+# Inputs (env):
+#   GH_TOKEN          GitHub token for `gh`
+#   DEFAULT_BRANCH    Repository default branch (e.g. "main")
+#   GITHUB_OUTPUT     Path to GitHub Actions output file (optional)
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH must be set}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+EXISTING_BRANCH=$(gh pr list --label "security-scan" --state open \
+  --json headRefName --jq '.[0].headRefName // empty')
+
+if [[ -n "$EXISTING_BRANCH" ]]; then
+  echo "Found existing security PR branch: $EXISTING_BRANCH"
+  git fetch origin "$EXISTING_BRANCH"
+  git checkout "$EXISTING_BRANCH"
+  if ! git merge "origin/$DEFAULT_BRANCH" --no-edit; then
+    echo "::error::Merge conflict with default branch. Aborting merge."
+    git merge --abort
+    exit 1
+  fi
+  {
+    echo "branch=$EXISTING_BRANCH"
+    echo "exists=true"
+  } >>"$GITHUB_OUTPUT"
+else
+  echo "No existing security PR found, will create new branch"
+  echo "exists=false" >>"$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -53,11 +53,10 @@ gh_api_section() {
 
 echo "## Dependabot Alerts" >"$REPORT_PATH"
 dependabot_tmp=$(mktemp)
-trap 'rm -f "$dependabot_tmp"' EXIT
 # echo-fallback-ok: same best-effort-section reasoning as gh_api_section above.
 if gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
   --arg repo "$REPO" \
-  --jq '.[] | "\(.dependency.scope // "unknown")\t- **\(.security_advisory.severity | ascii_upcase)**: [\(.security_advisory.summary)](https://github.com/\($repo)/security/dependabot/\(.number)) in `\(.dependency.package.name)` (\(.dependency.package.ecosystem))"' \
+  --jq '.[] | "\(.dependency.scope // "unclassified")\t- **\(.security_advisory.severity | ascii_upcase)**: [\(.security_advisory.summary)](https://github.com/\($repo)/security/dependabot/\(.number)) in `\(.dependency.package.name)` (\(.dependency.package.ecosystem))"' \
   >"$dependabot_tmp" 2>&1; then
   {
     echo ""
@@ -65,7 +64,10 @@ if gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
     grep '^runtime' "$dependabot_tmp" | cut -f2- || echo "_None._"
     echo ""
     echo "### Development (build/CI only — no visitor-facing exposure, but still a supply-chain risk if RCE/malicious-package)"
-    grep -v '^runtime' "$dependabot_tmp" | cut -f2- || echo "_None._"
+    grep '^development' "$dependabot_tmp" | cut -f2- || echo "_None._"
+    echo ""
+    echo "### Unclassified (GitHub didn't report a scope — verify manually before assuming build-only)"
+    grep -v -e '^runtime' -e '^development' "$dependabot_tmp" | cut -f2- || echo "_None._"
   } >>"$REPORT_PATH"
 else
   cat "$dependabot_tmp" >>"$REPORT_PATH"

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -10,9 +10,10 @@
 # packages only ever execute in the build/CI environment. Server-side
 # vulnerability classes (SQLi, auth bypass, session hijacking, etc.) can't be
 # exploited in either case since there's no server — the triage prompt applies
-# that judgment. Both groups are still reported: a "Development"-scope RCE or
-# malicious-package alert is a real supply-chain risk to the CI pipeline, so
-# scope alone must not silently drop alerts.
+# that judgment. All alerts are still reported, including ones GitHub didn't
+# scope at all (their own "Unclassified" section): a "Development"-scope RCE
+# or malicious-package alert is a real supply-chain risk to the CI pipeline,
+# so scope alone must not silently drop or reclassify alerts.
 #
 # Inputs (env):
 #   GH_TOKEN       GitHub token (Dependabot/secret APIs require security_events scope)

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Collect open security alerts (Dependabot, code scanning, secret scanning,
+# pnpm audit, Socket.dev) into a single Markdown report. Writes the report to
+# $REPORT_PATH and exports SECURITY_REPORT (first 50KB) to $GITHUB_ENV.
+#
+# turntrout.com is a statically generated site with no server runtime, so this
+# repo's Dependabot Alerts section splits on the alert's `dependency.scope`
+# (GitHub's own runtime/development classification): "Runtime" packages end up
+# in the built output and reach visitors' browsers, while "Development"
+# packages only ever execute in the build/CI environment. Server-side
+# vulnerability classes (SQLi, auth bypass, session hijacking, etc.) can't be
+# exploited in either case since there's no server — the triage prompt applies
+# that judgment. Both groups are still reported: a "Development"-scope RCE or
+# malicious-package alert is a real supply-chain risk to the CI pipeline, so
+# scope alone must not silently drop alerts.
+#
+# Inputs (env):
+#   GH_TOKEN       GitHub token (Dependabot/secret APIs require security_events scope)
+#   REPO           owner/repo
+#   GITHUB_ENV     Path to GitHub Actions env file (optional outside CI)
+#   REPORT_PATH    Output report file (default: /tmp/security-report.md)
+
+# --jq arguments are literal jq expressions; $-tokens in jq strings (e.g.
+# `\(.number)`) are intentional and shouldn't be shell-expanded.
+# shellcheck disable=SC2016
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${REPO:?REPO must be set (owner/repo)}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+REPORT_PATH="${REPORT_PATH:-/tmp/security-report.md}"
+
+# Append a section heading + `gh api` result to the report. Passes $REPO into
+# jq via `--arg repo` (not string interpolation) to keep jq parsing safe even
+# if the repo name later contains special characters.
+# echo-fallback-ok: this is a best-effort, per-section aggregator — one alert
+# source failing must not abort the whole report. The fallback text names the
+# failure explicitly ("could not fetch ... check repo permissions") rather than
+# rendering as clean/empty data, and the report's only consumer (a human or the
+# downstream Claude triage step) already reads that placeholder as "no signal
+# available", never as "no alerts exist".
+gh_api_section() {
+  local heading="$1" endpoint="$2" jq_expr="$3" fallback="$4"
+  {
+    echo ""
+    echo "$heading"
+  } >>"$REPORT_PATH"
+  # echo-fallback-ok: best-effort aggregator, see the function-level comment above.
+  gh api "$endpoint" --arg repo "$REPO" --jq "$jq_expr" \
+    >>"$REPORT_PATH" 2>&1 || echo "$fallback" >>"$REPORT_PATH"
+}
+
+echo "## Dependabot Alerts" >"$REPORT_PATH"
+dependabot_tmp=$(mktemp)
+trap 'rm -f "$dependabot_tmp"' EXIT
+# echo-fallback-ok: same best-effort-section reasoning as gh_api_section above.
+if gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
+  --arg repo "$REPO" \
+  --jq '.[] | "\(.dependency.scope // "unknown")\t- **\(.security_advisory.severity | ascii_upcase)**: [\(.security_advisory.summary)](https://github.com/\($repo)/security/dependabot/\(.number)) in `\(.dependency.package.name)` (\(.dependency.package.ecosystem))"' \
+  >"$dependabot_tmp" 2>&1; then
+  {
+    echo ""
+    echo "### Runtime (ships to visitors' browsers)"
+    grep '^runtime' "$dependabot_tmp" | cut -f2- || echo "_None._"
+    echo ""
+    echo "### Development (build/CI only — no visitor-facing exposure, but still a supply-chain risk if RCE/malicious-package)"
+    grep -v '^runtime' "$dependabot_tmp" | cut -f2- || echo "_None._"
+  } >>"$REPORT_PATH"
+else
+  cat "$dependabot_tmp" >>"$REPORT_PATH"
+  echo "_Could not fetch Dependabot alerts (check repo permissions)._" >>"$REPORT_PATH"
+fi
+
+gh_api_section \
+  "## Code Scanning Alerts" \
+  "repos/${REPO}/code-scanning/alerts?state=open&per_page=100" \
+  '.[] | "- **\(.rule.severity // .rule.security_severity_level | ascii_upcase)**: [\(.rule.description)](https://github.com/\($repo)/security/code-scanning/\(.number)) at `\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)`"' \
+  "_No code scanning alerts or code scanning not enabled._"
+
+gh_api_section \
+  "## Secret Scanning Alerts" \
+  "repos/${REPO}/secret-scanning/alerts?state=open&per_page=100" \
+  '.[] | "- **\(.state | ascii_upcase)**: \(.secret_type_display_name) — [Alert #\(.number)](https://github.com/\($repo)/security/secret-scanning/\(.number))"' \
+  "_No secret scanning alerts or secret scanning not enabled._"
+
+{
+  echo ""
+  echo "## pnpm audit"
+} >>"$REPORT_PATH"
+# Skip when there's no Node project — setup-base-env leaves pnpm uninstalled
+# in that case, and `pnpm audit` would error out instead of returning "clean".
+if [[ -f package.json ]]; then
+  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"
+  pnpm_rc=${PIPESTATUS[0]}
+  # Exit 0 = clean, exit 1 = vulnerabilities found (expected); higher = real error
+  [[ "${pnpm_rc:-0}" -le 1 ]] || echo "_pnpm audit encountered an error (exit code $pnpm_rc); output above may be incomplete._" >>"$REPORT_PATH"
+else
+  echo "_Skipped: no package.json (not a Node project)._" >>"$REPORT_PATH"
+fi
+
+{
+  echo ""
+  echo "## Socket.dev Alerts"
+} >>"$REPORT_PATH"
+
+# Bot username is "socket-security[bot]" (as of 2025); if Socket changes
+# their bot name this will silently return no results.
+socket_found=false
+socket_tmp=$(mktemp)
+pr_list_tmp=$(mktemp)
+pr_list_err=$(mktemp)
+trap 'rm -f "$dependabot_tmp" "$socket_tmp" "$pr_list_tmp" "$pr_list_err"' EXIT
+
+# Branch on the PR-list fetch's exit code rather than discarding its stderr: a
+# failed fetch (permissions/transient API error) must report "could not fetch"
+# instead of yielding an empty list that reads as a clean "no alerts found".
+if gh api "repos/${REPO}/pulls?state=open&per_page=5" --jq '.[].number' \
+  >"$pr_list_tmp" 2>"$pr_list_err"; then
+  while IFS= read -r pr_num; do
+    [[ -n "$pr_num" ]] || continue
+    # Fetch once into a temp file; avoids a second API call and command
+    # substitution (which strips trailing newlines and merges multi-comment output).
+    if ! gh api "repos/${REPO}/issues/${pr_num}/comments?per_page=30" \
+      --jq '.[] | select(.user.login == "socket-security[bot]") | .body' \
+      >"$socket_tmp" 2>/dev/null; then
+      # Tolerate a single PR's comment fetch failing (permissions/transient API
+      # error) — it must not abort the whole security report. Reset to empty so a
+      # prior iteration's content can't leak into this PR's section.
+      : >"$socket_tmp"
+    fi
+    if [[ -s "$socket_tmp" ]]; then
+      socket_found=true
+      {
+        echo "### PR #${pr_num}"
+        cat "$socket_tmp"
+        echo ""
+      } >>"$REPORT_PATH"
+    fi
+  done <"$pr_list_tmp"
+  if [[ "$socket_found" = "false" ]]; then
+    echo "_No Socket.dev alerts found in recent open PRs._" >>"$REPORT_PATH"
+  fi
+else
+  echo "_Could not fetch open PRs for Socket.dev scan (check repo permissions)._" >>"$REPORT_PATH"
+fi
+
+cat "$REPORT_PATH"
+
+# Use a random sentinel to prevent delimiter injection — report content comes
+# from external sources (advisory descriptions, bot comments) that an attacker
+# could craft to contain a static sentinel and inject arbitrary env vars.
+if [[ -r /proc/sys/kernel/random/uuid ]]; then
+  report_sentinel="REPORT_EOF_$(cat /proc/sys/kernel/random/uuid)"
+elif command -v uuidgen >/dev/null 2>&1; then
+  report_sentinel="REPORT_EOF_$(uuidgen)"
+else
+  report_sentinel="REPORT_EOF_$$_${RANDOM}_${RANDOM}"
+fi
+report_size=$(wc -c <"$REPORT_PATH" | tr -d '[:space:]')
+if [[ "$report_size" -gt 50000 ]]; then
+  echo "::warning::Security report is ${report_size} bytes; truncating to 50 KB for \$GITHUB_ENV. Full report is at $REPORT_PATH on the runner."
+fi
+{
+  echo "SECURITY_REPORT<<${report_sentinel}"
+  head -c 50000 "$REPORT_PATH"
+  echo ""
+  echo "${report_sentinel}"
+} >>"$GITHUB_ENV"

--- a/.github/scripts/list-dependabot-prs.sh
+++ b/.github/scripts/list-dependabot-prs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Emit a multi-line GITHUB_ENV variable (DEPENDABOT_PRS) describing open
+# dependabot PRs so a downstream "triage" step can subsume them.
+#
+# Inputs (env):
+#   GH_TOKEN       GitHub token for `gh`
+#   GITHUB_ENV     Path to GitHub Actions env file (optional outside CI)
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+
+if [[ -r /proc/sys/kernel/random/uuid ]]; then
+  sentinel="PR_EOF_$(cat /proc/sys/kernel/random/uuid)"
+elif command -v uuidgen >/dev/null 2>&1; then
+  sentinel="PR_EOF_$(uuidgen)"
+else
+  sentinel="PR_EOF_$$_${RANDOM}_${RANDOM}"
+fi
+# A swallowed failure here would silently hand Claude an empty list and the
+# downstream "subsume" step would close zero PRs while reporting success — fail
+# loudly per CLAUDE.md's "Fail loudly" guidance.
+listing=$(gh pr list \
+  --state open \
+  --search "author:app/dependabot" \
+  --json number,title,headRefName,headRefOid,url \
+  --jq '.[] | "- #\(.number) [\(.headRefName)@\(.headRefOid[0:7])] \(.title) — \(.url)"')
+
+{
+  echo "DEPENDABOT_PRS<<${sentinel}"
+  printf '%s\n' "${listing}"
+  echo "${sentinel}"
+} >>"$GITHUB_ENV"


### PR DESCRIPTION
## Summary

The user asked to narrow security alerts to those that actually affect a statically generated site. Investigation found the automated pipeline for this (`security-vulnerability-scan.yaml`) has been failing on **every weekly run since June** — it calls three scripts (`check-existing-security-pr.sh`, `list-dependabot-prs.sh`, `fetch-security-report.sh`) that were excluded from `template-sync.yaml`'s auto-sync but never given local versions, so the workflow dies at step one (`No such file or directory`, exit 127). GitHub currently reports **103 open vulnerabilities** (2 critical, 46 high, 42 moderate, 13 low) on `main` that this pipeline should have been triaging but never has.

- Restores `check-existing-security-pr.sh` and `list-dependabot-prs.sh` verbatim from the sibling template repo (`alexander-turner/claude-automation-template`) — generic CI glue, no repo-specific logic needed.
- Restores `fetch-security-report.sh` from the same template, customized: the Dependabot Alerts section is now split into three sub-sections using GitHub's own `dependency.scope` field — **Runtime** (ships to visitors' browsers), **Development** (build/CI only), and **Unclassified** (GitHub didn't report a scope — flagged for manual verification rather than silently bucketed as build-only).
- Sharpens `.github/prompts/security-vulnerability-scan.md` (the Claude triage prompt this workflow feeds) with static-site-specific guidance: this site has no server runtime/DB/auth layer, so server-side vulnerability classes (SQLi, auth bypass, SSRF) have no exploitable surface regardless of severity, while build-tooling RCE/supply-chain issues still matter since CI holds push credentials.

## Fixes Applied

- Restored 3 missing scripts referenced by `security-vulnerability-scan.yaml`, unblocking the workflow.
- Added runtime/development/unclassified scope grouping to the Dependabot alerts report.
- Added static-site-specific triage criteria and an explicit "do NOT fix" rule for vulnerability classes with no exploitable surface on a static site.

## Validation

- `bash -n` on all three scripts.
- `shellcheck` on all three scripts — no findings.
- Local test of the grep-based scope-splitting logic against synthetic runtime/development/unclassified rows — routes correctly.
- Three-pass self-critique loop (see commit history) caught and fixed: unscoped alerts silently mislabeled as build-only, a redundant trap statement, and a documentation gap where the new "Unclassified" bucket had no triage rule.

## Lessons learned

- When a CI workflow references scripts that don't exist in the repo, check `template-sync.yaml`'s `EXCLUDE_PATHS` — an exclusion entry for a file that was never actually created locally is a common way for template-sync repos to end up with silently-broken automation. `gh` / GitHub Actions run history (list runs, filter by `conclusion: failure`) is the fastest way to confirm a workflow has been dead rather than assuming it's fine because no one complained.
- For "narrow alerts to X" style requests in scripted CI reports, prefer grouping/labeling at the data-collection stage (here: splitting the Dependabot section by `dependency.scope`) over relying entirely on prose instructions to a downstream LLM triage step — it's more deterministic and cheaper to audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U72f9qBp1hy4QVnRfGqRn2)_