### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__agent-input-sanitizer__main__README.md
@@ -368,6 +368,17 @@ hook module, and every consumer waits on that path instead. `lib/control-plane`
 resolves the marker at module scope, so a call that lands after that import
 warns on stderr — it cannot steer the wait that already started.
 
+The marker's first line is the setup process's pid. A writer that also holds an
+exclusive `flock` on the marker file for the whole install says so by adding a
+second line reading `flock` (`SETUP_LOCK_DECLARATION`), and the hooks then judge
+liveness by the lock rather than the pid: the kernel releases an `flock` the
+instant its holder dies, so a killed setup is detected immediately instead of
+being read as alive for as long as a recycled pid keeps answering. A marker that
+declares nothing is judged by its pid. A writer must hold the lock BEFORE the
+declaring marker becomes visible: a marker that says `flock` while its writer
+has not yet locked reads as a free lock, so every waiter abandons an install
+that is still running.
+
 **A host's own remedy can replace the packaged one in every failure reason**
 (the fail-closed verdicts and the fail-open warning alike). Deep call sites (`lib/control-plane`'s missing-package throw) take no
 remedy argument, so by default they can only say `pnpm install`. A host whose

--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -4,7 +4,7 @@ Right now, you're probably barehanding AI, tossing it into a shell onto your mac
 
 After all, what's the chance that something bad happens?
 
-`glovebox` is a sealed enclosure that only gives the agent what it needs to do your work. Tap-tap-tap `glovebox` and press Enter to spin up a hardware-isolated, allowlist-firewalled microVM, employing input/output sanitization to strip injections and tricks the AI might play on you, with a ([currently experimental](#the-monitor-is-experimental)) AI monitor with a red-alert ability to push-notify your phone and halt the AI until you return. The goal is a minimal-friction secure experience that gets the job done.
+`glovebox` is a sealed enclosure that only gives the agent what it needs to do your work. Tap-tap-tap `glovebox` and press Enter to spin up a hardware-isolated, allowlist-firewalled microVM, employing input/output sanitization to strip injections and tricks the AI might play on you, with a (currently experimental) AI monitor with a red-alert ability to push-notify your phone and halt the AI until you return. The goal is a minimal-friction secure experience that gets the job done.
 
 ![A researcher reaches through the sealed gloves of a laboratory glove box to work with material sealed inside, the barrier keeping it contained.](https://assets.turntrout.com/static/images/glovebox.jpg)
 
@@ -28,7 +28,7 @@ _Disclaimer: I'm an AI professional but not a security professional. I welcome i
 ### GitHub (recommended)
 
 ```bash
-git clone https://github.com/AlexanderMattTurner/agent-glovebox.git ~/.local/share/glovebox &&
+git clone --depth 1 https://github.com/AlexanderMattTurner/agent-glovebox.git ~/.local/share/glovebox &&
   cd ~/.local/share/glovebox &&
   bash setup.bash
 ```
@@ -75,7 +75,7 @@ Claude Code itself is pinned to a verified, known-good version (`@anthropic-ai/c
 2. Installs the runtime prerequisites it can package safely.
 3. Installs the Docker `sbx` sandbox runtime and CLI (logged in via `sbx login`).
 4. Links the `glovebox` and `claude-github-app` wrappers into `~/.local/bin/`.
-5. Offers to configure the AI monitor (API key, push notifications) — experimental and off by default, so this step is optional.
+5. Asks nothing about the AI monitor. It is experimental and off by default, so `glovebox doctor --fix` sets its API key and `glovebox setup-ntfy` turns on its phone alerts, if and when you turn the monitor on.
 
 ### Uninstall
 
@@ -90,11 +90,11 @@ bash setup.bash --uninstall --purge  # also remove built images and volumes
 
 A few things `glovebox` has that auto mode doesn't:
 
-- **A sufficiently scary command lets `glovebox`'s monitor stop the AI immediately** (experimental, off by default). Auto mode only [pauses for a human after 3 consecutive or 20 total classifier blocks](https://www.anthropic.com/engineering/claude-code-auto-mode). Blocked attempts under those thresholds get no human attention at all.
-- **The allowlist firewall makes it harder to proliferate on some remote server farm.** Without it, bad-Claude could fire off experiments with one of your API tokens on a remote server, earn its own tokens, and proliferate unwatched.
 - **Tamper-evident audit logs**. A smart misaligned AI would remove traces of its bad behavior.
-- **Protect your own system with a sandbox.** Claude can make hard-to-audit changes to unversioned parts of your filesystem — high permissions, low accountability, and your computer pays for it.
-- **Ephemeral state blocks cross-session staging.** A misaligned AI seeds a payload _outside_ your project — like a poisoned shell init (`~/.bashrc`) — to fire in a later, innocent-looking session that the monitor/auto mode reviews fresh. With `glovebox`, the throwaway per-session volumes are wiped on exit. Nothing staged there survives.
+- **Protect your own system with a sandbox.** By default, Claude can make hard-to-audit changes to your entire filesystem.
+- - **The allowlist firewall often stops exfiltration and unauthorized communication.** 
+- **Ephemeral state blocks cross-session staging.** A misaligned AI seeds a payload _outside_ your project — like a poisoned shell init (`~/.bashrc`) — to fire in a later, innocent-looking session that the monitor/auto mode reviews fresh. With `glovebox`, the throwaway per-session volumes are wiped on exit. 
+- - **A sufficiently scary command lets `glovebox`'s monitor stop the AI immediately** (experimental, off by default). Auto mode only [pauses for a human after 3 consecutive or 20 total classifier blocks](https://www.anthropic.com/engineering/claude-code-auto-mode). Blocked attempts under those thresholds get no human attention at all.
 
 ### Why not just the built-in sandbox?
 
@@ -106,7 +106,7 @@ The Docker `sbx` microVM **is** this stack's foundation, and alone it does one j
 
 - **Stock `sbx` runs the agent with passwordless `sudo` and the `docker` group.** In-VM root can delete any settings file, hook, or log that watches it. `glovebox` removes both at boot and root-locks the guardrails, so the audit record and the permission veto survive an agent that turns on them.
 - **Containment says nothing about the allowed channel.** Some hosts must stay reachable (github.com, your package registries), and to stock `sbx` an allowed host is allowed for anything — its policy grants a `host:port` and has no way to tell a read from a write. `glovebox` marks each allowed host read-only or read-write and enforces that inside the VM: a read-only host serves `GET`, `HEAD`, `OPTIONS` and `git fetch`, and everything else gets a 403. So the agent clones from github.com and cannot push to it, even though the credential doing the talking is injected outside the VM and would authorize the push. On top of that it scopes the GitHub token to the current repo, strips injections from what comes in, redacts secrets from what goes out, and keeps the monitor and the audit log on the host, out of the agent's reach.
-- **Safe defaults are the actual work.** A curated allowlist, a signed prebuilt image, credentials injected outside the VM so keys never enter it, and `glovebox doctor` to prove it's all on — none of which stock `sbx` configures for you.
+- **Safe defaults are the actual work.** A curated allowlist, a signed prebuilt image, credentials injected outside the VM so keys never enter it, and `glovebox doctor` to prove it's all on.
 
 See [`SECURITY.md`](SECURITY.md) for what each layer does and does not stop.
 
@@ -131,11 +131,11 @@ If you need a Claude Code with nothing of glovebox in it: `glovebox disable-glob
 
 `glovebox` runs the whole session inside a [Docker `sbx`](https://docs.docker.com/ai/sandboxes/) microVM on your machine. The **hard boundaries** are the ones that isolation model enforces below the agent:
 
-- a hypervisor boundary it can't cross,
+- a hypervisor boundary it can't cross (it stops the agent running outside the VM, not CPU side channels — [`SECURITY.md`](SECURITY.md) covers those),
 - a host filesystem, network, and Docker engine it can't reach,
 - and an outbound proxy that only lets approved destinations through.
 
-Short of a novel exploit that breaks the VM itself, nothing the model can say, write, or run gets around them. The security argument rests on those boundaries holding, and [`SECURITY.md`](SECURITY.md) spells out the exact trust assumptions.
+Short of a novel exploit that breaks the VM itself, or a CPU side channel the host must mitigate, nothing the model can say, write, or run gets around them. The security argument rests on those boundaries holding, and [`SECURITY.md`](SECURITY.md) spells out the exact trust assumptions.
 
 ![Docker sandbox isolation model — a Sandbox VM inside the host, its workspace read-write while the host filesystem, processes, Docker engine, and network stay unreachable, with an allow/deny egress proxy](https://docs.docker.com/ai/sandboxes/images/sbx-security.png)
 
@@ -240,7 +240,7 @@ Sessions are **ephemeral by default**: attackers can't lay landmines in the syst
 - the monitor config,
 - and **PATH precedence** — that `claude` resolves to this wrapper, not some other `claude` that would silently bypass the stack.
 
-It exits `0` PROTECTED, `1` DEGRADED, or `2` UNPROTECTED. `--fix` repairs a missing or wrong `~/.local/bin/claude` alias.
+It exits `0` PROTECTED, `1` DEGRADED, or `2` UNPROTECTED. `--fix` repairs a missing or wrong `~/.local/bin/claude` alias, and stores a monitor API key once the monitor is on.
 
 **`glovebox audit`** — print this workspace's tool-call audit log. The monitor logs every call to an append-only log the agent can't read or alter, and at teardown that log is archived to a host directory. `audit` surfaces it **read-only** (over a throwaway `--network none` container for any live log), with or without a running session, and can never change the log. Flags:
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.