### PR TITLE
fix: split nested admonition bodies from linked titles, guard title length

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -264,6 +264,17 @@ Failures inside the parallel group don’t short-circuit—every sibling finish
 
 Heavier checks (Jest, Playwright, built-site checks, link validation) run in CI.
 
+### Python lint without the hooks
+
+`pnpm check` covers TypeScript/SCSS only, and the pre-push pipeline needs `core.hooksPath` pointed at `.hooks`. Where the hooks aren’t wired up, run `python-lint.yaml`’s steps directly—the pinned ruff version matters, since formatting differs between releases:
+
+```bash
+uv run pyright
+uvx ruff@0.15.8 format --config pyproject.toml scripts/   # --check to only report
+uvx ruff@0.15.8 check --config pyproject.toml scripts/
+uv run pylint . --rcfile config/python/.pylintrc
+```
+
 ### Markdown lint escape hatches
 
 A few `source_file_checks.py` rules judge prose, so each honors an HTML-comment marker anywhere on the offending line. Give a reason after the colon:

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -79,8 +79,16 @@ export function admonitionCollapseState(firstLine: string): "collapsed" | "expan
   return match.groups.collapse === "-" ? "collapsed" : "expanded"
 }
 
-/** Regular expression to match admonition lines in blockquotes */
-const admonitionLineRegex = new RegExp(`^> *\\[!${UNICODE_WORD_CHAR}+\\][+-]?.*$`, "gmu")
+/**
+ * Regular expression to match admonition lines in blockquotes. The `prefix`
+ * group captures every `>` marker leading the line, so an admonition nested
+ * inside another blockquote (`>  > [!quote] …`) matches too and the forced
+ * newline can be re-prefixed to stay inside the same nesting level.
+ */
+const admonitionLineRegex = new RegExp(
+  `^(?<prefix>(?:>[ \\t]*)+)\\[!${UNICODE_WORD_CHAR}+\\][+-]?.*$`,
+  "gmu",
+)
 
 /** Matches tags with Unicode support: #tag, #tag/subtag */
 const tagRegex = new RegExp(
@@ -996,9 +1004,10 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<OFMOption
 
       // pre-transform blockquotes
       if (opts.admonitions) {
-        src = src.replace(admonitionLineRegex, (value: string): string => {
-          // force newline after title of admonition
-          return `${value}\n> `
+        src = src.replace(admonitionLineRegex, (value: string, prefix: string): string => {
+          // force newline after title of admonition, re-using the line's own
+          // blockquote markers so the break lands inside the same blockquote
+          return `${value}\n${prefix}`
         })
       }
 

--- a/quartz/plugins/transformers/tests/ofm.test.ts
+++ b/quartz/plugins/transformers/tests/ofm.test.ts
@@ -204,6 +204,35 @@ describe("markdownPlugins", () => {
     },
   )
 
+  describe("body text under an admonition title", () => {
+    // The full source path: textTransform forces the newline that separates the
+    // title from a body typed on the next line, and only then do the markdown
+    // plugins split the blockquote into title and content nodes.
+    const renderFromSource = (source: string): string => {
+      const transformer = ObsidianFlavoredMarkdown(defaultOptions)
+      /* istanbul ignore next -- textTransform is always defined on the transformer */
+      if (!transformer.textTransform) throw new Error("textTransform is undefined")
+      return testMarkdownPlugins(transformer.textTransform({} as BuildCtx, source) as string)
+    }
+
+    it.each([
+      { name: "top level", markers: ">" },
+      { name: "nested", markers: "> >" },
+      { name: "nested behind an indented marker", markers: ">  >" },
+    ])("separates a linked title from its body when $name", ({ markers }) => {
+      const output = renderFromSource(
+        [
+          `${markers} [!quote] [Headline](https://example.com)`,
+          `${markers} Body text that belongs under the title.`,
+        ].join("\n"),
+      )
+      expect(output).toContain(
+        '<div class="admonition-content"><p>Body text that belongs under the title.</p></div>',
+      )
+      expect(output).not.toContain("Body text that belongs under the title.</span>")
+    })
+  })
+
   describe("usedAdmonitionIcons tracking", () => {
     const collectIcons = (input: string): readonly string[] | undefined => {
       const processor = unified()
@@ -738,6 +767,18 @@ describe("ObsidianFlavoredMarkdown", () => {
       options: { admonitions: true },
       input: "> [!note]",
       expected: "> [!note]\n> ",
+    },
+    {
+      name: "admonition nested one blockquote deep",
+      options: { admonitions: true },
+      input: "> > [!quote] Title",
+      expected: "> > [!quote] Title\n> > ",
+    },
+    {
+      name: "admonition nested behind indented blockquote markers",
+      options: { admonitions: true },
+      input: ">  > [!quote] Title",
+      expected: ">  > [!quote] Title\n>  > ",
     },
   ]
 

--- a/scripts/built_site_checks.py
+++ b/scripts/built_site_checks.py
@@ -777,6 +777,30 @@ def check_unrendered_subtitles(soup: BeautifulSoup) -> list[str]:
     return unrendered_subtitles
 
 
+# An admonition title is a label, not a paragraph. The longest deliberate title
+# in `website_content/` renders at ~180 characters, so a title past this bound
+# means body text was absorbed into the title instead of becoming content.
+MAX_ADMONITION_TITLE_LENGTH = 200
+
+
+def check_overlong_admonition_titles(soup: BeautifulSoup) -> list[str]:
+    """Check for admonition titles long enough to signal absorbed body text."""
+    overlong_titles: list[str] = []
+    titles = _tags_only(soup.find_all("div", class_="admonition-title"))
+    for title in titles:
+        text = " ".join(strip_invisible_chars(title.get_text()).split())
+        if len(text) > MAX_ADMONITION_TITLE_LENGTH:
+            _append_to_list(
+                overlong_titles,
+                text,
+                prefix=(
+                    f"Admonition title too long ({len(text)} characters, "
+                    f"max {MAX_ADMONITION_TITLE_LENGTH}): "
+                ),
+            )
+    return overlong_titles
+
+
 # Check the existence of local files with these extensions
 _MEDIA_EXTENSIONS = list(compress.ALLOWED_EXTENSIONS) + [
     ".svg",
@@ -2356,6 +2380,7 @@ def check_file_for_issues(
         "missing_assets": check_asset_references(soup, file_path, base_dir),
         "problematic_katex": check_katex_elements_for_errors(soup),
         "unrendered_subtitles": check_unrendered_subtitles(soup),
+        "overlong_admonition_titles": check_overlong_admonition_titles(soup),
         "unrendered_footnotes": check_unrendered_footnotes(soup),
         "footnote_ref_not_in_sup": check_footnote_refs_in_sup(soup),
         "missing_critical_css": not check_critical_css(soup),

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -804,6 +804,74 @@ def test_check_unrendered_subtitles():
     ]
 
 
+_MAX_TITLE = built_site_checks.MAX_ADMONITION_TITLE_LENGTH
+
+
+def _admonition_html(*title_inners: str) -> str:
+    return "".join(
+        '<blockquote class="admonition quote">'
+        '<div class="admonition-title"><span class="admonition-title-inner">'
+        f'<span class="admonition-icon"></span>{inner}</span></div>'
+        "</blockquote>"
+        for inner in title_inners
+    )
+
+
+def _overlong_issue(rendered_title: str) -> str:
+    return (
+        f"Admonition title too long ({len(rendered_title)} characters, "
+        f"max {_MAX_TITLE}): {rendered_title[:100]}"
+    )
+
+
+# A body absorbed into the title by a lazy continuation line: the newline
+# between the linked title and the run-on prose collapses to a single space.
+_ABSORBED_BODY = "Body sentence. " * 20
+_ABSORBED_TITLE_HTML = (
+    f'<a href="https://example.com">Headline</a>\n{_ABSORBED_BODY}'
+)
+_ABSORBED_RENDERED = f"Headline {_ABSORBED_BODY.strip()}"
+
+
+@pytest.mark.parametrize(
+    "title_inners,expected",
+    [
+        pytest.param(["Short title"], [], id="short"),
+        pytest.param(["t" * _MAX_TITLE], [], id="at_limit"),
+        pytest.param(
+            ["t" * (_MAX_TITLE + 1)],
+            [_overlong_issue("t" * (_MAX_TITLE + 1))],
+            id="over_limit",
+        ),
+        pytest.param(
+            [_ABSORBED_TITLE_HTML],
+            [_overlong_issue(_ABSORBED_RENDERED)],
+            id="absorbed_body",
+        ),
+        pytest.param(
+            # Markup, the icon span, and word joiners carry no visible text, so
+            # a title that reads short stays under the bound.
+            [f'<em>{"t" * _MAX_TITLE}</em>{WORD_JOINER * 50}'],
+            [],
+            id="invisible_characters_do_not_inflate_measurement",
+        ),
+        pytest.param(
+            ["t" * (_MAX_TITLE + 5), "Fine", "u" * (_MAX_TITLE + 7)],
+            [
+                _overlong_issue("t" * (_MAX_TITLE + 5)),
+                _overlong_issue("u" * (_MAX_TITLE + 7)),
+            ],
+            id="every_overlong_admonition_reported",
+        ),
+    ],
+)
+def test_check_overlong_admonition_titles(title_inners, expected):
+    soup = BeautifulSoup(_admonition_html(*title_inners), "html.parser")
+    assert (
+        built_site_checks.check_overlong_admonition_titles(soup) == expected
+    )
+
+
 @requires_xmllint
 def test_check_valid_rss_file_with_xmllint(temp_site_root):
     """Test that check_rss_file_for_issues validates a correctly formatted RSS

--- a/scripts/tests/test_built_site_checks.py
+++ b/scripts/tests/test_built_site_checks.py
@@ -851,7 +851,7 @@ _ABSORBED_RENDERED = f"Headline {_ABSORBED_BODY.strip()}"
         pytest.param(
             # Markup, the icon span, and word joiners carry no visible text, so
             # a title that reads short stays under the bound.
-            [f'<em>{"t" * _MAX_TITLE}</em>{WORD_JOINER * 50}'],
+            [f"<em>{'t' * _MAX_TITLE}</em>{WORD_JOINER * 50}"],
             [],
             id="invisible_characters_do_not_inflate_measurement",
         ),
@@ -867,9 +867,7 @@ _ABSORBED_RENDERED = f"Headline {_ABSORBED_BODY.strip()}"
 )
 def test_check_overlong_admonition_titles(title_inners, expected):
     soup = BeautifulSoup(_admonition_html(*title_inners), "html.parser")
-    assert (
-        built_site_checks.check_overlong_admonition_titles(soup) == expected
-    )
+    assert built_site_checks.check_overlong_admonition_titles(soup) == expected
 
 
 @requires_xmllint

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -64,7 +64,7 @@ This essay tells the story of why I left Google DeepMind. It is also the story o
 >
 >  Sundar tried to keep him:
 >  > [!quote] [4 of Google’s Top AI Brains Are Leaving—and Launching Their Own AI Startup](https://www.wired.com/story/jeff-dean-google-discovery-loop-startup/)
->  > Dean says that Alphabet CEO Sundar Pichai tried over multiple meetings to get them to keep their badges. Ultimately the team decided that they wanted the fun–and the freedom–of doing a startup.
+>  > Dean says that Alphabet CEO Sundar Pichai tried over multiple meetings to get them to keep their badges. Ultimately the team decided that they wanted the fun—and the freedom—of doing a startup.
 >  
 >  While no public information indicates he left due to the Pentagon deal, I think it's good that Jeff left and thereby honored his 2018 pledge.
 >
@@ -645,7 +645,7 @@ What should a pledge-signer do? I see three honest options: explain publicly how
 >
 >  Sundar tried to keep him:
 >  > [!quote] [4 of Google’s Top AI Brains Are Leaving—and Launching Their Own AI Startup](https://www.wired.com/story/jeff-dean-google-discovery-loop-startup/)
->  > Dean says that Alphabet CEO Sundar Pichai tried over multiple meetings to get them to keep their badges. Ultimately the team decided that they wanted the fun–and the freedom–of doing a startup.
+>  > Dean says that Alphabet CEO Sundar Pichai tried over multiple meetings to get them to keep their badges. Ultimately the team decided that they wanted the fun—and the freedom—of doing a startup.
 >  
 >  While no public information indicates he left due to the Pentagon deal, I think it's good that Jeff left and thereby honored his 2018 pledge.
 >

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -249,6 +249,9 @@ A plain section transclusion would include this text; the lede transclusion does
 > > The content of both the nested and non-nested "note" admonition.
 >
 > > [!quote] A nested quote
+>
+> > [!quote] [A nested admonition with a linked title](/dataset-protection)
+> > This body belongs to the nested admonition's content, not to its title.
 
 > [!goose]
 > Geese are better than dogs.


### PR DESCRIPTION
## Summary

- A nested admonition whose title ended in a link swallowed its body text into `.admonition-title`, so the Jeff Dean quote in "Why I left Google DeepMind" rendered title and body on one line.
- Added a built-site check so an admonition title that has absorbed a paragraph fails the build instead of shipping.
- The same quote's unspaced en dashes are now em dashes in the source.

## Changes

**`quartz/plugins/transformers/ofm.ts`**
: `admonitionLineRegex` matched only a single leading `>`, so the pre-parse pass that forces a newline after an admonition title skipped anything nested inside another blockquote. A plain-text title survived anyway — the marker text node carries its own `\n` — but a title ending in inline markup (a link) does not, so the body typed on the next line stayed in the title paragraph. The regex now captures every leading `>` marker and the replacement re-emits that prefix, keeping the forced break inside the same blockquote at any nesting depth.

**`scripts/built_site_checks.py`**
: New `check_overlong_admonition_titles`, registered as `overlong_admonition_titles`. A title is a label, not a paragraph; absorbed body text is what pushes one past a few hundred characters. The longest deliberate title across `website_content/` renders at 182 characters, so `MAX_ADMONITION_TITLE_LENGTH = 200` bounds it with headroom. Invisible characters (word joiners, zero-widths) are stripped before measuring, reusing `strip_invisible_chars`.

**`website_content/leaving-google-deepmind.md`**
: `fun–and` / `freedom–of` → em dashes. Punctilio deliberately leaves an unspaced en dash alone because it cannot be told apart from a compound-modifier en dash — this same file relies on `Anthropic–Pentagon` and `Francisco–Oakland`, and the corpus also has lowercase pairs like `deployment–chat` and `integration–sharpening`. There is no safe automatic rule, so the intended glyph has to be written in the source.

**`website_content/test-page.md`**
: Added a nested admonition with a linked title and a body line, so the previously-broken shape gets a visual baseline.

## Testing

- Full offline build (`build --offline`): the quote now renders a 75-character title with the body in `.admonition-content`, and the dashes render as `fun—and` / `freedom—of`. Before the fix the merged title measured 271 characters, which the new check catches.
- Ran the new check over all 1783 rendered admonition titles in `public/`: zero flagged, longest 182.
- `pnpm test` — 5182 tests, 104 suites, 100% coverage.
- `uv run pytest scripts/tests/test_built_site_checks.py` — 1041 passed; `pylint` 10.00/10.
- `pnpm check` (tsc + prettier) clean on the diff.
- Reverting only the `ofm.ts` change turns the four new `ofm.test.ts` cases red, so they are non-vacuous.

## Lessons Learned

- **What**: When a pre-parse text pass keys off a line prefix, capture the prefix and re-emit it rather than hardcoding the common case.
- **Where**: `quartz/plugins/transformers/ofm.ts`
- **Why**: The hardcoded `"> "` silently no-opped on nested blockquotes, and the bug only surfaced when the title also ended in inline markup — two conditions that had to coincide, which is why it survived a large existing test suite.

- **What**: Pick a lint threshold by measuring the real corpus first, then leaving explicit headroom, and record the measurement in the comment next to the constant.
- **Where**: `scripts/built_site_checks.py`
- **Why**: A threshold guessed without measuring either false-positives on legitimate content or sits so high it never fires; the recorded measurement also tells the next reader when it is safe to move.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bib2tvWJGMvHJbtYiJdeGM)_