### PR TITLE
fix(ci): group dependabot security-update PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+
+# Security-update PRs are grouped per ecosystem (npm-all / uv-all / actions-all)
+# so multiple CVE fixes land as one PR instead of one PR per package. The
+# weekly security-vulnerability-scan workflow subsumes these grouped PRs
+# alongside routine version-update PRs into a single rollup PR.
 updates:
   # Track punctilio for version updates only. Security updates for all packages
   # are handled separately by GitHub's Dependabot security alerts.
@@ -11,3 +16,37 @@ updates:
       - dependency-name: "punctilio"
     cooldown:
       default-days: 7
+    groups:
+      npm-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # No version-update PRs (uv deps are bumped via the weekly security-scan
+  # rollup); security updates still fire regardless of this limit and are
+  # grouped into a single PR.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    groups:
+      uv-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+      actions-all-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7
     groups:
       uv-all:
         applies-to: security-updates


### PR DESCRIPTION
## Summary

Follow-up to #1725: open Dependabot security-alert PRs were landing one-per-package (e.g. separate PRs for `axios`, `js-yaml`, `shell-quote`, `sharp`, `cryptography`) because `dependabot.yml` had no `groups` config for npm/uv and no `github-actions` ecosystem entry at all.

- Added `applies-to: security-updates` groups (`npm-all`, `uv-all`, `actions-all-security`) so future CVE fixes for one ecosystem land as a single PR instead of N individual ones.
- Added the missing `github-actions` ecosystem entry with a grouped monthly version-update bucket (`actions-all`), restoring behavior present in the sibling template repo but missing from this repo's config.
- Added `open-pull-requests-limit: 0` on the new `uv` entry so it only produces grouped security PRs, not routine version-update churn (mirroring the existing npm/`punctilio`-only philosophy); security PRs are exempt from this limit.

These group names (`npm-all`, `uv-all`, `actions-all`) match what `.github/prompts/security-vulnerability-scan.md` already expects when subsuming grouped Dependabot PRs into the weekly rollup.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — parses cleanly.
- Manually inspected the resulting structure (dumped to JSON) to confirm each ecosystem block and group is well-formed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U72f9qBp1hy4QVnRfGqRn2)_