### PR TITLE
fix: stop routing tweet-embed links through xcancel.com

### DIFF
--- a/.claude/dev-notes.md
+++ b/.claude/dev-notes.md
@@ -367,7 +367,7 @@ cookie-free endpoint doesn't expose retweet or view counts, so those are omitted
 JSON snapshot from `quartz/plugins/transformers/.tweet_snapshots/<id>.json` and
 renders from that. A referenced tweet with no snapshot **fails the build** (so a
 forgotten capture can't silently ship a degraded card); prefix the line with
-`unavailable:` to opt a deleted-before-capture tweet into the xcancel-link stub.
+`unavailable:` to opt a deleted-before-capture tweet into the X-link stub.
 
 Snapshots are captured by `scripts/tweet_snapshot.py`, which fetches the post
 from X's cookie-free syndication endpoint, mirrors the avatar + photos/video to

--- a/config/constants.json
+++ b/config/constants.json
@@ -167,10 +167,6 @@
       "to": "neurips.cc"
     },
     {
-      "pattern": "^xcancel\\.com$",
-      "to": "x.com"
-    },
-    {
       "pattern": "^.*effectivealtruism\\.org$",
       "to": "forum.effectivealtruism.org"
     }

--- a/quartz/components/tests/tweetEmbed.spec.ts
+++ b/quartz/components/tests/tweetEmbed.spec.ts
@@ -7,13 +7,13 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("Tweet embeds", () => {
-  test("single tweet renders author, body, and an xcancel permalink", async ({ page }) => {
+  test("single tweet renders author, body, and an X permalink", async ({ page }) => {
     const card = page.locator(".tweet-embed:not(.tweet-thread) .tweet-card").first()
     await card.scrollIntoViewIfNeeded()
     await expect(card).toBeVisible()
     await expect(card.locator(".tweet-name")).toContainText("Alex Turner")
-    // The handle links to the author's xcancel profile (not the post).
-    await expect(card.locator("a.tweet-handle")).toHaveAttribute("href", /xcancel\.com\/[^/]+$/)
+    // The handle links to the author's X profile (not the post).
+    await expect(card.locator("a.tweet-handle")).toHaveAttribute("href", /x\.com\/[^/]+$/)
     // The date is plain text, not a link.
     await expect(card.locator("a.tweet-date")).toHaveCount(0)
     // No favicons are stamped on the card's links.

--- a/quartz/plugins/transformers/.tweet_snapshots/2015160545331306894.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2015160545331306894.json
@@ -1,6 +1,6 @@
 {
   "id": "2015160545331306894",
-  "url": "https://xcancel.com/JeffDean/status/2015160545331306894",
+  "url": "https://x.com/JeffDean/status/2015160545331306894",
   "author": {
     "name": "Jeff Dean",
     "handle": "JeffDean",

--- a/quartz/plugins/transformers/.tweet_snapshots/2015477622969340248.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2015477622969340248.json
@@ -1,6 +1,6 @@
 {
   "id": "2015477622969340248",
-  "url": "https://xcancel.com/Larrydn22/status/2015477622969340248",
+  "url": "https://x.com/Larrydn22/status/2015477622969340248",
   "author": {
     "name": "Larry Nance",
     "handle": "Larrydn22",

--- a/quartz/plugins/transformers/.tweet_snapshots/2026566490619879574.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2026566490619879574.json
@@ -1,6 +1,6 @@
 {
   "id": "2026566490619879574",
-  "url": "https://xcancel.com/JeffDean/status/2026566490619879574",
+  "url": "https://x.com/JeffDean/status/2026566490619879574",
   "author": {
     "name": "Jeff Dean",
     "handle": "JeffDean",
@@ -18,7 +18,7 @@
   "snapshotAt": "2026-07-01T03:55:09.507389+00:00",
   "quoted": {
     "id": "2026390982460125305",
-    "url": "https://xcancel.com/boazbaraktcs/status/2026390982460125305",
+    "url": "https://x.com/boazbaraktcs/status/2026390982460125305",
     "author": {
       "name": "Boaz Barak",
       "handle": "boazbaraktcs",

--- a/quartz/plugins/transformers/.tweet_snapshots/2026668689802547231.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2026668689802547231.json
@@ -1,6 +1,6 @@
 {
   "id": "2026668689802547231",
-  "url": "https://xcancel.com/TopherSpiro/status/2026668689802547231",
+  "url": "https://x.com/TopherSpiro/status/2026668689802547231",
   "author": {
     "name": "Topher Spiro",
     "handle": "TopherSpiro",

--- a/quartz/plugins/transformers/.tweet_snapshots/2026683499919610153.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2026683499919610153.json
@@ -1,6 +1,6 @@
 {
   "id": "2026683499919610153",
-  "url": "https://xcancel.com/JeffDean/status/2026683499919610153",
+  "url": "https://x.com/JeffDean/status/2026683499919610153",
   "author": {
     "name": "Jeff Dean",
     "handle": "JeffDean",

--- a/quartz/plugins/transformers/.tweet_snapshots/2049153749743264231.json
+++ b/quartz/plugins/transformers/.tweet_snapshots/2049153749743264231.json
@@ -1,6 +1,6 @@
 {
   "id": "2049153749743264231",
-  "url": "https://xcancel.com/Turn_Trout/status/2049153749743264231",
+  "url": "https://x.com/Turn_Trout/status/2049153749743264231",
   "author": {
     "name": "Alex Turner",
     "handle": "Turn_Trout",

--- a/quartz/plugins/transformers/formatting_improvement_text.ts
+++ b/quartz/plugins/transformers/formatting_improvement_text.ts
@@ -183,16 +183,10 @@ export function noteAdmonition(text: string): string {
 const subtitlePattern = /^(?<quote>(?:> *)*)(?<subtitle>Subtitle:[\S ]+\n)(?!\k<quote>\n)/gm
 const subtitleReplacement = "$<quote>$<subtitle>$<quote>\n"
 
-// Replace x.com and twitter.com links with xcancel.com. The `(?![\w.-])`
-// guard keeps `.com` from matching inside a longer host label such as
-// `x.company.com` or `x.com.au`.
-const xcancelHostReplacementRegex = /https?:\/\/(?:www\.)?(?:x|twitter)\.com(?![\w.-])\/?/gi
-
 const massTransforms: [RegExp | string, string][] = [
   [/^\$\$(?= *\S)/gm, "$$$$\n"], // Display mode math should be on a new line
   [/^(?! *>| +\S)(?<content>\S.*?)\$\$ *$/gm, "$<content>\n$$$$"],
   [subtitlePattern, subtitleReplacement],
-  [xcancelHostReplacementRegex, "https://xcancel.com/"],
   [/(?<=\| *)\nTable: /g, "\n\nTable: "],
   // Insert a blank line after a block-level HTML tag so the markdown parser
   // doesn't swallow following prose into the same HTML block. Avoid inside of code blocks.

--- a/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
+++ b/quartz/plugins/transformers/tests/formatting_improvement_text.test.ts
@@ -325,22 +325,8 @@ And some hyphens-to-be-ignored.`
         "    $$\\begin{pmatrix}\\text{1 if the agent is dead, 0 otherwise}\\\\ \\text{1 if the agent is alive, 0 otherwise}\\end{pmatrix}.$$  ",
         "    $$\\begin{pmatrix}\\text{1 if the agent is dead, 0 otherwise}\\\\ \\text{1 if the agent is alive, 0 otherwise}\\end{pmatrix}.$$  ",
       ],
-      ["https://x.com/turntrout/status/123", "https://xcancel.com/turntrout/status/123"],
-      ["http://twitter.com/turntrout/status/123", "https://xcancel.com/turntrout/status/123"],
-      [
-        "[tweet](https://twitter.com/turntrout/status/123)",
-        "[tweet](https://xcancel.com/turntrout/status/123)",
-      ],
-      [
-        "[tweet](https://www.x.com/turntrout/status/123)",
-        "[tweet](https://xcancel.com/turntrout/status/123)",
-      ],
-      ["[`x.com`](https://x.com)", "[`x.com`](https://xcancel.com/)"],
-      ["[link](https://x.com/)", "[link](https://xcancel.com/)"],
+      ["https://x.com/turntrout/status/123", "https://x.com/turntrout/status/123"],
       ["twitter.com", "twitter.com"],
-      // A longer host label that merely starts with `x.com` must be left alone.
-      ["https://x.company.com/path", "https://x.company.com/path"],
-      ["https://x.com.au/page", "https://x.com.au/page"],
     ])("should perform transforms for %s", (input: string, expected: string) => {
       const result = formattingImprovement(input)
       expect(result).toBe(expected)

--- a/quartz/plugins/transformers/tests/tweetCard.test.ts
+++ b/quartz/plugins/transformers/tests/tweetCard.test.ts
@@ -19,7 +19,7 @@ import {
 
 const baseSnapshot: TweetSnapshot = {
   id: "123",
-  url: "https://xcancel.com/turntrout/status/123",
+  url: "https://x.com/turntrout/status/123",
   author: {
     name: "Alex Turner",
     handle: "turntrout",
@@ -94,12 +94,12 @@ describe("linkifyTweetText", () => {
     expect(html).not.toContain("t.co/abc")
   })
 
-  it("links mentions, hashtags, and cashtags to xcancel", () => {
+  it("links mentions, hashtags, and cashtags to X", () => {
     const nodes = linkifyTweetText("@bob loves #ai and $TSLA", [])
     const html = nodes.map((n) => (typeof n === "string" ? n : render(n))).join("")
-    expect(html).toContain('href="https://xcancel.com/bob"')
-    expect(html).toContain("https://xcancel.com/search?q=%23ai")
-    expect(html).toContain("https://xcancel.com/search?q=%24TSLA")
+    expect(html).toContain('href="https://x.com/bob"')
+    expect(html).toContain("https://x.com/search?q=%23ai")
+    expect(html).toContain("https://x.com/search?q=%24TSLA")
   })
 
   it("decodes HTML entities before building text nodes", () => {
@@ -146,7 +146,7 @@ describe("linkifyTweetText", () => {
   it("linkifies a text that is only a mention", () => {
     const nodes = linkifyTweetText("@bob", [])
     expect(nodes).toHaveLength(1)
-    expect(render(nodes[0] as Element)).toContain("https://xcancel.com/bob")
+    expect(render(nodes[0] as Element)).toContain("https://x.com/bob")
   })
 
   it("marks body entity links no-favicon so the favicon pass skips them", () => {
@@ -174,11 +174,11 @@ describe("buildTweetCard", () => {
   it("links the name and handle to the profile, and the source to the post", () => {
     const html = render(buildTweetCard(baseSnapshot))
     // Name and handle point at the profile (no trailing /status/...).
-    expect(html).toContain('href="https://xcancel.com/turntrout"')
+    expect(html).toContain('href="https://x.com/turntrout"')
     expect(html).toContain('class="tweet-name-link no-favicon"')
     expect(html).toContain('class="tweet-handle no-favicon"')
     // The X-logo source link points at the post permalink.
-    expect(html).toContain('href="https://xcancel.com/turntrout/status/123"')
+    expect(html).toContain('href="https://x.com/turntrout/status/123"')
     // The avatar is a plain image, not a link.
     expect(html).toContain('<span class="tweet-avatar-wrap"><img')
   })
@@ -365,7 +365,7 @@ describe("buildTweetCard", () => {
 describe("quote tweets", () => {
   const quoted: TweetSnapshot["quoted"] = {
     id: "456",
-    url: "https://xcancel.com/boazbaraktcs/status/456",
+    url: "https://x.com/boazbaraktcs/status/456",
     author: {
       name: "Boaz Barak",
       handle: "boazbaraktcs",
@@ -383,11 +383,11 @@ describe("quote tweets", () => {
     expect(html).toContain("tweet-quoted")
     expect(html).toContain('data-tweet-id="456"')
     expect(html).toContain("Boaz Barak")
-    expect(html).toContain('href="https://xcancel.com/boazbaraktcs"')
+    expect(html).toContain('href="https://x.com/boazbaraktcs"')
     expect(html).toContain("the original take")
-    // The quoted avatar is self-hosted, linkified mentions point at xcancel.
+    // The quoted avatar is self-hosted, linkified mentions point at X.
     expect(html).toContain("tweet-quoted-avatar")
-    expect(html).toContain('href="https://xcancel.com/someone"')
+    expect(html).toContain('href="https://x.com/someone"')
     // The post date sits at the bottom of the quoted card (base is Jan 21, quote Jan 20).
     expect(html).toContain('<span class="tweet-quoted-date">January 20th, 2025</span>')
   })
@@ -495,18 +495,18 @@ describe("retweet context", () => {
 })
 
 describe("buildUnavailableCard", () => {
-  it("links to xcancel and is marked unavailable", () => {
-    const html = render(buildUnavailableCard("https://xcancel.com/turntrout/status/999"))
+  it("links to X and is marked unavailable", () => {
+    const html = render(buildUnavailableCard("https://x.com/turntrout/status/999"))
     expect(html).toContain("tweet-card-unavailable")
-    expect(html).toContain('href="https://xcancel.com/turntrout/status/999"')
-    expect(html).toContain("View it on XCancel")
+    expect(html).toContain('href="https://x.com/turntrout/status/999"')
+    expect(html).toContain("View it on X")
     expect(html).toContain("no-favicon")
   })
 })
 
 describe("buildTweetEmbed", () => {
   it("wraps a single resolved tweet without the thread class", () => {
-    const html = render(buildTweetEmbed([{ snapshot: baseSnapshot, xcancelUrl: baseSnapshot.url }]))
+    const html = render(buildTweetEmbed([{ snapshot: baseSnapshot, url: baseSnapshot.url }]))
     expect(html).toContain("tweet-embed")
     expect(html).not.toContain("tweet-thread")
   })
@@ -514,8 +514,8 @@ describe("buildTweetEmbed", () => {
   it("renders multiple tweets as a thread", () => {
     const html = render(
       buildTweetEmbed([
-        { snapshot: baseSnapshot, xcancelUrl: baseSnapshot.url },
-        { snapshot: { ...baseSnapshot, id: "124" }, xcancelUrl: baseSnapshot.url },
+        { snapshot: baseSnapshot, url: baseSnapshot.url },
+        { snapshot: { ...baseSnapshot, id: "124" }, url: baseSnapshot.url },
       ]),
     )
     expect(html).toContain("tweet-thread")
@@ -524,9 +524,7 @@ describe("buildTweetEmbed", () => {
   })
 
   it("stubs slots without a snapshot", () => {
-    const html = render(
-      buildTweetEmbed([{ xcancelUrl: "https://xcancel.com/turntrout/status/777" }]),
-    )
+    const html = render(buildTweetEmbed([{ url: "https://x.com/turntrout/status/777" }]))
     expect(html).toContain("tweet-card-unavailable")
     expect(html).toContain("status/777")
   })
@@ -534,7 +532,7 @@ describe("buildTweetEmbed", () => {
   it("passes a slot's retweetedBy through to the card", () => {
     const html = render(
       buildTweetEmbed([
-        { snapshot: baseSnapshot, xcancelUrl: baseSnapshot.url, retweetedBy: "Jeff Dean" },
+        { snapshot: baseSnapshot, url: baseSnapshot.url, retweetedBy: "Jeff Dean" },
       ]),
     )
     expect(html).toContain("Jeff Dean retweeted")

--- a/quartz/plugins/transformers/tests/tweetEmbed.test.ts
+++ b/quartz/plugins/transformers/tests/tweetEmbed.test.ts
@@ -14,7 +14,7 @@ import {
   loadSnapshot,
   parseTweetReferences,
   replaceTweetBlocks,
-  toXcancelUrl,
+  toXUrl,
   tweetBlockBody,
   TweetEmbed,
 } from "../tweetEmbed"
@@ -28,7 +28,7 @@ const tweetBlock = (body: string): Element =>
 
 const snapshotObject = (id: string): Record<string, unknown> => ({
   id,
-  url: `https://xcancel.com/turntrout/status/${id}`,
+  url: `https://x.com/turntrout/status/${id}`,
   author: { name: "Alex", handle: "turntrout", verified: false, avatarSrc: "a.jpg" },
   createdAt: "2025-01-21T17:32:00.000Z",
   text: "hi",
@@ -64,7 +64,6 @@ describe("extractTweetId", () => {
     ["https://x.com/turntrout/status/123456", "123456"],
     ["https://twitter.com/u/statuses/987654", "987654"],
     ["123456789", "123456789"],
-    ["https://xcancel.com/u/status/111222333", "111222333"],
   ])("extracts %s", (input, expected) => {
     expect(extractTweetId(input)).toBe(expected)
   })
@@ -74,14 +73,13 @@ describe("extractTweetId", () => {
   })
 })
 
-describe("toXcancelUrl", () => {
+describe("toXUrl", () => {
   it.each([
-    ["https://x.com/u/status/1", "https://xcancel.com/u/status/1"],
-    ["https://www.twitter.com/u/status/1", "https://xcancel.com/u/status/1"],
-    ["https://xcancel.com/u/status/1", "https://xcancel.com/u/status/1"],
+    ["https://x.com/u/status/1", "https://x.com/u/status/1"],
+    ["https://www.twitter.com/u/status/1", "https://x.com/u/status/1"],
     ["1234567890", "1234567890"],
   ])("rewrites %s", (input, expected) => {
-    expect(toXcancelUrl(input)).toBe(expected)
+    expect(toXUrl(input)).toBe(expected)
   })
 })
 
@@ -91,8 +89,8 @@ describe("parseTweetReferences", () => {
       "https://x.com/u/status/10001\n\n  https://x.com/u/status/10002  \n",
     )
     expect(refs).toEqual([
-      { id: "10001", xcancelUrl: "https://xcancel.com/u/status/10001" },
-      { id: "10002", xcancelUrl: "https://xcancel.com/u/status/10002" },
+      { id: "10001", url: "https://x.com/u/status/10001" },
+      { id: "10002", url: "https://x.com/u/status/10002" },
     ])
   })
 
@@ -103,7 +101,7 @@ describe("parseTweetReferences", () => {
   it("attaches retweeted-by to the preceding tweet", () => {
     const refs = parseTweetReferences("https://x.com/u/status/10001\nretweeted-by:  Jeff Dean \n")
     expect(refs).toEqual([
-      { id: "10001", xcancelUrl: "https://xcancel.com/u/status/10001", retweetedBy: "Jeff Dean" },
+      { id: "10001", url: "https://x.com/u/status/10001", retweetedBy: "Jeff Dean" },
     ])
   })
 
@@ -113,9 +111,7 @@ describe("parseTweetReferences", () => {
 
   it("marks an `unavailable:`-prefixed line and parses its url", () => {
     const refs = parseTweetReferences("unavailable:  https://x.com/u/status/10001 \n")
-    expect(refs).toEqual([
-      { id: "10001", xcancelUrl: "https://xcancel.com/u/status/10001", unavailable: true },
-    ])
+    expect(refs).toEqual([{ id: "10001", url: "https://x.com/u/status/10001", unavailable: true }])
   })
 })
 

--- a/quartz/plugins/transformers/tweetCard.ts
+++ b/quartz/plugins/transformers/tweetCard.ts
@@ -63,7 +63,7 @@ export interface TweetSnapshot {
   snapshotAt: string
 }
 
-const XCANCEL_BASE = "https://xcancel.com"
+const X_BASE = "https://x.com"
 
 // X wordmark (the post source link) and the verified seal, inlined so the card
 // needs no extra network requests.
@@ -158,7 +158,7 @@ function externalAnchor(
   return h("a", props, children)
 }
 
-/** Linkify @mentions, #hashtags, and $cashtags within a plain-text run, pointing at xcancel. */
+/** Linkify @mentions, #hashtags, and $cashtags within a plain-text run, pointing at X. */
 function linkifyTokens(text: string): (Element | string)[] {
   const nodes: (Element | string)[] = []
   let lastIndex = 0
@@ -169,9 +169,7 @@ function linkifyTokens(text: string): (Element | string)[] {
     if (index > lastIndex) nodes.push(text.slice(lastIndex, index))
     const body = token.slice(1)
     const href =
-      token[0] === "@"
-        ? `${XCANCEL_BASE}/${body}`
-        : `${XCANCEL_BASE}/search?q=${encodeURIComponent(token)}`
+      token[0] === "@" ? `${X_BASE}/${body}` : `${X_BASE}/search?q=${encodeURIComponent(token)}`
     nodes.push(externalAnchor(href, [token], "tweet-entity"))
     lastIndex = index + token.length
   }
@@ -196,7 +194,7 @@ function withLineBreaks(nodes: (Element | string)[]): (Element | string)[] {
 /**
  * Turn a tweet's raw text into hast: `t.co` links become anchors to their
  * expanded targets (shown as the human-readable display URL), @mentions and
- * #hashtags link to xcancel, and newlines become `<br>`.
+ * #hashtags link to X, and newlines become `<br>`.
  */
 export function linkifyTweetText(text: string, urls: readonly TweetUrl[]): (Element | string)[] {
   let nodes: (Element | string)[] = [decodeHtmlEntities(text)]
@@ -346,7 +344,7 @@ function authorNameRow(author: TweetAuthor, profileUrl: string): Element {
  * as noise.
  */
 function quotedCard(quoted: QuotedTweet, outerDate: string): Element {
-  const profileUrl = `${XCANCEL_BASE}/${quoted.author.handle}`
+  const profileUrl = `${X_BASE}/${quoted.author.handle}`
   const header = h("div", { className: "tweet-quoted-header" }, [
     h("img", {
       className: "tweet-quoted-avatar",
@@ -378,7 +376,7 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
 
   // The avatar, name, and handle point at the author's profile; the X logo is
   // the permalink to the post.
-  const profileUrl = `${XCANCEL_BASE}/${author.handle}`
+  const profileUrl = `${X_BASE}/${author.handle}`
   const header = h("div", { className: "tweet-header" }, [
     h("span", { className: "tweet-avatar-wrap" }, [
       h("img", {
@@ -434,19 +432,19 @@ export function buildTweetCard(snapshot: TweetSnapshot, retweetedBy?: string): E
 }
 
 /** Fallback card for a tweet that resolved from neither a snapshot nor R2. */
-export function buildUnavailableCard(xcancelUrl: string): Element {
+export function buildUnavailableCard(url: string): Element {
   return h("article", { className: "tweet-card tweet-card-unavailable" }, [
     h("p", { className: "tweet-body" }, [
       "This post could not be embedded. ",
-      externalAnchor(xcancelUrl, ["View it on XCancel."], "tweet-entity"),
+      externalAnchor(url, ["View it on X."], "tweet-entity"),
     ]),
   ])
 }
 
-/** A slot in a tweet embed: a resolved snapshot, or just the xcancel URL to stub. */
+/** A slot in a tweet embed: a resolved snapshot, or just the post URL to stub. */
 export interface TweetSlot {
   snapshot?: TweetSnapshot
-  xcancelUrl: string
+  url: string
   retweetedBy?: string
 }
 
@@ -458,7 +456,7 @@ export function buildTweetEmbed(slots: readonly TweetSlot[]): Element {
   const cards = slots.map((slot) =>
     slot.snapshot
       ? buildTweetCard(slot.snapshot, slot.retweetedBy)
-      : buildUnavailableCard(slot.xcancelUrl),
+      : buildUnavailableCard(slot.url),
   )
   if (cards.length === 1) {
     return h("div", { className: "tweet-embed" }, cards)

--- a/quartz/plugins/transformers/tweetEmbed.ts
+++ b/quartz/plugins/transformers/tweetEmbed.ts
@@ -28,7 +28,7 @@ const snapshotCdnUrl = (id: string): string => `${cdnBaseUrl}/static/tweets/${id
 
 // Keep in sync with TWEET_ID_RE in scripts/tweet_snapshot.py.
 const TWEET_ID_RE = /(?:status(?:es)?\/)?(\d{5,25})/
-const TWEET_HOST_RE = /^https?:\/\/(?:www\.)?(?:x|twitter|xcancel|nitter\.[^/]+)\.com/i
+const TWEET_HOST_RE = /^https?:\/\/(?:www\.)?(?:x|twitter)\.com/i
 
 /** Extract the numeric status id from a tweet URL or bare id. */
 export function extractTweetId(text: string): string | null {
@@ -36,18 +36,18 @@ export function extractTweetId(text: string): string | null {
   return match ? match[1] : null
 }
 
-/** Rewrite an x.com/twitter.com permalink to its xcancel.com equivalent. */
-export function toXcancelUrl(rawUrl: string): string {
+/** Rewrite an x.com/twitter.com permalink to its canonical x.com equivalent. */
+export function toXUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim()
   if (TWEET_HOST_RE.test(trimmed)) {
-    return trimmed.replace(TWEET_HOST_RE, "https://xcancel.com")
+    return trimmed.replace(TWEET_HOST_RE, "https://x.com")
   }
   return trimmed
 }
 
 export interface TweetReference {
   id: string
-  xcancelUrl: string
+  url: string
   retweetedBy?: string
   /** Snapshot is intentionally absent (tweet deleted before capture); stub is OK. */
   unavailable?: boolean
@@ -83,7 +83,7 @@ export function parseTweetReferences(body: string): TweetReference[] {
     if (!id) {
       throw new Error(`tweetEmbed: no tweet id found in line ${JSON.stringify(line)}`)
     }
-    const ref: TweetReference = { id, xcancelUrl: toXcancelUrl(urlText) }
+    const ref: TweetReference = { id, url: toXUrl(urlText) }
     if (unavailable) ref.unavailable = true
     refs.push(ref)
   }
@@ -176,14 +176,14 @@ function resolveSlots(refs: readonly TweetReference[], dir: string): Promise<Twe
       const snapshot = await loadSnapshot(ref.id, dir)
       if (!snapshot && !ref.unavailable) {
         throw new Error(
-          `tweetEmbed: no snapshot for tweet ${ref.id} (${ref.xcancelUrl}) on disk or R2. ` +
+          `tweetEmbed: no snapshot for tweet ${ref.id} (${ref.url}) on disk or R2. ` +
             "Run `uv run python scripts/tweet_snapshot.py --write` to capture it and upload it to R2, or " +
             "prefix the line with `unavailable:` if the tweet is gone and can't be snapshotted.",
         )
       }
       return {
         snapshot: snapshot ?? undefined,
-        xcancelUrl: ref.xcancelUrl,
+        url: ref.url,
         retweetedBy: ref.retweetedBy,
       }
     }),
@@ -212,7 +212,7 @@ export async function replaceTweetBlocks(tree: Root, dir: string = snapshotDir):
  * Replaces ```tweet fenced blocks (one tweet URL per line) with self-hosted,
  * tracking-free tweet cards rendered from snapshots captured by
  * `scripts/tweet_snapshot.py`. Multiple URLs render as a connected thread;
- * tweets without a snapshot degrade to an xcancel link.
+ * tweets without a snapshot degrade to a link to the post on X.
  */
 export const TweetEmbed: QuartzTransformerPlugin = () => {
   return {

--- a/scripts/tests/test_tweet_snapshot.py
+++ b/scripts/tests/test_tweet_snapshot.py
@@ -286,7 +286,7 @@ def test_best_video_variant() -> None:
 def test_normalize() -> None:
     snapshot = ts.normalize(RAW_TWEET, "999")
     assert snapshot["id"] == "999"
-    assert snapshot["url"] == "https://xcancel.com/turntrout/status/999"
+    assert snapshot["url"] == "https://x.com/turntrout/status/999"
     assert snapshot["author"]["verified"] is True
     assert snapshot["author"]["avatarSrc"].endswith("_400x400.jpg")
     assert snapshot["snapshotAt"] == "2026-06-27T00:00:00+00:00"
@@ -355,7 +355,7 @@ def test_normalize_quoted_tweet() -> None:
     snapshot = ts.normalize(RAW_QUOTE_TWEET, "999")
     quoted = snapshot["quoted"]
     assert quoted["id"] == "888"
-    assert quoted["url"] == "https://xcancel.com/original/status/888"
+    assert quoted["url"] == "https://x.com/original/status/888"
     assert quoted["author"]["name"] == "Original"
     # No verified flag in the quoted user → not verified.
     assert quoted["author"]["verified"] is False

--- a/scripts/tweet_snapshot.py
+++ b/scripts/tweet_snapshot.py
@@ -70,8 +70,8 @@ TWEET_BLOCK_RE = re.compile(
     r"^```tweet[ \t]*\n(?P<body>.*?)\n```[ \t]*$",
     re.MULTILINE | re.DOTALL,
 )
-# Pull the numeric status id out of an x.com / twitter.com / xcancel.com URL,
-# or accept a bare id. Keep in sync with TWEET_ID_RE in tweetEmbed.ts.
+# Pull the numeric status id out of an x.com / twitter.com URL, or accept a
+# bare id. Keep in sync with TWEET_ID_RE in tweetEmbed.ts.
 TWEET_ID_RE = re.compile(r"(?:status(?:es)?/)?(?P<id>\d{5,25})")
 # Non-tweet directive lines inside a ``tweet`` block (a metadata header or an
 # opt-in stub). Keep in sync with RETWEETED_BY_RE / UNAVAILABLE_RE in tweetEmbed.ts.
@@ -344,7 +344,7 @@ def _normalize_quoted(quoted: dict) -> dict | None:
     entities = quoted.get("entities", {}) or {}
     return {
         "id": quoted_id,
-        "url": f"https://xcancel.com/{user['screen_name']}/status/{quoted_id}",
+        "url": f"https://x.com/{user['screen_name']}/status/{quoted_id}",
         "author": _build_author(user),
         "createdAt": quoted.get("created_at", ""),
         "text": _display_text(quoted, entities),
@@ -365,7 +365,7 @@ def normalize(raw: dict, tweet_id: str) -> dict:
 
     snapshot = {
         "id": tweet_id,
-        "url": f"https://xcancel.com/{handle}/status/{tweet_id}",
+        "url": f"https://x.com/{handle}/status/{tweet_id}",
         "author": _build_author(raw["user"]),
         "createdAt": raw.get("created_at", ""),
         "text": _display_text(raw, entities),
@@ -557,7 +557,7 @@ def process_all(
     Resolve every referenced tweet, returning the ids that resolved.
 
     Tweets that resolve from neither Twitter nor the CDN are logged and skipped
-    (the build renders them as xcancel stubs) so one dead tweet never fails the
+    (the build renders them as X-link stubs) so one dead tweet never fails the
     run.
     """
     session = script_utils.http_session()

--- a/website_content/advanced-privacy.md
+++ b/website_content/advanced-privacy.md
@@ -413,11 +413,11 @@ After following the first guide, you already have [a good browser](/privacy-desp
 
 Subtitle: Time: 10 minutes.
 
-Even if you're using [a VPN](/privacy-despite-authoritarianism#proton-vpn-stops-your-internet-service-provider-isp-from-spying-on-you) to hide your traffic with [Brave](/privacy-despite-authoritarianism#browse-the-web-using-brave) stopping tracking, the website still knows what you're doing since you're logged in. However, if you consume content using a different "frontend" (kinda like a viewport), you can still get the benefits with much lower privacy cost. For example, browsing [XCancel](https://xcancel.com/) instead of X:
+Even if you're using [a VPN](/privacy-despite-authoritarianism#proton-vpn-stops-your-internet-service-provider-isp-from-spying-on-you) to hide your traffic with [Brave](/privacy-despite-authoritarianism#browse-the-web-using-brave) stopping tracking, the website still knows what you're doing since you're logged in. However, if you consume content using a different "frontend" (kinda like a viewport), you can still get the benefits with much lower privacy cost. For example, you could browse a privacy-respecting frontend instead of X directly, like XCancel used to let you do before it shut down:
 
-![[https://assets.turntrout.com/static/images/posts/privacy-20251023183015.avif|A screenshot of XCancel, a private front-end for X, displaying posts about machine learning. ]]
+![[https://assets.turntrout.com/static/images/posts/privacy-20251023183015.avif|A screenshot of XCancel, a since-shut-down private front-end for X, displaying posts about machine learning. ]]
 
-The downside is you usually can't interact with the site. You can usually just lurk. These sites can also be unreliable, so be ready to ask the extension to redirect you to the original site.
+The downside is you usually can't interact with the site. You can usually just lurk. These sites can also be unreliable and shut down entirely, so be ready to ask the extension to redirect you to the original site.
 
 - [ ] Install the [LibRedirect](https://libredirect.github.io/index.html) extension, which automatically redirects you to an open source frontend which respects your privacy.
 - [ ] In the settings, enable redirects for your favorite sites; you may need to mess with the defaults.

--- a/website_content/design.md
+++ b/website_content/design.md
@@ -113,10 +113,10 @@ I later describe my [@title-lower](#deployment-pipeline) in more detail.
 
 ## Embedding tweets
 
-I enable tracking-free embeds of tweets, rendered in my site's style. Each card renders from a tweet-info JSON which I host on my own CDN, so it leaks nothing to X and still displays even if the original tweet is deleted. I also point the links at [`xcancel.com`](https://xcancel.com) rather than `x.com`, as I [avoid X for ethical reasons.](/advanced-privacy#gradually-migrate-your-social-network-away-from-x)
+I enable tracking-free embeds of tweets, rendered in my site's style. Each card renders from a tweet-info JSON which I host on my own CDN, so it leaks nothing to X and still displays even if the original tweet is deleted.
 
 ```tweet
-https://xcancel.com/Turn_Trout/status/2064426233769742627
+https://x.com/Turn_Trout/status/2064426233769742627
 ```
 
 # Color scheme

--- a/website_content/leaving-google-deepmind.md
+++ b/website_content/leaving-google-deepmind.md
@@ -98,11 +98,11 @@ I'd followed the news and guessed that Sundar Pichai (Google's CEO) was more of 
 That's when I remembered reading *Jeff Dean* tweeting about how bad ICE was, retweeting Anne Frank quotes. Maybe I didn't even need 10 engineers. Maybe I just needed *one*.
 
 ```tweet
-https://xcancel.com/JeffDean/status/2015160545331306894
+https://x.com/JeffDean/status/2015160545331306894
 ```
 
 ```tweet
-https://xcancel.com/Larrydn22/status/2015477622969340248
+https://x.com/Larrydn22/status/2015477622969340248
 retweeted-by: Jeff Dean
 ```
 
@@ -389,9 +389,9 @@ The way I saw it was: I don't need to get Jeff to agree to quit over this. In a 
 Signers include: Google DeepMind (the organization), Demis Hassabis, Shane Legg (cofounder, [now Chief AGI Scientist](https://en.wikipedia.org/wiki/Shane_Legg)), Raia Hadsell ([VP of Research](https://raiahadsell.com/index.html)), Jay Yagnik ([VP and Engineering Fellow at Google, leading large parts of Google AI](https://research.google/people/author36197/?&type=google)) and 🥁🥁🥁 Jeff Dean:
 
 ```tweet
-https://xcancel.com/JeffDean/status/2026566490619879574
-https://xcancel.com/TopherSpiro/status/2026668689802547231
-https://xcancel.com/JeffDean/status/2026683499919610153
+https://x.com/JeffDean/status/2026566490619879574
+https://x.com/TopherSpiro/status/2026668689802547231
+https://x.com/JeffDean/status/2026683499919610153
 ```
 
 Figure: Jeff Dean freely reiterated his pledge and agreed that "AI for mass surveillance of Americans" is "the last thing \[he wants\]."
@@ -525,7 +525,7 @@ That weekend prior, I had heard rumblings. [Along with over 600 other employees]
 I found out at 11:45 PM via a Signal group. Google never announced the deal internally. What surprised me was not that Google signed, but that the deal paid the barest of lip service to ethical concerns: the "should not" language [is not binding](https://x.com/CharlieBull0ck/status/2049249853947945369).
 
 ```tweet
-https://xcancel.com/Turn_Trout/status/2049153749743264231
+https://x.com/Turn_Trout/status/2049153749743264231
 ```
 
 I went to the field's premier safety & ethics organization (IASEAI). I asked some of the most distinguished AI scientists (Bengio and Stuart). I built a coalition and a plan for Google's most outspoken executive (Jeff). I even cold-messaged the CEO of my company (Demis), whose lieutenants never evaluated the proposal. Besides Jeff, none took *any* visible action to stop the deal. And the deal contains no binding provisions, which is what I'd expect if Jeff never threatened to walk.

--- a/website_content/test-page.md
+++ b/website_content/test-page.md
@@ -532,27 +532,27 @@ Equation and table nested in a list item (gaps must not stack with `<p>` margins
 A single tweet, rendered from a self-hosted snapshot, with an optional retweet indicator:
 
 ```tweet
-https://xcancel.com/Turn_Trout/status/2064426233769742627
+https://x.com/Turn_Trout/status/2064426233769742627
 retweeted-by: Shrek
 ```
 
 A single image keeps its natural aspect ratio up to a height cap; one that exceeds the cap is cropped and fades out at the bottom edge of the card:
 
 ```tweet
-https://xcancel.com/TechEmails/status/2071254764558676130
+https://x.com/TechEmails/status/2071254764558676130
 ```
 
 A thread (one URL per line) renders as a connected stack:
 
 ```tweet
-https://xcancel.com/Turn_Trout/status/2055343603224879417
-https://xcancel.com/Turn_Trout/status/2055343603958878231
+https://x.com/Turn_Trout/status/2055343603224879417
+https://x.com/Turn_Trout/status/2055343603958878231
 ```
 
 A quote-tweet renders the quoted post as a nested card:
 
 ```tweet
-https://xcancel.com/ChrisMurphyCT/status/2071998353664000365
+https://x.com/ChrisMurphyCT/status/2071998353664000365
 ```
 
 # Images


### PR DESCRIPTION
## Summary

- XCancel (the privacy-respecting X/Twitter frontend the site used for tweet-embed links) has shut down, so this stops routing any links through it.
- Tweet-card mention/hashtag/profile links, quoted-tweet links, and the "unavailable" stub fallback now point directly at `x.com` instead of `xcancel.com`.
- The markdown mass-transform that rewrote any authored `x.com`/`twitter.com` link to `xcancel.com` is removed entirely.

## Changes

- `quartz/plugins/transformers/tweetCard.ts`: `XCANCEL_BASE` → `X_BASE` (now `https://x.com`); `buildUnavailableCard`'s stub link and copy ("View it on X." instead of "View it on XCancel."); `TweetSlot.xcancelUrl` renamed to `url`.
- `quartz/plugins/transformers/tweetEmbed.ts`: `toXcancelUrl` renamed to `toXUrl` and now normalizes to `x.com` instead of `xcancel.com`; drops `xcancel`/`nitter.*` from the recognized host list; `TweetReference.xcancelUrl` renamed to `url`.
- `quartz/plugins/transformers/formatting_improvement_text.ts`: deletes the `xcancelHostReplacementRegex` mass-transform that rewrote `x.com`/`twitter.com` links to `xcancel.com`.
- `scripts/tweet_snapshot.py`: snapshot/quoted-tweet `url` fields now build `https://x.com/...` permalinks instead of `https://xcancel.com/...`.
- `config/constants.json`: removes the now-unused `xcancel.com → x.com` favicon domain mapping.
- Pinned tweet snapshots (`quartz/plugins/transformers/.tweet_snapshots/*.json`) had their baked-in `xcancel.com` post URLs updated to `x.com`.
- Content: `website_content/design.md`, `test-page.md`, and `leaving-google-deepmind.md` had their `tweet` fenced-block URLs updated from `xcancel.com` to `x.com`; `design.md` also drops the now-stale sentence explaining the (former) xcancel routing choice. `website_content/advanced-privacy.md` no longer recommends XCancel as a live example of a privacy frontend—the prose and image caption now note it has shut down, and the dead hyperlink to `xcancel.com` was removed.
- Tests updated in lockstep across `tweetCard.test.ts`, `tweetEmbed.test.ts`, `formatting_improvement_text.test.ts`, `tweetEmbed.spec.ts`, and `test_tweet_snapshot.py`.

Note: historical, non-pinned tweet snapshots hosted on R2 still have the old `xcancel.com` permalink baked in until someone re-runs `scripts/tweet_snapshot.py --write` for those tweet IDs (requires R2 credentials not available in this session); the code now produces `x.com` URLs for any future capture or re-capture.

## Testing

- `pnpm check` (typecheck + prettier + stylelint) — passing
- Targeted Jest run (`tweetCard.test.ts`, `tweetEmbed.test.ts`, `formatting_improvement_text.test.ts`) — 231 passed, 100% coverage on all three touched source files
- `uv run pytest scripts/tests/test_tweet_snapshot.py` — 43 passed
- `uv run pylint scripts/tweet_snapshot.py` — 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KfCPAbNFJeXqA9dHi6WxX)_