### PR TITLE
refactor(markdown): substitute prose characters on the mdast, not the source

### DIFF
--- a/config/quartz/quartz.config.ts
+++ b/config/quartz/quartz.config.ts
@@ -30,6 +30,7 @@ import {
   PopulateContainers,
   PopulateExternalMarkdown,
   PrefixExternalReadmeIds,
+  ProseCharacterSubstitutions,
   RecentPostsPage,
   rehypeCustomSpoiler,
   rehypeCustomSubtitle,
@@ -74,6 +75,9 @@ const config: QuartzConfig = {
   },
   plugins: {
     transformers: [
+      // Before FrontMatter, which gathers the search index from the tree: the
+      // index should carry the characters the reader sees, not the source ones.
+      ProseCharacterSubstitutions(),
       FrontMatter(),
       PopulateExternalMarkdown({
         sources: {

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -1,7 +1,18 @@
 /**
  * This module provides text formatting improvements for Quartz.
  * It includes various functions to enhance the formatting of markdown content.
+ *
+ * The rules run in two tiers. A rule that creates or repairs block structure —
+ * an admonition, a display-math break, a link destination the parser would
+ * otherwise reject — must rewrite the source before it is parsed. A rule that
+ * substitutes characters within prose runs on the mdast instead, where an
+ * `inlineCode` span is a node it cannot reach.
  */
+
+import type { Root as HastRoot } from "hast"
+import type { Root } from "mdast"
+
+import { visit } from "unist-util-visit"
 
 import type { QuartzTransformerPlugin } from "../types"
 
@@ -11,12 +22,88 @@ import { mdLinkRegex } from "./utils"
 
 // A literal NBSP is a paste artifact wherever it lands, and inside a code
 // sample it silently breaks copy-paste (Python rejects it as indentation), so
-// it is normalized everywhere — fenced blocks included.
+// the source pass normalizes it everywhere — fenced blocks included. The same
+// pattern runs again on the mdast, where it catches the NBSP a `&nbsp;` entity
+// decodes to.
 const nbspCharRegex = new RegExp(NBSP, "gu")
 
-// The `&nbsp;` entity is real markup in an HTML sample, so it is only cleaned
-// up in prose.
-const nbspEntityRegex = /&nbsp;/g
+/**
+ * Character substitutions applied to prose text nodes.
+ *
+ * Each rule rewrites characters of running prose, so none of them has any
+ * business inside a code sample: `n := f()`, `f(a , b)`, `GPT-4o` and `:)` are
+ * source the author typed and must render verbatim. On the mdast that
+ * guarantee is structural — a text-node pass cannot see into `inlineCode` or
+ * `code` — whereas the source tier can only skip whole code *blocks*, since a
+ * mid-line cut would let these rules' `^`/`$` anchors read a chunk edge as a
+ * line boundary.
+ *
+ * An `&nbsp;` reaches this tier already decoded to a literal NBSP, and inside
+ * a code sample it stays the entity it was written as — real markup in an HTML
+ * example.
+ */
+const proseSubstitutions: [RegExp, string][] = [
+  [nbspCharRegex, " "],
+  [/ +,/g, ","], // Remove space before commas
+  [/(?<!\$):=/g, "≝"], // mathematical definition symbol, not preceded by the start of a katex block
+  [/(?<= |^):\)(?= |$)/gm, "🙂"], // Smiling face
+  [/(?<= |^);\)(?= |$)/gm, "😉"], // Winking face
+  [/(?<= |^):\((?= |$)/gm, "🙁"], // Frowning face
+  [/GPT-4o\b/g, "GPT-4-o"],
+]
+
+/** Applies every substitution to a bare string. */
+function substituteInString(value: string): string {
+  return proseSubstitutions.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    value,
+  )
+}
+
+/**
+ * Substitutes within a math node's TeX, which the author writes as prose too:
+ * `\rho := \prod` should typeset as `≝`.
+ *
+ * Two of the rules read the characters flanking a match, and the delimiters
+ * that supplied them are gone by the time math is a node — so they are handed
+ * back for the substitution. That is what keeps `$:=$` a literal `:=`.
+ */
+function substituteInMath(value: string): string {
+  return substituteInString(`$${value}$`).slice(1, -1)
+}
+
+/**
+ * Applies {@link proseSubstitutions} to the prose of the tree: text nodes, the
+ * alt text and titles a reader sees on hover, and math.
+ *
+ * `inlineCode` and `code` are the point of running here rather than on the
+ * source — they hold what the author typed, so they are skipped. Every rule
+ * rewrites a node's value in place, leaving the node layout the later inline
+ * passes read (which atoms neighbor which words) exactly as the prose has it.
+ */
+export function substituteProseCharacters(tree: Root): void {
+  visit(tree, (node) => {
+    if (node.type === "text") {
+      node.value = substituteInString(node.value)
+    } else if (node.type === "inlineMath" || node.type === "math") {
+      node.value = substituteInMath(node.value)
+      // remark-math attaches the hast it wants rendered while parsing, and that
+      // copy — a `code` element for inline math, wrapped in a `pre` for display
+      // — is what reaches the page.
+      const hChildren = node.data?.hChildren
+      /* istanbul ignore next -- remark-math always attaches the rendered hast */
+      if (hChildren) {
+        const value = node.value
+        visit({ type: "root", children: hChildren } as HastRoot, "text", (texNode) => {
+          texNode.value = value
+        })
+      }
+    } else if (node.type === "image" || node.type === "link") {
+      if (node.type === "image") node.alt = node.alt && substituteInString(node.alt)
+      node.title = node.title && substituteInString(node.title)
+    }
+  })
+}
 
 // Regular expression for footnotes not followed by a colon (definition) or opening parenthesis (md URL)
 const footnoteSpacingRegex = /(?<content>\S) (?<footnote>\[\^[^\]]+\])(?![:(]) ?/g
@@ -102,12 +189,8 @@ const subtitleReplacement = "$<quote>$<subtitle>$<quote>\n"
 const xcancelHostReplacementRegex = /https?:\/\/(?:www\.)?(?:x|twitter)\.com(?![\w.-])\/?/gi
 
 const massTransforms: [RegExp | string, string][] = [
-  [/(?<!\$):=/g, "≝"], // mathematical definition symbol, not preceded by the start of a katex block
   [/^\$\$(?= *\S)/gm, "$$$$\n"], // Display mode math should be on a new line
   [/^(?! *>| +\S)(?<content>\S.*?)\$\$ *$/gm, "$<content>\n$$$$"],
-  [/(?<= |^):\)(?= |$)/gm, "🙂"], // Smiling face
-  [/(?<= |^);\)(?= |$)/gm, "😉"], // Winking face
-  [/(?<= |^):\((?= |$)/gm, "🙁"], // Frowning face
   [subtitlePattern, subtitleReplacement],
   [xcancelHostReplacementRegex, "https://xcancel.com/"],
   [/(?<=\| *)\nTable: /g, "\n\nTable: "],
@@ -115,7 +198,6 @@ const massTransforms: [RegExp | string, string][] = [
   // doesn't swallow following prose into the same HTML block. Avoid inside of code blocks.
   [/(?<closingTag><\/[^>]*>|<[^>]*\/>)[ \t]*\n(?=[ \t]*[^ \t\n<>/`=])/g, "$<closingTag>\n\n"],
   [/MIRIx(?=\s|$)/g, 'MIRI<sub class="mirix-subscript">x</sub>'],
-  [/GPT-4o\b/g, "GPT-4-o"],
 ]
 
 /** Sequentially applies a list of `[pattern, replacement]` regex substitutions to `text`. */
@@ -159,10 +241,7 @@ const concentrateEmphasisAroundLinks = (text: string): string => {
 
 /** Applies every prose rule to one run of markdown lines outside fenced code. */
 function improveProse(chunk: string): string {
-  let text = chunk.replaceAll(nbspEntityRegex, " ")
-
-  text = improveFootnoteFormatting(text)
-  text = text.replace(/ *,/g, ",") // Remove space before commas
+  let text = improveFootnoteFormatting(chunk)
   text = editAdmonition(text)
   text = noteAdmonition(text)
   text = spaceAdmonitions(text)
@@ -192,8 +271,8 @@ export const formattingImprovement = (text: string) => {
   }
 
   // Every rule below rewrites prose, so none may reach inside a fenced code
-  // block: a sample showing `<!-- -->`, `> [!note]`, or `:=` must render as the
-  // author typed it.
+  // block: a sample showing `<!-- -->` or `> [!note]` must render as the author
+  // typed it.
   const newContent = transformOutsideCode(content.replaceAll(nbspCharRegex, " "), improveProse)
 
   return yamlHeader + newContent // Concatenate YAML header and formatted content
@@ -211,6 +290,25 @@ export const TextFormattingImprovement: QuartzTransformerPlugin = () => {
       // Stryker disable next-line ConditionalExpression,EqualityOperator: String#toString() is the identity, so forcing the toString branch is behaviorally equivalent
       const content = typeof src === "string" ? src : src.toString()
       return formattingImprovement(content)
+    },
+  }
+}
+
+/**
+ * Quartz transformer plugin for the mdast tier of {@link proseSubstitutions}.
+ *
+ * Separate from {@link TextFormattingImprovement} because the two tiers belong
+ * at different points of the pipeline: every `textTransform` runs before any
+ * parse, but a markdown plugin runs where its transformer sits, and this one
+ * has to land before the search index is gathered from the tree.
+ *
+ * @returns An object with the plugin name and its mdast pass.
+ */
+export const ProseCharacterSubstitutions: QuartzTransformerPlugin = () => {
+  return {
+    name: "proseCharacterSubstitutions",
+    markdownPlugins() {
+      return [() => substituteProseCharacters]
     },
   }
 }

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -14,7 +14,10 @@ export {
   SetDropcapLetter,
   StripInlineBoundaryWhitespace,
 } from "./formatting_improvement_html"
-export { TextFormattingImprovement } from "./formatting_improvement_text"
+export {
+  ProseCharacterSubstitutions,
+  TextFormattingImprovement,
+} from "./formatting_improvement_text"
 export { FrontMatter } from "./frontmatter"
 export { GitHubFlavoredMarkdown } from "./gfm"
 export { InlineAtomGlue } from "./inlineAtomGlue"

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.property.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.property.test.ts
@@ -11,6 +11,7 @@ import {
   wrapLeadingNumbers,
   wrapNumbersBeforeColon,
 } from "../formatting_improvement_text"
+import { renderProse } from "./test-utils"
 
 // Deterministic runs: a fixed seed keeps CI reproducible (zero-flakiness policy).
 fc.configureGlobal({ seed: 20260612, numRuns: 300 })
@@ -39,7 +40,9 @@ describe("formatting_improvement_text (property)", () => {
             // sprinkle NBSPs between words
             const withNbsp = body.replace(/ /g, NBSP)
             expect(formattingImprovement(withNbsp)).not.toContain(NBSP)
-            expect(formattingImprovement(`a&nbsp;${body}`)).not.toContain("&nbsp;")
+            // The entity survives the source pass and is decoded by the parser,
+            // so only the rendered output shows whether it was normalized.
+            expect(renderProse(`a&nbsp;${body}`)).not.toContain(NBSP)
           },
         ),
       )
@@ -67,7 +70,7 @@ describe("formatting_improvement_text (property)", () => {
       const commaText = fc.stringMatching(/^[a-z, ]*$/)
       fc.assert(
         fc.property(commaText, (body) => {
-          expect(formattingImprovement(body)).not.toMatch(/ ,/)
+          expect(renderProse(body)).not.toMatch(/ ,/)
         }),
       )
     })

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
@@ -1,18 +1,25 @@
+import type { Paragraph, Root } from "mdast"
+
 import { describe, expect, it } from "@jest/globals"
+import remarkParse from "remark-parse"
+import { unified } from "unified"
 
 import type { BuildCtx } from "../../../util/ctx"
 
+import { NBSP } from "../../../components/constants"
 import {
   applyTextTransforms,
   editAdmonition,
   encodeLinkDestinationSpaces,
   formattingImprovement,
   noteAdmonition,
+  ProseCharacterSubstitutions,
   spaceAdmonitions,
   TextFormattingImprovement,
   wrapLeadingNumbers,
   wrapNumbersBeforeColon,
 } from "../formatting_improvement_text"
+import { renderProse } from "./test-utils"
 
 describe("TextFormattingImprovement Plugin", () => {
   describe("End-to-end formatting improvement", () => {
@@ -27,12 +34,76 @@ describe("TextFormattingImprovement Plugin", () => {
       expect(processed).toBe(expected)
     })
   })
-  describe("Non-breaking spaces", () => {
-    it("should replace &nbsp; with regular spaces", () => {
-      const input = "This&nbsp;is&nbsp;a&nbsp;test."
-      const expected = "This is a test."
-      const processed = formattingImprovement(input)
-      expect(processed).toBe(expected)
+  describe("Prose character substitutions", () => {
+    it.each([
+      {
+        name: "the &nbsp; entity",
+        input: "This&nbsp;is&nbsp;a&nbsp;test.",
+        expected: "This is a test.",
+      },
+      { name: "a literal NBSP", input: `This${NBSP}is a test.`, expected: "This is a test." },
+      { name: "spaces before a comma", input: "  ,", expected: "," },
+      { name: "a comma mid-sentence", input: "Hi, he said", expected: "Hi, he said" },
+      {
+        name: "spaces before a mid-sentence comma",
+        input: "Hi  , he said",
+        expected: "Hi, he said",
+      },
+      { name: "the definition symbol", input: "Let x := 5", expected: "Let x ≝ 5" },
+      { name: "a katex opener", input: "$:=$", expected: ":=" },
+      { name: "a spaced katex opener", input: "$ :=$", expected: " ≝" },
+      {
+        name: "math the author typed as prose",
+        input: "$\\rho := \\prod$",
+        expected: "\\rho ≝ \\prod",
+      },
+      {
+        name: "display math",
+        input: "$$\nx := y\n$$",
+        expected: "x ≝ y",
+      },
+      {
+        name: "the alt text of an image",
+        input: "![R(s) := 0 with a wink ;)](/img.png)",
+        expected: 'alt="R(s) ≝ 0 with a wink 😉"',
+      },
+      {
+        name: "a link title",
+        input: '[link](/page "GPT-4o explained")',
+        expected: 'title="GPT-4-o explained"',
+      },
+      { name: "repeated definitions", input: "a:=b:=c", expected: "a≝b≝c" },
+      { name: "a smile before words", input: " :) The best", expected: "🙂 The best" },
+      { name: "a lone smile", input: " :)", expected: "🙂" },
+      { name: "a smile with no leading space", input: ":)", expected: "🙂" },
+      { name: "a frown", input: " :( The worst", expected: "🙁 The worst" },
+      { name: "a wink before words", input: " ;) Winking", expected: "😉 Winking" },
+      { name: "a lone wink", input: ";)", expected: "😉" },
+      {
+        name: "a wink after a sentence",
+        input: "Join Team Shard! ;)",
+        expected: "Join Team Shard! 😉",
+      },
+      { name: "a wink at a line end", input: "line1 ;)\nline2", expected: "line1 😉\nline2" },
+      { name: "the model name", input: "Ask GPT-4o about it", expected: "Ask GPT-4-o about it" },
+      { name: "a longer model name", input: "GPT-4omni", expected: "GPT-4omni" },
+    ])("substitutes $name", ({ input, expected }) => {
+      expect(renderProse(input)).toContain(expected)
+    })
+
+    // Every rule above rewrites prose, so a sample of the same characters typed
+    // inside backticks must survive: the mdast pass sees `inlineCode` as a node
+    // it cannot descend into.
+    it.each([
+      { name: "a walrus operator", input: "Use `if (n := f()) > 0:` here." },
+      { name: "a spaced argument list", input: "Call `f(a , b)` now." },
+      { name: "a model name", input: "Model `GPT-4o` rocks." },
+      { name: "a smiley", input: "Draw `:)` in code." },
+      { name: "an entity", input: "Write `&nbsp;` for a space." },
+    ])("leaves $name in inline code alone", ({ input }) => {
+      const inlineCode = /<code>(?<sample>.*?)<\/code>/.exec(renderProse(input))?.groups?.sample
+      const original = /`(?<sample>.*?)`/.exec(input)?.groups?.sample
+      expect(inlineCode).toBe(original?.replaceAll("&", "&#x26;"))
     })
   })
   describe("Footnote Formatting", () => {
@@ -111,16 +182,6 @@ describe("TextFormattingImprovement Plugin", () => {
       ],
     ])("should correctly wrap numbers for %s", (input: string, expected: string) => {
       expect(wrapNumbersBeforeColon(input)).toBe(expected)
-    })
-
-    describe("Comma spacing", () => {
-      it.each([
-        ["  ,", ","],
-        ["Hi, he said", "Hi, he said"],
-      ])("Removes spaces before commas.", (input: string, expected: string): void => {
-        const result = formattingImprovement(input)
-        expect(result).toBe(expected)
-      })
     })
 
     describe("YAML Header Handling", () => {
@@ -242,18 +303,6 @@ And some hyphens-to-be-ignored.`
 
   describe("Mass transforms", () => {
     it.each([
-      ["Let x := 5", "Let x ≝ 5"],
-      ["$:=$", "$:=$"],
-      ["$ :=$", "$ ≝$"],
-      ["a:=b:=c", "a≝b≝c"],
-      [" :) The best", " 🙂 The best"],
-      [" :)", " 🙂"],
-      [":)", "🙂"],
-      [" :( The worst", " 🙁 The worst"],
-      [" ;) Winking", " 😉 Winking"],
-      [";)", "😉"],
-      ["Join Team Shard! ;)", "Join Team Shard! 😉"],
-      ["line1 ;)\nline2", "line1 😉\nline2"],
       ["Subtitle: This is a subtitle", "Subtitle: This is a subtitle"],
       ["Subtitle: This is a subtitle\nTest", "Subtitle: This is a subtitle\n\nTest"],
       ["Subtitle: This is a subtitle\n\n", "Subtitle: This is a subtitle\n\n"],
@@ -509,6 +558,20 @@ And some hyphens-to-be-ignored.`
       const input = Buffer.from("Test buffer input", "utf-8")
       const result = plugin.textTransform?.(mockCtx, input)
       expect(result).toBe("Test buffer input")
+    })
+  })
+
+  describe("ProseCharacterSubstitutions plugin", () => {
+    it("substitutes through the plugin it registers", () => {
+      const plugin = ProseCharacterSubstitutions()
+      expect(plugin.name).toBe("proseCharacterSubstitutions")
+
+      const [markdownPlugin] = plugin.markdownPlugins?.({} as BuildCtx) ?? []
+      const tree = unified().use(remarkParse).parse("Let x := 5")
+      ;(markdownPlugin as () => (tree: Root) => void)()(tree)
+
+      const [paragraph] = tree.children as Paragraph[]
+      expect(paragraph.children[0]).toMatchObject({ type: "text", value: "Let x ≝ 5" })
     })
   })
 })

--- a/quartz/plugins/transformers/tests/test-utils.ts
+++ b/quartz/plugins/transformers/tests/test-utils.ts
@@ -3,8 +3,14 @@ import type { Element, Parent, Root } from "hast"
 import { jest } from "@jest/globals"
 import rehypeParse from "rehype-parse"
 import rehypeStringify from "rehype-stringify"
+import remarkGfm from "remark-gfm"
+import remarkMath from "remark-math"
+import remarkParse from "remark-parse"
+import remarkRehype from "remark-rehype"
 import { unified } from "unified"
 import { visit } from "unist-util-visit"
+
+import { formattingImprovement, substituteProseCharacters } from "../formatting_improvement_text"
 
 /**
  * Mocks a single successful fetch request on the provided mock instance.
@@ -92,4 +98,21 @@ export function createRehypeProcessor(
       .process(input)
     return result.toString()
   }
+}
+
+/**
+ * Runs both formatting tiers over markdown and renders the result.
+ *
+ * The source pass repairs block structure, then the mdast pass substitutes
+ * prose characters, so a rule's end-to-end effect is what this returns.
+ */
+export function renderProse(markdown: string): string {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMath)
+    .use(() => substituteProseCharacters)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeStringify, { allowDangerousHtml: true })
+  return processor.processSync(formattingImprovement(markdown)).toString()
 }


### PR DESCRIPTION
## Summary

- The five character-level prose rules (`:=`→`≝`, the smileys, `GPT-4o`→`GPT-4-o`, space-before-comma, the `&nbsp;` entity) rewrote raw markdown, so they reached into **inline code**: `` `if (n := f())` `` shipped as `≝`, `` `f(a , b)` `` lost its space, `` `GPT-4o` `` became `GPT-4-o`, and `` `&nbsp;` `` collapsed to a space.
- #1753 left inline code unprotected on purpose — a source transform is line-oriented, so it can only skip whole code *blocks*. It named the fix: "protecting inline code is the job of the mdast passes, where it is a node rather than a range." This is that pass.
- Rules that create or repair block structure (admonitions, display-math breaks, link destinations, the blank line after an HTML block) stay pre-parse, where they belong.

## Changes

`quartz/plugins/transformers/formatting_improvement_text.ts`
: The five substitutions move off `improveProse`/`massTransforms` into `substituteProseCharacters`, which walks the mdast. `inlineCode` and `code` are simply nodes it never descends into. Each rule rewrites a node's value in place rather than splitting the node, so the later inline passes (favicon/atom gluing, NBSP insertion) read the same node layout as before. Prose also lives outside text nodes, so the pass covers three more values:

- **Math.** `\rho := \prod` should still typeset as `≝`. Two rules look at the characters flanking a match, and a math node's `$` delimiters are gone by then — they are handed back for the substitution, which is what keeps `$:=$` a literal `:=`. remark-math attaches the hast it wants rendered at parse time, so that copy is rewritten too.
- **Image alt text and link titles**, which a reader sees but a text-node walk does not.

`config/quartz/quartz.config.ts`
: A second plugin, `ProseCharacterSubstitutions`, carries the mdast tier and sits before `FrontMatter`. The tiers can't share one entry: every `textTransform` runs before any parse, but a markdown plugin runs where its transformer sits, and `FrontMatter` gathers the search index from the tree. Registered any later, `contentIndex.json` would carry `:=` and `:)` while the page showed `≝` and `🙂`.

## Testing

- **Rebuilt all 180 pages and diffed against a pre-change build.** Two pages differ, both intended: `top-right-steering-vector` and `understanding-and-controlling-a-maze-solving-policy-network` now render `` `CheeseActivations := (1, 3)` `` as the author typed it. Every other page, and `contentIndex.json`, is byte-identical.
- Getting there took three build-diff rounds, each of which caught a silent regression that reasoning had missed: math stopped being substituted (mdast math is not a text node), image alt text stopped being substituted (nor is `alt`), and a bare-comma rule that matched with zero spaces split text nodes for a no-op replacement, which moved an NBSP on `test-page`.
- `pnpm test` — 5241 tests, 106 suites, 100% coverage on the touched files. The moved cases keep their inputs; they now assert against the rendered output of both tiers via a shared `renderProse` helper, plus new cases pinning that each character survives inside backticks.
- `pnpm check` (tsc + prettier + stylelint) and eslint clean.

## Lessons learned

- **What**: When moving a transform from raw text onto an AST, enumerate every place the format keeps prose *outside* text nodes — alt text, titles, math, table captions — before trusting a text-node walk.
- **Where**: any text→AST refactor
- **Why**: An mdast text-node pass silently stopped rewriting math and image alt text, which the previous source-level regex had covered. Both looked correct in unit tests and only surfaced in a full build diff.

- **What**: Prefer rewriting a node's value in place over a find-and-replace that splits nodes, when the replacement is a plain string.
- **Where**: any AST text pass
- **Why**: `mdast-util-find-and-replace` splits a text node at every match, including no-op ones. A rule matching a bare comma fragmented ordinary prose, and a downstream pass that reads neighboring nodes changed its output — a diff with no visible cause in the rule itself.

- **What**: Check what a rewritten AST node has already precomputed for downstream stages, not just its own value.
- **Where**: any pass editing nodes from a plugin that supplies `data.hChildren`
- **Why**: remark-math attaches the hast to render while parsing. Editing `node.value` alone changed nothing on the page, and the unit test that asserted on the value passed anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQV8E1fANkUNYcrB6MEfm1)_