### PR TITLE
refactor(markdown): split admonitions on the AST, let the parser guard the source passes

### DIFF
--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -6,9 +6,17 @@
 import type { QuartzTransformerPlugin } from "../types"
 
 import { NBSP } from "../../components/constants"
+import { transformOutsideCode } from "./markdownSource"
 import { mdLinkRegex } from "./utils"
 
-const nbspCleanupRegex = new RegExp(`(?:${NBSP}|&nbsp;)`, "gu")
+// A literal NBSP is a paste artifact wherever it lands, and inside a code
+// sample it silently breaks copy-paste (Python rejects it as indentation), so
+// it is normalized everywhere — fenced blocks included.
+const nbspCharRegex = new RegExp(NBSP, "gu")
+
+// The `&nbsp;` entity is real markup in an HTML sample, so it is only cleaned
+// up in prose.
+const nbspEntityRegex = /&nbsp;/g
 
 // Regular expression for footnotes not followed by a colon (definition) or opening parenthesis (md URL)
 const footnoteSpacingRegex = /(?<content>\S) (?<footnote>\[\^[^\]]+\])(?![:(]) ?/g
@@ -149,6 +157,25 @@ const concentrateEmphasisAroundLinks = (text: string): string => {
   return text.replace(emphRegex, "$<whitespace1>$<emph>$<url>$<emph>$<whitespace2>")
 }
 
+/** Applies every prose rule to one run of markdown lines outside fenced code. */
+function improveProse(chunk: string): string {
+  let text = chunk.replaceAll(nbspEntityRegex, " ")
+
+  text = improveFootnoteFormatting(text)
+  text = text.replace(/ *,/g, ",") // Remove space before commas
+  text = editAdmonition(text)
+  text = noteAdmonition(text)
+  text = spaceAdmonitions(text)
+  text = concentrateEmphasisAroundLinks(text)
+  text = encodeLinkDestinationSpaces(text)
+  text = wrapLeadingNumbers(text)
+  text = wrapNumbersBeforeColon(text)
+  text = applyTextTransforms(text, massTransforms)
+
+  // Ensure that bulleted lists display properly
+  return text.replaceAll("\\-", "-")
+}
+
 /**
  * Applies formatting improvements to the input text.
  * @param text - The input text to process.
@@ -164,22 +191,10 @@ export const formattingImprovement = (text: string) => {
     content = text.substring(yamlHeader.length)
   }
 
-  // Format the content (non-YAML part)
-  let newContent = content.replaceAll(nbspCleanupRegex, " ")
-
-  newContent = improveFootnoteFormatting(newContent)
-  newContent = newContent.replace(/ *,/g, ",") // Remove space before commas
-  newContent = editAdmonition(newContent)
-  newContent = noteAdmonition(newContent)
-  newContent = spaceAdmonitions(newContent)
-  newContent = concentrateEmphasisAroundLinks(newContent)
-  newContent = encodeLinkDestinationSpaces(newContent)
-  newContent = wrapLeadingNumbers(newContent)
-  newContent = wrapNumbersBeforeColon(newContent)
-  newContent = applyTextTransforms(newContent, massTransforms)
-
-  // Ensure that bulleted lists display properly
-  newContent = newContent.replaceAll("\\-", "-")
+  // Every rule below rewrites prose, so none may reach inside a fenced code
+  // block: a sample showing `<!-- -->`, `> [!note]`, or `:=` must render as the
+  // author typed it.
+  const newContent = transformOutsideCode(content.replaceAll(nbspCharRegex, " "), improveProse)
 
   return yamlHeader + newContent // Concatenate YAML header and formatted content
 }

--- a/quartz/plugins/transformers/markdownSource.ts
+++ b/quartz/plugins/transformers/markdownSource.ts
@@ -11,7 +11,7 @@
  *
  * Deciding *where* such a transform may write is still the parser's job:
  * {@link transformOutsideCode} parses the source and skips the span every
- * `code` and `inlineCode` node occupies.
+ * `code` node occupies.
  */
 
 import type { Root } from "mdast"

--- a/quartz/plugins/transformers/markdownSource.ts
+++ b/quartz/plugins/transformers/markdownSource.ts
@@ -3,92 +3,89 @@
  * the mdast.
  *
  * A transform belongs here only when it repairs the *input to the parser* —
- * markdown that would otherwise parse into the wrong nodes (a link destination
- * holding raw spaces, display math sharing a line with prose, an HTML block
- * swallowing the prose beneath it). Everything that merely rewrites prose runs
- * on the mdast instead, where node types make code, math, and HTML untouchable.
+ * markdown that would otherwise parse into the wrong nodes. Comments are the
+ * clearest case: left in the source, an HTML comment opens an HTML block, which
+ * ends the enclosing list or footnote and re-parses the remainder as indented
+ * code. Once an mdast exists that damage is already done, and undoing it means
+ * guessing which sibling blocks were meant to be one.
  *
- * Source-level transforms still must not reach inside fenced code, so they run
- * through {@link transformOutsideCode}.
+ * Deciding *where* such a transform may write is still the parser's job:
+ * {@link transformOutsideCode} parses the source and skips the span every
+ * `code` and `inlineCode` node occupies.
  */
 
-/** The maximum indent CommonMark allows before a fence still counts as one. */
-const maxFenceIndent = 3
+import type { Root } from "mdast"
 
-/** The shortest run of fence characters that opens a block. */
-const minFenceLength = 3
+import remarkFrontmatter from "remark-frontmatter"
+import remarkGfm from "remark-gfm"
+import remarkParse from "remark-parse"
+import { unified } from "unified"
+import { visit } from "unist-util-visit"
 
-interface Fence {
-  marker: string
-  length: number
-  info: string
+/**
+ * Parses markdown for span discovery only; this tree is never emitted.
+ *
+ * It must carry the same block-level grammar the real pipeline registers, or it
+ * reads a different language: without GFM a footnote definition is an ordinary
+ * paragraph, so its indented body looks like an indented code block and the
+ * transforms are steered away from prose they are supposed to reach.
+ */
+const sourceParser = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkFrontmatter, ["yaml", "toml"])
+
+/** Half-open `[start, end)` source offsets of a block the transforms must not touch. */
+interface CodeSpan {
+  start: number
+  end: number
 }
 
 /**
- * Reads the fence a line carries, or `null` when the line is not a fence.
- * Scanned by hand rather than by regex: a fence run and its info string are
- * both unbounded, and any regex splitting them backtracks super-linearly.
+ * Source offsets of every code *block* in `src`, in document order.
+ *
+ * Only the parser knows these: four leading spaces are code or a list
+ * continuation depending on what encloses them, and a fence ends at the first
+ * line of the same marker that is at least as long.
+ *
+ * Inline code is deliberately not included. A `code` node always spans whole
+ * lines, so skipping one leaves the surrounding prose line-aligned and the
+ * `^`/`$` anchors these transforms rely on keep their meaning. An `inlineCode`
+ * node sits mid-line, and cutting there would turn one line into two chunks
+ * whose edges those anchors would read as line boundaries. Protecting inline
+ * code is the job of the mdast passes, where it is a node rather than a range.
  */
-function readFence(line: string): Fence | null {
-  let index = 0
-  while (index < line.length && line[index] === " ") index++
-  if (index > maxFenceIndent) return null
+function findCodeSpans(src: string): CodeSpan[] {
+  const tree = sourceParser.parse(src) as Root
+  const spans: CodeSpan[] = []
 
-  const marker = line[index]
-  if (marker !== "`" && marker !== "~") return null
+  visit(tree, "code", (node) => {
+    const start = node.position?.start.offset
+    const end = node.position?.end.offset
+    /* istanbul ignore next -- remark-parse records offsets for every node when parsing a string */
+    if (start === undefined || end === undefined) return
+    spans.push({ start, end })
+  })
 
-  const start = index
-  while (index < line.length && line[index] === marker) index++
-  const length = index - start
-  if (length < minFenceLength) return null
-
-  return { marker, length, info: line.slice(index) }
-}
-
-/** Reports whether `line` closes `open`: same marker, at least as long, no info string. */
-function closesFence(line: string, open: Fence): boolean {
-  const fence = readFence(line)
-  if (!fence) return false
-  return fence.marker === open.marker && fence.length >= open.length && fence.info.trim() === ""
+  // Code blocks never nest and a visit is document-ordered, so the spans come
+  // out ascending and disjoint.
+  return spans
 }
 
 /**
- * Applies `transform` to every run of lines outside fenced code blocks, leaving
- * fenced blocks (and their delimiters) byte-for-byte intact.
- *
- * Indented code blocks are not recognized: four leading spaces are a list
- * continuation as often as they are code, and telling the two apart is the job
- * of the parser, not of this scanner. Content that needs that guarantee should
- * use a fence.
+ * Applies `transform` to every run of source outside a code block, leaving
+ * fenced and indented code byte-for-byte intact.
  */
 export function transformOutsideCode(src: string, transform: (chunk: string) => string): string {
-  const lines = src.split("\n")
   const out: string[] = []
-  let prose: string[] = []
-  let open: Fence | null = null
+  let cursor = 0
 
-  const flushProse = (): void => {
-    if (prose.length === 0) return
-    out.push(transform(prose.join("\n")))
-    prose = []
+  for (const span of findCodeSpans(src)) {
+    if (span.start > cursor) out.push(transform(src.slice(cursor, span.start)))
+    out.push(src.slice(span.start, span.end))
+    cursor = span.end
   }
+  if (cursor < src.length) out.push(transform(src.slice(cursor)))
 
-  for (const line of lines) {
-    if (open) {
-      out.push(line)
-      if (closesFence(line, open)) open = null
-      continue
-    }
-    const fence = readFence(line)
-    if (fence) {
-      flushProse()
-      out.push(line)
-      open = fence
-      continue
-    }
-    prose.push(line)
-  }
-  flushProse()
-
-  return out.join("\n")
+  return out.join("")
 }

--- a/quartz/plugins/transformers/markdownSource.ts
+++ b/quartz/plugins/transformers/markdownSource.ts
@@ -1,0 +1,94 @@
+/**
+ * Helpers for the few source-level (pre-parse) transforms that cannot run on
+ * the mdast.
+ *
+ * A transform belongs here only when it repairs the *input to the parser* —
+ * markdown that would otherwise parse into the wrong nodes (a link destination
+ * holding raw spaces, display math sharing a line with prose, an HTML block
+ * swallowing the prose beneath it). Everything that merely rewrites prose runs
+ * on the mdast instead, where node types make code, math, and HTML untouchable.
+ *
+ * Source-level transforms still must not reach inside fenced code, so they run
+ * through {@link transformOutsideCode}.
+ */
+
+/** The maximum indent CommonMark allows before a fence still counts as one. */
+const maxFenceIndent = 3
+
+/** The shortest run of fence characters that opens a block. */
+const minFenceLength = 3
+
+interface Fence {
+  marker: string
+  length: number
+  info: string
+}
+
+/**
+ * Reads the fence a line carries, or `null` when the line is not a fence.
+ * Scanned by hand rather than by regex: a fence run and its info string are
+ * both unbounded, and any regex splitting them backtracks super-linearly.
+ */
+function readFence(line: string): Fence | null {
+  let index = 0
+  while (index < line.length && line[index] === " ") index++
+  if (index > maxFenceIndent) return null
+
+  const marker = line[index]
+  if (marker !== "`" && marker !== "~") return null
+
+  const start = index
+  while (index < line.length && line[index] === marker) index++
+  const length = index - start
+  if (length < minFenceLength) return null
+
+  return { marker, length, info: line.slice(index) }
+}
+
+/** Reports whether `line` closes `open`: same marker, at least as long, no info string. */
+function closesFence(line: string, open: Fence): boolean {
+  const fence = readFence(line)
+  if (!fence) return false
+  return fence.marker === open.marker && fence.length >= open.length && fence.info.trim() === ""
+}
+
+/**
+ * Applies `transform` to every run of lines outside fenced code blocks, leaving
+ * fenced blocks (and their delimiters) byte-for-byte intact.
+ *
+ * Indented code blocks are not recognized: four leading spaces are a list
+ * continuation as often as they are code, and telling the two apart is the job
+ * of the parser, not of this scanner. Content that needs that guarantee should
+ * use a fence.
+ */
+export function transformOutsideCode(src: string, transform: (chunk: string) => string): string {
+  const lines = src.split("\n")
+  const out: string[] = []
+  let prose: string[] = []
+  let open: Fence | null = null
+
+  const flushProse = (): void => {
+    if (prose.length === 0) return
+    out.push(transform(prose.join("\n")))
+    prose = []
+  }
+
+  for (const line of lines) {
+    if (open) {
+      out.push(line)
+      if (closesFence(line, open)) open = null
+      continue
+    }
+    const fence = readFence(line)
+    if (fence) {
+      flushProse()
+      out.push(line)
+      open = fence
+      continue
+    }
+    prose.push(line)
+  }
+  flushProse()
+
+  return out.join("\n")
+}

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -11,7 +11,7 @@ import type {
   Parent,
   Properties,
 } from "hast"
-import type { BlockContent, Blockquote, Html, Paragraph, PhrasingContent, Root } from "mdast"
+import type { BlockContent, Blockquote, Html, Paragraph, PhrasingContent, Root, Text } from "mdast"
 import type { PluggableList } from "unified"
 
 import fs from "fs"
@@ -31,6 +31,7 @@ import { escapeHTML } from "../../util/escape"
 import { type FilePath, slugifyFilePath, slugTag } from "../../util/path"
 import { UNICODE_WORD_CHAR } from "../../util/regex"
 import { resetSlugger, slugify as slugAnchor } from "./gfm"
+import { transformOutsideCode } from "./markdownSource"
 import { isEffectivelyTitleCased } from "./utils"
 
 const currentFilePath = fileURLToPath(import.meta.url)
@@ -60,8 +61,11 @@ export const tableWikilinkRegex = new RegExp(/(?<wikilink>!?\[\[[^\]]*\]\])/, "g
 /** Regular expression to match highlight syntax (==text==) */
 const highlightRegex = new RegExp(/[=]{2}(?<content>[^=]+)[=]{2}/, "g")
 
-/** Regular expression to match Obsidian-style comments (%%comment%%) */
+/** Matches an Obsidian-style comment (%%comment%%) inside a text node. */
 const commentRegex = new RegExp(/%%[\s\S]*?%%/, "g")
+
+/** Matches an HTML comment inside a raw-HTML node. */
+const htmlCommentRegex = /<!--[\s\S]*?-->/g
 
 /** Regular expression to match admonition syntax ([!type][fold]) */
 const admonitionRegex = new RegExp(`^\\[!(?<type>${UNICODE_WORD_CHAR}+)\\](?<collapse>[+-]?)`, "u")
@@ -78,17 +82,6 @@ export function admonitionCollapseState(firstLine: string): "collapsed" | "expan
   if (!match?.groups) return null
   return match.groups.collapse === "-" ? "collapsed" : "expanded"
 }
-
-/**
- * Regular expression to match admonition lines in blockquotes. The `prefix`
- * group captures every `>` marker leading the line, so an admonition nested
- * inside another blockquote (`>  > [!quote] …`) matches too and the forced
- * newline can be re-prefixed to stay inside the same nesting level.
- */
-const admonitionLineRegex = new RegExp(
-  `^(?<prefix>(?:>[ \\t]*)+)\\[!${UNICODE_WORD_CHAR}+\\][+-]?.*$`,
-  "gmu",
-)
 
 /** Matches tags with Unicode support: #tag, #tag/subtag */
 const tagRegex = new RegExp(
@@ -361,24 +354,84 @@ const parseAdmonitionHeader = (firstLine: string): AdmonitionHeader | null => {
   }
 }
 
-/** Builds the title element from an admonition's first paragraph. */
+/** An opening callout paragraph split into its title and its first body block. */
+interface AdmonitionParagraphSplit {
+  /** The paragraph's opening text node, truncated when the break falls inside it. */
+  head: Text
+  /** Inline nodes after the head that still belong to the title. */
+  titleRest: PhrasingContent[]
+  body: PhrasingContent[]
+}
+
+/**
+ * Splits a callout's opening paragraph at its first line break. The title ends
+ * there; everything after it is body content the author typed on the next line.
+ *
+ * The break is a `\n` inside a text node for a soft wrap and a `break` node for
+ * a hard one, and it can sit behind any number of inline nodes — a linked title
+ * leaves the break in a *later* text node, not the paragraph's first child.
+ */
+function splitAdmonitionParagraph(
+  head: Text,
+  rest: readonly PhrasingContent[],
+): AdmonitionParagraphSplit {
+  const headBreak = head.value.indexOf("\n")
+  if (headBreak !== -1) {
+    const after = head.value.slice(headBreak + 1)
+    return {
+      head: { ...head, value: head.value.slice(0, headBreak) },
+      titleRest: [],
+      body: [...(after !== "" ? [{ ...head, value: after }] : []), ...rest],
+    }
+  }
+
+  const titleRest: PhrasingContent[] = []
+  for (const [index, child] of rest.entries()) {
+    if (child.type === "break") {
+      return { head, titleRest, body: [...rest.slice(index + 1)] }
+    }
+    if (child.type === "text") {
+      const newline = child.value.indexOf("\n")
+      if (newline !== -1) {
+        const before = child.value.slice(0, newline)
+        const after = child.value.slice(newline + 1)
+        if (before !== "") titleRest.push({ ...child, value: before })
+        return {
+          head,
+          titleRest,
+          body: [...(after !== "" ? [{ ...child, value: after }] : []), ...rest.slice(index + 1)],
+        }
+      }
+    }
+    titleRest.push(child)
+  }
+
+  return { head, titleRest, body: [] }
+}
+
+/** Reports whether inline nodes carry anything beyond whitespace. */
+function hasVisibleContent(nodes: readonly PhrasingContent[]): boolean {
+  return nodes.some((node) => node.type !== "text" || node.value.trim() !== "")
+}
+
+/** Builds the title element from an admonition's title nodes. */
 const buildAdmonitionTitle = (
-  firstChild: Paragraph,
-  firstLine: string,
+  split: AdmonitionParagraphSplit,
   header: AdmonitionHeader,
 ): BlockContent => {
-  const rawTitle = firstLine.slice(header.admonitionDirective.length)
+  // The directive opens the paragraph's first text node; the rest of that node
+  // is the plain-text head of the title.
+  const rawTitle = split.head.value.slice(header.admonitionDirective.length)
   const titleContent = rawTitle.trim()
   // Preserve the source spacing between the plain-text title and any following
   // inline child (e.g. a link). Appending a space unconditionally would insert
   // one after a trailing opening delimiter, turning "remarks ([video])" into
   // "remarks ( video)".
   const titleSeparator = /\s$/u.test(rawTitle) ? " " : ""
-  /* istanbul ignore next -- admonition title detection edge case */
-  const useDefaultTitle = titleContent === "" && firstChild.children.length === 1
+  const useDefaultTitle = titleContent === "" && split.titleRest.length === 0
   const capitalizedTypeString =
     header.typeString.charAt(0).toUpperCase() + header.typeString.slice(1)
-  const remainingChildren = firstChild.children.slice(1)
+  const remainingChildren = split.titleRest
 
   // An admonition title that already reads as a title-cased work name (a
   // cited article, a named act) should not render its acronyms as
@@ -386,9 +439,7 @@ const buildAdmonitionTitle = (
   // A blank title (the admonition type's own name, e.g. "Note") is never a
   // work title, and an empty string is vacuously "title-cased" by the Hamming
   // check, so guard on non-empty text first.
-  const fullTitleText = `${titleContent} ${collectInlineText(
-    remainingChildren as PhrasingContent[],
-  )}`.trim()
+  const fullTitleText = `${titleContent} ${collectInlineText(remainingChildren)}`.trim()
   const noSmallcaps = fullTitleText !== "" && isEffectivelyTitleCased(fullTitleText)
 
   return createAdmonitionTitle(
@@ -402,21 +453,15 @@ const buildAdmonitionTitle = (
   ) as unknown as BlockContent
 }
 
-/** Builds the content node holding the body after an admonition's first line. */
-const buildAdmonitionContentNode = (node: Blockquote, remainingText: string): Element | null => {
-  // The body is the title line's trailing text (any lines the user typed under
-  // the title, minus the title line itself) followed by the blockquote's
+/** Builds the content node holding the body after an admonition's title. */
+const buildAdmonitionContentNode = (
+  node: Blockquote,
+  body: readonly PhrasingContent[],
+): Element | null => {
+  // The body is what followed the title line's break, then the blockquote's
   // remaining block children — the first block held the title and is dropped.
-  /* istanbul ignore next -- admonition content handling edge case */
   const contentChildren = [
-    ...(remainingText.trim() !== ""
-      ? [
-          {
-            type: "paragraph" as const,
-            children: [{ type: "text" as const, value: remainingText }],
-          },
-        ]
-      : []),
+    ...(hasVisibleContent(body) ? [{ type: "paragraph" as const, children: [...body] }] : []),
     ...node.children.slice(1),
   ]
 
@@ -460,17 +505,14 @@ const processAdmonitionBlockquote = (node: Blockquote, file: VFile): void => {
     return
   }
 
-  // The marker text node also carries body text typed on lines beneath the
-  // title: textTransform injects a newline after the title, so the first line
-  // is the directive + title and the rest is leading body content.
-  const [firstLine, ...remainingLines] = firstChild.children[0].value.split("\n")
-  const header = parseAdmonitionHeader(firstLine)
+  const header = parseAdmonitionHeader(firstChild.children[0].value)
   if (!header) return // Not a `[!type]` directive — an ordinary blockquote.
 
   recordAdmonitionIcons(file, header.admonitionType, header.collapse)
 
-  const admonitionTitle = buildAdmonitionTitle(firstChild, firstLine, header)
-  const contentNode = buildAdmonitionContentNode(node, remainingLines.join("\n"))
+  const split = splitAdmonitionParagraph(firstChild.children[0], firstChild.children.slice(1))
+  const admonitionTitle = buildAdmonitionTitle(split, header)
+  const contentNode = buildAdmonitionContentNode(node, split.body)
 
   // Swap the blockquote's children for the title (+ content when present); the
   // admonition classes/data attributes go on the blockquote element itself.
@@ -994,22 +1036,15 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<OFMOption
       // Reset slugger per file so IDs are unique per page, not globally
       resetSlugger()
 
-      // strip HTML comments
-      src = src.replace(/<!--[\s\S]*?-->/g, "")
-
-      /* istanbul ignore next -- comment removal is optional feature */
-      if (opts.comments) {
-        src = src.replace(commentRegex, "")
-      }
-
-      // pre-transform blockquotes
-      if (opts.admonitions) {
-        src = src.replace(admonitionLineRegex, (value: string, prefix: string): string => {
-          // force newline after title of admonition, re-using the line's own
-          // blockquote markers so the break lands inside the same blockquote
-          return `${value}\n${prefix}`
-        })
-      }
+      // Comments are stripped before parsing, not on the tree: an HTML comment
+      // left in the source opens an HTML block, which ends the surrounding list
+      // or footnote and re-parses the rest of it as indented code. Running
+      // outside fenced blocks keeps a code sample that documents comment syntax
+      // rendering as the author typed it.
+      src = transformOutsideCode(src, (chunk) => {
+        const stripped = chunk.replace(htmlCommentRegex, "")
+        return opts.comments ? stripped.replace(commentRegex, "") : stripped
+      })
 
       // pre-transform wikilinks (fix anchors to things that may contain illegal syntax e.g. codeblocks, latex)
       if (opts.wikilinks) {

--- a/quartz/plugins/transformers/tests/markdownSource.test.ts
+++ b/quartz/plugins/transformers/tests/markdownSource.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals"
+
+import { transformOutsideCode } from "../markdownSource"
+
+describe("transformOutsideCode", () => {
+  const shout = (chunk: string): string => chunk.toUpperCase()
+
+  it.each([
+    { name: "plain prose", input: "hello there", expected: "HELLO THERE" },
+    {
+      name: "a backtick fence",
+      input: "before\n```js\nlet x\n```\nafter",
+      expected: "BEFORE\n```js\nlet x\n```\nAFTER",
+    },
+    {
+      name: "a tilde fence",
+      input: "before\n~~~py\nx = 1\n~~~\nafter",
+      expected: "BEFORE\n~~~py\nx = 1\n~~~\nAFTER",
+    },
+    {
+      name: "a fence indented up to three spaces",
+      input: "before\n   ```\nlet x\n   ```\nafter",
+      expected: "BEFORE\n   ```\nlet x\n   ```\nAFTER",
+    },
+    {
+      // CommonMark closes a fence on any line of the same marker that is at
+      // least as long, so the 5-backtick line ends the 3-backtick block.
+      name: "a block closed by a longer fence, resuming prose after it",
+      input: "a\n```\ninner\n`````\nstill prose\n```\nb",
+      expected: "A\n```\ninner\n`````\nSTILL PROSE\n```\nb",
+    },
+    {
+      name: "backticks nested inside a tilde fence",
+      input: "a\n~~~\n```\ncode\n```\n~~~\nb",
+      expected: "A\n~~~\n```\ncode\n```\n~~~\nB",
+    },
+    {
+      name: "a fence closed only by end of input",
+      input: "a\n```js\nunterminated",
+      expected: "A\n```js\nunterminated",
+    },
+    {
+      name: "a fence opening the input",
+      input: "```\ncode\n```\ntail",
+      expected: "```\ncode\n```\nTAIL",
+    },
+    {
+      name: "an info string on the closing line, which opens a new fence",
+      input: "a\n```\ncode\n``` js\nb",
+      expected: "A\n```\ncode\n``` js\nb",
+    },
+    {
+      name: "consecutive fences",
+      input: "a\n```\none\n```\nmid\n```\ntwo\n```\nz",
+      expected: "A\n```\none\n```\nMID\n```\ntwo\n```\nZ",
+    },
+  ])("leaves $name intact", ({ input, expected }) => {
+    expect(transformOutsideCode(input, shout)).toBe(expected)
+  })
+
+  it.each([
+    { name: "a single backtick", input: "a `code` b" },
+    { name: "a two-backtick run", input: "a\n``\nb" },
+    { name: "a run of two tildes", input: "a\n~~\nb" },
+    { name: "a fence indented four spaces", input: "a\n    ```\nb" },
+    { name: "a line of other characters", input: "a\n---\nb" },
+  ])("treats $name as prose, not a fence", ({ input }) => {
+    expect(transformOutsideCode(input, shout)).toBe(input.toUpperCase())
+  })
+
+  it("hands each prose run to the transform as one chunk", () => {
+    const chunks: string[] = []
+    transformOutsideCode("a\nb\n```\ncode\n```\nc", (chunk) => {
+      chunks.push(chunk)
+      return chunk
+    })
+    expect(chunks).toEqual(["a\nb", "c"])
+  })
+
+  it("does not invoke the transform when there is no prose", () => {
+    const chunks: string[] = []
+    transformOutsideCode("```\ncode\n```", (chunk) => {
+      chunks.push(chunk)
+      return chunk
+    })
+    expect(chunks).toEqual([])
+  })
+
+  it("keeps a multi-line replacement produced by the transform", () => {
+    expect(transformOutsideCode("a\n```\nx\n```", (chunk) => `${chunk}\n${chunk}`)).toBe(
+      "a\na\n```\nx\n```",
+    )
+  })
+})

--- a/quartz/plugins/transformers/tests/markdownSource.test.ts
+++ b/quartz/plugins/transformers/tests/markdownSource.test.ts
@@ -59,36 +59,60 @@ describe("transformOutsideCode", () => {
   })
 
   it.each([
-    { name: "a single backtick", input: "a `code` b" },
-    { name: "a two-backtick run", input: "a\n``\nb" },
+    {
+      name: "an indented code block",
+      input: "intro\n\n    let x = 1\n\nouttro",
+      expected: "INTRO\n\n    let x = 1\n\nOUTTRO",
+    },
+    {
+      name: "a fenced block inside a list item",
+      input: "- item\n\n  ```js\n  let x\n  ```\n\ntail",
+      expected: "- ITEM\n\n  ```js\n  let x\n  ```\n\nTAIL",
+    },
+  ])("leaves $name intact", ({ input, expected }) => {
+    expect(transformOutsideCode(input, shout)).toBe(expected)
+  })
+
+  it.each([
+    { name: "an inline code span", input: "say `n := 5` loudly" },
+    { name: "a double-backtick span", input: "a ``x ` y`` b" },
+  ])(
+    // Inline code sits mid-line, and cutting there would let the `^`/`$`
+    // anchors these transforms use read a chunk edge as a line boundary. The
+    // mdast passes protect it instead, where it is a node rather than a range.
+    "hands $name to the transform, leaving it to the mdast passes",
+    ({ input }) => {
+      expect(transformOutsideCode(input, shout)).toBe(input.toUpperCase())
+    },
+  )
+
+  it.each([
+    { name: "an unmatched backtick", input: "a ` b" },
+    { name: "a two-backtick run on its own line", input: "a\n``\nb" },
     { name: "a run of two tildes", input: "a\n~~\nb" },
-    { name: "a fence indented four spaces", input: "a\n    ```\nb" },
+    { name: "four spaces continuing a list item", input: "- one\n\n    still the item\n" },
     { name: "a line of other characters", input: "a\n---\nb" },
-  ])("treats $name as prose, not a fence", ({ input }) => {
+  ])("treats $name as prose, not code", ({ input }) => {
     expect(transformOutsideCode(input, shout)).toBe(input.toUpperCase())
   })
 
-  it("hands each prose run to the transform as one chunk", () => {
+  it("passes prose to the transform as exact source slices", () => {
     const chunks: string[] = []
     transformOutsideCode("a\nb\n```\ncode\n```\nc", (chunk) => {
       chunks.push(chunk)
       return chunk
     })
-    expect(chunks).toEqual(["a\nb", "c"])
+    expect(chunks).toEqual(["a\nb\n", "\nc"])
   })
 
-  it("does not invoke the transform when there is no prose", () => {
-    const chunks: string[] = []
-    transformOutsideCode("```\ncode\n```", (chunk) => {
-      chunks.push(chunk)
-      return chunk
-    })
-    expect(chunks).toEqual([])
+  it("reproduces the source exactly when the transform is the identity", () => {
+    const source = "intro `x` mid\n\n```js\nlet y\n```\n\n    indented\n\ntail"
+    expect(transformOutsideCode(source, (chunk) => chunk)).toBe(source)
   })
 
   it("keeps a multi-line replacement produced by the transform", () => {
-    expect(transformOutsideCode("a\n```\nx\n```", (chunk) => `${chunk}\n${chunk}`)).toBe(
-      "a\na\n```\nx\n```",
+    expect(transformOutsideCode("a\n```\nx\n```", (chunk) => `${chunk}|${chunk}`)).toBe(
+      "a\n|a\n```\nx\n```",
     )
   })
 })

--- a/quartz/plugins/transformers/tests/ofm.test.ts
+++ b/quartz/plugins/transformers/tests/ofm.test.ts
@@ -215,6 +215,43 @@ describe("markdownPlugins", () => {
       return testMarkdownPlugins(transformer.textTransform({} as BuildCtx, source) as string)
     }
 
+    it("keeps a body that opens with inline markup out of the title", () => {
+      const output = renderFromSource(
+        "> [!quote] [Headline](https://example.com)\n> **Bold body** and more.",
+      )
+      expect(output).toContain(
+        '<div class="admonition-content"><p><strong>Bold body</strong> and more.</p></div>',
+      )
+    })
+
+    it.each([
+      {
+        name: "a plain title whose body opens with inline markup",
+        source: "> [!note] Title\n> **Bold body**",
+        expectedTitle: ">Title</span>",
+        expectedBody: '<div class="admonition-content"><p><strong>Bold body</strong></p></div>',
+      },
+      {
+        name: "a linked title with trailing plain text",
+        source: "> [!quote] [Headline](https://example.com) and a tail\n> Body text.",
+        expectedTitle: "and a tail</span>",
+        expectedBody: '<div class="admonition-content"><p>Body text.</p></div>',
+      },
+    ])("splits $name", ({ source, expectedTitle, expectedBody }) => {
+      const output = renderFromSource(source)
+      expect(output).toContain(expectedTitle)
+      expect(output).toContain(expectedBody)
+    })
+
+    it("separates a title from its body across a hard line break", () => {
+      const output = renderFromSource(
+        "> [!quote] [Headline](https://example.com)\\\n> Body text that belongs under the title.",
+      )
+      expect(output).toContain(
+        '<div class="admonition-content"><p>Body text that belongs under the title.</p></div>',
+      )
+    })
+
     it.each([
       { name: "top level", markers: ">" },
       { name: "nested", markers: "> >" },
@@ -230,6 +267,66 @@ describe("markdownPlugins", () => {
         '<div class="admonition-content"><p>Body text that belongs under the title.</p></div>',
       )
       expect(output).not.toContain("Body text that belongs under the title.</span>")
+    })
+  })
+
+  describe("comment stripping", () => {
+    // Comments are stripped before parsing, so the assertions must run the
+    // source through textTransform — asserting on the plugins alone would pass
+    // no matter what the transform did.
+    const renderSource = (source: string, options: OFMOptions = defaultOptions): string => {
+      const transformer = ObsidianFlavoredMarkdown(options)
+      /* istanbul ignore next -- textTransform is always defined on the transformer */
+      if (!transformer.textTransform) throw new Error("textTransform is undefined")
+      return testMarkdownPlugins(
+        transformer.textTransform({} as BuildCtx, source) as string,
+        options,
+      )
+    }
+
+    it.each([
+      {
+        name: "an HTML comment in prose",
+        input: "Hello <!-- this is a comment --> World",
+        expected: ["Hello", "World"],
+        notExpected: ["this is a comment"],
+      },
+      {
+        name: "an Obsidian comment in prose",
+        input: "Hello %%this is an obsidian comment%% World",
+        expected: ["Hello", "World"],
+        notExpected: ["this is an obsidian comment"],
+      },
+      {
+        name: "a comment inside a larger HTML block",
+        input: '<video>\n  <!-- only Safari -->\n  <source src="a.mp4" />\n</video>',
+        expected: ["<video>", '<source src="a.mp4" />'],
+        notExpected: ["only Safari"],
+      },
+    ])("removes $name", ({ input, expected, notExpected }) => {
+      const output = renderSource(input)
+      for (const fragment of expected) expect(output).toContain(fragment)
+      for (const fragment of notExpected) expect(output).not.toContain(fragment)
+    })
+
+    it("leaves Obsidian comments alone when the option is off", () => {
+      const output = renderSource("Hello %%kept%% World", {
+        ...defaultOptions,
+        comments: false,
+      })
+      expect(output).toContain("%%kept%%")
+    })
+
+    it.each([
+      {
+        name: "an HTML comment",
+        body: "const x = 1 // <!-- keep me -->",
+        keep: "&#x3C;!-- keep me -->",
+      },
+      { name: "an Obsidian comment", body: "%%keep me%%", keep: "%%keep me%%" },
+    ])("preserves $name inside a fenced code block", ({ body, keep }) => {
+      const output = renderSource(`\`\`\`js\n${body}\n\`\`\``)
+      expect(output).toContain(keep)
     })
   })
 
@@ -741,44 +838,21 @@ describe("ObsidianFlavoredMarkdown", () => {
 
   const textTransformCases: TextTransformTestCase[] = [
     {
-      name: "HTML comments",
-      input: "Hello <!-- this is a comment --> World",
-      expected: "Hello  World",
-    },
-    {
-      name: "Obsidian comments when enabled",
-      options: { comments: true },
-      input: "Hello %%this is an obsidian comment%% World",
-      expected: "Hello  World",
-    },
-    {
       name: "Buffer input",
       input: Buffer.from("Hello World"),
       expected: "Hello World",
     },
     {
-      name: "admonition line regex",
-      options: { admonitions: true },
-      input: "> [!note] Title",
-      expected: "> [!note] Title\n> ",
+      name: "a wikilink rewritten to markdown link syntax",
+      options: { wikilinks: true },
+      input: "See [[some page|the docs]]",
+      expected: "See [[some page|the docs]]",
     },
     {
-      name: "empty admonition titles",
-      options: { admonitions: true },
-      input: "> [!note]",
-      expected: "> [!note]\n> ",
-    },
-    {
-      name: "admonition nested one blockquote deep",
-      options: { admonitions: true },
-      input: "> > [!quote] Title",
-      expected: "> > [!quote] Title\n> > ",
-    },
-    {
-      name: "admonition nested behind indented blockquote markers",
-      options: { admonitions: true },
-      input: ">  > [!quote] Title",
-      expected: ">  > [!quote] Title\n>  > ",
+      name: "source left untouched inside a fenced code block",
+      options: { wikilinks: true, admonitions: true },
+      input: "```md\n> [!note] Title\n[[page]]\n```",
+      expected: "```md\n> [!note] Title\n[[page]]\n```",
     },
   ]
 


### PR DESCRIPTION
## Summary

- The markdown pipeline rewrote raw source with regexes that can't tell prose from code. I probed nine patterns; **eight corrupted fenced code blocks**, and one is shipped today: `design.md`'s `<video>` sample renders with its explanatory HTML comments silently deleted.
- Admonition title/body splitting moves onto the mdast, which deletes the pre-parse `admonitionLineRegex` hack from #1752 and makes the nesting/linked-title bug structurally impossible.
- The transforms that must stay pre-parse now use **the parser** to decide where they may write, instead of a hand-rolled scanner.

## The bug class

Probing the text pipeline with code fences (all silent corruption):

| Fenced content | Became |
| --- | --- |
| `const x = 1 // <!-- keep -->` | `const x = 1 // ` |
| `> [!note] Title` / `> Body` | extra blank `>` lines injected |
| `if (n := f()) > 0:` | `if (n ≝ f()) > 0:` |
| `const face = smile(); // :)` | `// 🙂` |
| `const model = 'GPT-4o'` | `'GPT-4-o'` |
| `# 10 apples` | `# <span style="…">10</span> apples` |
| `f(a , b)` | `f(a, b)` |

## Changes

**`quartz/plugins/transformers/ofm.ts`**
: Admonition splitting is now a paragraph split on the mdast rather than a newline injected into the source. `splitAdmonitionParagraph` finds the first line break wherever it sits — inside the opening text node, behind a link or other inline markup, or as a hard-break node — so a linked title with a body on the next line works at any blockquote nesting depth. The `admonitionLineRegex` pre-parse pass is gone.

**`quartz/plugins/transformers/markdownSource.ts`** (new)
: `transformOutsideCode` parses the source with remark and skips the span every `code` node occupies. It registers the same block-level grammar the pipeline does (`remark-gfm`, `remark-frontmatter`) — a span-finding parse with a *different* grammar reads a different language.

**`quartz/plugins/transformers/formatting_improvement_text.ts`**
: All prose rules now run through `transformOutsideCode`. No rule's behavior changed, so every existing expectation still holds — 5210 tests pass with zero edits to their assertions.

## Where the tiers actually fall, and why

Three boundaries here were found by building the site and diffing, not by reasoning. All three are documented at their call sites.

**HTML comments must be stripped before parsing.** Moving them to the AST broke 12 pages: a comment left in the source opens an HTML block, which terminates the enclosing list or footnote and re-parses the remainder as indented code. `date-me` split one `<ol>` into three; `disagreements-with-list-of-lethalities` turned a footnote's blockquote into a `<pre>`. Once an mdast exists that damage is done, and undoing it means guessing which sibling blocks were meant to be one.

**Inline code cannot be protected at the source tier.** Skipping `inlineCode` spans as well as `code` looks obviously right and is wrong: a source transform is line-oriented, so cutting a line at a mid-line span lets its `^`/`$` anchors read a chunk edge as a line boundary. That collapsed `dataset-protection`'s admonition title from ``[!warning] `easy-dataset-share` will not stop sophisticated scrapers`` to just "Warning". A `code` node always spans whole lines, so skipping one keeps the surrounding prose line-aligned. Inline code is the mdast passes' to protect.

**A literal NBSP is normalized everywhere, code included.** Preserving it inside `gradient-routing`'s Python sample would be "correct" by the code rule and actively harmful: copying the snippet yields NBSP indentation, which Python rejects. The `&nbsp;` *entity* stays prose-only, since it's real markup in an HTML sample.

## Testing

- **Rebuilt the site and diffed all 180 pages against a pre-refactor build.** The only rendered change is `design.md`'s restored comments. `contentIndex.json` also shows the admonition split correctly separating title from body on `why-i-left-google-deepmind` — the #1752 bug, now fixed structurally.
- `pnpm test` — 5210 tests, 105 suites, 100% coverage on all four touched files.
- `pnpm check` (tsc + prettier + stylelint) and `eslint` clean.
- New `markdownSource.test.ts` covers fenced and indented blocks, fences inside list items, nesting, unterminated fences, non-fence backtick runs, and the inline-code carve-out.

## Scope

This covers the TypeScript markdown pipeline, where not having a parser actively corrupts output. Two things are deliberately left alone:

- **Wikilink rewriting** stays lexical. `[[page]]` is syntax remark cannot parse without a micromark extension, so rewriting it to link syntax is by definition a pre-parse job. A proper syntax extension would be the principled fix and is a bigger change than this PR.
- **The Python scripts** read markdown with regex too, but for asset-path rewriting and validation rather than prose transforms, and `built_site_checks.py` already parses with BeautifulSoup.

## Lessons learned

- **What**: When splitting regex passes into "AST" and "must stay lexical", verify by rebuilding the artifact and diffing it, not by reasoning about which passes look structural.
- **Where**: `quartz/plugins/transformers/`
- **Why**: Two changes that looked obviously correct — stripping HTML comments on the AST, and skipping inline-code spans in source transforms — each silently broke a dozen pages. The build diff caught both in one pass; no amount of staring at the regexes would have.

- **What**: A helper that parses a format to decide where a transform may write must register the same grammar the real pipeline uses.
- **Where**: any pre-parse helper built on a parser
- **Why**: A bare `remark-parse` treats a GFM footnote definition as a paragraph, so its indented body reads as an indented code block. The helper then protected prose it was supposed to transform, changing 10 pages — a failure that looks like a transform bug, not a parser-configuration bug.

- **What**: Prefer the real parser to a hand-written scanner for "is this position inside construct X".
- **Where**: any lexer-shaped helper
- **Why**: A hand-rolled fence scanner is a second, worse implementation of the format: mine missed indented code entirely, left inline code unprotected, and needed a lint suppression for super-linear backtracking. Reusing the parser deleted all three problems.
