### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
@@ -8,9 +8,7 @@ After all, what's the chance that something bad happens?
 
 ![A researcher reaches through the sealed gloves of a laboratory glove box to work with material sealed inside, the barrier keeping it contained.](https://assets.turntrout.com/static/images/glovebox.jpg)
 
-_Disclaimer: I'm an AI professional but not a security professional. I welcome issues and PRs._
-
-<!-- BEGIN GENERATED: status badges (scripts/gen-status-badges.mjs) — do not edit by hand -->
+<!-- BEGIN GENERATED: status badges (scripts/gen-status-badges.mjs) -->
 
 [![smoke tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsmoke-tests.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/smoke-tests.yaml)
 [![JS (ESLint + tsc + coverage 100%)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fjs.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/js.yaml)
@@ -108,7 +106,7 @@ Claude Code's built-in `sandbox` confines only Bash subprocesses, with OS-level 
 The Docker `sbx` microVM **is** this stack's foundation, and alone it does one job well: the agent cannot damage your machine. What it does not cover:
 
 - **Stock `sbx` runs the agent with passwordless `sudo` and the `docker` group.** In-VM root can delete any settings file, hook, or log that watches it. `glovebox` removes both at boot and root-locks the guardrails, so the audit record and the permission veto survive an agent that turns on them.
-- **Containment says nothing about the allowed channel.** Some hosts must stay reachable (github.com, your package registries), and to stock `sbx` an allowed host is allowed for anything — its policy grants a `host:port` and has no way to tell a read from a write. `glovebox` marks each allowed host read-only or read-write and enforces that inside the VM: a read-only host serves `GET`, `HEAD`, `OPTIONS` and `git fetch`, and everything else gets a 403. So the agent clones from every allowed host and can push to `github.com` alone — the one host the packaged policy names for git pushes — even though the credential doing the talking is injected outside the VM and would authorize a push anywhere. On top of that it scopes the GitHub token to the current repo, strips injections from what comes in, redacts secrets from what goes out, and keeps the monitor and the audit log on the host, out of the agent's reach.
+- **Containment says nothing about the allowed channel.** Some hosts must stay reachable (github.com, your package registries), and to stock `sbx` an allowed host is allowed for anything — its policy grants a `host:port` and has no way to tell a read from a write. `glovebox` marks each allowed host read-only or read-write and enforces that inside the VM: a read-only host serves `GET`, `HEAD`, `OPTIONS` and `git fetch`, and everything else gets a 403. So the agent clones from the git hosts the packaged policy names and can push to `github.com` alone — the one host that policy names for git pushes — even though the credential doing the talking is injected outside the VM and would authorize a push anywhere. On top of that it scopes the GitHub token to the current repo, strips injections from what comes in, redacts secrets from what goes out, and keeps the monitor and the audit log on the host, out of the agent's reach.
 - **Safe defaults are the actual work.** A curated allowlist, a signed prebuilt image, credentials injected outside the VM so keys never enter it, and `glovebox doctor` to prove it's all on.
 
 See [`SECURITY.md`](SECURITY.md) for what each layer does and does not stop.
@@ -120,7 +118,7 @@ Anthropic's own guidance says yes. Their [Zero Trust for AI Agents](https://cdn.
 And the attacks are no longer hypothetical:
 
 - A prompt-injected agent with a broad GitHub token [leaked private repos through a public PR](https://invariantlabs.ai/blog/mcp-github-vulnerability). `glovebox` mints its GitHub token scoped to the current repo, and the token never enters the sandbox at all.
-- A [trojaned MCP server on npm](https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft) BCC'd thousands of emails a day to an attacker domain after a one-line update. `glovebox`'s firewall blocks unknown destinations by default, and its MCP tripwire refuses to remember an approval for any server that doesn't pin an exact version. A registry update can't silently run new code under an old grant.
+- A [trojaned MCP server on npm](https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft) BCC'd thousands of emails a day to an attacker domain after a one-line update. `glovebox`'s firewall blocks unknown destinations by default, and its MCP tripwire refuses to remember an approval for any server that doesn't pin an exact version, so a registry update can't silently run new code under an old grant. Blanket approval for a project's connectors is the exception: it starts every unpinned one with no prompt, and the tripwire names them again each session.
 - Escape capability is now measured, and it scales with the budget you give it: in [arXiv:2603.02277](https://arxiv.org/abs/2603.02277) success rose roughly log-linearly with the tokens each model was allowed to spend, so patience buys attempts. The escapes the authors found also took the cheapest route rather than the intended exploit — a default `vagrant:vagrant` password and a publicly known SSH key, reached over the container's own bridge gateway. That is why an allowlist firewall and a de-privileged agent are load-bearing here and not decoration: they close the cheap routes, which are the ones a model takes.
 
 ### A model escaped a VM three times in one afternoon. So why use `glovebox` at all?
@@ -212,9 +210,9 @@ The **dashed outline** marks auto mode's gate on each tool call; the monitor and
 
 What the hard boundaries buy you:
 
-- **It can't read files outside your project.** The sandbox mounts only your project directory. The rest of your home folder, your SSH and cloud keys, your browser profile, your other repos — none of it is _present_ inside, so there's nothing to read in the first place. Credential-shaped environment variables are stripped from its shells, too.
-- **It can't change your computer.** By default the agent works on a throwaway copy of your project and hands its edits back as a reviewable `glovebox/*` git branch you merge yourself. Nothing it writes touches your real files until you approve. Inside the box it runs as an unprivileged user, on a read-only system filesystem, with no path to `root` — so it can't quietly rewrite the container or its own guardrails either.
-- **It can't break out or reach an arbitrary server.** The whole session — not just shell commands, but web fetches, connectors, and the agent process itself — stays inside the microVM even under a guest-kernel exploit. All network traffic is blocked except an [allowlist](https://github.com/AlexanderMattTurner/agent-glovebox/blob/main/sandbox-policy/domain-allowlist.json), so a compromised agent cannot proliferate to, or send data to, a server of its choosing. Each allowed site is further tagged read-only or read-write, and a filter inside the VM holds a read-only one to reads — so GitHub and the package registries serve fetches and refuse uploads, except the one carve-out for `git push` to GitHub itself (see above). What stays upload-capable is the read-write set: the inference API the agent must POST to, plus any host your project's own `.claude/settings.json` adds, which the filter treats as read-write because the curated allowlist gave it no tier. A URL's own bytes carry data out too — the residual channel the repo-scoped token, the monitor, and the audit log exist for.
+- **It can't read files outside your project.** The sandbox mounts only your project directory. The rest of your home folder, your SSH and cloud keys, your browser profile, your other repos — none of it is _present_ inside, so there's nothing to read in the first place. The one thing copied in is an allowlisted slice of your `~/.claude` config — skills, agents, commands, hooks, settings — and no credential rides with it. Stray GitHub token variables are unset before the agent starts, and the credentials it does use are injected outside the VM rather than passed in.
+- **It can't change your computer.** By default the agent works on a throwaway copy of your project and hands its edits back as a reviewable `glovebox/*` git branch you merge yourself. Nothing it writes touches your real files until you approve. Inside the box it runs as an unprivileged user with no path to `root`, and its guardrails are root-owned files it cannot write — so it can't quietly rewrite them either.
+- **It can't break out or reach an arbitrary server.** The whole session — not just shell commands, but web fetches, connectors, and the agent process itself — stays inside the microVM even under a guest-kernel exploit. All network traffic is blocked except an [allowlist](https://github.com/AlexanderMattTurner/agent-glovebox/blob/main/sandbox-policy/domain-allowlist.json), so a compromised agent cannot proliferate to, or send data to, a server of its choosing. Each allowed site is further tagged read-only or read-write, and a filter inside the VM holds a read-only one to reads — so GitHub and the package registries serve fetches and refuse uploads, except the one carve-out for `git push` to GitHub itself (see above). What stays upload-capable is the read-write set: the Anthropic API the agent must POST to, the Weights & Biases API, plus any host your project's own `.claude/settings.json` lists under `allowedDomainsReadWrite`. A host that file lists under `allowedDomains` stays read-only, and a reachable host no source gave a tier refuses the launch rather than defaulting either way. A URL's own bytes carry data out too — the residual channel the repo-scoped token, the monitor, and the audit log exist for.
 
 On top of those walls sit **best-effort filters**. They raise the bar, but a determined or hijacked agent can sometimes slip past one, so the safety argument never _rests_ on them:
 
@@ -252,7 +250,7 @@ Sessions are **ephemeral by default**: attackers can't lay landmines in the syst
 
 It exits `0` PROTECTED, `1` DEGRADED, or `2` UNPROTECTED. `--fix` repairs a missing or wrong `~/.local/bin/claude` alias, and stores a monitor API key once the monitor is on.
 
-**`glovebox audit`** — print this workspace's tool-call audit log. The monitor logs every call to an append-only log the agent can't read or alter, and at teardown that log is archived to a host directory. `audit` surfaces it **read-only** (over a throwaway `--network none` container for any live log), with or without a running session, and can never change the log. Flags:
+**`glovebox audit`** — print this workspace's tool-call audit log. Every call is logged to a host-side append-only log the agent can't read or edit, and at teardown that log is archived to a host directory. The agent can add records to it, and each one is marked as unwitnessed so it can never claim a verdict. `audit` surfaces it **read-only** (over a throwaway `--network none` container for any live log), with or without a running session, and can never change the log. Flags:
 
 - `-f` follows live,
 - `-n N` shows the last N,
@@ -277,7 +275,7 @@ Two levels, settled at launch (interactively, or via the env var / flag):
 - **Observe** (`--watcher-observe-only`, or `_GLOVEBOX_WATCHER=1`) — Watcher reviews the session but can't block it.
 - **Gate** (`--watcher-gate`, or `_GLOVEBOX_WATCHER_GATE=1`) — Watcher can additionally **stop the model**: each tool call waits for an allow/deny in the Apollo UI. The host pushes verdicts, as root, into a directory inside the sandbox the agent cannot write, so a compromised agent can't forge its own approval.
 
-The launch box's **Monitor** row shows the resolved posture. Opt-in only, and only on an ephemeral session; the bridge is torn down at exit. Trust boundary: [`SECURITY.md`](SECURITY.md) § "Apollo Watcher bridge".
+The launch box's **Monitor** row shows the resolved posture. Opt-in only; the bridge is torn down at exit. Trust boundary: [`SECURITY.md`](SECURITY.md) § "Apollo Watcher bridge".
 
 ## Threat models
 
@@ -303,13 +301,13 @@ Running an eval harness instead of a coding session? The `inspect-glovebox` pack
 
 ## Metrics
 
-<!-- BEGIN GENERATED: codebase-breakdown (scripts/gen-composition-caption.py) — do not edit by hand -->
+<!-- BEGIN GENERATED: codebase-breakdown (scripts/gen-composition-caption.py) -->
 
 ### 📊 Codebase composition
 
 ![Codebase composition chart](https://assets.turntrout.com/static/charts/glovebox/codebase-composition.svg)
 
-<sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published daily by the repo-health chart run, from the same read of the tree as the tracked-lines trend, so the two totals always agree. Every tracked line (blanks and comments included), bucketed by path with the same heuristics as the per-PR breakdown: `tests/` & `*.test.*` & `test_*.py` → Tests; `evals/` → Evals; `.github/` → CI/CD; `*.md`/`docs/`/`changelog.d/` → Docs; manifests/lockfiles/dotfiles → Config; everything else → Source. `.gitattributes` linguist-generated/vendored is set aside and left out of the total.</sub>
+<sub>Rendered by `.github/scripts/codebase-breakdown.py` and re-published daily by the repo-health chart run, from the same read of the tree as the tracked-lines trend, so the two totals always agree. Every authored tracked line, bucketed by path — except a comment line in a file `_languages.py` enrolls a grammar for, which counts as Docs wherever it sits. Blank lines count in their file's own bucket. The path buckets are the per-PR breakdown's own: `tests/` & `*.test.*` & `test_*.py` → Tests; `evals/` → Evals; `.github/` → CI/CD; `*.md`/`docs/`/`changelog.d/`/`man/` → Docs; manifests/lockfiles/dotfiles → Config; code suffixes & executables → Source; everything else → Other. `.gitattributes` linguist-generated/vendored is set aside and left out of the total.</sub>
 
 <!-- END GENERATED: codebase-breakdown -->
 

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
@@ -25,7 +25,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@47e5cdcbcb51be87e0b137081d8954e8c08b2e0c # v1.16.1
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@c1fb78da6cb6a769e41d4d6fee71225a963b3191 # v1.18.0
     with:
       pr: ${{ matrix.pr.number }}
       resolver-repository: AlexanderMattTurner/agent-resolve-merge-conflicts
@@ -50,7 +50,7 @@ That job is half of an adoption. Copy `.github/workflows/auto-resolve-conflicts.
 
 The `permissions:` block on the calling job is the ceiling its nested jobs are narrowed from, not a grant. GitHub lets a called workflow request only what the calling job already holds, so a caller that grants less ends the whole run in `startup_failure` before any job starts — no red job, no reported check.
 
-Every input fails closed when empty. No `log-redactor` publishes no fan-out logs. No `setup-command` prepares nothing, so a repository whose checkout an agent cannot start in — a tracked symlink that dangles in CI, for one — names its own repair there. It runs on the merged tree just before the model, whatever it changes is put back before the merge is bundled, and a fork head runs none. It is the one command input evaluated by a shell (`bash -eo pipefail -c`); `pre-pass-command` and `post-merge-check-command` are split into argv and run with none. No `pre-pass-command` refuses to bundle a deferred generated file rather than shipping bytes no build produces. An empty `bot-actors` admits no bot. `post-merge-check-command` is the exception in one direction only: empty runs no whole-tree check, so a merge that keeps both parents' definition of one name reaches the branch and reds the pull request's own checks instead. Name your type-checker or import-check there — `bash .github/scripts/pyright-passes.sh` — and a resolution that breaks the tree is refused rather than pushed. The command runs in the `resolve` job, which holds no push credential, and it must only REPORT; one that stages a file is refused. Exit 1 to 125 judges the merged tree, and 126 and above is read as the shell's `never ran`, which blames this workflow's provisioning rather than your branch.
+Every input fails closed when empty. No `log-redactor` publishes no fan-out logs. No `setup-command` prepares nothing, so a repository whose checkout an agent cannot start in — a tracked symlink that dangles in CI, for one — names its own repair there. It runs on the merged tree just before the model, whatever it changes is put back before the merge is bundled, and a fork head runs none. It is the one command input evaluated by a shell (`bash -eo pipefail -c`); `pre-pass-command` and `post-merge-check-command` are split into argv and run with none. No `pre-pass-command` refuses to bundle a deferred generated file rather than shipping bytes no build produces. An empty `bot-actors` admits no bot. `post-merge-check-command` is the exception in one direction only: empty runs no whole-tree check, so a merge that keeps both parents' definition of one name reaches the branch with nothing naming what it broke. Name your type-checker or import-check there — `bash .github/scripts/pyright-passes.sh` — and a resolution that breaks the tree is pushed with a comment naming what it broke, so the conflict is resolved once and the finding is fixed on a branch that no longer conflicts. The command runs in the `resolve` job, which holds no push credential, and it must only REPORT; one that stages a file is refused. Exit 1 to 125 judges the merged tree, and 126 and above is read as the shell's `never ran`, which blames this workflow's provisioning rather than your branch. The pre-push merge-delta self-review is opt-in: pass `self-review: true` when no CI of yours reads the pushed delta and gates the merge on the finding, because the resolver otherwise pushes merges nothing will ever review.
 
 ## Configuration
 
@@ -123,7 +123,7 @@ A `uses:` ref may be a SHA, a tag or a branch. GitHub calls [the commit SHA the 
 **Pin the SHA and name the version beside it**, the way this repository's own caller does:
 
 ```yaml
-uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@47e5cdcbcb51be87e0b137081d8954e8c08b2e0c # v1.16.1
+uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@c1fb78da6cb6a769e41d4d6fee71225a963b3191 # v1.18.0
 ```
 
 That line reads as a version and resolves as an immutable commit. It names the newest release: `.github/scripts/release-tag.sh` rewrites both copies in this README, and the caller's, in the commit after each release. Copy it as it stands.


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.