### PR TITLE
fix(navbar): center "Search" text in the nav search pill

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -60,6 +60,10 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
       cursor: pointer;
       width: 0.625rem;
 
+      // Overrides the global bottom margin on `svg`, which the flex line would
+      // otherwise center along with the glyph and leave the icon sitting high.
+      margin: 0;
+
       .search-path {
         stroke: var(--midground);
         stroke-width: 2px;

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -42,7 +42,11 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
       font-size: var(--font-size-minus-1);
       color: color-mix(in srgb, var(--midground) 75%, var(--foreground));
       display: inline;
-      padding: 0;
+
+      // Nudges the glyphs down to their optical center: EBGaramond's line box
+      // reserves more room above the cap line than below the baseline, so an
+      // untouched flex-centered box leaves "Search" looking too high.
+      padding: 0.125em 0 0;
       margin: 0 $base-margin;
 
       // Make it more centered for mobile

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -34,6 +34,11 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
     cursor: pointer;
     white-space: nowrap;
 
+    // Matching the gap after the magnifying glass to the padding after the
+    // label centers "Search" in the width the glass leaves over.
+    gap: calc(1.5 * $base-margin);
+    padding: 0 calc(1.5 * $base-margin) 0 $base-margin;
+
     & > div {
       flex-grow: 1;
     }
@@ -42,24 +47,18 @@ $search-panel-max-height: 100vh - $search-space-top-offset - $search-modal-botto
       font-size: var(--font-size-minus-1);
       color: color-mix(in srgb, var(--midground) 75%, var(--foreground));
       display: inline;
+      margin: 0;
 
       // Nudges the glyphs down to their optical center: EBGaramond's line box
       // reserves more room above the cap line than below the baseline, so an
       // untouched flex-centered box leaves "Search" looking too high.
       padding: 0.125em 0 0;
-      margin: 0 $base-margin;
-
-      // Make it more centered for mobile
-      @media all and (max-width: $max-mobile-width) {
-        margin-right: calc(1.5 * $base-margin);
-      }
     }
 
     // The actual search icon
     & svg {
       cursor: pointer;
       width: 0.625rem;
-      margin: 0 $base-margin;
 
       .search-path {
         stroke: var(--midground);
@@ -377,10 +376,4 @@ $match-color: var(--green);
 // which animates `color` back to `inherit`, is left untouched.
 #search-container .search-match {
   color: $match-color !important;
-}
-
-@media all and (max-width: $tablet-breakpoint) {
-  .search > #search-icon > p {
-    padding: 0;
-  }
 }

--- a/quartz/styles/variables.ts
+++ b/quartz/styles/variables.ts
@@ -25,7 +25,7 @@ export const lineHeight = "1.8rem"
 export const listPaddingLeft = "1.875rem"
 export const fontScaleFactor = 1.2
 
-export const backgroundDark = "#000000"
+export const backgroundDark = "#000"
 export const backgroundLight = "#fcfcff"
 export const foregroundDark = "#eff2ff"
 export const foregroundLight = "#383a4e"


### PR DESCRIPTION
## Summary

Centering fixes for the "Search" label in the nav search pill, plus one unrelated CI fix.

**Vertical (label).** The label sat visibly high inside its bordered box. `EBGaramond`'s line box reserves more empty room above the cap line than below the baseline, so flex-centering the untouched `<p>` left the glyphs looking too high even though the invisible font-metrics box was itself centered. `padding-top: 0.125em` nudges the glyphs down to their optical center.

**Horizontal (label).** The magnifying glass's `margin-right` and the label's `margin-left` *both* contributed to the gap before "Search", so the label sat twice as far from the glass as from the pill's right edge — crowding the right border. Both margins are replaced by a single `gap` on the flex container plus matching right padding, so the label is centered in the width the glass leaves over. On desktop the pill keeps its exact width and the glass keeps its position; only the label moves. The ad-hoc `margin-right: calc(1.5 * $base-margin)` mobile hack that partially compensated for this is no longer needed and is removed.

**Vertical (icon).** Dropping the icon's `margin: 0 $base-margin` in favour of container `gap` had a side effect: a site-wide `svg { margin-bottom: 0.5rem }` rule had been shadowed by that shorthand, and once it applied, `align-items: center` centered the icon's *margin box* and lifted the glyph half a base margin above the flex line. The icon's margin is now reset explicitly.

