### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
@@ -3,8 +3,9 @@
 Most prompt-injection tools run a classifier _over_ the text and hope it
 generalizes. This library targets a narrower, verifiable claim: the
 specific byte-level channels—invisible Unicode, ANSI escapes, human-hidden
-HTML, confusable glyphs, exfil-shaped URLs—that let an attacker smuggle a
-payload the operator can't see but the model still reads. Every layer is a
+HTML, confusable glyphs and look-alike hosts, exfil-shaped URLs—that let an
+attacker smuggle a payload the operator can't see but the model still reads.
+Every layer is a
 deterministic transform you can unit-test with equality assertions.
 
 **As a library:**
@@ -63,8 +64,8 @@ the callback you inject for the agent-specific concern; `—` is a pure transfor
 | --- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | 1   | `/invisible`    | Strip zero-width, bidi, variation-selector and tag chars + ANSI/SGR escapes. Preserves ZWNJ/ZWJ for Arabic/Indic/emoji. Zero deps.                                                       | —                           |
 | 2   | `/html`         | Splice out HTML comments and elements hidden via `display:none`, off-screen, white-on-white, `hidden`. Each splice leaves a keyed, round-trippable placeholder.                          | —                           |
-| 3   | `/html`         | Detect exfil-shaped URLs (payloads in query/path, embedded creds, `data:`/`javascript:`, off-origin redirects). Reports only.                                                            | —                           |
-| 4   | `/confusables`  | Fold look-alike glyphs in tool-call input (paths, commands) to ASCII, closing a cross-script deny-rule bypass. Gated per token, so non-Latin prose passes through unfolded.              | `scan`                      |
+| 3   | `/html`         | Detect exfil-shaped URLs (payloads in query/path, embedded creds, `data:`/`javascript:`, off-origin redirects) and confusable HOSTS (`аpple.com`). Reports only — never rewrites.        | —                           |
+| 4   | `/confusables`  | Fold look-alike glyphs in tool-call input (paths, commands) to ASCII, closing a cross-script deny-rule bypass. Gated per token, so non-Latin prose passes through unfolded.              | `scan` (optional)           |
 | 5   | `/instructions` | Scan/auto-clean `CLAUDE.md`, `AGENTS.md`, `SKILL.md`, etc., decoding Unicode-tag + zero-width-binary payloads.                                                                           | `fs` (direct)               |
 | 6   | `/prompt`       | Classify a prompt pass / note / block on payload-capable invisible/ANSI content (inert escapes get the note).                                                                            | —                           |
 | 7   | `/output`       | Run Layers 1–4 over structured tool output, preserving shape. The Layer-5 slot takes a delete-only filter.                                                                               | `redact`, `filterInjection` |
@@ -79,16 +80,17 @@ See [`THREAT-MODEL.md`](./THREAT-MODEL.md) for per-vector detail.
 contract—branch on these codes, not on `warnings` prose, which can be reworded
 without notice.
 
-| Code                  | Meaning                                                                                                 |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| `cf-format`           | Unicode format chars (`Cf`): zero-width space/joiner, bidi overrides, tag chars                         |
-| `variation-selectors` | Variation selectors (U+FE00–FE0F, U+E0100–E01EF)                                                        |
-| `blank-fillers`       | Blank-rendering fillers not covered by `Cf` (Hangul fillers, Braille blank, zero-width combining marks) |
-| `ansi`                | ANSI/SGR escapes and other terminal control sequences                                                   |
-| `lone-surrogates`     | Unpaired UTF-16 surrogates                                                                              |
-| `html-comments`       | HTML comments (incl. bogus `<!…>`/`<?…?>` forms) spliced out by Layer 2, recoverable via `splices`      |
-| `hidden-html`         | Elements hidden via CSS/attribute (`display:none`, `hidden`, etc.) spliced out by Layer 2               |
-| `exfil-urls`          | Exfil-shaped URLs detected by Layer 3 (reported, not removed)                                           |
+| Code                  | Meaning                                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `cf-format`           | Unicode format chars (`Cf`): zero-width space/joiner, bidi overrides, tag chars                              |
+| `variation-selectors` | Variation selectors (U+FE00–FE0F, U+E0100–E01EF)                                                             |
+| `blank-fillers`       | Blank-rendering fillers not covered by `Cf` (Hangul fillers, Braille blank, zero-width combining marks)      |
+| `ansi`                | ANSI/SGR escapes and other terminal control sequences                                                        |
+| `lone-surrogates`     | Unpaired UTF-16 surrogates                                                                                   |
+| `html-comments`       | HTML comments (incl. bogus `<!…>`/`<?…?>` forms) spliced out by Layer 2, recoverable via `splices`           |
+| `hidden-html`         | Elements hidden via CSS/attribute (`display:none`, `hidden`, etc.) spliced out by Layer 2                    |
+| `exfil-urls`          | Exfil-shaped URLs detected by Layer 3 (reported, not removed)                                                |
+| `confusable-host`     | URL hosts that are look-alikes of an ASCII name (`аpple.com`), detected by Layer 3 (reported, not rewritten) |
 
 ### warnings vs notes
 
