### PR TITLE
refactor: use ASTs instead of regex/HTML-parsing in transformers and checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 node_modules
 .venv/
 .worktrees/
+.claude/worktrees/
 
 # Build Output & Caches
 public

--- a/quartz/plugins/transformers/tablecaption.ts
+++ b/quartz/plugins/transformers/tablecaption.ts
@@ -1,7 +1,6 @@
 import type { Element, ElementContent } from "hast"
 import type { Parent } from "unist"
 
-import { fromHtml } from "hast-util-from-html"
 import { h } from "hastscript"
 
 import { createElementVisitorPlugin, isElementNode, isTextNode } from "./utils"
@@ -25,13 +24,14 @@ export function extractCaptionText(value: string): string {
 }
 
 /**
- * Creates a figcaption element from the caption text
+ * Creates a figcaption element from the caption text.
+ *
+ * The caption arrives as already-decoded text, so it becomes a text node
+ * verbatim: angle brackets and ampersands stay literal characters.
  */
 export function createFigcaption(captionText: string): Element[] {
-  const captionHtml = fromHtml(`<figcaption>${captionText}</figcaption>`, {
-    fragment: true,
-  })
-  return captionHtml.children as Element[]
+  const children: ElementContent[] = captionText ? [{ type: "text", value: captionText }] : []
+  return [h("figcaption", children)]
 }
 
 /** True if `element` is a `<table>` element. */
@@ -65,21 +65,21 @@ function processTableCaptionNode(
   }
 
   const captionText = extractCaptionText(firstChild.value)
-  const captionElements = createFigcaption(captionText)
+  const [figcaption] = createFigcaption(captionText)
 
   // Inline markup in the caption (e.g. `*emphasis*`, links) is already parsed
   // into sibling nodes at this rehype stage; createFigcaption only rebuilds the
   // leading text node, so carry the remaining siblings into the figcaption.
-  captionElements[0].children.push(...node.children.slice(1))
+  figcaption.children.push(...node.children.slice(1))
 
-  // Replace the paragraph with the figcaption elements
-  parent.children.splice(parentChildrenIndex, 1, ...captionElements)
+  // Replace the paragraph with the figcaption
+  parent.children.splice(parentChildrenIndex, 1, figcaption)
 
   // Find the preceding table and wrap it with a figure
   if (parentChildrenIndex > 0) {
     const prevElement = parent.children[parentChildrenIndex - 1]
     if (isTableElement(prevElement) && isElementNode(prevElement)) {
-      const figure = createTableFigure(prevElement, captionElements)
+      const figure = createTableFigure(prevElement, [figcaption])
       parent.children.splice(parentChildrenIndex - 1, 2, figure)
     }
   }

--- a/quartz/plugins/transformers/tests/tablecaption.test.ts
+++ b/quartz/plugins/transformers/tests/tablecaption.test.ts
@@ -100,19 +100,13 @@ describe("TableCaption helper functions", () => {
       ["tag-looking text", "compare <b> and <i> tags"],
       ["a closing-figcaption token", "the </figcaption> token"],
       ["a stray ampersand", "Costs 5 & 6"],
+      ["an element-looking span", "My <strong>bold</strong> caption"],
     ])("should keep %s verbatim in a single element", (_description, captionText) => {
       const result = createFigcaption(captionText)
       expect(result).toHaveLength(1)
       expect(result[0].tagName).toBe("figcaption")
       expect(result[0].children).toHaveLength(1)
       expect((result[0].children[0] as Text).value).toBe(captionText)
-    })
-
-    it("should create figcaption elements from HTML content", () => {
-      const result = createFigcaption("My <strong>bold</strong> caption")
-      expect(result).toHaveLength(1)
-      expect(result[0].tagName).toBe("figcaption")
-      expect(result[0].children).toHaveLength(3) // "My ", <strong>, " caption"
     })
   })
 
@@ -273,7 +267,7 @@ describe("TableCaption transformer integration", () => {
       expect((root.children[1] as Element).tagName).toBe("figure")
     })
 
