### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
@@ -1,10 +1,15 @@
 # agent-resolve-merge-conflicts
 
-A reusable GitHub Actions workflow that resolves one pull request's merge conflicts with its base branch, then pushes the result back as a normal merge commit.
+**A reusable GitHub Actions workflow that clears a pull request's merge conflicts for you.** It merges the base branch into the pull request, then pushes the result as an ordinary merge commit.
 
-It runs two passes. A deterministic pre-pass re-derives every conflicted DERIVED file — a generated artifact through its generator, a lockfile through its own lock command. An LLM pass then handles the SOURCE conflicts that remain. A conflict with neither a deterministic nor a textual resolution (a binary file, or a `-merge` file no rule owns) fails the run with a pull request comment BEFORE any model cost.
+It resolves in two passes:
 
-Callers pin this workflow by commit SHA. Nothing is published to a package registry, and the workflow is not listed on the GitHub Marketplace — see [Versioning](#versioning) and [Decisions](#decisions).
+1. **The pre-pass rebuilds every conflicted generated file instead of guessing it.** A lockfile goes through its own lock command, and a generated artifact through its generator.
+2. **A model resolves the source conflicts that remain.**
+
+A conflict that neither pass can settle stops the run and comments on the pull request. A binary file is one example, and a `-merge` file that no rule owns is another. This check runs before any model call, so an unresolvable conflict costs nothing.
+
+You call it from your own repository by `uses:`, pinned to a commit with the release version in a trailing comment — see [Versioning](#versioning).
 
 ## Call it
 
@@ -20,7 +25,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@<sha>
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@7e68f3683d1247c66109aa6293bf358565a03d98 # v1.10.1
     with:
       pr: ${{ matrix.pr.number }}
       resolver-repository: AlexanderMattTurner/agent-resolve-merge-conflicts
@@ -109,9 +114,21 @@ The `secrets:` block names 10 secrets and never uses `secrets: inherit`. The lis
 
 ## Versioning
 
-Each release tags `vX.Y.Z` and advances a moving major tag (`v1`) to the same commit.
+Each release tags `vX.Y.Z` and advances a moving major tag (`v1`) to the same commit. This repository publishes no package, so the git tag IS the release.
 
-**Callers still pin by SHA.** The major tag is not a supply chain you should depend on — it is what makes a bump reviewable: `v1` moving tells you a compatible release exists, and you update your pinned SHA deliberately.
+A `uses:` ref may be a SHA, a tag or a branch. GitHub calls [the commit SHA the safest option](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows), because a tag can be moved onto a commit you never reviewed. `v1` moves on every compatible release, so it is the least reviewable ref this repository offers.
+
+**Pin the SHA and name the version beside it**, the way this repository's own caller does:
+
+```yaml
+uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@7e68f3683d1247c66109aa6293bf358565a03d98 # v1.10.1
+```
+
+That line reads as a version and resolves as an immutable commit. It names the newest release: `.github/scripts/release-tag.sh` rewrites both copies in this README, and the caller's, in the commit after each release. Copy it as it stands.
+
+In your own repository Dependabot's `github-actions` ecosystem updates a reusable-workflow ref, so it bumps the SHA and rewrites the comment for you. This repository moves its own copies instead, because a caller pins the releases of the repository it calls rather than its own.
+
+A tag ref works if you prefer one. The resolver checks out whatever commit the ref names, so nothing inside the run depends on the choice.
 
 ## Tests
 
@@ -124,4 +141,6 @@ uvx zizmor==1.25.2 .github/
 
 ## Decisions
 
-**No GitHub Marketplace listing, and no root `action.yml`.** Listing requires an `action.yml` at the repository root, and only actions are listed — a reusable workflow cannot be listed at all. A thin root composite would be listable, but a composite runs in ONE job, so it cannot give the two-job privilege split that is the reason this workflow exists; publishing one would advertise a shape that silently drops the security boundary. A root `action.yml` also means one listing per repository, so it would cost any later automation here its own listing. SHA pinning needs no listing.
+**No GitHub Marketplace listing, and no root `action.yml`.** [Marketplace lists actions only](https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace), from an `action.yml` in the repository root, so a reusable workflow cannot be listed. A thin root composite would be listable, but a composite runs in ONE job, so it cannot give the two-job privilege split that is the reason this workflow exists; publishing one would advertise a shape that silently drops the security boundary.
+
+A listing is a discovery surface, not a delivery one. Every public repository is already callable by `uses:`, so a listing would change nothing about how you adopt this workflow or how you pin it.

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
@@ -1,12 +1,8 @@
 # `agent-sanitizer`
 
-Most prompt-injection tools run a classifier _over_ the text and hope it
-generalizes. This library targets a narrower, verifiable claim: the
-specific byte-level channels—invisible Unicode, ANSI escapes, human-hidden
-HTML, confusable glyphs and look-alike hosts, exfil-shaped URLs—that let an
-attacker smuggle a payload the operator can't see but the model still reads.
-Every layer is a
-deterministic transform you can unit-test with equality assertions.
+**Cleans untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs, look-alike hosts, and exfil-shaped URLs.
+
+This library handles each channel on its own terms. It strips invisible characters and ANSI escapes by default, splices out hidden HTML when you opt in, and _reports_ exfil-shaped URLs and look-alike hosts rather than rewriting them — mangling a legitimate link is the worse failure. Every layer is a deterministic transform, so you can unit-test it with equality assertions. There is no classifier and no model call, so nothing rests on whether a prediction generalized.
 
 **As a library:**
 
@@ -28,9 +24,7 @@ Enter one at a time:
 
 Finally, navigate: `/plugin` → Marketplaces → `agent-sanitizer` → Enable auto-update.
 
-[What installing entails](#what-installing-entails) covers the footprint of each
-path and how a failure looks; [Using it with Claude
-Code](#using-it-with-claude-code) covers each hook and hand-wiring.
+[What installing entails](#what-installing-entails) covers the footprint of each path and how a failure looks; [Using it with Claude Code](#using-it-with-claude-code) covers each hook and hand-wiring.
 
 ## Quick start
 

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__ci-truth-serum__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__ci-truth-serum__main__README.md
@@ -1,15 +1,11 @@
 # ci-truth-serum
 
-**A green CI check can hide a failure. This pack of pre-commit lints finds the
-places where that happens.** The lints are fast and they run offline. They catch
-two kinds of false report:
+**A green check does not always mean the work passed.** These pre-commit lints find the places where CI reports success over a real failure. They are fast and they run offline.
 
-- **Honesty failures:** the pipeline reports success, but the real work failed.
-  A pipe hides the exit code of the command that failed. Or a required check
-  never reports at all, and the pull request waits forever.
-- **Identity failures:** a base image or a downloaded file names a _mutable_
-  target, such as a tag or a bare URL. The target can change. You cannot prove
-  that the bytes you run are the bytes you reviewed.
+Two things go wrong, and neither one shows up as a red check:
+
+- **The pipeline hides a failure.** A pipe drops the exit code of the command that failed. Or a required check never reports, so the pull request waits forever.
+- **You cannot prove what you ran.** A base image or a download names a tag or a bare URL. That target can change, so the bytes you run may differ from the bytes you reviewed.
 
 ## What it checks
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.