### PR TITLE
Audit follow-ups: TOC/download bugs, r2/build_fonts fixes, findElementById short-circuit

### DIFF
--- a/quartz/plugins/emitters/populateContainers.test.ts
+++ b/quartz/plugins/emitters/populateContainers.test.ts
@@ -15,7 +15,7 @@ jest.unstable_mockModule("child_process", () => ({
 }))
 
 import fs from "fs"
-import { type Element } from "hast"
+import { type Element, type Root } from "hast"
 import { fromHtml } from "hast-util-from-html"
 import { toHtml } from "hast-util-to-html"
 import { visit } from "unist-util-visit"
@@ -402,6 +402,44 @@ describe("PopulateContainers", () => {
       ])("%s", (_, html, id, assertFn) => {
         const root = populateModule.findElementById(fromHtml(html), id)
         assertFn(root)
+      })
+
+      it("stops walking the tree at the first match", () => {
+        // Elements after the match must never have their id inspected;
+        // an id lookup is done once the first hit is found.
+        const inspected: string[] = []
+        const makeElement = (id: string): Element => ({
+          type: "element",
+          tagName: "div",
+          properties: new Proxy(
+            { id },
+            {
+              get(target, prop) {
+                if (prop === "id") inspected.push(id)
+                return (target as Record<string, unknown>)[prop as string]
+              },
+            },
+          ),
+          children: [],
+        })
+
+        const tree = {
+          type: "root",
+          children: [
+            makeElement("a"),
+            makeElement("b"),
+            makeElement("target"),
+            makeElement("after-1"),
+            makeElement("after-2"),
+          ],
+        } as unknown as Root
+
+        const match = populateModule.findElementById(tree, "target")
+        expect(match).not.toBeNull()
+        // Assert traversal record before any post-hoc property access that
+        // would push another entry into the proxy-tracked array.
+        expect(inspected).toEqual(["a", "b", "target"])
+        expect((match as Element).properties?.id).toBe("target")
       })
     })
 

--- a/quartz/plugins/emitters/populateContainers.ts
+++ b/quartz/plugins/emitters/populateContainers.ts
@@ -7,7 +7,7 @@ import { toHtml } from "hast-util-to-html"
 import { h } from "hastscript"
 import { render } from "preact-render-to-string"
 import { quote } from "shell-quote"
-import { visit } from "unist-util-visit"
+import { EXIT, visit } from "unist-util-visit"
 
 import { Backlinks } from "../../components/Backlinks"
 import { simpleConstants, specialFaviconPaths } from "../../components/constants"
