### PR TITLE
chore(readmes): refresh external README snapshots

### DIFF
--- a/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
+++ b/quartz/plugins/transformers/.readme-snapshots/AlexanderMattTurner__agent-glovebox__main__README.md
@@ -17,7 +17,7 @@ After all, what's the chance that something bad happens?
 [![pytest](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fpytest-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/pytest-checks.yaml)
 [![CI](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fci.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/ci.yaml)
 [![actionlint + zizmor + bash config](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Flint-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/ci.yaml)
-[![isolation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsbx-live-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/sbx-live-checks.yaml)
+[![isolation](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAlexanderMattTurner%2Fagent-glovebox%2Fbadges%2Fsbx-live-checks.json)](https://github.com/AlexanderMattTurner/agent-glovebox/actions/workflows/ci.yaml)
 
 <!-- END GENERATED: status badges -->
 


### PR DESCRIPTION
Automated refresh of the committed GitHub README snapshots that
the build embeds into pages.

Generated by `.github/workflows/refresh-readme-snapshots.yaml`
running `scripts/refresh_readme_snapshots.ts`.