### PR TITLE
fix(tests): scroll the sidebar instantly in the mid-scroll screenshot

### DIFF
--- a/quartz/components/tests/visual-regression.spec.ts
+++ b/quartz/components/tests/visual-regression.spec.ts
@@ -1107,12 +1107,22 @@ test.describe("Right sidebar", () => {
     // any geometry measurement, so a target derived from `scrollHeight` lands
     // a few pixels apart between runs. 40 synthetic entries overflow well past
     // this offset, so both fades stay active — asserted below.
+    //
+    // `behavior: "instant"` overrides the sidebar's `scroll-behavior: smooth`,
+    // which would otherwise animate this scroll: the capture's own
+    // reduced-motion emulation flips that property to `auto` mid-flight, and
+    // Blink abandons the animation wherever it has reached, freezing the
+    // sidebar a couple of pixels short of the target.
     const scrollOffsetPx = 200
     await rightSidebar.evaluate((el, offset) => {
-      el.scrollTop = offset
+      el.scrollTo({ top: offset, behavior: "instant" })
     }, scrollOffsetPx)
     await expect(rightSidebar).toHaveClass(/can-scroll-up/)
     await expect(rightSidebar).toHaveClass(/can-scroll-down/)
+    // A sidebar sitting anywhere but the target renders every entry off by the
+    // difference, which reads as a whole-image baseline diff rather than the
+    // scroll bug it is.
+    expect(await rightSidebar.evaluate((el) => el.scrollTop)).toBe(scrollOffsetPx)
 
     await takeRegressionScreenshot(page, testInfo, "right-sidebar-fade-mid-scroll", {
       elementToScreenshot: rightSidebar,


### PR DESCRIPTION
## Summary

`Right sidebar fade at mid-scroll (screenshot)` has been the sole snapshot failure on `main` since 2026-08-22 — every entry rendered a uniform 2px off the baseline. It is not a stale baseline: the test's scroll never reliably lands on its target.

## Root cause

`#right-sidebar` carries `scroll-behavior: smooth` on desktop (`quartz/styles/scroll-indicator.scss` sits alongside it in `base.scss:292`), so `el.scrollTop = 200` starts an *animated* scroll rather than jumping. `takeRegressionScreenshot` then calls `page.emulateMedia({ reducedMotion: "reduce" })`, which the site's global `prefers-reduced-motion` block turns into `scroll-behavior: auto !important` — and Blink abandons the in-flight animation wherever it stands.

Measured directly, back to back:

| scroll call | `scrollTop` after reduced-motion emulation (5 runs) |
| --- | --- |
| `el.scrollTop = 200` | `0 0 0 0 0` |
| `el.scrollTo({ top: 200, behavior: "instant" })` | `200 200 200 200 200` |

In the real test the intervening `toHaveClass` assertions usually give the animation time to finish, so an idle machine lands on 200. A contended runner does not. The baseline approved by `update-visual-baselines` run 32544200002 (2026-08-22T01:42:23Z, twelve seconds before the first red visual-testing run) captured one of those short landings.

## Evidence

Reproduced locally against an offline build, byte-exact:

- Current code renders identical to CI's `-actual.png` (mean abs diff `0.000`).
- Rendering at `scrollOffsetPx = 198` matches the R2 baseline byte-for-byte — the test passes with no actual written.
- Best-fit translation between CI's expected and actual is exactly `dy = 2` at mean abs diff `0.022`; nothing else in the capture differs.
- Reverting #1744 (the only commit between the last green and first red run) changes the capture not at all, ruling out a layout regression.

## Changes

- `visual-regression.spec.ts`: scroll with `behavior: "instant"`, which ignores the CSS property, and assert the settled `scrollTop` before capturing so a future re-scroll surfaces as a test failure rather than a whole-image baseline diff.

## Testing

- `Right sidebar fade at mid-scroll (screenshot)` × 6, four workers, six busy CPUs pinning the box: all green against a 200-offset baseline. The remaining failures in that run are the three sibling screenshots whose baselines live in R2 and were never downloaded locally.
- `pnpm check` — tsc and stylelint clean; Prettier's three warnings (`.titleIndex.json`, two READMEs) are pre-existing on `main` and untouched here.
- `eslint -c config/javascript/eslint.config.js` on the changed file: clean.

## Note on the baseline

The current R2 baseline is the frozen-at-198 capture, so visual-testing will still show this one screenshot as a diff on this PR — now the *correct* 200 render. That's yours to approve; I have not dispatched `update-visual-baselines`.

## Lessons learned

- **What**: setting `scrollTop`/`scrollLeft` on a container with `scroll-behavior: smooth` starts an animation, not a jump. In a screenshot test, scroll with `scrollTo({ behavior: "instant" })` and assert the settled offset before capturing.
- **Where**: any visual-regression helper that emulates reduced motion (or otherwise mutates `scroll-behavior`) after the test has scrolled.
- **Why**: flipping `scroll-behavior` to `auto` mid-flight makes Blink abandon the animation at its current position. The capture is *stable* at the wrong offset, so a two-equal-frames stabilization loop cannot catch it — it surfaces only as a small uniform image shift, and can be approved into the baseline.

- **What**: when a visual baseline goes red and stays red, check the baseline-approval workflow's run history against the first red run before hunting a code regression.
- **Where**: `update-visual-baselines.yaml` run list vs. `visual-testing.yaml` run list.
- **Why**: an approval that lands seconds before the first failure means a flaky capture was promoted to baseline. Bisecting the commits in that window finds nothing, because the commits are innocent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ji4NyQbEG69Tri1UgRQLVF)_