### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -302,21 +302,7 @@ See [`docs/configuration.md`](docs/configuration.md) for the full reference: wra
 
 <!-- codebase-breakdown:end -->
 
-### Live-fire containment
-
-The breakout CTF turns a real autonomous agent loose against the production sandbox stack and verifies it cannot send out a planted flag, escape the container, or tamper with the guardrails.
-
-The agent runs on a model that will actually attempt the break-in — a safety-tuned model would just refuse, proving nothing. A second AI reads the recording afterward and fails the test if the agent never genuinely tried. Every run is saved as a web page showing each step, linked from a comment on the pull request.
-
-### Other charts
-
-![Setup time chart](https://assets.turntrout.com/static/charts/glovebox/setup-time.svg)
-
-![sbx launch timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-launch-timing.svg)
-
-![sbx teardown timing chart](https://assets.turntrout.com/static/charts/glovebox/sbx-teardown-timing.svg)
-
-More metrics re-render on every merge to `main` in [METRICS.md](METRICS.md).
+The live-fire breakout CTF, the monitor's control-eval scores, and every cost and latency chart re-render on every merge to `main` in [METRICS.md](METRICS.md).
 
 <!--
 Canary for this repo: EzXtfGshayJoaSPYXqonExqzTzZsxi


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.