While fixing the horizontal case I also found that a trailing `@media (max-width: $tablet-breakpoint)` rule setting `padding: 0` on the label was cancelling the vertical nudge at ≤1000px. That rule was dead code before this PR (the label's padding was already `0`), so it's removed and the vertical fix now applies at every width.

**Unrelated CI fix.** `$background-dark: #000000` in `quartz/styles/variables.ts` violated stylelint's `color-hex-length` rule once the generated `variables.scss` was linted, failing `lint` on this PR. Shortened to `#000` (equivalent CSS/HTML color, used only as a `theme-color` meta value).

## Verification

Built the site offline and pixel-measured the rendered `#search-icon` at 8x device scale — detecting the border rows/columns and the glyph *ink* extents from the screenshot, rather than trusting `getBoundingClientRect`.

Label, horizontal (ink off-center within the space right of the glass; `+` = too far right):

| viewport | before | after | pill width |
| --- | --- | --- | --- |
| desktop 1500px | **+6.81px** | **+0.81px** | 115.00px → 115.00px (unchanged) |
| mobile 390px | **+2.50px** | **+0.50px** | 92px → 87px |

Vertical (ink center vs. box center; `−` = too high):

| viewport | label before | label after | icon before | icon after |
| --- | --- | --- | --- | --- |
| desktop 1500px | −0.19px | −0.19px | −0.06px | −0.06px |
| mobile 390px | **−1.56px** | **−0.56px** | 0.00px | 0.00px |

The mobile label column is the win from deleting the dead `padding: 0` rule. The icon columns are the regression above, caught and reverted to baseline — intermediate state was −6.06px (desktop) / −4.94px (mobile). Residual sub-pixel offsets on the label are glyph side-bearing asymmetry, which is ordinary typesetting and not worth over-fitting to one string.

Also confirmed the `1.5` and `1` `$base-margin` multipliers are dyadic, and that the built `index.css` contains the expected rules.

## Test plan

- [x] `pnpm exec stylelint 'quartz/**/*.scss' --config config/stylelint/.stylelintrc.json` — clean
- [x] `jest quartz/styles/tests/base-margin-multipliers.test.ts` — 16/16 pass
- [x] `jest quartz/util/tests/head.test.ts quartz/styles` — 58/58 pass
- [x] Offline production build succeeds; generated CSS verified
- [x] Pixel-measurement verification of both icon and label at desktop + mobile (see above)
- [ ] CI (visual regression, a11y, lighthouse, etc.) — see checks on this PR

## Lessons learned

- **Removing a shorthand can un-shadow a global rule.** `margin: 0 $base-margin` was silently doing two jobs: setting the horizontal spacing *and* zeroing a site-wide `svg { margin-bottom }`. Replacing it with a container `gap` kept the first job and lost the second. Before deleting a shorthand declaration, check what the element's computed value becomes without it — not just what the declaration appeared to be for.
- **Validate the built output, not a hand-written approximation of it.** This regression survived my verification pass because I prototyped the change as an injected stylesheet using `margin: 0 !important` on the icon, then shipped SCSS that *deleted* the margin declaration instead. The two are not the same CSS. Prototyping against a live page is fine for iterating, but the final measurement must run against the real build.
- **Measure every element the change could move, not just the one you're fixing.** My verification measured the label's ink at both viewports and the icon's not at all, so a 6px icon shift went unnoticed until a human looked at the diff gallery. When a change alters a shared container's layout model, re-measure every child.
- Text next to an icon in a flex-centered box can be mathematically centered by font metrics (`Range.getBoundingClientRect` on the text node) while still looking visually off, because a font's ascent/descent metrics aren't symmetric around the actual glyph ink for strings without descenders. Verify centering claims with rendered pixel measurements (screenshot + border/ink detection), not DOM rects — the latter reflects the font's em-box, not the visible glyphs.
- When two adjacent flex children each carry a margin on their facing edges, the visual gap is the *sum* of both, which silently doubles it relative to the container's own padding. Prefer a single `gap` on the container plus container padding, so the spacing budget is stated in one place and stays symmetric by construction.
- Before adding a rule, check whether a later rule in the same file already resets the property you're setting. A redundant reset (`padding: 0` on an element whose padding was already `0`) is invisible dead code right up until someone sets that property, at which point it silently cancels the new value at some breakpoints only.
- A CI `lint` failure on a generated file (gitignored, regenerated from a `.ts` source at build time) can be latent on `main` until some PR happens to trigger a full lint pass on it — fix it in whatever PR surfaces it rather than treating it as out of scope.
