### PR TITLE
fix(checks): catch a title sentinel split across text nodes

### DIFF
--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -408,26 +408,38 @@ def check_unrendered_title_sentinel(soup: BeautifulSoup) -> list[str]:
     ``@title-lower``).
 
     A surviving sentinel means the build-time title binding never resolved,
-    leaking the raw token into the page instead of the target's title. The
-    sentinel is matched as a substring of any non-code text node—not just as
-    exact link text—because formatting passes can move punctuation into the
-    anchor around the sentinel or split it into sibling text nodes.
+    leaking the raw token into the page instead of the target's title. Anchor
+    text is matched as one joined string because the favicon pass lifts a
+    link's trailing characters into a ``nowrap-span``, so no single text node
+    holds the whole sentinel. Text outside anchors is matched per node, as a
+    substring, since formatting passes can leave punctuation beside it.
     Legitimate mentions of the sentinel live inside ``<code>`` elements, which
     ``should_skip`` excludes.
     """
     leaked: list[str] = []
-    for element in soup.find_all(string=True):
-        if not isinstance(element, NavigableString):  # pragma: no cover
-            continue
-        if not element.strip() or should_skip(element):
-            continue
-        match = _TITLE_SENTINEL_PATTERN.search(str(element))
+
+    def record(text: str) -> None:
+        match = _TITLE_SENTINEL_PATTERN.search(text)
         if match:
             _append_to_list(
                 leaked,
-                str(element),
+                text,
                 prefix=f"Unrendered title sentinel {match.group(0)}: ",
             )
+
+    for link in soup.find_all("a"):
+        if not should_skip(link):
+            record(link.get_text())
+
+    for element in soup.find_all(string=True):
+        if (
+            not element.strip()
+            or should_skip(element)
+            or element.find_parent("a") is not None
+        ):
+            continue
+        record(str(element))
+
     return leaked
 
 

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -2403,6 +2403,18 @@ def test_check_invalid_internal_links(html, expected_count):
         ('<a href="/page">“@title.”</a>', 1),
         # A leaked sentinel outside any anchor is also flagged.
         ("<p>Check out @title-lower today.</p>", 1),
+        # The favicon pass lifts the link's last characters into a
+        # `nowrap-span`, so the sentinel spans two text nodes.
+        (
+            '<a href="https://example.com">@t'
+            '<span class="nowrap-span">itle<svg class="favicon"/></span></a>',
+            1,
+        ),
+        (
+            '<a href="https://example.com">@title-l'
+            '<span class="nowrap-span">ower<svg class="favicon"/></span></a>',
+            1,
+        ),
         # Sentinel glued to letters/digits is prose, not a leak (mirrors the
         # transformer, which leaves such anchors untouched).
         ("<p>@titles and quote smallcaps</p>", 0),


### PR DESCRIPTION
## Summary

- The `@title` leak fixed in #1740 should have been caught by `built-site-checks`, but `check_unrendered_title_sentinel` missed it.
- Cause: the favicon pass (`spliceAndWrapLastChars`, `maxCharsToRead = 4`) lifts a link's last four characters into a `nowrap-span`, so the leaked anchor rendered as `@t` + `<span class="nowrap-span">itle<svg class="favicon"/></span>`. The check scanned one text node at a time, and neither `@t` nor `itle` matches the sentinel.
- Now anchor text is matched as one joined string, so a split sentinel is caught in the built HTML regardless of how the transformer behaves.

## Changes

- `scripts/built_site_checks.py`: `check_unrendered_title_sentinel` scans each `<a>`'s joined text, and keeps the per-node scan for text outside anchors (so a sentinel leaked into prose is still flagged and nothing is double-reported).
- `scripts/tests/test_built_site_checks.py`: two cases covering the exact split-node markup the favicon pass emits, for both `@title` and `@title-lower`.

## Testing

- `uv run pytest scripts/tests/test_built_site_checks.py` — 1035 passed. The new cases fail against the previous implementation (both text nodes are sub-sentinel fragments).

## Lessons learned

- **What**: When a built-HTML check greps text nodes for a token, match the joined text of the enclosing element too — later transform passes routinely split a token across sibling nodes, silently blinding a per-node scan.
- **Where**: `scripts/built_site_checks.py` (any per-`NavigableString` check).
- **Why**: The favicon pass moves a link's trailing characters into a `nowrap-span`, so the sentinel check that was supposed to be the safety net never saw the leak it was written for.


---
_Generated by [Claude Code](https://claude.ai/code/session_013nGaRj7V1XeLMeLPcvAS9T)_