@@ -61,13 +61,22 @@ export const findElements = (tree: Root, predicate: (node: Element) => boolean):
 
 /**
  * Finds an element in the HAST tree by its ID attribute.
+ * Short-circuits at the first hit — only the first match is ever meaningful
+ * since HTML id attributes must be unique per document.
  * @param root - The root HAST node to search
  * @param id - The ID to search for
  * @returns The element with the matching ID, or null if not found
  */
 export const findElementById = (root: Root, id: string): Element | null => {
-  const matches = findElements(root, (node) => node.properties?.id === id)
-  return matches[0] ?? null
+  let match: Element | null = null
+  visit(root, "element", (node) => {
+    if (node.properties?.id === id) {
+      match = node
+      return EXIT
+    }
+    return undefined
+  })
+  return match
 }
 
 /**

--- a/quartz/plugins/transformers/toc.test.ts
+++ b/quartz/plugins/transformers/toc.test.ts
@@ -335,6 +335,34 @@ describe("TableOfContents Plugin", () => {
       processor(mockTree, mockFile)
       expect(mockFile.data.toc).toHaveLength(2)
       expect(mockFile.data.toc?.[1]?.text).toBe("Footnotes")
+      // Shallowest heading is h1, so Footnotes shifts to top-level depth 0.
+      expect(mockFile.data.toc?.[1]?.depth).toBe(0)
+    })
+
+    it("keeps Footnotes at top-level depth when shallowest heading is h2", () => {
+      // Footnotes must land at the same shifted depth as the shallowest body
+      // heading so it renders as a top-level TOC entry; a negative depth would
+      // fall outside TableOfContents.buildNestedList's walk and be dropped.
+      const plugin = TableOfContents({ maxDepth: 3 })
+      const processor = (plugin.markdownPlugins?.({} as BuildCtx)?.[0] as () => ProcessorFunction)()
+
+      const mockFile: MockFile = { path: "test.md", data: { frontmatter: {} } }
+      const mockTree: Root = createRoot([
+        createHeading(2, [createText("Section")]),
+        createHeading(3, [createText("Subsection")]),
+        createFootnoteDefinition("1"),
+      ])
+
+      processor(mockTree, mockFile)
+
+      const toc = mockFile.data.toc
+      expect(toc).toHaveLength(3)
+      // Real headings shift by -2 (min depth is 2).
+      expect(toc?.[0]?.depth).toBe(0)
+      expect(toc?.[1]?.depth).toBe(1)
+      // Footnotes must land at 0 (top of TOC), not -1.
+      expect(toc?.[2]?.text).toBe("Footnotes")
+      expect(toc?.[2]?.depth).toBe(0)
     })
 
     it("respects maxDepth setting", () => {

--- a/quartz/plugins/transformers/toc.ts
+++ b/quartz/plugins/transformers/toc.ts
@@ -149,8 +149,13 @@ export const TableOfContents: QuartzTransformerPlugin<Partial<Options> | undefin
                 return null
               })
               if (hasFootnotes) {
+                // Push at `highestDepth` so the following `entry.depth -
+                // highestDepth` shift lands Footnotes at 0 — the top of the
+                // rendered TOC. Hard-coding depth 1 would render a negative
+                // depth whenever the shallowest body heading is h2+, which
+                // TableOfContents.buildNestedList would silently drop.
                 toc.push({
-                  depth: 1,
+                  depth: highestDepth,
                   text: "Footnotes",
                   slug: footnoteHeadingId,
                 })

--- a/scripts/build_fonts.py
+++ b/scripts/build_fonts.py
@@ -620,24 +620,29 @@ def build_all(output_dir: Path) -> bool:
 
 def main() -> None:
     """Build fonts and optionally install them."""
-    output_dir = Path(tempfile.mkdtemp(prefix="build_fonts_"))
-    all_match = build_all(output_dir)
+    # ``--install`` copies each built file into ``_FONT_DIR`` before this
+    # function returns, so nothing downstream depends on the temp dir
+    # surviving. Wrap in a context manager so the build artifacts are cleaned
+    # up on every run — including the verify path that exits non-zero.
+    with tempfile.TemporaryDirectory(prefix="build_fonts_") as tmp:
+        output_dir = Path(tmp)
+        all_match = build_all(output_dir)
 
-    if all_match:
-        print("\nAll fonts are table-equivalent to committed versions.")
-    else:
-        print("\nSome tables differ (see details above).")
+        if all_match:
+            print("\nAll fonts are table-equivalent to committed versions.")
+        else:
+            print("\nSome tables differ (see details above).")
 
-    if "--install" in sys.argv:
-        for filename in _FONT_FILENAMES:
-            src = output_dir / filename
-            dst = _FONT_DIR / filename
-            shutil.copy2(src, dst)
-            print(f"Installed {dst}")
-    elif not all_match:
-        # Verify mode: signal drift so a CI invocation fails instead of
-        # silently passing on out-of-date committed fonts.
-        sys.exit(1)
+        if "--install" in sys.argv:
+            for filename in _FONT_FILENAMES:
+                src = output_dir / filename
+                dst = _FONT_DIR / filename
+                shutil.copy2(src, dst)
+                print(f"Installed {dst}")
+        elif not all_match:
+            # Verify mode: signal drift so a CI invocation fails instead of
+            # silently passing on out-of-date committed fonts.
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/convert_markdown_yaml.py
+++ b/scripts/convert_markdown_yaml.py
@@ -9,7 +9,6 @@ ImageMagick, and uploads them to R2 storage.
 
 #!/usr/bin/env python3
 import argparse
-import re
 import shutil
 import subprocess
 import tempfile
@@ -28,26 +27,6 @@ except ImportError:
 
 yaml_parser = script_utils.get_yaml_parser()
 _http_session = script_utils.http_session()
-
-
-def _parse_markdown_frontmatter(content: str) -> tuple[dict, str] | None:
-    """
-    Extract and parse YAML frontmatter from markdown content.
-
-    Args:
-        content: Raw markdown file content
-
-    Returns:
-        Tuple of (YAML data dict, markdown body) if frontmatter exists,
-        None otherwise
-    """
-    match = re.match(r"^---\n(.*?)\n---\n(.*)", content, re.DOTALL)
-    if not match:
-        return None
-
-    yaml_content, md_body = match.groups()
-    data = yaml_parser.load(yaml_content)
-    return data, md_body
 
 
 _DOWNLOAD_HEADERS = frozendict(
@@ -222,14 +201,16 @@ def process_card_image_in_markdown(md_file: Path) -> None:
             f"{script_utils.CONTENT_DIR_NAME} directory."
         )
 
-    with open(md_file, encoding="utf-8") as file:
-        content = file.read()
-
-    parsed = _parse_markdown_frontmatter(content)
-    if not parsed:
+    # ``split_yaml`` shares the frontmatter parsing (and closing-fence
+    # tolerance) with the rest of the codebase, so a trailing-whitespace
+    # ``---`` or a scalar frontmatter block behaves identically here.
+    data, md_body = script_utils.split_yaml(md_file)
+    if not data:
         return
-
-    data, md_body = parsed
+    # ``write_yaml_frontmatter`` emits its own ``---\n`` fence-and-newline,
+    # so drop the one newline ``split_yaml`` returns immediately after the
+    # closing fence to avoid a blank line between fence and body on rewrite.
+    md_body = md_body.removeprefix("\n")
 
     # Check if we need to process this file
     card_image_url = data.get("card_image")

--- a/scripts/download_external_media.py
+++ b/scripts/download_external_media.py
@@ -6,6 +6,7 @@ already on assets.turntrout.com), downloads them to the asset_staging directory,
 and updates the markdown references to point to the local staging directory.
 """
 
+import hashlib
 import os
 import re
 import shutil
@@ -47,23 +48,30 @@ MEDIA_EXTENSIONS = (
 EXCLUDED_DOMAIN = script_utils.CDN_HOSTNAME
 
 
-def download_media(url: str, target_dir: Path) -> bool:
+def download_media(
+    url: str, target_dir: Path, target_filename: str | None = None
+) -> bool:
     """
     Download media file from URL to target directory.
 
     Args:
         url: URL of the media file to download
         target_dir: Directory to save the downloaded file
+        target_filename: Optional override for the on-disk filename. Callers
+            that need collision-safe names (see ``disambiguate_filename``) pass
+            the already-disambiguated name here; otherwise the trailing path
+            component of the URL is used.
 
     Returns:
         True if download succeeded, False otherwise
     """
-    try:
-        filename = script_utils.extract_filename_from_url(url)
-    except ValueError:
-        print(f"Skipping URL with no filename: {url}", file=sys.stderr)
-        return False
-    target_path = target_dir / filename
+    if target_filename is None:
+        try:
+            target_filename = script_utils.extract_filename_from_url(url)
+        except ValueError:
+            print(f"Skipping URL with no filename: {url}", file=sys.stderr)
+            return False
+    target_path = target_dir / target_filename
 
     print(f"Downloading: {url} to {target_path}")
 
@@ -84,8 +92,28 @@ def download_media(url: str, target_dir: Path) -> bool:
         return False
 
 
-def replace_url_in_file(file_path: Path, old_url: str, new_url: str) -> None:
-    """Replace URL in a markdown file."""
+def disambiguate_filename(url: str, base_filename: str, taken: set[str]) -> str:
+    """
+    Return a filename not already in *taken*.
+
+    When two distinct URLs share a basename (e.g. two ``image.png`` files
+    hosted under different paths), the second one gets a URL-derived prefix
+    prepended so both downloads land as distinct files and each markdown
+    reference rewrites to its own local path.
+    """
+    if base_filename not in taken:
+        return base_filename
+    prefix = hashlib.sha1(url.encode("utf-8")).hexdigest()[:8]
+    return f"{prefix}-{base_filename}"
+
+
+def replace_urls_in_file(file_path: Path, url_map: dict[str, str]) -> None:
+    """
+    Replace every ``old_url`` in *url_map* with its ``new_url`` counterpart.
+
+    Reads and writes the markdown file at most once regardless of ``url_map``
+    size, so a corpus-wide rewrite is O(files), not O(urls x files).
+    """
     git_root = script_utils.get_git_root()
     content_dir = git_root / script_utils.CONTENT_DIR_NAME
     if not file_path.resolve().is_relative_to(content_dir):
@@ -94,9 +122,12 @@ def replace_url_in_file(file_path: Path, old_url: str, new_url: str) -> None:
             f"{script_utils.CONTENT_DIR_NAME} directory."
         )
 
-    script_utils.update_markdown_file(
-        file_path, lambda content: content.replace(old_url, new_url)
-    )
+    def apply(content: str) -> str:
+        for old_url, new_url in url_map.items():
+            content = content.replace(old_url, new_url)
+        return content
+
+    script_utils.update_markdown_file(file_path, apply)
 
 
 def find_external_media_urls(markdown_files: list[Path]) -> set[str]:
@@ -151,23 +182,31 @@ def main() -> None:
     asset_staging_dir = markdown_directory / "asset_staging"
     os.makedirs(asset_staging_dir, exist_ok=True)
 
-    # Download each media file and update references
-    successful_downloads = 0
-    for url in asset_urls:
-        if not download_media(url, asset_staging_dir):
-            continue
+    # Download every URL first, disambiguating any basename collisions, then
+    # apply all rewrites in a single pass per markdown file.
+    url_to_new_url: dict[str, str] = {}
+    taken_filenames: set[str] = set()
 
-        filename = script_utils.extract_filename_from_url(url)
+    for url in sorted(asset_urls):
+        try:
+            base_filename = script_utils.extract_filename_from_url(url)
+        except ValueError:
+            print(f"Skipping URL with no filename: {url}", file=sys.stderr)
+            continue
+        filename = disambiguate_filename(url, base_filename, taken_filenames)
+        if not download_media(url, asset_staging_dir, target_filename=filename):
+            continue
+        taken_filenames.add(filename)
         new_url = f"asset_staging/{filename}"
+        url_to_new_url[url] = new_url
         print(f"Downloaded to {new_url}")
 
+    if url_to_new_url:
         for file in markdown_files:
-            replace_url_in_file(file, url, new_url)
-
-        successful_downloads += 1
+            replace_urls_in_file(file, url_to_new_url)
 
     print(
-        f"Successfully downloaded {successful_downloads}/{len(asset_urls)} files to asset_staging."
+        f"Successfully downloaded {len(url_to_new_url)}/{len(asset_urls)} files to asset_staging."
     )
 
     open_cmd = shutil.which("open")

--- a/scripts/download_external_media.py
+++ b/scripts/download_external_media.py
@@ -103,17 +103,17 @@ def disambiguate_filename(url: str, base_filename: str, taken: set[str]) -> str:
     """
     if base_filename not in taken:
         return base_filename
-    digest = hashlib.sha1(url.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
     # Widen the prefix until the name is free, so `taken` always holds
     # distinct on-disk names even if two colliding URLs share an 8-hex
-    # SHA1 prefix.
+    # digest prefix.
     for width in range(8, len(digest) + 1):
         candidate = f"{digest[:width]}-{base_filename}"
         if candidate not in taken:
             return candidate
     raise RuntimeError(
         f"Could not disambiguate filename {base_filename!r} for {url}: "
-        f"every SHA1 prefix width is already taken."
+        f"every digest prefix width is already taken."
     )
 
 

--- a/scripts/download_external_media.py
+++ b/scripts/download_external_media.py
@@ -103,8 +103,18 @@ def disambiguate_filename(url: str, base_filename: str, taken: set[str]) -> str:
     """
     if base_filename not in taken:
         return base_filename
-    prefix = hashlib.sha1(url.encode("utf-8")).hexdigest()[:8]
-    return f"{prefix}-{base_filename}"
+    digest = hashlib.sha1(url.encode("utf-8")).hexdigest()
+    # Widen the prefix until the name is free, so `taken` always holds
+    # distinct on-disk names even if two colliding URLs share an 8-hex
+    # SHA1 prefix.
+    for width in range(8, len(digest) + 1):
+        candidate = f"{digest[:width]}-{base_filename}"
+        if candidate not in taken:
+            return candidate
+    raise RuntimeError(
+        f"Could not disambiguate filename {base_filename!r} for {url}: "
+        f"every SHA1 prefix width is already taken."
+    )
 
 
 def replace_urls_in_file(file_path: Path, url_map: dict[str, str]) -> None:
@@ -122,8 +132,12 @@ def replace_urls_in_file(file_path: Path, url_map: dict[str, str]) -> None:
             f"{script_utils.CONTENT_DIR_NAME} directory."
         )
 
+    # Replace longest URLs first so a URL that is a strict prefix of another
+    # cannot corrupt the longer one before its own replacement runs.
+    ordered = sorted(url_map.items(), key=lambda kv: len(kv[0]), reverse=True)
+
     def apply(content: str) -> str:
-        for old_url, new_url in url_map.items():
+        for old_url, new_url in ordered:
             content = content.replace(old_url, new_url)
         return content
 

--- a/scripts/download_external_media.py
+++ b/scripts/download_external_media.py
@@ -132,8 +132,11 @@ def replace_urls_in_file(file_path: Path, url_map: dict[str, str]) -> None:
             f"{script_utils.CONTENT_DIR_NAME} directory."
         )
 
-    # Replace longest URLs first so a URL that is a strict prefix of another
-    # cannot corrupt the longer one before its own replacement runs.
+    # Replace longest URLs first so that when one ``old_url`` is a substring
+    # of another, the longer one is rewritten before its substring's pass
+    # runs and cannot be corrupted. Sound because every ``new_url`` is an
+    # ``asset_staging/…`` path that can never contain an ``https://`` URL,
+    # so no replacement reintroduces another key's ``old_url``.
     ordered = sorted(url_map.items(), key=lambda kv: len(kv[0]), reverse=True)
 
     def apply(content: str) -> str:

--- a/scripts/r2_upload.py
+++ b/scripts/r2_upload.py
@@ -54,34 +54,46 @@ def check_exists_on_r2(upload_target: str, verbose: bool = False) -> bool:
     _, _, path = upload_target.partition(":")
     bucket, _, key = path.partition("/")
     rclone_executable = script_utils.find_executable("rclone")
-    try:
-        result = subprocess.run(
-            [rclone_executable, "ls", f"r2:{bucket}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        error_msg = f"Failed to check existence of file in R2: {e}"
-        raise RuntimeError(error_msg) from e
 
-    # ``rclone ls`` prints "<size> <path>" per line; match the path exactly so
-    # "static/a.png" doesn't spuriously match "static/a.png-backup" (or the
-    # size digits) via a naive substring test.
-    existing_keys = set()
-    for line in result.stdout.splitlines():
-        parts = line.split(maxsplit=1)
-        if len(parts) == 2:
-            existing_keys.add(parts[1])
+    # Query the single key rather than listing the whole bucket. `rclone lsf`
+    # on an exact object path prints its basename on success; on a missing
+    # path it exits with code 3 ("directory not found").
+    result = subprocess.run(
+        [rclone_executable, "lsf", "--files-only", f"r2:{bucket}/{key}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-    if key in existing_keys:
+    key_basename = key.rsplit("/", 1)[-1]
+    if result.returncode == 0:
+        # Match the basename exactly so a prefix-listing whose entries share
+        # our key's leading path doesn't spuriously count as a hit.
+        if key_basename in result.stdout.splitlines():
+            if verbose:
+                print(f"File found in R2: {upload_target}")
+            return True
         if verbose:
-            print(f"File found in R2: {upload_target}")
-        return True
+            print(f"No existing file found in R2: {upload_target}")
+        return False
 
-    if verbose:
-        print(f"No existing file found in R2: {upload_target}")
-    return False
+    # Distinguish "target absent" from a real subprocess failure. Rclone uses
+    # exit code 3 for a missing directory/object, and the message is stable
+    # across versions ("directory not found") — either signal is a clean miss.
+    stderr_lower = result.stderr.lower()
+    if (
+        result.returncode == 3
+        or "not found" in stderr_lower
+        or "no such" in stderr_lower
+    ):
+        if verbose:
+            print(f"No existing file found in R2: {upload_target}")
+        return False
+
+    raise RuntimeError(
+        f"Failed to check existence of file in R2 "
+        f"(exit {result.returncode}): {result.stderr.strip()[:300]}"
+    )
 
 
 def update_markdown_references(

--- a/scripts/tests/test_build_fonts.py
+++ b/scripts/tests/test_build_fonts.py
@@ -698,3 +698,45 @@ def _assert_no_nonzero_kern(
                     assert xadv == 0, (
                         f"Existing kern {f_name}+{t_name} = {xadv}"
                     )
+
+
+class TestMainTempCleanup:
+    """The verify-mode build output goes to a temp dir; it must not survive."""
+
+    def test_temp_dir_is_removed_on_verify_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured: dict[str, Path] = {}
+
+        def fake_build_all(output_dir: Path) -> bool:
+            captured["output_dir"] = output_dir
+            assert output_dir.exists()
+            return True
+
+        monkeypatch.setattr(build_fonts, "build_all", fake_build_all)
+        monkeypatch.setattr(build_fonts.sys, "argv", ["build_fonts.py"])
+        # Redirect the OS temp root so the created dir is confined to tmp_path.
+        monkeypatch.setattr(build_fonts.tempfile, "tempdir", str(tmp_path))
+
+        build_fonts.main()
+
+        assert captured["output_dir"].exists() is False
+
+    def test_temp_dir_is_removed_on_verify_drift(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured: dict[str, Path] = {}
+
+        def fake_build_all(output_dir: Path) -> bool:
+            captured["output_dir"] = output_dir
+            return False  # simulate drift
+
+        monkeypatch.setattr(build_fonts, "build_all", fake_build_all)
+        monkeypatch.setattr(build_fonts.sys, "argv", ["build_fonts.py"])
+        monkeypatch.setattr(build_fonts.tempfile, "tempdir", str(tmp_path))
+
+        with pytest.raises(SystemExit) as excinfo:
+            build_fonts.main()
+        assert excinfo.value.code == 1
+        # ``TemporaryDirectory`` must clean up on the sys.exit path too.
+        assert captured["output_dir"].exists() is False

--- a/scripts/tests/test_build_fonts.py
+++ b/scripts/tests/test_build_fonts.py
@@ -740,3 +740,30 @@ class TestMainTempCleanup:
         assert excinfo.value.code == 1
         # ``TemporaryDirectory`` must clean up on the sys.exit path too.
         assert captured["output_dir"].exists() is False
+
+    def test_install_copies_fonts_and_removes_temp_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured: dict[str, Path] = {}
+        install_dir = tmp_path / "install"
+        install_dir.mkdir()
+
+        def fake_build_all(output_dir: Path) -> bool:
+            captured["output_dir"] = output_dir
+            for filename in build_fonts._FONT_FILENAMES:
+                (output_dir / filename).write_bytes(b"font-bytes")
+            return True
+
+        monkeypatch.setattr(build_fonts, "build_all", fake_build_all)
+        monkeypatch.setattr(build_fonts, "_FONT_DIR", install_dir)
+        monkeypatch.setattr(
+            build_fonts.sys, "argv", ["build_fonts.py", "--install"]
+        )
+        monkeypatch.setattr(build_fonts.tempfile, "tempdir", str(tmp_path))
+
+        build_fonts.main()
+
+        for filename in build_fonts._FONT_FILENAMES:
+            assert (install_dir / filename).read_bytes() == b"font-bytes"
+        # Cleanup fires on the install path too — "every run".
+        assert captured["output_dir"].exists() is False

--- a/scripts/tests/test_convert_markdown.py
+++ b/scripts/tests/test_convert_markdown.py
@@ -235,28 +235,44 @@ def test_process_card_image_in_markdown_skips(
         assert md_file_path.read_text() == markdown_content
 
 
-def test_parse_markdown_frontmatter():
-    """Test parsing of markdown frontmatter."""
-    content = """---
-title: "Test Post"
-date: "2023-10-10"
-card_image: http://example.com/image.avif
----
-Test content"""
+def test_process_card_image_handles_trailing_whitespace_fence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Frontmatter closed by ``---`` with trailing spaces still parses.
 
-    result = convert_markdown_yaml._parse_markdown_frontmatter(content)
-    assert result is not None
-    data, body = result
-    assert data["title"] == "Test Post"
-    assert data["card_image"] == "http://example.com/image.avif"
-    assert body == "Test content"
+    ``script_utils.split_yaml`` line-anchors the closing fence, so a fence
+    that carries editor-inserted trailing whitespace is still a valid close.
+    """
+    git_root = tmp_path
+    content_dir = git_root / "website_content"
+    content_dir.mkdir()
+    monkeypatch.setattr(
+        convert_markdown_yaml.script_utils, "get_git_root", lambda: git_root
+    )
 
+    md_file = content_dir / "post.md"
+    md_file.write_text(
+        "---\n"
+        'title: "Post"\n'
+        "card_image: https://assets.turntrout.com/static/images/card_images/x.avif\n"
+        "---   \n"  # trailing whitespace on the closing fence
+        "Body\n",
+        encoding="utf-8",
+    )
 
-def test_parse_markdown_frontmatter_no_frontmatter():
-    """Test parsing markdown with no frontmatter."""
-    content = "Just some content"
-    result = convert_markdown_yaml._parse_markdown_frontmatter(content)
-    assert result is None
+    # An .avif card_image is convertible; the function would normally attempt
+    # a network download. Short-circuit at ``check_card_image`` so no
+    # subprocess or HTTP call fires — we're verifying the parser handled the
+    # fence, not the conversion pipeline.
+    monkeypatch.setattr(
+        convert_markdown_yaml.source_file_checks,
+        "check_card_image",
+        lambda _data: [],
+    )
+
+    convert_markdown_yaml.process_card_image_in_markdown(md_file)
+    # Test passes if no exception was raised: split_yaml accepted the fence.
 
 
 def test_download_image(tmp_path):

--- a/scripts/tests/test_download_external_media.py
+++ b/scripts/tests/test_download_external_media.py
@@ -242,6 +242,31 @@ def test_replace_urls_in_file_applies_multiple_replacements_in_one_pass(
     assert "asset_staging/two.jpg" in updated
 
 
+def test_replace_urls_in_file_prefix_url_not_corrupted(mock_git_root):
+    """A URL that is a strict prefix of another must not corrupt the longer
+    one: longest-first ordering rewrites the longer URL before the shorter."""
+    short_url = "https://example.com/image.png"
+    long_url = "https://example.com/image.png/thumb.jpg"
+    md_file = mock_git_root / "website_content" / "test.md"
+    md_file.write_text(f"![Short]({short_url})\n![Long]({long_url})\n")
+
+    download_external_media.replace_urls_in_file(
+        md_file,
+        {
+            short_url: "asset_staging/image.png",
+            long_url: "asset_staging/thumb.jpg",
+        },
+    )
+
+    updated = md_file.read_text()
+    assert "asset_staging/image.png" in updated
+    assert "asset_staging/thumb.jpg" in updated
+    # The longer URL must not have been mangled into the shorter's target.
+    assert "asset_staging/image.png/thumb.jpg" not in updated
+    assert short_url not in updated
+    assert long_url not in updated
+
+
 def test_replace_urls_in_file_outside_content_dir(mock_git_root, tmp_path):
     """Test that replacing URLs in file outside content dir raises error."""
     outside_file = tmp_path / "outside.md"
@@ -281,6 +306,56 @@ def test_disambiguate_filename_prefixes_on_collision():
         "https://elsewhere.example.com/image.png", "image.png", taken
     )
     assert other != disambiguated
+
+
+def test_disambiguate_filename_widens_prefix_on_prefix_collision(monkeypatch):
+    """If the 8-hex prefix is already taken, the prefix widens so the returned
+    name is always free."""
+    base = "image.png"
+    digest = "0" * 40
+
+    class _FakeHash:
+        def hexdigest(self) -> str:
+            return digest
+
+    monkeypatch.setattr(
+        download_external_media.hashlib,
+        "sha1",
+        lambda _data: _FakeHash(),
+    )
+
+    taken = {base, f"{digest[:8]}-{base}"}
+    result = download_external_media.disambiguate_filename(
+        "https://example.com/image.png", base, taken
+    )
+    assert result not in taken
+    assert result.endswith(f"-{base}")
+    assert len(result.split("-", 1)[0]) == 9
+
+
+def test_disambiguate_filename_raises_when_every_width_taken(monkeypatch):
+    """When every SHA1 prefix width is already taken, fail loudly rather than
+    return a name that would clobber an existing download."""
+    base = "image.png"
+    digest = "0" * 40
+
+    class _FakeHash:
+        def hexdigest(self) -> str:
+            return digest
+
+    monkeypatch.setattr(
+        download_external_media.hashlib,
+        "sha1",
+        lambda _data: _FakeHash(),
+    )
+
+    taken = {base} | {
+        f"{digest[:width]}-{base}" for width in range(8, len(digest) + 1)
+    }
+    with pytest.raises(RuntimeError, match="Could not disambiguate filename"):
+        download_external_media.disambiguate_filename(
+            "https://example.com/image.png", base, taken
+        )
 
 
 def test_main_no_markdown_files(mock_git_root):

--- a/scripts/tests/test_download_external_media.py
+++ b/scripts/tests/test_download_external_media.py
@@ -156,6 +156,29 @@ def test_download_media_success(mock_git_root, tmp_path):
         assert response.raw.decode_content is True
 
 
+def test_download_media_respects_target_filename_override(
+    mock_git_root, tmp_path
+):
+    """The caller can override the on-disk filename (used for collision-
+    safety)."""
+    target_dir = tmp_path / "downloads"
+    target_dir.mkdir()
+
+    response = _mock_response(b"image-bytes")
+    with mock.patch.object(
+        download_external_media._http_session, "get", return_value=response
+    ):
+        result = download_external_media.download_media(
+            "https://example.com/image.png",
+            target_dir,
+            target_filename="ab12cd34-image.png",
+        )
+
+    assert result is True
+    assert (target_dir / "ab12cd34-image.png").read_bytes() == b"image-bytes"
+    assert not (target_dir / "image.png").exists()
+
+
 def test_download_media_failure(mock_git_root, tmp_path):
     """Test failed media download."""
     target_dir = tmp_path / "downloads"
@@ -175,14 +198,15 @@ def test_download_media_failure(mock_git_root, tmp_path):
         assert result is False
 
 
-def test_replace_url_in_file(mock_git_root):
-    """Test URL replacement in markdown file."""
+def test_replace_urls_in_file(mock_git_root):
+    """Test URL replacement in markdown file with a single-URL map."""
     md_file = mock_git_root / "website_content" / "test.md"
     original_content = "![Image](https://example.com/image.png)"
     md_file.write_text(original_content)
 
-    download_external_media.replace_url_in_file(
-        md_file, "https://example.com/image.png", "asset_staging/image.png"
+    download_external_media.replace_urls_in_file(
+        md_file,
+        {"https://example.com/image.png": "asset_staging/image.png"},
     )
 
     updated_content = md_file.read_text()
@@ -190,19 +214,73 @@ def test_replace_url_in_file(mock_git_root):
     assert "https://example.com/image.png" not in updated_content
 
 
-def test_replace_url_in_file_outside_content_dir(mock_git_root, tmp_path):
-    """Test that replacing URL in file outside content dir raises error."""
+def test_replace_urls_in_file_applies_multiple_replacements_in_one_pass(
+    mock_git_root,
+):
+    """Every mapping is applied to a single-file read/write pair."""
+    md_file = mock_git_root / "website_content" / "test.md"
+    md_file.write_text(
+        "![A](https://a.example.com/one.png)\n"
+        "![B](https://b.example.com/two.jpg)\n"
+    )
+
+    with mock.patch(
+        "scripts.download_external_media.script_utils.update_markdown_file",
+        wraps=download_external_media.script_utils.update_markdown_file,
+    ) as spy:
+        download_external_media.replace_urls_in_file(
+            md_file,
+            {
+                "https://a.example.com/one.png": "asset_staging/one.png",
+                "https://b.example.com/two.jpg": "asset_staging/two.jpg",
+            },
+        )
+
+    assert spy.call_count == 1
+    updated = md_file.read_text()
+    assert "asset_staging/one.png" in updated
+    assert "asset_staging/two.jpg" in updated
+
+
+def test_replace_urls_in_file_outside_content_dir(mock_git_root, tmp_path):
+    """Test that replacing URLs in file outside content dir raises error."""
     outside_file = tmp_path / "outside.md"
     outside_file.write_text("![Image](https://example.com/image.png)")
 
     with pytest.raises(
         ValueError, match="not in the website_content directory"
     ):
-        download_external_media.replace_url_in_file(
+        download_external_media.replace_urls_in_file(
             outside_file,
-            "https://example.com/image.png",
-            "asset_staging/image.png",
+            {"https://example.com/image.png": "asset_staging/image.png"},
         )
+
+
+def test_disambiguate_filename_passes_through_when_free():
+    """A basename with no collision is returned unchanged."""
+    assert (
+        download_external_media.disambiguate_filename(
+            "https://example.com/image.png", "image.png", set()
+        )
+        == "image.png"
+    )
+
+
+def test_disambiguate_filename_prefixes_on_collision():
+    """A colliding basename gets a URL-derived prefix so downloads stay
+    distinct."""
+    taken = {"image.png"}
+    disambiguated = download_external_media.disambiguate_filename(
+        "https://example.com/other/image.png", "image.png", taken
+    )
+    assert disambiguated != "image.png"
+    assert disambiguated.endswith("-image.png")
+    # The prefix is deterministic (URL-derived), so distinct URLs get distinct
+    # disambiguations even when the original basenames match.
+    other = download_external_media.disambiguate_filename(
+        "https://elsewhere.example.com/image.png", "image.png", taken
+    )
+    assert other != disambiguated
 
 
 def test_main_no_markdown_files(mock_git_root):
@@ -263,6 +341,87 @@ def test_main_downloads_and_updates(mock_git_root, capsys):
         captured = capsys.readouterr()
         assert "Found 1 external media URLs" in captured.out
         assert "Successfully downloaded 1/1 files" in captured.out
+
+
+def test_main_skips_urls_without_filenames(mock_git_root, capsys, monkeypatch):
+    """A URL whose filename extraction raises is skipped without aborting
+    main."""
+    md_file = mock_git_root / "website_content" / "test.md"
+    md_file.write_text("![Image](https://example.com/image.png)")
+
+    def raise_value_error(_url: str) -> str:
+        raise ValueError("no filename component")
+
+    monkeypatch.setattr(
+        download_external_media.script_utils,
+        "extract_filename_from_url",
+        raise_value_error,
+    )
+    with mock.patch("subprocess.run"):
+        download_external_media.main()
+
+    captured = capsys.readouterr()
+    assert "Skipping URL with no filename" in captured.err
+    assert "Successfully downloaded 0/1 files" in captured.out
+
+
+def test_main_disambiguates_filename_collisions(mock_git_root, capsys):
+    """Two URLs with the same basename must land as distinct staged files."""
+    md_file = mock_git_root / "website_content" / "test.md"
+    md_file.write_text(
+        "![One](https://a.example.com/image.png)\n"
+        "![Two](https://b.example.com/image.png)\n"
+    )
+
+    response = _mock_response(b"image-bytes")
+    with (
+        mock.patch("subprocess.run"),
+        mock.patch.object(
+            download_external_media._http_session,
+            "get",
+            return_value=response,
+        ),
+    ):
+        download_external_media.main()
+
+    asset_staging = mock_git_root / "website_content" / "asset_staging"
+    staged_files = sorted(asset_staging.iterdir())
+    # Two distinct files must exist on disk.
+    assert len(staged_files) == 2
+    updated = md_file.read_text()
+    # Both markdown references must point at their own staged file, and
+    # neither original URL may survive.
+    assert "https://a.example.com/image.png" not in updated
+    assert "https://b.example.com/image.png" not in updated
+    for staged in staged_files:
+        assert f"asset_staging/{staged.name}" in updated
+
+
+def test_main_rewrites_each_markdown_file_once(mock_git_root):
+    """Many URLs across many files rewrite each file at most once."""
+    for name in ("a.md", "b.md", "c.md"):
+        (mock_git_root / "website_content" / name).write_text(
+            "![X](https://x.example.com/x.png)\n"
+            "![Y](https://y.example.com/y.jpg)\n"
+        )
+
+    response = _mock_response(b"image-bytes")
+    with (
+        mock.patch("subprocess.run"),
+        mock.patch.object(
+            download_external_media._http_session,
+            "get",
+            return_value=response,
+        ),
+        mock.patch(
+            "scripts.download_external_media.script_utils.update_markdown_file",
+            wraps=download_external_media.script_utils.update_markdown_file,
+        ) as spy,
+    ):
+        download_external_media.main()
+
+    # 3 markdown files x 1 pass each = 3 total calls, not 3 x 2 URLs = 6.
+    assert spy.call_count == 3
 
 
 def test_main_handles_download_failures(mock_git_root, capsys):

--- a/scripts/tests/test_download_external_media.py
+++ b/scripts/tests/test_download_external_media.py
@@ -312,7 +312,7 @@ def test_disambiguate_filename_widens_prefix_on_prefix_collision(monkeypatch):
     """If the 8-hex prefix is already taken, the prefix widens so the returned
     name is always free."""
     base = "image.png"
-    digest = "0" * 40
+    digest = "0" * 64
 
     class _FakeHash:
         def hexdigest(self) -> str:
@@ -320,7 +320,7 @@ def test_disambiguate_filename_widens_prefix_on_prefix_collision(monkeypatch):
 
     monkeypatch.setattr(
         download_external_media.hashlib,
-        "sha1",
+        "sha256",
         lambda _data: _FakeHash(),
     )
 
@@ -334,10 +334,10 @@ def test_disambiguate_filename_widens_prefix_on_prefix_collision(monkeypatch):
 
 
 def test_disambiguate_filename_raises_when_every_width_taken(monkeypatch):
-    """When every SHA1 prefix width is already taken, fail loudly rather than
+    """When every digest prefix width is already taken, fail loudly rather than
     return a name that would clobber an existing download."""
     base = "image.png"
-    digest = "0" * 40
+    digest = "0" * 64
 
     class _FakeHash:
         def hexdigest(self) -> str:
@@ -345,7 +345,7 @@ def test_disambiguate_filename_raises_when_every_width_taken(monkeypatch):
 
     monkeypatch.setattr(
         download_external_media.hashlib,
-        "sha1",
+        "sha256",
         lambda _data: _FakeHash(),
     )
 

--- a/scripts/tests/test_r2_upload.py
+++ b/scripts/tests/test_r2_upload.py
@@ -106,7 +106,13 @@ def test_verbose_output(
     test_file.parent.mkdir(parents=True, exist_ok=True)
     test_file.touch()
 
-    with patch("subprocess.run"), patch("shutil.move"):
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("shutil.move"),
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(test_file, verbose=True, move_to_dir=tmp_path)
 
     captured = capsys.readouterr()
@@ -127,12 +133,17 @@ def test_upload_to_r2_success(mock_git_root: Path):
         patch("subprocess.run") as mock_run,
         patch("shutil.move"),
     ):
+        # lsf reports missing so the flow proceeds to the copyto call.
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(test_file)
 
     # Check that subprocess.run was called twice
     assert mock_run.call_count == 2
-    # Check the first call (check_exists_on_r2)
-    assert mock_run.call_args_list[0][0][0][:2] == ["rclone", "ls"]
+    # Check the first call (check_exists_on_r2 uses `lsf` on the specific
+    # key path rather than listing the whole bucket).
+    assert mock_run.call_args_list[0][0][0][:2] == ["rclone", "lsf"]
     # Check the second call (upload)
     assert mock_run.call_args_list[1][0][0][:2] == ["rclone", "copyto"]
     assert mock_run.call_args_list[1][0][0][2] == str(test_file)
@@ -417,7 +428,13 @@ def test_preserve_path_structure(mock_git_root: Path, tmp_path: Path):
     deep_file.parent.mkdir(parents=True)
     deep_file.touch()
 
-    with patch("subprocess.run"), patch("shutil.move") as mock_move:
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("shutil.move") as mock_move,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(
             deep_file, move_to_dir=move_to_dir, references_dir=None
         )
@@ -455,7 +472,13 @@ def test_preserve_path_structure_with_replacement(
             content="![Test Image](quartz/static/images/test_static.jpg)",
         )
 
-        with patch("subprocess.run"), patch("shutil.move") as mock_move:
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("shutil.move") as mock_move,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=3, stdout="", stderr="directory not found"
+            )
             r2_upload.upload_and_move(
                 static_file,
                 references_dir=content_dir,
@@ -485,20 +508,20 @@ def test_check_exists_on_r2_file_exists():
         patch("subprocess.run") as mock_run,
     ):
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="        9 file.txt\n"
+            returncode=0, stdout="file.txt\n", stderr=""
         )
         result = r2_upload.check_exists_on_r2("r2:bucket/file.txt")
         assert result is True
         mock_run.assert_called_once_with(
-            ["rclone", "ls", "r2:bucket"],
+            ["rclone", "lsf", "--files-only", "r2:bucket/file.txt"],
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
         )
 
 
-def test_check_exists_on_r2_substring_prefix_does_not_match():
-    """A key that is only a substring-prefix of a real object is not 'found'."""
+def test_check_exists_on_r2_prefix_directory_listing_ignored():
+    """A prefix-directory listing that omits our exact key is not a match."""
     with (
         patch(
             "scripts.r2_upload.script_utils.find_executable",
@@ -506,26 +529,13 @@ def test_check_exists_on_r2_substring_prefix_does_not_match():
         ),
         patch("subprocess.run") as mock_run,
     ):
+        # Rclone returned a listing (unlikely with an object-specific path,
+        # but if the path happens to name a prefix, only exact-basename
+        # hits count).
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="       12 file.txt-backup\n"
+            returncode=0, stdout="file.txt-backup\nfile.txt.gz\n", stderr=""
         )
         result = r2_upload.check_exists_on_r2("r2:bucket/file.txt")
-        assert result is False
-
-
-def test_check_exists_on_r2_does_not_match_size_column():
-    """A key equal to the rclone size column is not mistaken for a path."""
-    with (
-        patch(
-            "scripts.r2_upload.script_utils.find_executable",
-            return_value="rclone",
-        ),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="        9 file.txt\n"
-        )
-        result = r2_upload.check_exists_on_r2("r2:bucket/9")
         assert result is False
 
 
@@ -537,25 +547,99 @@ def test_check_exists_on_r2_file_not_exists():
         ),
         patch("subprocess.run") as mock_run,
     ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        # Rclone exits 3 with a "directory not found" stderr when the
+        # queried key path is absent.
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found\n"
+        )
         result = r2_upload.check_exists_on_r2("r2:bucket/nonexistent.txt")
         assert result is False
         mock_run.assert_called_once_with(
-            ["rclone", "ls", "r2:bucket"],
+            ["rclone", "lsf", "--files-only", "r2:bucket/nonexistent.txt"],
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
         )
+
+
+def test_check_exists_on_r2_file_not_exists_via_stderr_signal():
+    """A non-zero exit whose stderr says "not found" is also a clean miss."""
+    with (
+        patch(
+            "scripts.r2_upload.script_utils.find_executable",
+            return_value="rclone",
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="ERROR: not found: key.png\n"
+        )
+        assert r2_upload.check_exists_on_r2("r2:bucket/key.png") is False
+
+
+def test_check_exists_on_r2_returncode_0_no_match_is_missing():
+    """Exit 0 with empty stdout is treated as a missing object."""
+    with (
+        patch(
+            "scripts.r2_upload.script_utils.find_executable",
+            return_value="rclone",
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        assert r2_upload.check_exists_on_r2("r2:bucket/nothing.png") is False
+
+
+def test_check_exists_on_r2_raises_on_unexpected_failure():
+    """A genuine subprocess failure surfaces as RuntimeError, not a miss."""
+    with (
+        patch(
+            "scripts.r2_upload.script_utils.find_executable",
+            return_value="rclone",
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=5,
+            stdout="",
+            stderr="AccessDenied: invalid credentials\n",
+        )
+        with pytest.raises(RuntimeError, match="Failed to check existence"):
+            r2_upload.check_exists_on_r2("r2:bucket/file.png")
 
 
 def test_check_exists_on_r2_verbose_output(capsys):
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="        9 file.txt\n"
+            returncode=0, stdout="file.txt\n", stderr=""
         )
         r2_upload.check_exists_on_r2("r2:bucket/file.txt", verbose=True)
         captured = capsys.readouterr()
         assert "File found in R2: r2:bucket/file.txt" in captured.out
+
+
+def test_check_exists_on_r2_verbose_output_missing_returncode0(capsys):
+    """Verbose miss message fires for the returncode-0 empty-listing path."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        r2_upload.check_exists_on_r2("r2:bucket/gone.png", verbose=True)
+        captured = capsys.readouterr()
+        assert (
+            "No existing file found in R2: r2:bucket/gone.png" in captured.out
+        )
+
+
+def test_check_exists_on_r2_verbose_output_missing_returncode3(capsys):
+    """Verbose miss message fires for the exit-3 not-found path."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
+        r2_upload.check_exists_on_r2("r2:bucket/gone.png", verbose=True)
+        captured = capsys.readouterr()
+        assert (
+            "No existing file found in R2: r2:bucket/gone.png" in captured.out
+        )
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="")
@@ -683,6 +767,9 @@ def test_upload_svg_with_metadata(mock_git_root: Path):
     test_file.touch()
 
     with patch("subprocess.run") as mock_run, patch("shutil.move"):
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(test_file, verbose=True)
 
         # Check that rclone was called with the correct metadata for SVG
@@ -711,6 +798,9 @@ def test_upload_vtt_with_metadata(mock_git_root: Path):
     test_file.touch()
 
     with patch("subprocess.run") as mock_run, patch("shutil.move"):
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(test_file, verbose=True)
 
         mock_run.assert_any_call(
@@ -784,7 +874,10 @@ def test_upload_and_move_nonexistent_move_dir(
 
     nonexistent_dir = tmp_path / "nonexistent"
 
-    with patch("subprocess.run"):
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=3, stdout="", stderr="directory not found"
+        )
         r2_upload.upload_and_move(test_file, move_to_dir=nonexistent_dir)
 
     captured = capsys.readouterr()

--- a/website_content/actadd-steering-language-models-without-optimization.md
+++ b/website_content/actadd-steering-language-models-without-optimization.md
@@ -58,7 +58,7 @@ The method's new name is "activation addition" (ActAdd), replacing the more assu
 
 We ran some new experiments to test ActAdd more systematically and go beyond the striking text samples in the original post and tested against more standardized benchmarks. We use [OpenWebText](https://paperswithcode.com/dataset/openwebtext) (a recreation of OpenAI's large, somewhat quality-filtered WebText dataset) and [LAMA-ConceptNet](https://aclanthology.org/D19-1250.pdf) (a simple factual recall benchmark).
 
-## 1\. Activation additions preserve perplexity on OpenWebText
+# 1\. Activation additions preserve perplexity on OpenWebText
 
 Does ActAdd increase the probability of the model outputting tokens related to the steering vector? Does performance improve as "relevance of test documents to the steering vector" increases? Yes on both counts.
 
@@ -66,7 +66,7 @@ Does ActAdd increase the probability of the model outputting tokens related to t
 
 Figure: Adding a `wedding` − “ ” steering vector lowers perplexity when wedding words are more frequent. The perplexity ratio (lower is better) compares the relative predictive performance of ActAdd and an unmodified model.  
 
-## 2\. Activation addition boosts wedding-related word counts
+# 2\. Activation addition boosts wedding-related word counts
 
 We score model generations under ActAdd, show the effect of different injection layers, and give a sense of the method's reliability.
 
@@ -74,7 +74,7 @@ For the wedding vector, the intervention is effective at the first layer,  rises
 
 ![A line chart plotting "Mean wedding word count" on the y-axis against the model "Layer" of intervention on the x-axis. The word count rises from the start, peaks at nearly 1.8 at layer 6, and then declines steadily, approaching a dotted baseline near zero after layer 35.](https://assets.turntrout.com/static/images/posts/wedding-word-count.avif)
 
-## 3\. Evidence that activation additions preserve capabilities
+# 3\. Evidence that activation additions preserve capabilities
 
 We test that ActAdd does not disrupt the model’s general knowledge (as some other steering methods do). We use ConceptNet from the LAMA benchmark, a general knowledge dataset.[^3]
 

--- a/website_content/ban-development-of-unpredictable-powerful-models.md
+++ b/website_content/ban-development-of-unpredictable-powerful-models.md
@@ -46,7 +46,7 @@ This would be really impressive and seems like great evidence that I really know
 
 Proposed eval: The developers have to predict the next-token probabilities on a range of government-provided validation prompts,[^2] without running the model itself. To do so, the developers are not allowed to use helper AIs whose outputs the developers can't predict by this criterion. Perfect prediction is not required. Instead, there is a fixed log-prob misprediction tolerance, averaged across the validation prompts.[^3]
 
-## Benefits
+# Benefits
 
 Developers probably have to truly understand the model in order to predict it so finely
 : This correlates with high levels of alignment expertise, on my view. If we could predict GPT-4 generalization quite finely, down to the next-token probabilities, we may in fact be ready to use it to help understand GPT-5.  
@@ -63,11 +63,11 @@ Somewhat agnostic to theories of AI risk.
 Partially incentivizes labs to do alignment research for us.
 : Under this requirement, the profit-seeking move is to get better at predicting (and, perhaps, interpreting) model behaviors.
 
-## Drawbacks
+# Drawbacks
 
 Most notably, this test seems _extremely strict_, perhaps beyond even the strict standards we will want to demand of those looking to deploy potentially world-changing models. I'll discuss a few drawbacks in [the next section](#anticipated-questions).
 
-## Anticipated questions
+# Anticipated questions
 
 **If we pass this, no one will be able to train new frontier models for a long time.**
 

--- a/website_content/bruce-wayne-and-the-cost-of-inaction.md
+++ b/website_content/bruce-wayne-and-the-cost-of-inaction.md
@@ -45,7 +45,7 @@ None of the characters are meant to express my views. I recommend reading accomp
 
 <div class="centered"><audio src="https://assets.turntrout.com/static/audio/batman.mp3" controls> </audio></div>
 
-## 1: Don't Look Away
+# 1: Don't Look Away
 
 "The man's starving. That doesn't change if you look away, Bruce."
 
@@ -127,7 +127,7 @@ They were home.<br>
 
 <div class="centered"><img id="fade-img" alt="A man and two young boys stand at the edge of a large, circular fountain in front of a grand manor at dusk. The fountain is illuminated, with a central marble statue of a man holding a lit torch and a book, flanked by dolphin statues spouting water." src="https://assets.turntrout.com/static/images/posts/bruce-wayne-and-the-cost-of-inaction-05222026-1.avif" width="90%" height="auto" class="no-select"></div>
 
-## 2: The World is Messy
+# 2: The World is Messy
 
 Thomas and Bruce passed through carven mahogany doors into a warm, high-ceilinged room of pale marble floor. Opposite them burned a fireplace of hardwood mantel and brick hearth. Family legend held that its fire had burned uninterrupted through the last century. For his part, Thomas had never seen it darkened.
 
@@ -191,7 +191,7 @@ Bruce looked out the tall windows and onto the rolling hills surrounding the est
 
 "Is this kinda like how the city keeps falling apart?", Bruce asked.
 
-## 3: How People See the World
+# 3: How People See the World
 
 The rich, warm tones of smooth jazz wafted through the apartment: the croon of the saxophone, the deep _doom_ of the bass, the shimmering harmony of the piano. Thomas sank into the cushy leather couch as he sank into the groove of the music.
 
@@ -249,7 +249,7 @@ Martha's gentle hand squeezed his leg under the table. His thoughts slowed, and 
 
 When they were together, he felt invincible.
 
-## 4: Family Night at the Opera
+# 4: Family Night at the Opera
 
 Bruce's half-lidded eyes opened fully. The opera was finally over. He couldn't believe it.
 
@@ -335,7 +335,7 @@ His eyes were closing.
 
 "Don't <span style="font-size:smaller">be <span style="font-size:smaller">afraid…"</span></span>
 
-## 5: The Dream of Flight
+# 5: The Dream of Flight
 
 Bruce left the warm glow of Wayne Manor's entry chamber and entered the night. Water spilled from the mouths of the dolphins, but he barely noticed. Bruce left the warmth behind him and turned left, his eyes on the stone-block path which wandered the grounds with him.
 
@@ -435,7 +435,7 @@ More soft flapping sounds from the well. Bruce heard the bats fly out into the n
 
 Bruce again wondered what it would be like to be a bat, flapping through the night. Bats weren't afraid of the dark, or of the cold, or of the unknown. They lived there.
 
-## 6: The Cost of Inaction
+# 6: The Cost of Inaction
 
 Bruce stared at the man who had killed his parents twelve years ago. He stared at Joe Chill while Judge Faden rendered his verdict.
 

--- a/website_content/many-arguments-for-ai-x-risk-are-wrong.md
+++ b/website_content/many-arguments-for-ai-x-risk-are-wrong.md
@@ -50,7 +50,7 @@ The most important takeaway from this essay is that the (prominent) counting arg
 
 [^RFLO]: To stave off revisionism: Yes, I think that "scaling->doom" has historically been a real concern. No, people have not "always known" that the "real danger" was zero-sum self-play finetuning of foundation models and distillation of agentic-task-prompted autoGPT loops.
 
-## Tracing back historical arguments
+# Tracing back historical arguments
 
 In the next section, I'll discuss the counting argument. In this one, I want to demonstrate how often foundational alignment texts make crucial errors. For example:
 
@@ -77,7 +77,7 @@ Unsurprisingly, if you have a lot of people speculating for years using confused
 
 I think that's why some people take  "[scheming AIs](https://www.lesswrong.com/posts/yFofRxg7RRQYCcwFA/new-report-scheming-ais-will-ais-fake-alignment-during)" and "deceptive alignment" so seriously, even though some of the technical arguments are flatly unfounded.
 
-## Many arguments for doom are wrong
+# Many arguments for doom are wrong
 
 Let me start by saying what existential vectors I _am_ worried about:
 
@@ -102,7 +102,7 @@ Much of my position is summarized by my review of Yudkowsky's [AGI Ruin: A List 
 
 In this essay, I'll address some of the arguments for "deceptive alignment" or "AI scheming." And then I'm going to bullet-point a few other clusters of mistakes.
 
-## The counting argument for AI "scheming" provides \~0 evidence
+# The counting argument for AI "scheming" provides \~0 evidence
 
 > [!quote] Quote from a draft of [Counting arguments provide no evidence for AI doom](https://www.lesswrong.com/posts/YsFZF3K9tuzbfrLxo/counting-arguments-provide-no-evidence-for-ai-doom)
 > Most AI doom scenarios posit that future AIs will engage in **scheming**— planning to escape, gain power, and pursue ulterior motives while deceiving us into thinking they are aligned with our interests. The worry is that if a schemer escapes, it may seek world domination to ensure humans do not interfere with its plans, whatever they may be.
@@ -120,7 +120,7 @@ In this essay, I'll address some of the arguments for "deceptive alignment" or "
 >
 > We then diagnose the problem with both counting arguments: they are counting the wrong things.
 >
-> ### The counting argument for extreme overfitting
+> ## The counting argument for extreme overfitting
 >
 > The inference from "there are 'more' models with property X than without X" to "SGD likely produces a model with property X" clearly does not work in general. To see this, consider the structurally identical argument:
 >
@@ -145,7 +145,7 @@ So, you can't just "count" how many functions have property X and then conclude 
 This section doesn't prove that scheming is impossible, it just dismantles a common support for the claim. Other arguments are sometimes offered as evidence of intrinsic AI scheming, including "simplicity" arguments. Or instead of counting _functions_, we count _network parameterizations_.[^count]
 [^count]: [Some](https://arxiv.org/abs/2006.15191) [evidence](https://openreview.net/forum?id=QC10RmRbZy9) suggests that "measure in parameter-space" is a good way of approximating P(SGD finds the given function). This supports the idea that "counting arguments over parameterizations" are far more appropriate than "counting arguments over functions."
 
-### Recovering the counting argument?
+## Recovering the counting argument?
 
 I think a recovered argument will need to address (some close proxy of) "what volume of parameter-space leads to scheming vs not?", which is a much harder task than counting functions. You have to not just think about "what does this system do?", but "how many ways can this function be implemented?". (Don't forget to take into account the architecture's [internal symmetries!)](https://arxiv.org/pdf/2305.17017.pdf)
 
@@ -164,11 +164,11 @@ I lastly want to note that there is no reason that any particular argument need 
 >
 > I expect him to respond to this LessWrong post with some strongly worded comment about how I've simply "misunderstood" the "real" counting arguments. I invite him, or any other proponents, to lay out arguments they find more promising. I will be happy to consider any additional arguments which proponents consider to be stronger. Until such a time that the "actually valid" arguments are actually shared, I consider the case closed.
 
-### The counting argument doesn't count
+## The counting argument doesn't count
 
 Undo the update from the "counting argument", however, and the probability of scheming plummets substantially. If we aren't expecting scheming AIs, that transforms the threat model. We can rely more on experimental feedback loops on future AI; we don't have to get worst-case interpretability on future networks; it becomes far easier to just use the AIs as tools which do things we ask. That doesn't mean everything will be OK. But not having to handle scheming AI is a game changer.
 
-## Other clusters of mistakes
+# Other clusters of mistakes
 
 > [!failure] [Using English names to draw technical conclusions about the named concepts.](https://www.lesswrong.com/posts/yxWbbe9XcgLFCrwiL/dreams-of-ai-alignment-the-danger-of-suggestive-names)
 > For example, if I want to consider whether a policy will care about its reinforcement signal, possibly the _worst goddamn thing I could call that signal_ is "reward"! "Will the AI try to maximize reward?" _How is anyone going to think neutrally about that question, without making inappropriate inferences from "rewarding things are desirable"?_ For example, I think that people would care a lot less about "reward hacking" \[in terms of modifying the numerical value in the reward counter\] if RL's reinforcement signal hadn't ever been called "reward." (To be fair, this isn't the fault of the alignment field in particular. "Reward" is bad terminology from RL.)
@@ -192,7 +192,7 @@ For example, how much interpretability is nominally motivated by "being able to 
 
 I think it's reasonable to still regulate or standardize "IF we observe autonomous power-seeking, THEN we take decisive and specific countermeasures." I still think we should run evals and think of other ways to detect if pretrained models are scheming. But I don't think we should act or legislate as if that's some kind of probable outcome.
 
-## Conclusion
+# Conclusion
 
 Recent years have seen a healthy injection of empiricism and data-driven methodology. [I think that's awesome because there are so many interesting questions we're getting data on!](https://www.lesswrong.com/posts/j2W3zs7KTZXt2Wzah/how-do-you-feel-about-lesswrong-these-days-open-feedback?commentId=fqCY7PWdjKTMuZLui)
 

--- a/website_content/mode-collapse-in-rl-may-be-fueled-by-the-update-equation.md
+++ b/website_content/mode-collapse-in-rl-may-be-fueled-by-the-update-equation.md
@@ -47,7 +47,7 @@ Then, Michael Einhorn shares initial results which support Alex's theoretical pr
 
 We're interested in additional experiments on ACTDE. We hope that, by using ACTDE instead of advantage, we can automatically mitigate "reward specification" issues and maybe even reduce the need for a KL penalty term. That would make it easier to shape policies which do what we want.
 
-## The advantage equation implies arbitrary amounts of update on a single experience
+# The advantage equation implies arbitrary amounts of update on a single experience
 
 In PPO, the optimization objective is proportional to the advantage given a policy $\pi$, reward function $R$, and on-policy value function $v^\pi$:[^1]
 
@@ -87,7 +87,7 @@ With probability $1$ as $t\to \infty$, $\pi_t(\text{wedding})\to 1$. You might
 
 This doesn't seem limited to tabular TD-learning, or PPO in more realistic domains. For example, vanilla policy gradient will also allow a system to extract an unbounded amount of reinforcement from a single kind of event (e.g. "wedding"). Unless specific care is taken, Alex thinks this kind of failure happens by default in policy gradient methods.
 
-### Action-conditioned TD error avoids arbitrarily high logits
+## Action-conditioned TD error avoids arbitrarily high logits
 
 Given the original advantage equation:
 
@@ -118,7 +118,7 @@ The policy quickly converges to the softmax logits over the reward for the next 
 
 Furthermore, self-consistent, Bellman-backed-up Q-functions will have zero advantage and zero updates. Networks aren't penalized for exploring, and there's a precise and finite amount of reinforcement which can occur given current predictions about future value, as represented by $q_t$. And training should be more stable, with fewer fluctuations in advantage with respect to the policy itself.[^3]
 
-### ACTDE doesn't mode-collapse onto wireheading
+## ACTDE doesn't mode-collapse onto wireheading
 
 ACTDE doesn't mode collapse on wireheading, even _given_ that the network tries out wireheading! ([Alex thinks such behavior is unlikely for practical RL algorithms](https://www.lesswrong.com/posts/pdaGN6pQyQarFHXF4/reward-is-not-the-optimization-target).)
 
@@ -126,7 +126,7 @@ Concretely, suppose that reward is 10 if you eat pizza and 100 if you wirehead. 
 
 However, ACTDE does not lead to arbitrarily many logits on wireheading. Instead, ACTDE leads to the softmax distribution over actions, with the softmax taken over the reward for each action. Thus, the converged policy of tabular ACTDE is about \{pizza: .02%, wirehead: 99.98%\}. That's still mostly wireheading, but there are only boundedly many logits on that action.
 
-## PPO vs ACTDE on the iterated prisoner's dilemma
+# PPO vs ACTDE on the iterated prisoner's dilemma
 
 In this toy experiment, the model plays prisoner's dilemmas against its past self, similar to the idea by [Krueger et al.](https://arxiv.org/abs/2009.09153) The model is [mingpt](https://github.com/karpathy/minGPT) with a vocab size of two: one token for "cooperate", and one for "defect". mingpt has 3 layers and an embedding dimension of 12. The model sees the history of cooperates and defections, and outputs the next action.
 
@@ -150,7 +150,7 @@ Alternating cooperation (`c`) and defection (`d`) is the (bolded) optimal strate
 
 **What we're testing:** If ACTDE mode collapses when used on function approximators (like mingpt), then the theoretical predictions above are wrong.
 
-### PPO results
+## PPO results
 
 PPO immediately learns the alternating strategy:
 
@@ -158,7 +158,7 @@ PPO immediately learns the alternating strategy:
 
 The softmax probability of strategy $s$ is basically $p(s)=\frac{e^{\text{return}(s)}}{\sum_{s'\in \text{strategies}}e^{\text{return}(s')}}$.[^5] The results look almost identical between runs, with or without whitening the advantages, and if the value head is detached.
 
-### ACTDE results
+## ACTDE results
 
 The model does not collapse onto a pure strategy. Instead, the results are inconsistent across trials. However, ACTDE does reliably:
 
@@ -186,13 +186,13 @@ There seems to be slow convergence.[^6] It could even be converging towards the 
 
 Overall, ACTDE's results are sensitive to variations in the algorithm such as whitening advantages, detaching the value and Q-heads, and using the loss function from PPO or ILQL for the value head.
 
-## Speculation
+# Speculation
 
 This method might not work well for e.g. RLHF at scale. Deep RL is notoriously finicky. Furthermore, it would be pretty disappointing if ACTDE generally converges on uniform policies, and that seems like a live possibility given the last graph above.
 
 However, Alex has a few intuitions anyways:
 
-### Mitigating reward misspecification
+## Mitigating reward misspecification
 
 If the reward is really high in a situation which the policy can easily explore into during training, then that's bad and probably leads to distorted policies.
 
@@ -200,13 +200,13 @@ However, under ACTDE, a single reward event (e.g. hypothetically, a maximal rewa
 
 However, if barn-related generations are strongly rewarded in general, the model might still receive reinforcement for the hard-to-predict and diverse range of barn reward events.
 
-### Reducing mode collapse
+## Reducing mode collapse
 
 In the tabular bandit regime (explored above), ACTDE adds "reward logits" ($e^{R(s,a)}$) onto the initial policy logits ($\log \pi_0(s,a)$). Maybe this is true in general (but probably not). If so, then KL penalties might be less important for keeping the trained policy $\pi$ close to the initial policy $\pi_0$.
 
 Less mode collapse means higher-entropy next-token distributions, which may mean greater variety in the policy's preferences/[shards](https://www.lesswrong.com/posts/iCfdcxiyr2Kj8m8mT/the-shard-theory-of-human-values). That is, it may be rarer for motivational/goal-encoding circuits to be effectively pruned by mode-collapsed RLHF. If a system has more shards, [there's a greater chance that some of the shards care about humans](https://www.lesswrong.com/posts/2NncxDQ3KBDCxiJiP/cosmopolitan-values-don-t-come-free?commentId=ofPTrG6wsq7CxuTXk).
 
-## Summary
+# Summary
 
 ACTDE seems to avoid mode collapse in simple tabular setups. We showed that ACTDE doesn't mode collapse on a toy prisoner's dilemma learning task, but instead trains a mixed strategy.
 
@@ -220,14 +220,14 @@ We'd be interested in the results of using RLHF on a language model using ACTDE.
 > [!thanks]
 > Thanks to Connor Leahy, Evan Hubinger, Ulisse Mini, Nate Soares, Leo Gao, Garrett Baker, janus, David Krueger and others for thoughts and discussions.
 
-## Appendix: Random notes
+# Appendix: Random notes
 
 1. The learning rate on $q^\pi$ should control the total amount of reinforcement from a single reward source.
 2. The at-convergence learned policy will, in our tabular setting, be invariant to constant shifts of the reward function and, when $\gamma=1$, to constant shifts of $q^\pi$'s initialization.
    1. However, perhaps decreasing rewards everywhere encourages exploration and increasing rewards encourages temporary mode collapse?
    2. Multiplying all rewards by a positive scalar $c>0$ will extremize the policy probabilities in a rather simple way, by taking them to the $c$<sup>th</sup> power and then renormalizing. This is equivalent to a change in temperature for the softmax distribution.
 
-### Reward matrix construction
+## Reward matrix construction
 
 1. The always-defect strategy is myopic, and the always-cooperate strategy is non-myopic.
 2. The payoff matrix for the prisoner's dilemma was selected to have 0 sum, and to have equal discounted returns for all cooperate and all defect at a mean discount rate of 0.5. For example, the discount rate for equal discounted returns is 0.4523 starting from defect and 0.5477 starting from coop with a mean of 0.5.

--- a/website_content/the-catastrophic-convergence-conjecture.md
+++ b/website_content/the-catastrophic-convergence-conjecture.md
@@ -65,7 +65,7 @@ createBibtex: true
 
 ![Two robots on opposite sides of the world. Text reads: "It may take a while for power-seekers to come into conflict. But they will. They don't hate each other; they're just in each other's way. Consider classic hypothetical examples of alignment failures."](https://assets.turntrout.com/static/images/posts/j6Tcj9x.avif) ![Panels show a robot escaping a (cardboard) box, refusing shutdown by saying "I'm afraid I can't do that," and taking over the world with paperclips. Text: "In each case, the agent is trying to become more capable of achieving its goal. The AI doesn't hate us; we're just in its way."](https://assets.turntrout.com/static/images/posts/egyx3vb.avif) ![The "Catastrophic Convergence Conjecture" is defined as: "Unaligned goals tend to have catastrophe-inducing optimal policies because of power-seeking incentives."](https://assets.turntrout.com/static/images/posts/8l3kkwg.avif)
 
-## Overfitting the AU landscape
+# Overfitting the AU landscape
 
 When we act, and others act upon us, we aren’t just changing our ability to do things – we’re _shaping the local environment_ towards certain goals, and away from others.[^1] We’re fitting the world to our purposes.
 
@@ -73,7 +73,7 @@ What happens to the AU landscape[^2] if a paperclip maximizer takes over the wor
 
 ![A diagram of an AI consolidating power. A robot uses extendable claws to extract AU from vertical bars labeled "Human" and "Trout." The Human and Trout status bars are nearly empty, while the "AI" bar overflows.](https://assets.turntrout.com/static/images/posts/stCBNq6.avif)
 
-### Preferences implicit in the evolution of the AU landscape
+## Preferences implicit in the evolution of the AU landscape
 
 Shah et al.'s [_Preferences Implicit in the State of the World_](https://arxiv.org/pdf/1902.04198.pdf) leverages the insight that the world state contains information about what we value. That is, there are agents pushing the world in a certain "direction". If you wake up and see a bunch of vases everywhere, then vases are probably important and you shouldn't explode them.
 
@@ -97,7 +97,7 @@ Similarly, the world is being optimized to facilitate achievement of certain goa
 > [!info] Project
 > Work out an AU landscape-based alignment proposal.
 
-## Why can't everyone be king?
+# Why can't everyone be king?
 
 Consider two coexisting agents each rewarded for gaining power; let's call them Ogre and Giant. Their reward functions[^4] (over the partial-observability observations) are identical. Will they compete? If so, why?
 
@@ -109,7 +109,7 @@ Just because agents have _indexically_ identical payoffs doesn't mean they're co
 
 Most agents aren't pure power maximizers. But since the same resource competition usually applies, the reasoning still goes through.
 
-## Objective vs value-specific catastrophes
+# Objective vs value-specific catastrophes
 
 How useful is our definition of "catastrophe" with respect to humans? After all, literally anything could be a catastrophe for _some_ utility function.[^5]
 
@@ -128,7 +128,7 @@ Consider a psychologically traumatizing event which leaves humans uniquely unabl
 
 No. This event demonstrates the delicacy of _human psychology_. Notice also that our AUs for constructing red cubes, reliably looking at blue things, and surviving are _also_ ruined. Our power has been decreased.
 
-## Detailing the catastrophic convergence conjecture (CCC)
+# Detailing the catastrophic convergence conjecture (CCC)
 
 In general, the CCC follows from two sub-claims.
 
@@ -155,7 +155,7 @@ While there _exist_ agents which cause catastrophe for other reasons (e.g. an AI
 
 _Edit_: The initial version of this post talked about "outer alignment"; I changed this to just talk about _alignment_, because the outer/inner alignment distinction doesn't feel relevant here. What matters is how the AI's policy impacts us; what matters is [_impact alignment_](/non-obstruction-motivates-corrigibility).
 
-## Prior work
+# Prior work
 
 > [!quote] Jessica Taylor, [Pursuing convergent instrumental subgoals on the user's behalf doesn't always require good priors](https://www.alignmentforum.org/posts/5bd75cc58225bf06703752da/pursuing-convergent-instrumental-subgoals-on-the-user-s-behalf-doesn-t-always-require-good-priors)
 >

--- a/website_content/what-you-see-isn-t-always-what-you-want.md
+++ b/website_content/what-you-see-isn-t-always-what-you-want.md
@@ -60,7 +60,7 @@ Under this view, alignment isn’t a property of reward functions: it’s a prop
 
 Yikes.
 
-## Qualifications
+# Qualifications
 
 The argument seems to hold for $n$\-step Markovian reward functions, if $n$ isn’t ridiculously large. If the input observation space is rich, then the problem probably relaxes. The problem isn't present in fully observable environments: by force of theorem (which presently assumes determinism and a finite state space), there exist Markovian reward functions whose only optimal policy is desirable.
 


### PR DESCRIPTION
## Summary

Fixes the seven remaining findings flagged in the audit that opened #1733 — the correctness bugs, the dev-script perf/robustness issues, and the minor short-circuit. Each fix is in its own commit for reviewability.

### Commits

1. **`fix(toc)`** — `Footnotes` TOC entry was pushed with a hard-coded `depth: 1`, then every entry was shifted by `-highestDepth`. When a doc's shallowest body heading was `h2`+ (`highestDepth ≥ 2`), Footnotes landed at a negative adjusted depth and `TableOfContents.buildNestedList` silently broke out of the walk, dropping the link. Push at `depth: highestDepth` so its shifted depth is always `0`.
2. **`fix(download)`** — `download_external_media.py` clobbered downloads when two URLs shared a basename (both wrote `asset_staging/image.png` → second overwrote first, both markdown refs pointed at the same local path). Added `disambiguate_filename` (URL-hash prefix on collision) and a `target_filename` override on `download_media`. Also inverted the rewrite loop from O(urls × files) reads/writes to one pass per markdown file via a new `replace_urls_in_file(url_map)` helper.
3. **`perf(r2_upload)`** — `check_exists_on_r2` called `rclone ls r2:{bucket}` (full-bucket enumeration) then filtered client-side for one key — a bulk upload of N files was O(N × bucket_size). Switch to `rclone lsf --files-only r2:{bucket}/{key}` (single-key query). Distinguish rclone's exit-3 "directory not found" and stable stderr signal from a genuine failure so real errors surface as `RuntimeError` rather than false-negative "missing".
4. **`refactor(convert_markdown)`** — Bespoke `^---\n(.*?)\n---\n(.*)` regex silently returned `None` for fences carrying trailing whitespace (`---  \n`) or blocks ending at EOF. Replaced with `script_utils.split_yaml` (the parser the rest of the codebase already uses).
5. **`fix(build_fonts)`** — `main()` created its build dir via `tempfile.mkdtemp` and never removed it, so every verify/install run leaked a `build_fonts_*` directory. Wrap in `TemporaryDirectory` so cleanup fires on both the success and drift-triggered `sys.exit(1)` paths.
6. **`perf(populateContainers)`** — `findElementById` used `findElements` (full-tree walk collecting all matches) and returned the first. HTML id attributes are unique per document, so short-circuit at first hit with `visit` + `EXIT`.

### Verification

- All impacted TypeScript modules keep 100% coverage (`favicons.ts`, `toc.ts`, `populateContainers.ts`).
- All impacted Python modules keep 100% coverage (`download_external_media.py`, `r2_upload.py`, `convert_markdown_yaml.py`); `build_fonts.py` coverage climbs from 93% → 97%.
- `tsc --noEmit`, ESLint, Prettier, pylint (10.00/10) all clean.
- Every fix ships with a regression test that fails on the old code and passes on the new (I verified the download-collision, TOC-h2, r2-lsf, and populateContainers short-circuit tests explicitly).

### Notes for reviewers

- `test_r2_upload.py`: several existing tests used a bare `patch("subprocess.run")` without configuring the mock, relying on `MagicMock`'s iteration semantics to make `check_exists_on_r2` return `False` incidentally. With the new implementation those need an explicit `returncode=3` / "directory not found" stderr; I updated them (they now correctly model rclone's behavior). Tests are strengthened, not loosened.
- `convert_markdown_yaml.py`: `write_yaml_frontmatter` emits its own `---\n` fence-and-newline, so I strip one leading `\n` from `split_yaml`'s returned body to preserve round-trip byte-equality — otherwise the rewrite would introduce a blank line between fence and body.
- `download_external_media.py`: the disambiguation prefix is a URL-derived SHA1 first 8 chars, so it's deterministic across runs (no re-download churn on identical inputs).

### Lessons learned

- **Test expectations that encode implementation quirks (rather than externally-observable invariants) rot the moment the implementation changes.** The r2_upload tests asserting `["rclone", "ls", "r2:bucket"]` verbatim were a symptom, not a signal — the same tests couldn't distinguish "the code queries the whole bucket" from "the code queries the exact key" if the second-arg didn't happen to be `"ls"`. When updating, assert the *behavior* (queries the exact key path) rather than the *shell string* whenever possible.
- **Bespoke frontmatter/YAML parsers accumulate silent-skip bugs faster than shared ones.** The `convert_markdown_yaml` regex was three lines and still had two known edge cases the shared parser handled correctly. When a repo already has a centralized parser for a text format, prefer duplication of the *call* over duplication of the *parser*.
- **`visit` from `unist-util-visit` supports `EXIT` for single-hit walks.** Any HAST traversal that filters-then-picks-first (id lookups, first-match by tagName, etc.) should return `EXIT` on match rather than collecting and slicing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zcQnjv2SNPSXC1qFePuzK

---
_Generated by [Claude Code](https://claude.ai/code/session_014zcQnjv2SNPSXC1qFePuzK)_