-    it("should handle complex HTML in caption", () => {
+    it("should not interpret tag-looking caption text as markup", () => {
       const root: Root = {
         type: "root",
         children: [
@@ -294,7 +288,10 @@ describe("TableCaption transformer integration", () => {
       expect(root.children).toHaveLength(1)
       const figure = root.children[0] as Element
       const figcaption = figure.children[1] as Element
-      expect(figcaption.children.length).toBeGreaterThan(1) // Should have parsed HTML
+      expect(figcaption.children).toHaveLength(1)
+      expect((figcaption.children[0] as Text).value).toBe(
+        "Caption with <strong>bold</strong> and <em>italic</em>",
+      )
     })
 
     it("should handle empty caption text", () => {

--- a/quartz/plugins/transformers/tests/tablecaption.test.ts
+++ b/quartz/plugins/transformers/tests/tablecaption.test.ts
@@ -96,6 +96,18 @@ describe("TableCaption helper functions", () => {
       expect(result[0].tagName).toBe("figcaption")
       expect(result[0].children).toHaveLength(0)
     })
+    it.each([
+      ["tag-looking text", "compare <b> and <i> tags"],
+      ["a closing-figcaption token", "the </figcaption> token"],
+      ["a stray ampersand", "Costs 5 & 6"],
+    ])("should keep %s verbatim in a single element", (_description, captionText) => {
+      const result = createFigcaption(captionText)
+      expect(result).toHaveLength(1)
+      expect(result[0].tagName).toBe("figcaption")
+      expect(result[0].children).toHaveLength(1)
+      expect((result[0].children[0] as Text).value).toBe(captionText)
+    })
+
     it("should create figcaption elements from HTML content", () => {
       const result = createFigcaption("My <strong>bold</strong> caption")
       expect(result).toHaveLength(1)
@@ -383,6 +395,32 @@ describe("TableCaption transformer integration", () => {
       )
       expect(link?.properties?.href).toBe("/source")
       expect((link?.children[0] as Text).value).toBe("source")
+    })
+
+    it.each([
+      ["tag-looking text", "compare <b> and <i> tags"],
+      ["a closing-figcaption token", "the </figcaption> token"],
+    ])("keeps %s inside one figcaption alongside its siblings", (_description, captionText) => {
+      const root: Root = {
+        type: "root",
+        children: [
+          h("table", [h("tr", [h("td", "Data")])]),
+          h("p", [{ type: "text", value: `^Table: ${captionText}` }, h("em", "note")]),
+        ],
+      }
+
+      const plugin = TableCaption()
+      const transformer = getTransformer(plugin)
+      transformer(root)
+
+      expect(root.children).toHaveLength(1)
+      const figure = root.children[0] as Element
+      expect(figure.children).toHaveLength(2)
+      const figcaption = figure.children[1] as Element
+      expect(figcaption.tagName).toBe("figcaption")
+      expect(figcaption.children).toHaveLength(2)
+      expect((figcaption.children[0] as Text).value).toBe(captionText)
+      expect((figcaption.children[1] as Element).tagName).toBe("em")
     })
   })
 


### PR DESCRIPTION
Follow-up to #1754, which moved prose character substitutions onto the mdast. That PR fixed one instance of a defect class; this one works through the rest of the class.

The shared bug: **text is treated as source syntax when it is already data.** A regex over raw markdown cannot tell prose from a fenced code block; re-serializing a decoded text node back through an HTML parser cannot tell a caption from markup. Both let user content escape into structure.

## Changes

### `tablecaption.ts` — stop round-tripping caption text through an HTML parser

`createFigcaption` built its node with `fromHtml(\`<figcaption>${captionText}</figcaption>\`)`. But `captionText` comes from a hast **text** node, which is already decoded — so any angle bracket in a caption was re-parsed as markup:

| caption | before | after |
| --- | --- | --- |
| `compare <b> and <i> tags` | `<figcaption>compare <b> and <i> tags</i></b></figcaption>` — real elements, injected | literal text |
| `the </figcaption> token` | **two** elements returned; the caller indexes `[0]` and splices both, breaking the `<figure>` wrapper | one element |

The node is now constructed directly (`h("figcaption", [text])`), so it returns exactly one element by construction and the caption text is never interpreted. Genuinely-parsed inline markup (`*emphasis*`, links) is unaffected — those arrive as real sibling nodes at this rehype stage and are still carried into the figcaption.

Further commits on this branch cover the remaining three sites (ofm wikilinks rewritten inside code blocks, source-tier substitution rules firing inside inline code, and the hand-rolled `remove_code`/`remove_math` regexes in `scripts/source_file_checks.py`). Details will be added here as they land.

## Testing

- New `it.each` coverage on `createFigcaption` and through the full transformer, asserting one element and one verbatim text node for the `<b>`/`<i>`, `</figcaption>`, and `&` cases.
- `pnpm check` clean.

## Lessons learned

- **Serializing data back into its own source syntax is a bug, not a shortcut.** `fromHtml(\`<tag>${value}</tag>\`)` on a value that came *out* of an AST is the string-concatenation-SQL-injection shape, applied to markup. If you already hold a decoded value and want a node, build the node — don't render text and re-parse it.
- **A helper whose return arity depends on user input will eventually be indexed wrongly.** `createFigcaption` returned `Element[]` because a parser *can* return several nodes; every caller assumed one. Construct-don't-parse fixed the arity as a side effect.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BQV8E1fANkUNYcrB6MEfm1)_