### PR TITLE
ci: fix template-sync conflict reports, deepen security-scan checkout, repin subfont

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -333,7 +333,6 @@ main() {
       echo "has_conflicts=true"
       echo "conflict_files=$conflicts"
     } >>"$GITHUB_OUTPUT"
-    emit_multiline_output "conflict_report" "$(cat "$CONFLICT_REPORT")"
     echo "Template updates available for: $conflicts" >.template-sync-conflicts
   else
     echo "has_conflicts=false" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -196,7 +196,7 @@ jobs:
           project-name: turntrout
           branch: ${{ github.ref_name }}
 
-      # subfont is pinned to @turntrout/subfont@1.8.1 in package.json and
+      # subfont is pinned in package.json and
       # installed by setup-site's `pnpm install`, so we run it via
       # `pnpm exec` (in scripts/subfont.sh) — no separate global install.
       - name: Make script executable

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -35,6 +35,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Full history so check-existing-security-pr.sh can merge the
+          # default branch into an existing security-PR branch.
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup base environment

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -130,6 +130,15 @@ jobs:
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
         run: bash .github/scripts/show-sync-diff.sh
 
+      - name: Upload conflict report
+        if: steps.sync.outputs.has_conflicts == 'true'
+        id: conflict-report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: template-sync-conflicts
+          path: /tmp/conflict_report.md
+          if-no-files-found: error
+
       - name: Create Pull Request
         if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
@@ -171,7 +180,7 @@ jobs:
 
             The following files need conflict resolution. Claude will resolve these automatically.
 
-            ' || '' }}${{ steps.sync.outputs.conflict_report }}
+            ' || '' }}${{ steps.conflict-report.outputs.artifact-url && format('[Download the full conflict report]({0}).', steps.conflict-report.outputs.artifact-url) || '' }}
 
             ---
             Please review the changes and merge if appropriate.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "shell-quote": "1.8.3",
     "shiki": "4.0.2",
     "source-map-support": "0.5.21",
-    "subfont": "npm:@turntrout/subfont@1.11.1",
+    "subfont": "github:AlexanderMattTurner/subfont#9ef75626d6c4118dff0394996f072b96fa42d33e",
     "title-case": "4.3.2",
     "to-vfile": "8.0.0",
     "toml": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
         specifier: 0.5.21
         version: 0.5.21
       subfont:
-        specifier: npm:@turntrout/subfont@1.11.1
-        version: '@turntrout/subfont@1.11.1(@types/babel__core@7.20.5)'
+        specifier: github:AlexanderMattTurner/subfont#9ef75626d6c4118dff0394996f072b96fa42d33e
+        version: '@turntrout/subfont@https://codeload.github.com/AlexanderMattTurner/subfont/tar.gz/9ef75626d6c4118dff0394996f072b96fa42d33e(@types/babel__core@7.20.5)'
       title-case:
         specifier: 4.3.2
         version: 4.3.2
@@ -2719,8 +2719,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turntrout/subfont@1.11.1':
-    resolution: {integrity: sha512-KWYf2EvXw16RYzq4lqfD0EP+/d1SzLtpQWKhtw4WVt7M9HQvUsLwctQP0f/n/Nw12gJsSHfTfGSPgNqr9yZ8pA==}
+  '@turntrout/subfont@https://codeload.github.com/AlexanderMattTurner/subfont/tar.gz/9ef75626d6c4118dff0394996f072b96fa42d33e':
+    resolution: {gitHosted: true, integrity: sha512-hbBRbu4wcasB/1CUPX18Ekcz2oUVqU3cbkkim2MXQ/6+nzuTWlfhZJzZhCpt6RPUzjZbDvZEqeEFTiXNakO8SQ==, tarball: https://codeload.github.com/AlexanderMattTurner/subfont/tar.gz/9ef75626d6c4118dff0394996f072b96fa42d33e}
+    version: 1.0.0
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -12367,7 +12368,7 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
-  '@turntrout/subfont@1.11.1(@types/babel__core@7.20.5)':
+  '@turntrout/subfont@https://codeload.github.com/AlexanderMattTurner/subfont/tar.gz/9ef75626d6c4118dff0394996f072b96fa42d33e(@types/babel__core@7.20.5)':
     dependencies:
       '@hookun/parse-animation-shorthand': 0.1.5
       '@puppeteer/browsers': 2.13.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,7 @@ onlyBuiltDependencies:
   - workerd
 
 allowBuilds:
+  "@turntrout/subfont@https://codeload.github.com/AlexanderMattTurner/subfont/tar.gz/9ef75626d6c4118dff0394996f072b96fa42d33e": true
   "@parcel/watcher": true
   esbuild: true
   puppeteer: true


### PR DESCRIPTION
## Summary

- Template-sync conflict reports were being passed through `GITHUB_OUTPUT` as multiline text, which silently truncates once the report exceeds GitHub's output size limit. Upload the report as a workflow artifact instead and link to it from the auto-generated PR body.
- `security-vulnerability-scan.yaml`'s checkout now uses `fetch-depth: 0`, since `check-existing-security-pr.sh` merges the default branch into an existing security-PR branch and needs full history to do that.
- `subfont` moves from the npm-published `@turntrout/subfont@1.11.1` to a pinned commit on a fork (`github:AlexanderMattTurner/subfont#9ef75626d6c4118dff0394996f072b96fa42d33e`), so fixes can land without waiting on an npm release. Dropped the now-stale hardcoded version number from the `deploy.yaml` comment referencing it.

## Changes

- `.github/scripts/template-sync.sh`: stop emitting the `conflict_report` multiline `GITHUB_OUTPUT`.
- `.github/workflows/template-sync.yaml`: upload `/tmp/conflict_report.md` as an artifact (`if: has_conflicts == 'true'`) and link to it from the PR body via `steps.conflict-report.outputs.artifact-url`.
- `.github/workflows/security-vulnerability-scan.yaml`: `fetch-depth: 0` on checkout, with a comment explaining why.
- `.github/workflows/deploy.yaml`: drop a stale version number from a comment.
- `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`: repoint `subfont` at the pinned fork commit; add the corresponding `allowBuilds` entry.

## Testing

- `shellcheck .github/scripts/template-sync.sh` — clean.
- Validated all touched YAML/JSON files parse (`yaml.safe_load` / `json.load`).
- Traced `template-sync.sh`'s `WORK_DIR` default (`/tmp`) against the new artifact step's `path: /tmp/conflict_report.md` to confirm they match, and confirmed `emit_multiline_output` is still used elsewhere (for `changelog`) so it isn't dead code.
- Two independent critique passes over the full diff found no correctness issues; this sandbox's egress proxy blocks direct `codeload.github.com` tarball fetches for unattached repos, so the `pnpm install` fetch of the new fork commit couldn't be exercised locally — CI's runners have unrestricted internet and should fetch it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZPoF55KoQrkjG6EoSUS4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZPoF55KoQrkjG6EoSUS4p)_