### PR TITLE
fix(links): bind broken @title on the reward-hacking page

### DIFF
--- a/quartz/plugins/transformers/bindLinkTitles.test.ts
+++ b/quartz/plugins/transformers/bindLinkTitles.test.ts
@@ -176,10 +176,11 @@ describe("bindTitlesInTree", () => {
     expect(textOf(root)).toContain("@title")
   })
 
-  it("leaves the sentinel on an external/unresolvable link as literal text", () => {
+  it("throws on the sentinel on an external/unresolvable link", () => {
     const root = tree(boundAnchor({ href: "https://example.com" }))
-    bindTitlesInTree(root, idx, "source" as FullSlug, "source.md")
-    expect(textOf(root)).toContain(">@title<")
+    expect(() => bindTitlesInTree(root, idx, "source" as FullSlug, "source.md")).toThrow(
+      /external or unresolvable href "https:\/\/example\.com"/,
+    )
   })
 
   it("ignores anchors without an href", () => {

--- a/quartz/plugins/transformers/bindLinkTitles.ts
+++ b/quartz/plugins/transformers/bindLinkTitles.ts
@@ -86,8 +86,9 @@ const sentinelTextRegex = new RegExp(
  * resolved) and before AddFavicons (so the favicon is woven into the real
  * title, not the sentinel). Punctuation surrounding the sentinel inside the
  * anchor is preserved around the resolved title. Throws when a bound link
- * targets a missing page or heading—this surfaces drift when a page or
- * heading is renamed.
+ * targets a missing page or heading, or an external href—this surfaces drift
+ * when a page or heading is renamed, and catches sentinels that would
+ * otherwise render as literal "@title".
  */
 export function bindTitlesInTree(
   tree: Root,
@@ -114,8 +115,11 @@ export function bindTitlesInTree(
     } else if (href.startsWith("#")) {
       targetSlug = curSlug
     } else {
-      // Sentinel on an external or unresolvable link: leave it as literal text.
-      return
+      // Only an internal target has a title to bind, so a sentinel here can
+      // never resolve and would otherwise ship as literal "@title".
+      throw new Error(
+        `Title-bound link in ${source} points at external or unresolvable href "${href}".`,
+      )
     }
 
     const target = targetSlug ? index.get(targetSlug) : undefined

--- a/website_content/reward-hacking-doesnt-show-reward-is-optimization-target.md
+++ b/website_content/reward-hacking-doesnt-show-reward-is-optimization-target.md
@@ -172,7 +172,7 @@ Why didn't I realize this in 2022? I didn't yet deeply understand LLMs. As evide
 
 To my credit, I noted my ignorance:
 
-> [!quote] [@title](https://github.com/alexander-turner/TurnTrout.com/blob/main/website_content/reward-is-not-the-optimization-target.md)
+> [!quote] [@title](/reward-is-not-the-optimization-target)
 > Pretraining a language model and then slotting that into an RL setup changes the initial \[agent's\] computations in a way which I have not yet tried to analyze.
 
 # Conclusion


### PR DESCRIPTION
## Summary

- [Reward hacking doesn't show that reward is the optimization target](https://turntrout.com/reward-hacking-doesnt-show-reward-is-optimization-target) rendered a literal `@title` (with a GitHub favicon) as the attribution of the closing `[!quote]`.
- The cause: the link pointed at the target's GitHub blob URL rather than its site slug, and `BindLinkTitles` silently left unresolvable sentinels as literal text.
- Both halves are fixed, so a future mis-targeted `@title` fails the build instead of shipping.

## Changes

- `website_content/reward-hacking-doesnt-show-reward-is-optimization-target.md`: point the quote attribution at `/reward-is-not-the-optimization-target`.
- `quartz/plugins/transformers/bindLinkTitles.ts`: throw on a `@title`/`@title-lower` sentinel whose href is external or otherwise unresolvable, matching the existing throws for missing pages and headings.
- `quartz/plugins/transformers/bindLinkTitles.test.ts`: the external-link case now asserts the throw.

## Testing

- `jest quartz/plugins/transformers/bindLinkTitles.test.ts` — 31 passed, 100% coverage on `bindLinkTitles.ts`.
- Repo-wide grep confirms this was the only `@title` sentinel on a non-internal href, so no other page trips the new error.

## Lessons learned

- **What**: When a transformer has a "leave it alone" branch for input it cannot resolve, prefer throwing — a silent fallback ships the raw sentinel/placeholder to production.
- **Where**: `quartz/plugins/transformers/bindLinkTitles.ts` (generalizes to any placeholder-substitution pass).
- **Why**: The literal `@title` sat live on the site because the only unresolvable-href path returned quietly instead of failing the build.


---
_Generated by [Claude Code](https://claude.ai/code/session_013nGaRj7V1XeLMeLPcvAS9T)_