### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/alexander-turner__claude-guard__main__README.md
@@ -215,7 +215,7 @@ On top of those walls sit **best-effort filters**. They raise the bar, but a det
 
 ### The monitor is experimental
 
-The monitor is a **work in progress and is OFF by default.** It still reports false positives: it stops safe tool calls and asks you to approve them, which is the opposite of what an unattended session needs. Turn it on for one launch with `--experimental-monitor`; it needs its own API key (see [`docs/configuration.md` § Monitor](docs/configuration.md#monitor)). Nothing else depends on it. The microVM, the outgoing-traffic firewall, the deny rules, auto mode and the tamper-evident audit log all run whether the monitor is on or off.
+The monitor is a **work in progress and is OFF by default.** It still reports false positives: it stops safe tool calls and asks you to approve them, which is the opposite of what an unattended session needs. Turn it on for one launch with `--experimental-monitor`; it needs its own API key (see [`docs/configuration.md` § Monitor](docs/configuration.md#monitor)). Nothing else depends on its verdict. The microVM, the outgoing-traffic firewall, the deny rules, auto mode and the tamper-evident audit log all run whether the monitor is on or off. The host monitor process still starts on every sandbox launch, because the output sanitizer runs its HTML parser there instead of inside the VM; with the review off it costs no API key.
 
 Sessions are **ephemeral by default**: attackers can't lay landmines in the system state which are hard for monitors to spot. Claude's work is backed out fine, but the rest of the session state is lost. That'd normally be annoying (e.g. re-login to every service) but I did some fancy mitigations.
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.