### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
@@ -15,6 +15,7 @@ After all, what's the chance that something bad happens?
 [![mutation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fmutation-testing.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/mutation-testing.yaml)
 [![pytest](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fpytest-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/pytest-checks.yaml)
 [![hadolint](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fhadolint.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/hadolint.yaml)
+[![CI](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fci.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/ci.yaml)
 [![actionlint + zizmor + bash config](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Flint-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/lint-checks.yaml)
 [![isolation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsbx-live-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/sbx-live-checks.yaml)
 
@@ -49,7 +50,7 @@ brew trust --formula AlexanderMattTurner/tap/agent-glovebox &&
 
 ### Apt repos
 
-Download the package for your distribution from the [latest release](https://github.com/AlexanderMattTurner/agent-glovebox/releases/latest), then run the appropriate install command.
+Download the package and its matching `.sigstore.json` bundle from the [latest release](https://github.com/AlexanderMattTurner/agent-glovebox/releases/latest). Verify the package with the command in [`packaging/README.md`](packaging/README.md) before you install it.
 
 #### Debian/Ubuntu
 
@@ -216,7 +217,7 @@ The **dashed outline** marks auto mode's gate on each tool call; the monitor and
 What the hard boundaries buy you:
 
 - **It can't read files outside your project.** The sandbox mounts only your project directory. The rest of your home folder, your SSH and cloud keys, your browser profile, your other repos — none of it is _present_ inside, so there's nothing to read in the first place. The one thing copied in is an allowlisted slice of your `~/.claude` config — skills, agents, commands, hooks, settings — and no credential rides with it. Stray GitHub token variables are unset before the agent starts, and the credentials it does use are injected outside the VM rather than passed in.
-- **It can't change your computer.** By default the agent works on a throwaway copy of your project and hands its edits back as a reviewable `glovebox/*` git branch you merge yourself. Nothing it writes touches your real files until you approve. Inside the box it runs as an unprivileged user with no path to `root`, and its guardrails are root-owned files it cannot write — so it can't quietly rewrite them either.
+- **It can't change your computer outside the workspace.** For a Git repository, the agent works on a copy and returns a reviewable `glovebox/*` branch. A directory without a Git repository is shared directly, so agent writes change its real files. Inside the box the agent runs as an unprivileged user, and root owns its guardrails.
 - **It can't break out or reach an arbitrary server.** The whole session — not just shell commands, but web fetches, connectors, and the agent process itself — stays inside the microVM even under a guest-kernel exploit. All network traffic is blocked except an [allowlist](https://github.com/AlexanderMattTurner/agent-glovebox/blob/main/sandbox-policy/domain-allowlist.json), so a compromised agent cannot proliferate to, or send data to, a server of its choosing. Each allowed site is further tagged read-only or read-write, and a filter inside the VM holds a read-only one to reads — so GitHub and the package registries serve fetches and refuse uploads, except the one carve-out for `git push` to GitHub itself (see above). What stays upload-capable is the read-write set: the Anthropic API the agent must POST to, the Weights & Biases API, plus any host your project's own `.claude/settings.json` lists under `allowedDomainsReadWrite`. A host that file lists under `allowedDomains` stays read-only, and a reachable host no source gave a tier refuses the launch rather than defaulting either way. A URL's own bytes carry data out too — the residual channel the repo-scoped token, the monitor, and the audit log exist for.
 
 On top of those walls sit **best-effort filters**. They raise the bar, but a determined or hijacked agent can sometimes slip past one, so the safety argument never _rests_ on them:
@@ -255,7 +256,7 @@ Sessions are **ephemeral by default**: attackers can't lay landmines in the syst
 
 It exits `0` PROTECTED, `1` DEGRADED, or `2` UNPROTECTED. `--fix` repairs a missing or wrong `~/.local/bin/claude-glovebox` link, and stores a monitor API key once the monitor is on.
 
-**`glovebox audit`** — print this workspace's tool-call audit log. Every call is logged to a host-side append-only log the agent can't read or edit, and at teardown that log is archived to a host directory. The agent can add records to it, and each one is marked as unwitnessed so it can never claim a verdict. `audit` surfaces it **read-only** (over a throwaway `--network none` container for any live log), with or without a running session, and can never change the log. Flags:
+**`glovebox audit`** — print this workspace's observed tool-call audit log. With the experimental monitor on, the host records each observed attempt and verdict. Every launch records redacted results that reach `PostToolUse`. Claude Code emits no usable result event for some calls, so this is not a complete call count. At teardown the host archives the log outside the virtual machine. `audit` reads it through a throwaway `--network none` container and never changes it. Flags:
 
 - `-f` follows live,
 - `-n N` shows the last N,
@@ -318,7 +319,7 @@ Already have your own isolation and want only the tool-call review? The `glovebo
 
 <!-- END GENERATED: codebase-breakdown -->
 
-The live-fire breakout CTF, the monitor's control-eval scores, and every cost and latency chart re-render on every merge to `main` in [METRICS.md](METRICS.md).
+[METRICS.md](METRICS.md) states the trigger and measured revision for each live-fire result, control score, cost chart, and latency chart.
 
 <!--
 Canary for this repo: EzXtfGshayJoaSPYXqonExqzTzZsxi

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
@@ -8,7 +8,7 @@ The workflow resolves a conflict in three passes. Only the last one spends model
 
 1. **The pre-pass rebuilds every conflicted generated file instead of guessing it.** A lockfile goes through its own lock command, and a generated artifact through its generator.
 2. **The structural pre-pass re-merges what is left, syntax-aware.** It runs [mergiraf](https://mergiraf.org), which this workflow installs at a pinned version from its own tree. mergiraf merges a conflict by the file's syntax rather than its lines, so it settles many source conflicts for free. Nothing reaches the model that this pass already solved.
-3. **A model resolves the source conflicts that remain.** With the pre-pass configured, the model sees only files a person wrote by hand. Without it the model sees every remaining conflict, generated files included. That is what a fork head gets, because the workflow empties `resolver-mjs` there, and what a repository that declares no rules gets. A generator that fails sends its file to the model the same way.
+3. **A model resolves the source conflicts that remain.** With the pre-pass configured, the model sees only files a person wrote by hand. Without it the model sees every remaining conflict, generated files included. That is what a fork head gets, because the workflow empties `resolver-mjs` there, and what a repository that declares no rules gets. A generator that fails sends its file to the model the same way. A pre-pass that could not RUN at all refuses instead, because it re-derived nothing: a missing binary or module names itself in the command's own output.
 
 A conflict that no pass can settle stops the run and comments on the pull request. A binary file is one example, and a `-merge` file that no rule owns is another. This check runs before any model call, so an unresolvable conflict costs nothing.
 
@@ -28,7 +28,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@4f5669dc6818f30b5ad19e8ff0c74cc3462fd13a # v1.25.1
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@39a4a40eebc2b0e6920b14dc8ad077ace513d28f # v1.27.3
     with:
       pr: ${{ matrix.pr.number }}
       resolver-repository: AlexanderMattTurner/agent-resolve-merge-conflicts
@@ -61,9 +61,31 @@ Every input fails closed when empty. The workflow does less, rather than guessin
 - **`setup-command`** — no command prepares nothing. A repository whose checkout an agent cannot start in names its own repair here. A tracked symlink that dangles in CI is one such repository. The command runs on the merged tree just before the model. Whatever it changes is put back before the merge is bundled. A fork head runs none. It is the one command input a shell evaluates (`bash -eo pipefail -c`). `pre-pass-command` and `post-merge-check-command` are split into argv and run with no shell.
 - **`pre-pass-command`** — no command refuses to bundle a deferred generated file, rather than shipping bytes no build produces.
 - **`bot-actors`** — an empty value admits no bot.
-- **`post-merge-check-command`** — this input is the exception in one direction only. Empty runs no whole-tree check, so a merge that keeps both parents' definition of one name reaches the branch with nothing naming what it broke. Name your type-checker or import-check here — `bash .github/scripts/pyright-passes.sh`. A resolution that breaks the tree is then pushed with a comment naming what it broke, so the conflict is resolved once and the finding is fixed on a branch that no longer conflicts. The command runs in the `resolve` job, which holds no push credential. It must only REPORT: a command that stages a file is refused. Exit 1 to 125 judges the merged tree. Exit 126 and above is read as the shell's `never ran`, which blames this workflow's provisioning rather than your branch.
+- **`post-merge-check-command`** — this input is the exception in one direction only. Empty runs no whole-tree check, so a merge that keeps both parents' definition of one name reaches the branch with nothing naming what it broke. Name your type-checker or import-check here — `bash .github/scripts/pyright-passes.sh`. A resolution that breaks the tree is then pushed with a comment naming what it broke, so the conflict is resolved once and the finding is fixed on a branch that no longer conflicts. The command runs in the `resolve` job, which holds no push credential. It must only REPORT: a command that stages a file is refused. Exit 1 to 125 judges the merged tree, unless the command's own output shows an interpreter dying on a missing dependency of its own. Exit 126 and above, or that crash signature, is read as the shell's `never ran`, which blames this workflow's provisioning rather than your branch.
+- **`plumbing-notice-issue`** — empty posts nothing beyond the pull request's sticky comment. A refusal that blames this WORKFLOW's own pins, grants or tooling is not the pull request's defect, so that comment reaches whoever owns the branch, not whoever owns the plumbing, and the next run overwrites it. Name an issue number in the calling repository and such a refusal is also repeated there, as a comment. The calling repository's `resolve` job needs `issues: write` for the comment to post.
 - **`self-review`** — empty runs the review. The pre-push merge-delta self-review is on by default, so a repository that adopts this workflow never pushes a merge nothing reads. A model reads the merge commit while it is still local, fixes what it flags, and refuses the push on a finding it cannot fix. When every rung of your credential ladder is spent, the merge lands marked unverified and auto-merge stays off, so a human reads it. Keep it on even when CI of yours already reads the pushed delta: this pass fixes before the push, so it saves the review cycle your own reader would otherwise spend. Pass `self-review: false` only to make no pre-push model call at all. A repository that configures no model credential runs no review either way.
 - **`review-model`** — empty runs the review on its own default. This input is separate from `model` because that one lowers the per-file shards to save cost, while this pass judges those shards. Raise it when nothing of yours reads the pushed delta, since this pass is then the only read your merges get.
+
+## Label the conflicted pull requests
+
+The resolver acts on the `merge-conflict` label, and it ships the script that applies that label: `.github/resolver/label-merge-conflicts.sh`. Run that one rather than keeping a copy, so the label the resolver reads and the label a scan writes are always the same string — both read the name from `.github/resolver/lib/shared-names.json`.
+
+It syncs one pull request when `PR_NUMBER` is set, the pull requests based on one branch when `BASE_REF` is, and every open one otherwise. It only reads the API and edits labels; it never pushes to a branch.
+
+```yaml
+- uses: actions/checkout@v5 # the clone that carries the resolver
+  with:
+    repository: AlexanderMattTurner/agent-resolve-merge-conflicts
+    ref: v1.25.2 # pin the same commit your caller pins
+    path: resolver
+- env:
+    GH_TOKEN: ${{ github.token }}
+    REPO: ${{ github.repository }}
+    PR_NUMBER: ${{ github.event.pull_request.number }}
+  run: bash resolver/.github/resolver/label-merge-conflicts.sh
+```
+
+The job needs `pull-requests: write` and `issues: write`, because a pull-request label rides the issues API.
 
 ## Read the merge deltas after the push
 
@@ -176,7 +198,7 @@ A `uses:` ref may be a SHA, a tag or a branch. GitHub calls [the commit SHA the 
 **Pin the SHA and name the version beside it**, the way this repository's own caller does:
 
 ```yaml
-uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@4f5669dc6818f30b5ad19e8ff0c74cc3462fd13a # v1.25.1
+uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@39a4a40eebc2b0e6920b14dc8ad077ace513d28f # v1.27.3
 ```
 
 That line reads as a version and resolves as an immutable commit. It names the newest release: `.github/scripts/release-tag.sh` rewrites both copies in this README, and the caller's, in the commit after each release. Copy it as it stands.

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
@@ -1,18 +1,6 @@
 # `agent-sanitizer`
 
-**Cleans untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs, look-alike hosts, and exfil-shaped URLs.
-
-This library handles each channel on its own terms. It strips invisible characters and ANSI escapes by default, splices out hidden HTML when you opt in, and _reports_ exfil-shaped URLs and look-alike hosts rather than rewriting them — mangling a legitimate link is the worse failure. Every layer is a deterministic transform, so you can unit-test it with equality assertions. There is no classifier and no model call, so nothing rests on whether a prediction generalized.
-
-**As a library:**
-
-```sh
-npm install agent-sanitizer
-```
-
-**As a Claude Code plugin:**
-
-Enter one at a time:
+**Cleans untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs, look-alike hosts, and exfil-shaped URLs. This library handles each channel. Easy to use as a Claude Code plugin, and the plugin itself is recommended by [`alignment-hive`](https://github.com/crazytieguy/alignment-hive/)!
 
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
@@ -176,7 +164,12 @@ buy you:
 3. Look-alike glyphs in tool inputs are folded to ASCII, so a Cyrillic `а` can't
    walk a command past a deny rule.
 4. Tool output has invisible characters and terminal escapes stripped, hidden
-   HTML spliced out with a placeholder, and exfil-shaped URLs flagged.
+   HTML spliced out with a placeholder, and exfil-shaped URLs flagged. A hex
+   value one digest wide is exempt under a generic query or fragment parameter
+   name, because a commit or blob id in a link is ordinary — under a name that
+   already says credential it still flags, and a path segment never reaches the
+   exemption at all. `AGENT_SANITIZER_FLAG_DIGEST_VALUES=1` turns it off for a
+   consumer that reads such a value as a leak.
 5. With `AGENT_SANITIZER_SECRETS_ENABLED=1` set, secrets in tool output are
    redacted locally by `detect-secrets` — the engine ships with the plugin and
    provisions itself on first run, no further setup from you.
@@ -291,7 +284,7 @@ singleton, and two copies in one bundle double-fire the inlined CLIs.
 | `claude-hooks/scan-loaded-instructions` | InstructionsLoaded scan of each instruction file as Claude Code loads it                   |
 | `claude-hooks/lib/hook-io`              | Shared hook I/O: the lazy-module registry, the CLI slot, deadlines, the hookgate marker    |
 | `claude-hooks/lib/control-plane`        | Bridge to `agent-control-plane-core` and the shared judge-CLI transport                    |
-| `claude-hooks/lib/authored-content`     | Stego + terminal-control stripping of the fields the MODEL authors                         |
+| `claude-hooks/lib/authored-content`     | Stego + terminal-control stripping of the fields the MODEL authors (colour is kept)        |
 | `claude-hooks/lib/env-config`           | The env-bound secret vocabulary the Layer-4 pre-gate and the redactor client share         |
 | `claude-hooks/lib/invisible-alert`      | Cross-hook alert state for uncleanable invisible-char injection in instruction files       |
 | `claude-hooks/lib/redactor-client`      | Client for the long-lived `agent-secret-redactor-daemon` (Layer 4's transport)             |

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__claude-automation-template__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__claude-automation-template__main__README.md
@@ -85,6 +85,16 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 | --------------- | ------------------------------------------------------------------------------------ |
 | `code-reviewer` | Read-only reviewer (Read/Grep/Glob, `model: opus`)—unbiased second opinion on a diff |
 
+### Plugins (`.claude/settings.json`)
+
+Enabled at project scope, so every session in this repo loads them—local and cloud alike. Each downloads what it needs on its own and fails open when it cannot.
+
+| Plugin                  | What it does                                                                         | Needs                                       |
+| ----------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------- |
+| `precis@precis`         | Injects a structural codebase overview at session start; `precis <dir>` zooms in     | Downloads its own binary                    |
+| `codex@codex-plugin-cc` | Delegates code review and tasks to Codex, so a non-Claude model reviews the diff     | `node`, plus `/codex:setup` for OpenAI auth |
+| `tldr@alignment-hive`   | Adds a one-sentence TL;DR after a reply over ~100 words; `/focus` collapses to those | Nothing                                     |
+
 ### GitHub Actions (`.github/workflows/`)
 
 | Workflow                           | What it does                                                                                                                                                                                                          |


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.