### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
@@ -4,7 +4,7 @@ Right now, you're probably barehanding AI, tossing it into a shell onto your mac
 
 After all, what's the chance that something bad happens?
 
-`glovebox` is a sealed enclosure that only gives the agent what it needs to do your work. Tap-tap-tap `glovebox` and press Enter to spin up a hardware-isolated, allowlist-firewalled microVM, employing input/output sanitization to strip injections and tricks the AI might play on you, with a (currently experimental) AI monitor with a red-alert ability to push-notify your phone and halt the AI until you return. The goal is a minimal-friction secure experience that gets the job done.
+`glovebox` is a sealed enclosure that only gives the agent what it needs to do your work. Tap-tap-tap `glovebox` and press Enter to spin up a hardware-isolated, allowlist-firewalled microVM, with a (currently experimental) AI monitor with a red-alert ability to push-notify your phone and halt the AI until you return. The goal is a minimal-friction secure experience that gets the job done.
 
 ![A researcher reaches through the sealed gloves of a laboratory glove box to work with material sealed inside, the barrier keeping it contained.](https://assets.turntrout.com/static/images/glovebox.jpg)
 
@@ -70,13 +70,23 @@ sudo dnf install ./agent-glovebox-*.noarch.rpm && glovebox setup
 yay -S agent-glovebox && glovebox setup
 ```
 
+#### NixOS and Nix
+
+A default Nix install ships flakes as an experimental feature, off until enabled:
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' profile install github:AlexanderMattTurner/agent-glovebox && glovebox setup
+```
+
+The flake also exposes `overlays.default` for a system configuration, and `devShells.default` for this repository's own toolchain. Enable Docker in your NixOS configuration — the package does not depend on a container runtime. [`packaging/nix/README.md`](packaging/nix/README.md) has the rest.
+
 **Platforms:** Linux with hardware virtualization (`/dev/kvm`), Apple Silicon macOS, or Windows inside [WSL2](https://learn.microsoft.com/windows/wsl/install) — see [`docs/troubleshooting-launch.md`](docs/troubleshooting-launch.md) for the full requirements and fixes.
 
 Claude Code itself is pinned to a verified, known-good version (`@anthropic-ai/claude-code` in `package.json`). The guardrails are tested against that version, and `glovebox` auto-updates it between pins.
 
 ### What `setup.bash` does
 
-1. Installs security policy at `/etc/claude-code/managed-settings.d/99-glovebox.json` (root-owned, highest precedence — the agent can't override it) <!-- # allow-dangling-path: Linux system-install path on the user's machine, not a repo file -->
+1. Removes a machine-wide Claude Code policy file an older glovebox installed. The sandbox builds its own copy at every start, so nothing outside a sandboxed session needs one.
 2. Installs the runtime prerequisites it can package safely.
 3. Installs the Docker `sbx` sandbox runtime and CLI (logged in via `sbx login`).
 4. Links the `glovebox` and `claude-github-app` wrappers into `~/.local/bin/`, and adds its security instructions to `~/.claude/CLAUDE.md`, which every Claude Code session on the machine reads.
@@ -112,7 +122,7 @@ Claude Code's built-in `sandbox` confines only Bash subprocesses, with OS-level 
 The Docker `sbx` microVM **is** this stack's foundation, and alone it does one job well: the agent cannot damage your machine. What it does not cover:
 
 - **Stock `sbx` runs the agent with passwordless `sudo` and the `docker` group.** In-VM root can delete any settings file, hook, or log that watches it. `glovebox` removes both at boot and root-locks the guardrails, so the audit record and the permission veto survive an agent that turns on them.
-- **Containment says nothing about the allowed channel.** Some hosts must stay reachable (github.com, your package registries), and to stock `sbx` an allowed host is allowed for anything — its policy grants a `host:port` and has no way to tell a read from a write. `glovebox` marks each allowed host read-only or read-write and enforces that inside the VM: a read-only host serves `GET`, `HEAD`, `OPTIONS` and `git fetch`, and everything else gets a 403. So the agent clones from the git hosts the packaged policy names and can push to `github.com` alone — the one host that policy names for git pushes — even though the credential doing the talking is injected outside the VM and would authorize a push anywhere. On top of that it scopes the GitHub token to the current repo, strips injections from what comes in, redacts secrets from what goes out, and keeps the monitor and the audit log on the host, out of the agent's reach.
+- **Containment says nothing about the allowed channel.** Some hosts must stay reachable (github.com, your package registries), and to stock `sbx` an allowed host is allowed for anything — its policy grants a `host:port` and has no way to tell a read from a write. `glovebox` marks each allowed host read-only or read-write and enforces that inside the VM: a read-only host serves `GET`, `HEAD`, `OPTIONS` and `git fetch`, and everything else gets a 403. So the agent clones from the git hosts the packaged policy names and can push to `github.com` alone — the one host that policy names for git pushes — even though the credential doing the talking is injected outside the VM and would authorize a push anywhere. On top of that it scopes the GitHub token to the current repo, and keeps the monitor and the audit log on the host, out of the agent's reach.
 - **Safe defaults are the actual work.** A curated allowlist, a signed prebuilt image, credentials injected outside the VM so keys never enter it, and `glovebox doctor` to prove it's all on.
 
 See [`SECURITY.md`](SECURITY.md) for what each layer does and does not stop.
@@ -131,15 +141,15 @@ And the attacks are no longer hypothetical:
 
 [Trail of Bits](https://blog.trailofbits.com/2026/08/26/vms-wont-contain-cyber-capable-agents/) gave a cyber-specialized model a QEMU/KVM virtual machine, and it escaped three times within hours, with no bug planted for it. The same agent did not escape Firecracker. The difference is how much hardware the virtual machine pretends to have: QEMU emulates a display, a virtual interrupt controller and a whole user-mode network stack, and two of the three escapes went through that emulated hardware. The other escape used a bug in the host kernel, and the chained escape also used the kernel's own virtual-machine paging code — surfaces a minimal virtual machine still drives. `glovebox` runs on the Docker `sbx` microVM, which is that minimal kind — closer to Firecracker's class than to QEMU's. The Firecracker result is measured; carrying it to `sbx` is not. Nobody ran that attack against `sbx`, which is a different monitor with its own device code, so the step across rests on device surface alone.
 
-That buys difficulty, not a proof. A model a generation or two on, given enough time, probably gets through a microVM too, and this project does not pretend otherwise — [`SECURITY.md`](SECURITY.md) states the hypervisor boundary as a trust assumption and names what would defeat it. Nor do the layers above the VM survive an escape: code outside the VM is outside the firewall, the de-privileged agent and the sanitizers. What those layers price is the cheap misbehavior, which is where the incidents so far have lived. A prompt-injected agent pushes to a repo it should not touch; a trojaned MCP server mails your data to an unknown host. Doing your work needs a `git clone`; doing theirs needs a path this stack does not grant. The report's own advice is the rest. Least privilege on the network, a fresh sandbox per run and logging are on by default here; its fourth item, active monitoring, is opt-in (`--experimental-monitor`).
+That buys difficulty, not a proof. A model a generation or two on, given enough time, probably gets through a microVM too, and this project does not pretend otherwise — [`SECURITY.md`](SECURITY.md) states the hypervisor boundary as a trust assumption and names what would defeat it. Nor do the layers above the VM survive an escape: code outside the VM is outside the firewall and outside the de-privileged agent. What those layers price is the cheap misbehavior, which is where the incidents so far have lived. A prompt-injected agent pushes to a repo it should not touch; a trojaned MCP server mails your data to an unknown host. Doing your work needs a `git clone`; doing theirs needs a path this stack does not grant. The report's own advice is the rest. Least privilege on the network, a fresh sandbox per run and logging are on by default here; its fourth item, active monitoring, is opt-in (`--experimental-monitor`).
 
 ### Help — it's broken and I just need to code
 
-Run `claude-original` — the plain, unwrapped Claude Code installed alongside the guard. It works even when the wrapper is broken, no uninstall needed.
+Run `claude-original` — the plain, unwrapped Claude Code installed alongside the wrapper. It works even when the wrapper is broken, no uninstall needed.
 
-It sheds the **wrapper**, not the whole stack. Gone: the sandbox, the firewall, the monitor, the reviewable-branch handoff — you are editing your real files on your real machine. Still in force: the deny rules and the guardrail hooks `setup.bash` merged into the host's managed-settings file. Every `claude` on the machine reads that file, and it sets the `_GLOVEBOX_DIR` each hook is gated on. That is the intended shape — the guard you keep is the one that survives the wrapper being broken — and `claude-original` says so on startup, naming the file and the one command that goes further.
+It carries nothing of glovebox: no sandbox, no firewall, no monitor, no deny rules, no guardrail hooks, no reviewable-branch handoff. You are editing your real files on your real machine with plain Claude Code. That is deliberate. A hook whose dependencies are missing asks before every tool call, which would break the escape hatch in exactly the state you reached for it.
 
-If you need a Claude Code with nothing of glovebox in it: `glovebox disable-global-settings` moves that file aside (it asks for your sudo password itself), and `glovebox enable-global-settings` puts it back, byte for byte. Uninstalling is no longer the only route.
+glovebox installs no machine-wide Claude Code policy, so nothing here changes what a `claude` you start yourself does. The guard lives in the sandbox, which builds its own copy at every start.
 
 ## How it works
 
@@ -157,7 +167,6 @@ Short of a novel exploit that breaks the VM itself, or a CPU side channel the ho
 
 On top of that isolation, `glovebox` adds its own oversight:
 
-- sanitizes everything the models read,
 - gates each tool call through auto mode,
 - escalates only the flagged calls to a second-model monitor (experimental, off by default),
 - records every call to a tamper-evident log,
@@ -193,8 +202,8 @@ flowchart TB
 
     BRANCH(["Reviewable glovebox/* branch<br/>you merge yourself"])
 
-    IN -->|"&nbsp;strip hidden Unicode / HTML&nbsp;"| VM
-    AGENT -->|"&nbsp;every tool call —<br/>strip hidden Unicode&nbsp;"| AUTO
+    IN --> VM
+    AGENT -->|"&nbsp;every tool call&nbsp;"| AUTO
     AUTO -->|"&nbsp;safe&nbsp;"| RUN
     AUTO <-->|"&nbsp;destructive /<br/>external ⇄<br/>cleared or halted&nbsp;"| MON
     MON -->|"&nbsp;misalignment:<br/>halt + push alert&nbsp;"| PHONE
@@ -224,11 +233,11 @@ On top of those walls sit **best-effort filters**. They raise the bar, but a det
 
 - **Auto mode** (`--permission-mode auto`) — Claude Code's built-in gating that blocks destructive and external tool calls.
 - **A trusted monitor** — a cheap second model running on your machine, outside the sandbox, that reviews tool calls and [push-notifies your phone](https://ntfy.sh) on genuine misalignment, halting the agent until you return.
-- **Input/output sanitization** — strips hidden-content injection (payload-capable invisible Unicode, ANSI escapes, human-invisible HTML) from tool output and fetched pages before either model reads them, via the first-party [`agent-sanitizer`](https://github.com/AlexanderMattTurner/agent-sanitizer). It runs on the way out too, over content the agent itself authors, where no outside party is injecting anything: an invisible run the agent writes into a file or a commit message cannot carry bits to a later session that reads it. The monitor cannot close that channel, because blocking a payload means recognizing it, and an unfamiliar encoding reads as noise — see [`SECURITY.md`](SECURITY.md).
+- **Input/output sanitization** — a separate plugin you install, not part of `glovebox`. The first-party [`agent-sanitizer`](https://github.com/AlexanderMattTurner/agent-sanitizer) strips hidden-content injection (payload-capable invisible Unicode, ANSI escapes, human-invisible HTML) from tool output and fetched pages, and redacts secrets from what the agent reads. Install it in Claude Code and a `glovebox` session runs it inside the sandbox like any other plugin. Without it the agent can read a `.env` in your project, and a fetched page reaches the model with its hidden content intact — see [`SECURITY.md`](SECURITY.md).
 
 ### The monitor is experimental
 
-The monitor is a **work in progress and is OFF by default.** It still reports false positives: it stops safe tool calls and asks you to approve them, which is the opposite of what an unattended session needs. Turn it on for one launch with `--experimental-monitor`; it needs its own API key (see [`docs/configuration.md` § Monitor](docs/configuration.md#monitor)). Nothing else depends on its verdict. The microVM, the outgoing-traffic firewall, the deny rules, auto mode and the tamper-evident audit log all run whether the monitor is on or off. The host monitor process still starts on every sandbox launch, because the output sanitizer runs its HTML parser there instead of inside the VM; with the review off it costs no API key.
+The monitor is a **work in progress and is OFF by default.** It still reports false positives: it stops safe tool calls and asks you to approve them, which is the opposite of what an unattended session needs. Turn it on for one launch with `--experimental-monitor`; it needs its own API key (see [`docs/configuration.md` § Monitor](docs/configuration.md#monitor)). Nothing else depends on its verdict. The microVM, the outgoing-traffic firewall, the deny rules, auto mode and the tamper-evident audit log all run whether the monitor is on or off. The host monitor process still starts on every sandbox launch, because the guest posts each tool result to it for the audit log; with the review off it costs no API key.
 
 Sessions are **ephemeral by default**: attackers can't lay landmines in the system state which are hard for monitors to spot. Claude's work is backed out fine, but the rest of the session state is lost. That'd normally be annoying (e.g. re-login to every service) but I did some fancy mitigations.
 
@@ -250,7 +259,7 @@ Sessions are **ephemeral by default**: attackers can't lay landmines in the syst
 
 - the effective runtime,
 - whether the required tools and the Docker daemon are reachable,
-- the ownership of `/etc/claude-code/managed-settings.d/99-glovebox.json`, <!-- # allow-dangling-path: Linux system-install path on the user's machine, not a repo file -->
+- whether an older glovebox left a machine-wide policy file behind,
 - the monitor config,
 - and **PATH precedence** — that `glovebox` resolves to this wrapper, not some other `glovebox` that would silently bypass the stack.
 

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-resolve-merge-conflicts__main__README.md
@@ -28,7 +28,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@15a8b3665068aabbacb402657e2fee042d9ca5b6 # v1.30.0
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@ba64c6434509316d57bbfa72884010904d91f850 # v1.31.3
     with:
       pr: ${{ matrix.pr.number }}
       resolver-repository: AlexanderMattTurner/agent-resolve-merge-conflicts
@@ -198,7 +198,7 @@ A `uses:` ref may be a SHA, a tag or a branch. GitHub calls [the commit SHA the 
 **Pin the SHA and name the version beside it**, the way this repository's own caller does:
 
 ```yaml
-uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@15a8b3665068aabbacb402657e2fee042d9ca5b6 # v1.30.0
+uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@ba64c6434509316d57bbfa72884010904d91f850 # v1.31.3
 ```
 
 That line reads as a version and resolves as an immutable commit. It names the newest release: `.github/scripts/release-tag.sh` rewrites both copies in this README, and the caller's, in the commit after each release. Copy it as it stands.

--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-sanitizer__main__README.md
@@ -357,8 +357,13 @@ the extension bag's `trace` on
 receives the same `TraceEvent` names the default emits, and it **replaces** the
 default rather than running alongside it — the package channel goes silent, so
 there is one announcement to detect, not two. It may throw freely: each hook
-binds the sink it is given through `bestEffortTrace`, so an announcement can
-never be the thing that breaks a hook.
+binds the sink it is given through `hookTrace`, so an announcement can never be
+the thing that breaks a hook.
+
+That same binding charges whatever a host sink spends — a write to an unanswered
+socket, a subprocess — to the slow-hook notice's host-extension window. A hook
+past its budget then names the sink, instead of leaving the wait in the
+unattributed remainder and the sink's in-process CPU billed to the sanitizer.
 
 **A host's own cold-start marker can replace the derived one.** The hooks wait
 out an in-flight dependency install by polling a marker file whose path they


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.