### PR TITLE
De-flake WebKit video paints: stop restarting an in-flight fetch before captures

### DIFF
--- a/quartz/components/tests/visual_utils.ts
+++ b/quartz/components/tests/visual_utils.ts
@@ -779,7 +779,9 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
             reject(
               new Error(
                 `Video never painted within ${dataTimeoutMs}ms ` +
-                  `(readyState=${videoEl.readyState}): ${videoEl.currentSrc || "<no src>"}`,
+                  `(readyState=${videoEl.readyState}, ` +
+                  `networkState=${videoEl.networkState}): ` +
+                  `${videoEl.currentSrc || "<no src>"}`,
               ),
             )
           }, dataTimeoutMs)
@@ -825,10 +827,14 @@ async function waitForVideosPainted(scope: Page | Locator): Promise<void> {
             videoEl.addEventListener("loadeddata", waitForPaint, { once: true })
             // WebKit parks a paused video at HAVE_METADATA and fetches no
             // further media data until something asks for it, so waiting on
-            // "loadeddata" alone can never return. Kick the load at every
-            // readyState below HAVE_CURRENT_DATA; navbar.inline.ts kicks the
-            // same stall on the page itself.
-            videoEl.load()
+            // "loadeddata" alone can never return. Kick the load only while no
+            // fetch is in flight: `load()` restarts resource selection from
+            // scratch, discarding whatever the `preload="auto"` fetch already
+            // buffered and returning the element to HAVE_NOTHING.
+            // navbar.inline.ts guards the same kick on the page itself.
+            if (videoEl.networkState !== HTMLMediaElement.NETWORK_LOADING) {
+              videoEl.load()
+            }
           }
         }),
       VIDEO_PAINT_TIMEOUT_MS,


### PR DESCRIPTION
Fixes the `visual-testing-macos` flake that turned a shard red on #1737.

## The failure

```
[Desktop Safari] › quartz/components/tests/navbar.spec.ts:424:3
  › Left sidebar is visible on desktop in dark mode (screenshot)

Error: Video never painted within 15000ms (readyState=0):
       http://localhost:8080/static/pond.mov
```

`readyState=0` is HAVE_NOTHING — the element had no metadata at all after 15s, despite `preload="auto"`. That is the tell: the video was not slow, it had been **reset**.

## Root cause

`waitForVideosPainted` kicked `videoEl.load()` unconditionally at every `readyState` below HAVE_CURRENT_DATA. But `Navbar.tsx:114-127` gives the pond video `preload="auto"` and lists the HEVC `.mov` *first*:

```tsx
<video id={pondVideoId} loop muted playsInline preload="auto" ...>
  ``&lt;source src="/static/pond.mov" type="video/mp4; codecs=hvc1" /&gt;``
  ``&lt;source src="/static/pond.webm" type="video/webm" /&gt;``
</video>
```

So WebKit selects the `.mov` directly and starts fetching on page load. `pinDecodableVideoSource` correctly leaves it alone (it only repoints videos that landed on the WebM). Then `waitForVideosPainted` called `load()` on it — and `load()` aborts any in-flight fetch and restarts resource selection from scratch. The buffered progress was discarded, the element dropped back to HAVE_NOTHING, and the 15s budget was spent refetching.

That also explains the flakiness: when the preload happened to complete before the capture, `readyState >= 2` and the `else` branch never ran at all. The failure only appears when a capture races an unfinished preload.

## Fix

Guard the kick on `networkState`, which is the idiom the site's own code already uses at `navbar.inline.ts:151`:

```ts
if (videoEl.networkState !== HTMLMediaElement.NETWORK_LOADING) {
  videoEl.load()
}
```

- `NETWORK_LOADING` — a fetch is already running; wait for `loadeddata` instead of restarting it.
- Anything else (`NETWORK_IDLE`, `NETWORK_EMPTY`, `NETWORK_NO_SOURCE`) — genuinely parked, so the kick still fires. This preserves the HAVE_METADATA stall fix from dac0d4d.

The timeout error now also reports `networkState` next to `readyState`. That pair is what distinguishes a stalled load from a parked one, and its absence is why diagnosing this took an artifact dig.

## What this does not do

No timeout was raised, no retry count changed, no assertion weakened — the 15s budget is untouched. The whole point is that the budget was being spent on a self-inflicted refetch.

## Testing

`tsc --noEmit`, `eslint`, and `prettier --check` are clean.

There's no new unit test: `visual_utils.ts` is Playwright-only test infrastructure with no Jest coverage, and the defect is a fetch-timing race that a stubbed `networkState` would assert into existence rather than reproduce. The real exercise is the macOS/WebKit visual shards, which run this path on every screenshot — the pond video is in the navbar on every page.

## Lessons learned

- **`HTMLMediaElement.load()` is destructive, not idempotent.** It aborts any in-flight fetch and restarts the resource selection algorithm. Test helpers that "kick" a stalled media element must first check `networkState !== NETWORK_LOADING`, or they convert a slow load into a failed one — and the resulting flake looks like an engine bug rather than a self-inflicted reset.
- **When a media timeout reports `readyState=0` despite `preload="auto"`, suspect a reset rather than slowness.** An element that was never going to load and an element that was reset mid-load are indistinguishable without `networkState`; include both in media-timeout diagnostics from the start.
- **Test infrastructure should reuse the guards the production code already derived.** The site's `navbar.inline.ts` had the correct `networkState` check; the test helper reimplemented the same kick without it. When prod and test both poke the same browser API, the test helper is usually the one missing hard-won conditions.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zcQnjv2SNPSXC1qFePuzK)_