@@ -397,7 +399,7 @@ doesn't render at all.
 
 |                               | `agent-sanitizer`                                                                                                                   | Semantic guard/classifier (Lakera, Prompt Guard, Rebuff, NeMo rails)                                       | PII redactor (Presidio)                                      |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **What it catches**           | Payload-capable invisible chars, ANSI/SGR, hidden HTML, confusable glyphs, exfil-shaped URLs                                        | Malicious _intent_—jailbreaks, injected instructions, off-topic asks                                       | Names, emails, SSNs, and other PII spans                     |
+| **What it catches**           | Payload-capable invisible chars, ANSI/SGR, hidden HTML, confusable glyphs and look-alike hosts, exfil-shaped URLs                   | Malicious _intent_—jailbreaks, injected instructions, off-topic asks                                       | Names, emails, SSNs, and other PII spans                     |
 | **How it decides**            | Deterministic parsing/regex over real tokenizer output—no model call                                                                | ML/LLM classification—probabilistic, needs a threshold and retuning as attacks shift                       | NER + pattern matching                                       |
 | **Failure mode**              | Fails open on ambiguous input (see [`THREAT-MODEL.md`](./THREAT-MODEL.md)); false negative over false positive by design            | False positives silently mangle or block legitimate prompts; false negatives are invisible until exploited | Under/over-redaction depending on locale and entity coverage |
 | **Latency / infra**           | Pure JS, mostly zero-dep (`/html` lazy-loads ~200 ms once)                                                                          | Network round-trip to a hosted model, or a local model to host yourself                                    | Local, but heavier NLP pipeline                              |
@@ -414,10 +416,16 @@ for the hidden channel both are blind to.
 import { stripInvisibleWithReport } from "agent-sanitizer/invisible";
 const { cleaned, found } = stripInvisibleWithReport(text); // found: ["variation-selectors"]
 
-import { sanitizeHtml, detectExfil, checkExfilUrl } from "agent-sanitizer/html";
+import {
+  sanitizeHtml,
+  detectExfil,
+  checkExfilUrl,
+  detectConfusableHosts,
+} from "agent-sanitizer/html";
 sanitizeHtml(pageSource); // { text, removed, warned } | null — text may be unchanged if only reportable (not strippable) tags were found
 detectExfil(pageSource); // [{ isImage, reason, target }] or null
 checkExfilUrl(oneUrl); // reason string or null
+detectConfusableHosts(pageSource); // [{ severity, description }] or null
 ```
 
 The agent-pipeline entry points take plain arguments and inject their
@@ -425,11 +433,12 @@ agent-specific seam:
 
 ```js
 import { normalizeConfusables } from "agent-sanitizer/confusables";
+normalizeConfusables("Bash", { command: "/аpt update" }); // null, or { updatedInput, normalized }
 normalizeConfusables(
   "Bash",
   { command: "/аpt update" },
-  { scan: (t) => myHomoglyphEngine.scan(t) }, // -> { findings: [{ index, char, latinEquivalent }] }
-); // null, or { updatedInput, normalized }
+  { scan: (t) => myHomoglyphEngine.scan(t) }, // override the default namespace-guard engine
+);
 
 import { scanInstructionFiles, cleanFile } from "agent-sanitizer/instructions";
 const findings = scanInstructionFiles(["CLAUDE.md", "**/SKILL.md"], {

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -15,6 +15,7 @@ _Disclaimer: I'm an AI professional but not a security professional. I welcome i
 [![smoke tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsmoke-tests.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/smoke-tests.yaml)
 [![JS (ESLint + tsc + coverage 100%)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fjs.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/js.yaml)
 [![mutation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fmutation-testing.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/mutation-testing.yaml)
+[![bash mutation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fbash-mutation.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/bash-mutation.yaml)
 [![pytest](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fpytest-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/pytest-checks.yaml)
 [![hadolint](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fhadolint.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/hadolint.yaml)
 [![actionlint + zizmor + bash config](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Flint-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/lint-checks.yaml)
@@ -257,7 +258,7 @@ Other subcommands: **`gc`** (reap orphaned sbx sandboxes and stale access-log ar
 
 Researchers run experiments on remote GPU pods, where the sandbox's outbound firewall can't easily be reproduced. Rather than tunnelling a local `claude` out to the pod, `glovebox remote` ships the hardened image **to** the compute and runs `claude` natively on it, so the controls travel with the job. The rendered app runs a networked **setup** phase (clone/install/secrets), then a locked-down **agent** phase with the setup secrets scrubbed. The boundary there is the provider's isolation (gVisor) plus Claude Code's native sandbox, so the agent never runs with `--dangerously-skip-permissions`.
 
-**[Modal](https://modal.com) and [RunPod](https://www.runpod.io) are wired up today but may not work reliably. This is an important area for future testing.** See [`docs/remote-execution.md`](docs/remote-execution.md) for the operator guide and [`docs/remote-execution-design.md`](docs/remote-execution-design.md) for the design rationale.
+**Not supported yet.** [Modal](https://modal.com) and [RunPod](https://www.runpod.io) are wired up but unsupported, and we plan to restrict remote use to MCP servers. See [`docs/remote-execution.md`](docs/remote-execution.md) for the operator guide and [`docs/remote-execution-design.md`](docs/remote-execution-design.md) for the design rationale.
 
 ### Apollo Watcher integration
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.