### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
@@ -299,11 +299,11 @@ An agent with shell access can hurt you in at least seven distinct ways:
 
 See [`docs/configuration.md`](docs/configuration.md) for the full reference: wrapper environment variables and flags, the `--dangerously-*` security levels, and how to expand network access for a specific workflow.
 
-Running an eval harness instead of a coding session? `pip install inspect-glovebox` registers glovebox as an [Inspect](https://inspect.ai-safety-institute.org.uk/) sandbox provider, so one microVM backs each sample. [`docs/for-eval-harnesses.md`](docs/for-eval-harnesses.md) says which tasks run today and what the limits are; [`docs/inspect-provider.md`](docs/inspect-provider.md) is the reference.
+Running an eval harness instead of a coding session? The `inspect-glovebox` package registers glovebox as an [Inspect](https://inspect.ai-safety-institute.org.uk/) sandbox provider, so one microVM backs each sample. It is not on PyPI yet: [`docs/inspect-provider.md`](docs/inspect-provider.md) is the reference and carries the install command from this repository, and [`docs/for-eval-harnesses.md`](docs/for-eval-harnesses.md) says which tasks run today and what the limits are.
 
 ## Metrics
 
-<!-- codebase-breakdown:start -->
+<!-- BEGIN GENERATED: codebase-breakdown (scripts/gen-composition-caption.py) — do not edit by hand -->
 
 ### 📊 Codebase composition
 
@@ -311,7 +311,7 @@ Running an eval harness instead of a coding session? `pip install inspect-gloveb
 
 <sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published daily by the repo-health chart run, from the same read of the tree as the tracked-lines trend, so the two totals always agree. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` → Tests; `evals/` → Evals; `.github/` → CI/CD; `*.md`/`docs/`/`changelog.d/` → Docs; manifests/lockfiles/dotfiles → Config; everything else → Source. `.gitattributes` linguist-generated/vendored is set aside and left out of the total.</sub>
 
-<!-- codebase-breakdown:end -->
+<!-- END GENERATED: codebase-breakdown -->
 
 The live-fire breakout CTF, the monitor's control-eval scores, and every cost and latency chart re-render on every merge to `main` in [METRICS.md](METRICS.md).
 

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
@@ -25,7 +25,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@b4e4a501aa806830db3bb32edf9329ed7c14de0d # v1.14.0
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@47e5cdcbcb51be87e0b137081d8954e8c08b2e0c # v1.16.1
     with:
       pr: ${{ matrix.pr.number }}
       resolver-repository: AlexanderMattTurner/agent-resolve-merge-conflicts
@@ -123,7 +123,7 @@ A `uses:` ref may be a SHA, a tag or a branch. GitHub calls [the commit SHA the 
 **Pin the SHA and name the version beside it**, the way this repository's own caller does:
 
 ```yaml
-uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@b4e4a501aa806830db3bb32edf9329ed7c14de0d # v1.14.0
+uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@47e5cdcbcb51be87e0b137081d8954e8c08b2e0c # v1.16.1
 ```
 
 That line reads as a version and resolves as an immutable commit. It names the newest release: `.github/scripts/release-tag.sh` rewrites both copies in this README, and the caller's, in the commit after each release. Copy it as it stands.


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.